### PR TITLE
fix(ci): use buildx container driver for cache export

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary\n- set up Buildx with docker-container driver so gha cache export is supported\n\n## Context\n- CD run 21609830179 failed with: "Cache export is not supported for the docker driver"\n\n## Validation\n- Not run locally (CI workflow change only)