### PR TITLE
fix(green-card): use server-safe translations to ensure deterministic render

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/green-card/page.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/green-card/page.tsx
@@ -1,7 +1,7 @@
-import { useTranslations } from 'next-intl';
+import { getTranslations } from 'next-intl/server';
 
-export default function Page() {
-  const t = useTranslations('dashboard.home_grid');
+export default async function Page() {
+  const t = await getTranslations('dashboard.home_grid');
   return (
     <div className="container py-8" data-testid="green-card-page-ready">
       <h1 className="text-2xl font-bold mb-4">{t('cta_green_card')}</h1>


### PR DESCRIPTION
## Why
mk-mk gate failure: green-card page never rendered the readiness marker. This page uses a server component and should use server-safe translations.

## What changed
- Switch from useTranslations to getTranslations (server-safe)
- Keep data-testid=green-card-page-ready unchanged

## Validation
- bash scripts/m4-gatekeeper.sh
- pnpm --filter @interdomestik/web exec playwright test e2e/gate/member-home-cta.spec.ts --project=mk-mk