### PR TITLE
test(e2e): add member empty-state seed and spec

### DIFF
--- a/apps/web/e2e/fixtures/auth.fixture.ts
+++ b/apps/web/e2e/fixtures/auth.fixture.ts
@@ -35,7 +35,7 @@ type GlobalE2E = typeof globalThis & {
 
 type Tenant = 'ks' | 'mk';
 
-type Role = 'member' | 'admin' | 'agent' | 'staff' | 'branch_manager' | 'admin_mk';
+type Role = 'member' | 'member_empty' | 'admin' | 'agent' | 'staff' | 'branch_manager' | 'admin_mk';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // HELPER FUNCTIONS (Pure / Utils)
@@ -119,6 +119,7 @@ function ipForRole(role: Role): string {
   // Stable IPs for each role to avoid unexpected rate limiting collision if checking by IP
   switch (role) {
     case 'member':
+    case 'member_empty':
       return '10.0.0.11';
     case 'admin':
       return '10.0.0.12';
@@ -143,6 +144,7 @@ function getUserForTenant(role: Role, tenant: Tenant) {
   if (tenant === 'mk') {
     switch (role) {
       case 'member':
+      case 'member_empty':
         return E2E_USERS.MK_MEMBER;
       case 'admin':
         return E2E_USERS.MK_ADMIN;
@@ -156,6 +158,8 @@ function getUserForTenant(role: Role, tenant: Tenant) {
   switch (role) {
     case 'member':
       return E2E_USERS.KS_MEMBER;
+    case 'member_empty':
+      return E2E_USERS.KS_MEMBER_EMPTY;
     case 'admin':
       return E2E_USERS.KS_ADMIN;
     case 'agent':

--- a/apps/web/e2e/fixtures/auth.project.ts
+++ b/apps/web/e2e/fixtures/auth.project.ts
@@ -2,7 +2,14 @@ import { E2E_PASSWORD, E2E_USERS } from '@interdomestik/database';
 import { type TestInfo } from '@playwright/test';
 
 export type Tenant = 'ks' | 'mk';
-export type Role = 'member' | 'admin' | 'agent' | 'staff' | 'branch_manager' | 'admin_mk';
+export type Role =
+  | 'member'
+  | 'member_empty'
+  | 'admin'
+  | 'agent'
+  | 'staff'
+  | 'branch_manager'
+  | 'admin_mk';
 
 export type ProjectUrlInfo = {
   baseURL: string;
@@ -56,6 +63,7 @@ export function ipForRole(role: Role): string {
   // Stable IPs for each role to avoid unexpected rate limiting collision if checking by IP
   switch (role) {
     case 'member':
+    case 'member_empty':
       return '10.0.0.11';
     case 'admin':
       return '10.0.0.12';
@@ -82,6 +90,7 @@ export function getUserForTenant(role: Role, tenant: Tenant) {
   if (tenant === 'mk') {
     switch (role) {
       case 'member':
+      case 'member_empty':
         return E2E_USERS.MK_MEMBER;
       case 'admin':
         return E2E_USERS.MK_ADMIN;
@@ -95,6 +104,8 @@ export function getUserForTenant(role: Role, tenant: Tenant) {
   switch (role) {
     case 'member':
       return E2E_USERS.KS_MEMBER;
+    case 'member_empty':
+      return E2E_USERS.KS_MEMBER_EMPTY;
     case 'admin':
       return E2E_USERS.KS_ADMIN;
     case 'agent':

--- a/apps/web/e2e/golden/member-dashboard-empty-state.spec.ts
+++ b/apps/web/e2e/golden/member-dashboard-empty-state.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '../fixtures/auth.fixture';
+import { routes } from '../routes';
+import { gotoApp } from '../utils/navigation';
+
+test.describe('Member Dashboard (Empty State)', () => {
+  test('Member with no claims sees empty state and start CTA', async ({
+    page,
+    loginAs,
+  }, testInfo) => {
+    await loginAs('member_empty');
+
+    await gotoApp(page, routes.member(testInfo), testInfo, { marker: 'dashboard-page-ready' });
+
+    await expect(page.getByTestId('member-empty-state')).toBeVisible();
+    await expect(page.getByTestId('member-claims-list')).toHaveCount(0);
+    await expect(page.getByTestId('member-active-claim')).toHaveCount(0);
+
+    const cta = page.getByTestId('member-primary-actions').getByTestId('member-start-claim-cta');
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute('href', new RegExp(`${routes.memberNewClaim(testInfo)}$`));
+  });
+});

--- a/packages/database/src/e2e-users.ts
+++ b/packages/database/src/e2e-users.ts
@@ -86,6 +86,13 @@ export const E2E_USERS = {
     tenantId: 'tenant_ks',
     branchId: 'ks_branch_a',
   },
+  KS_MEMBER_EMPTY: {
+    email: 'member.ks.empty@interdomestik.com',
+    name: 'KS Empty Member',
+    dbRole: 'member',
+    tenantId: 'tenant_ks',
+    branchId: 'ks_branch_a',
+  },
 } as const;
 
 export type E2EUserKey = keyof typeof E2E_USERS;

--- a/packages/database/src/seed-golden.ts
+++ b/packages/database/src/seed-golden.ts
@@ -203,6 +203,16 @@ export async function seedGolden(config: SeedConfig) {
       memberNumber: `MEM-2026-0000${12 + i}`,
       memberNumberIssuedAt: at(),
     })),
+    {
+      id: goldenId('ks_empty_member'),
+      name: 'KS Empty Member',
+      email: 'member.ks.empty@interdomestik.com',
+      role: 'member' as const,
+      tenantId: TENANTS.KS,
+      branchId: 'ks_branch_a',
+      memberNumber: 'MEM-2026-000015',
+      memberNumberIssuedAt: at(),
+    },
     // Balkan Agent
     {
       id: goldenId('agent_balkan_1'),


### PR DESCRIPTION
## What
- Add empty-state member seed (member.ks.empty@interdomestik.com)
- Extend E2E users/fixtures for member_empty role
- Add golden E2E spec for member dashboard empty state

## Why
- Deterministic coverage for member dashboard when no claims exist
- Keeps empty-state behavior stable without impacting smoke

## Validation
- ✅ bash scripts/m4-gatekeeper.sh
- ✅ pnpm --filter @interdomestik/web exec playwright test e2e/golden/member-dashboard-empty-state.spec.ts --project=ks-sq --max-failures=1
