### PR TITLE
feat: add staff readonly claims views

### DIFF
--- a/apps/web/e2e/staff-claims-readonly.spec.ts
+++ b/apps/web/e2e/staff-claims-readonly.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from './fixtures/auth.fixture';
+import { routes } from './routes';
+import { gotoApp } from './utils/navigation';
+
+const goldenId = (...parts: Array<string | number>) => `golden_${parts.join('_').toLowerCase()}`;
+
+test.describe('Staff Claims Readonly', () => {
+  test('staff can view claims and cannot access other-tenant claim', async ({
+    page,
+    loginAs,
+  }, testInfo) => {
+    await loginAs('staff');
+
+    await gotoApp(page, routes.staff(testInfo), testInfo, {
+      marker: 'staff-dashboard-ready',
+    });
+
+    await gotoApp(page, routes.staffClaims(testInfo), testInfo, {
+      marker: 'staff-claims-list-ready',
+    });
+
+    await page.getByTestId('staff-claims-view').first().click();
+
+    await expect(page.getByTestId('staff-claim-detail-ready')).toBeVisible();
+    await expect(page.getByTestId('staff-claim-detail-member')).toBeVisible();
+    await expect(page.getByTestId('staff-claim-detail-agent')).toBeVisible();
+
+    await expect(page.getByRole('button', { name: /assign|update|save|change/i })).toHaveCount(0);
+
+    const otherTenantClaimId = goldenId('mk_track_claim_001');
+    await gotoApp(page, routes.staffClaimDetail(otherTenantClaimId, testInfo), testInfo, {
+      marker: 'not-found-page',
+    });
+    await expect(page.getByTestId('not-found-page')).toBeVisible();
+  });
+});

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
@@ -1,4 +1,9 @@
-import { StaffClaimDetailV2Page } from '@/features/staff/claims/components/StaffClaimDetailV2Page';
+import { getStaffClaimDetail } from '@interdomestik/domain-claims';
+import { setRequestLocale } from 'next-intl/server';
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+
+import { auth } from '@/lib/auth';
 
 interface PageProps {
   params: Promise<{
@@ -9,5 +14,87 @@ interface PageProps {
 
 export default async function StaffClaimDetailsPage({ params }: PageProps) {
   const { id, locale } = await params;
-  return <StaffClaimDetailV2Page id={id} locale={locale} />;
+  setRequestLocale(locale);
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return notFound();
+  if (session.user.role !== 'staff' && session.user.role !== 'branch_manager') {
+    return notFound();
+  }
+
+  const detail = await getStaffClaimDetail({
+    staffId: session.user.id,
+    tenantId: session.user.tenantId,
+    claimId: id,
+  });
+
+  if (!detail) return notFound();
+
+  return (
+    <div className="space-y-6" data-testid="staff-claim-detail-ready">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold tracking-tight">
+          {detail.claim.claimNumber || detail.claim.id}
+        </h1>
+        <p className="text-muted-foreground">{detail.claim.stageLabel}</p>
+      </div>
+
+      <section className="rounded-lg border bg-white p-4" data-testid="staff-claim-detail-claim">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Claim
+        </h2>
+        <div className="mt-3 grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+          <div>
+            <span className="text-muted-foreground">Status</span>
+            <div className="font-medium text-slate-900">{detail.claim.stageLabel}</div>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Updated</span>
+            <div className="font-medium text-slate-900">
+              {detail.claim.updatedAt ? new Date(detail.claim.updatedAt).toLocaleDateString() : '-'}
+            </div>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Submitted</span>
+            <div className="font-medium text-slate-900">
+              {detail.claim.submittedAt
+                ? new Date(detail.claim.submittedAt).toLocaleDateString()
+                : '-'}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border bg-white p-4" data-testid="staff-claim-detail-member">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Member
+        </h2>
+        <div className="mt-3 grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+          <div>
+            <span className="text-muted-foreground">Name</span>
+            <div className="font-medium text-slate-900">{detail.member.fullName}</div>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Membership #</span>
+            <div className="font-medium text-slate-900">
+              {detail.member.membershipNumber || '-'}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border bg-white p-4" data-testid="staff-claim-detail-agent">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Agent
+        </h2>
+        <div className="mt-3 text-sm">
+          {detail.agent ? (
+            <div className="font-medium text-slate-900">{detail.agent.name}</div>
+          ) : (
+            <div className="text-muted-foreground">Unassigned</div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/_core.entry.tsx
@@ -1,68 +1,37 @@
-import { AgentClaimsFilters } from '@/components/agent/agent-claims-filters';
-import { AgentClaimsTable } from '@/components/agent/agent-claims-table';
-import { Link, redirect } from '@/i18n/routing';
+import { Link } from '@/i18n/routing';
 import { auth } from '@/lib/auth';
-import { badgeVariants } from '@interdomestik/ui';
+import { getStaffClaimsList } from '@interdomestik/domain-claims';
+import { Button } from '@interdomestik/ui';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
 
 type Props = {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<{
-    queue?: string;
-    status?: string;
-    search?: string;
-    page?: string;
-  }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
 export default async function StaffClaimsPage({ params, searchParams }: Props) {
   const { locale } = await params;
-  const query = await searchParams;
+  await searchParams;
   setRequestLocale(locale);
 
   const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    redirect({ href: '/login', locale });
-    return null;
-  }
-
-  if (session.user.role !== 'staff') {
-    if (session.user.role === 'admin') {
-      redirect({ href: '/admin', locale });
-    } else if (session.user.role === 'agent') {
-      redirect({ href: '/agent', locale });
-    } else {
-      redirect({ href: '/member', locale });
-    }
-    return null;
+  if (!session) return notFound();
+  if (session.user.role !== 'staff' && session.user.role !== 'branch_manager') {
+    return notFound();
   }
 
   const tClaims = await getTranslations('agent-claims.claims');
 
-  const queueParam = query.queue;
-  let queue: 'unassigned' | 'mine' | 'all' = 'unassigned';
-  let scope: 'staff_queue' | 'staff_all' | 'staff_unassigned' = 'staff_unassigned';
-
-  if (queueParam === 'mine') {
-    queue = 'mine';
-    scope = 'staff_queue';
-  } else if (queueParam === 'all') {
-    queue = 'all';
-    scope = 'staff_all';
-  }
-
-  const buildQueueHref = (nextQueue: 'unassigned' | 'mine' | 'all') => {
-    const params = new URLSearchParams();
-    params.set('queue', nextQueue);
-    if (query.status) params.set('status', query.status);
-    if (query.search) params.set('search', query.search);
-    const queryString = params.toString();
-    return queryString ? `?${queryString}` : '';
-  };
+  const claims = await getStaffClaimsList({
+    staffId: session.user.id,
+    tenantId: session.user.tenantId,
+    limit: 20,
+  });
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="staff-claims-list-ready">
       <div>
         <h1 className="text-3xl font-bold tracking-tight" data-testid="page-title">
           {tClaims('queue')}
@@ -71,35 +40,40 @@ export default async function StaffClaimsPage({ params, searchParams }: Props) {
         <p className="text-muted-foreground">{tClaims('manage_triage')}</p>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        <Link
-          href={buildQueueHref('unassigned')}
-          className={badgeVariants({
-            variant: queue === 'unassigned' ? 'default' : 'outline',
-          })}
-        >
-          Unassigned
-        </Link>
-        <Link
-          href={buildQueueHref('mine')}
-          className={badgeVariants({
-            variant: queue === 'mine' ? 'default' : 'outline',
-          })}
-        >
-          My Queue
-        </Link>
-        <Link
-          href={buildQueueHref('all')}
-          className={badgeVariants({
-            variant: queue === 'all' ? 'default' : 'outline',
-          })}
-        >
-          All
-        </Link>
+      <div className="rounded-lg border bg-white shadow-sm">
+        <div className="grid grid-cols-1 gap-4 border-b px-4 py-3 text-sm font-medium text-muted-foreground md:grid-cols-5">
+          <span>{tClaims('table.claim')}</span>
+          <span>{tClaims('table.status')}</span>
+          <span>{tClaims('table.date')}</span>
+          <span>{tClaims('table.claimant')}</span>
+          <span className="text-right">{tClaims('table.actions')}</span>
+        </div>
+        <div className="divide-y">
+          {claims.map(claim => (
+            <div
+              key={claim.id}
+              className="grid grid-cols-1 items-center gap-4 px-4 py-3 text-sm md:grid-cols-5"
+            >
+              <div className="font-medium text-slate-900">{claim.claimNumber || claim.id}</div>
+              <div>{claim.stageLabel}</div>
+              <div>{claim.updatedAt ? new Date(claim.updatedAt).toLocaleDateString() : '-'}</div>
+              <div>{claim.agentName || claim.memberName || '-'}</div>
+              <div className="text-right">
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/staff/claims/${claim.id}`} data-testid="staff-claims-view">
+                    {tClaims('actions.review')}
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          ))}
+          {claims.length === 0 && (
+            <div className="px-4 py-10 text-center text-muted-foreground">
+              {tClaims('table.no_claims')}
+            </div>
+          )}
+        </div>
       </div>
-
-      <AgentClaimsFilters />
-      <AgentClaimsTable scope={scope} detailBasePath="/staff/claims" userRole="staff" />
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/(staff)/staff/page.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/page.tsx
@@ -1,30 +1,8 @@
-import { AgentStatsCards } from '@/components/agent/agent-stats-cards';
-import { ClaimStatusBadge } from '@/components/dashboard/claims/claim-status-badge';
 import { Link } from '@/i18n/routing';
-import { db } from '@/lib/db.server';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@interdomestik/ui';
-import { ArrowRight, FileText } from 'lucide-react';
+import { getSessionSafe, requireSessionOrRedirect } from '@/components/shell/session';
+import { Button } from '@interdomestik/ui';
+import { ArrowRight } from 'lucide-react';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import { headers } from 'next/headers';
-import { notFound, redirect } from 'next/navigation';
-import { getStaffDashboardCore } from './_core';
-
-// Minimal placeholder auth
-async function getAuth() {
-  try {
-    const { auth } = await import('@/lib/auth');
-    return await auth.api.getSession({ headers: await headers() });
-  } catch {
-    return null;
-  }
-}
 
 export default async function StaffDashboardPage({
   params,
@@ -34,41 +12,18 @@ export default async function StaffDashboardPage({
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const session = await getAuth();
-  if (!session) redirect(`/${locale}/login`);
-
-  const result = await getStaffDashboardCore({
-    tenantId: session.user.tenantId,
-    userId: session.user.id,
-    role: session.user.role,
-    db,
-  });
-
-  if (!result.ok) {
-    if (result.code === 'FORBIDDEN') return notFound();
-    throw new Error('Internal Server Error');
-  }
-
-  const { stats, recentClaims } = result.data;
+  const session = await getSessionSafe('StaffDashboardPage');
+  requireSessionOrRedirect(session, locale);
 
   const tNav = await getTranslations('nav');
-  const tCommon = await getTranslations('common');
   const tClaims = await getTranslations('agent-claims.claims');
 
   return (
-    <div className="space-y-8 animate-in fade-in duration-500">
+    <div className="space-y-6" data-testid="staff-dashboard-ready">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">{tNav('overview')}</h1>
-          <p className="text-muted-foreground">
-            {tCommon('roles.staff')} —{' '}
-            {new Date().toLocaleDateString(locale, {
-              weekday: 'long',
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </p>
+          <p className="text-muted-foreground">{tClaims('manage_triage')}</p>
         </div>
         <Button asChild>
           <Link href="/staff/claims">
@@ -76,45 +31,6 @@ export default async function StaffDashboardPage({
           </Link>
         </Button>
       </div>
-
-      <AgentStatsCards stats={stats} />
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <FileText className="h-4 w-4 text-primary" />
-            {tClaims('table.recent_activity')}
-          </CardTitle>
-          <CardDescription>{tClaims('manage_triage')}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {recentClaims.map(claim => (
-              <div key={claim.id} className="flex items-center justify-between gap-4">
-                <div className="space-y-1">
-                  <p className="text-sm font-medium leading-none">{claim.title}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {claim.user?.name || 'Unknown'} • {claim.companyName}
-                  </p>
-                </div>
-                <div className="flex items-center gap-3">
-                  <ClaimStatusBadge
-                    status={claim.status as import('@interdomestik/database/constants').ClaimStatus}
-                  />
-                  <Button asChild variant="outline" size="sm">
-                    <Link href={`/staff/claims/${claim.id}`}>{tCommon('view')}</Link>
-                  </Button>
-                </div>
-              </div>
-            ))}
-            {recentClaims.length === 0 && (
-              <div className="py-10 text-center text-muted-foreground opacity-70">
-                <p>{tClaims('table.no_claims')}</p>
-              </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/packages/domain-claims/package.json
+++ b/packages/domain-claims/package.json
@@ -15,6 +15,8 @@
     "./agent-claims/assign": "./src/agent-claims/assign.ts",
     "./agent-claims/update-status": "./src/agent-claims/update-status.ts",
     "./staff-claims/assign": "./src/staff-claims/assign.ts",
+    "./staff-claims/get-staff-claims-list": "./src/staff-claims/get-staff-claims-list.ts",
+    "./staff-claims/get-staff-claim-detail": "./src/staff-claims/get-staff-claim-detail.ts",
     "./staff-claims/update-status": "./src/staff-claims/update-status.ts",
     "./staff-claims/types": "./src/staff-claims/types.ts",
     "./admin-claims/update-status": "./src/admin-claims/update-status.ts",

--- a/packages/domain-claims/src/index.ts
+++ b/packages/domain-claims/src/index.ts
@@ -12,4 +12,6 @@ export { updateClaimStatusCore as updateAgentClaimStatusCore } from './agent-cla
 export * from './claims/list';
 export { updateClaimStatusCore } from './claims/status';
 export { assignClaimCore as assignStaffClaimCore } from './staff-claims/assign';
+export { getStaffClaimsList } from './staff-claims/get-staff-claims-list';
+export { getStaffClaimDetail } from './staff-claims/get-staff-claim-detail';
 export { updateClaimStatusCore as updateStaffClaimStatusCore } from './staff-claims/update-status';

--- a/packages/domain-claims/src/staff-claims/get-staff-claim-detail.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claim-detail.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const claimChain = {
+    from: vi.fn(),
+    leftJoin: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  };
+
+  const agentChain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  };
+
+  return {
+    claimChain,
+    agentChain,
+    db: { select: vi.fn() },
+    claims: {
+      id: 'claims.id',
+      tenantId: 'claims.tenant_id',
+      claimNumber: 'claims.claim_number',
+      status: 'claims.status',
+      updatedAt: 'claims.updated_at',
+      createdAt: 'claims.created_at',
+      staffId: 'claims.staff_id',
+      userId: 'claims.user_id',
+      agentId: 'claims.agent_id',
+    },
+    user: {
+      id: 'user.id',
+      name: 'user.name',
+      memberNumber: 'user.member_number',
+    },
+    eq: vi.fn((left, right) => ({ left, right, op: 'eq' })),
+    and: vi.fn((...conditions) => ({ conditions, op: 'and' })),
+    withTenant: vi.fn((_tenantId, _column, condition) => ({ scoped: true, condition })),
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  db: mocks.db,
+  claims: mocks.claims,
+  user: mocks.user,
+  eq: mocks.eq,
+  and: mocks.and,
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+import { getStaffClaimDetail } from './get-staff-claim-detail';
+
+describe('getStaffClaimDetail', () => {
+  beforeEach(() => {
+    mocks.db.select.mockReset();
+    mocks.db.select.mockReturnValueOnce(mocks.claimChain).mockReturnValueOnce(mocks.agentChain);
+    mocks.claimChain.from.mockReturnValue(mocks.claimChain);
+    mocks.claimChain.leftJoin.mockReturnValue(mocks.claimChain);
+    mocks.claimChain.where.mockReturnValue(mocks.claimChain);
+    mocks.agentChain.from.mockReturnValue(mocks.agentChain);
+    mocks.agentChain.where.mockReturnValue(mocks.agentChain);
+  });
+
+  it('returns member and claim details for tenant', async () => {
+    mocks.claimChain.limit.mockResolvedValue([
+      {
+        claimId: 'claim-1',
+        claimNumber: 'KS-0001',
+        status: 'submitted',
+        updatedAt: new Date('2026-01-02T00:00:00Z'),
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        memberId: 'member-1',
+        memberName: 'Member One',
+        memberNumber: 'MEM-001',
+        agentId: 'agent-1',
+        agentName: 'Agent One',
+      },
+    ]);
+    mocks.agentChain.limit.mockResolvedValue([{ id: 'agent-1', name: 'Agent One' }]);
+
+    const result = await getStaffClaimDetail({
+      staffId: 'staff-1',
+      tenantId: 'tenant-ks',
+      claimId: 'claim-1',
+    });
+
+    expect(mocks.withTenant).toHaveBeenCalledWith(
+      'tenant-ks',
+      mocks.claims.tenantId,
+      expect.any(Object)
+    );
+    expect(result?.claim.claimNumber).toBe('KS-0001');
+    expect(result?.member.membershipNumber).toBe('MEM-001');
+    expect(result?.agent?.name).toBe('Agent One');
+  });
+
+  it('returns null when claim is outside tenant scope', async () => {
+    mocks.claimChain.limit.mockResolvedValue([]);
+
+    const result = await getStaffClaimDetail({
+      staffId: 'staff-9',
+      tenantId: 'tenant-mk',
+      claimId: 'claim-9',
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/domain-claims/src/staff-claims/get-staff-claim-detail.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claim-detail.ts
@@ -1,0 +1,91 @@
+import { and, claims, db, eq, user } from '@interdomestik/database';
+import { withTenant } from '@interdomestik/database/tenant-security';
+
+export type StaffClaimDetail = {
+  claim: {
+    id: string;
+    claimNumber: string | null;
+    status: string | null;
+    stageLabel: string;
+    submittedAt: string | null;
+    updatedAt: string | null;
+  };
+  member: {
+    id: string;
+    fullName: string;
+    membershipNumber: string | null;
+  };
+  agent?: {
+    id: string;
+    name: string;
+  };
+};
+
+function formatStageLabel(status: string | null | undefined) {
+  if (!status) return 'Draft';
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function normalizeDate(value: Date | string | null | undefined) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export async function getStaffClaimDetail(params: {
+  staffId: string;
+  tenantId: string;
+  claimId: string;
+}): Promise<StaffClaimDetail | null> {
+  const { tenantId, claimId } = params;
+
+  const rows = await db
+    .select({
+      claimId: claims.id,
+      claimNumber: claims.claimNumber,
+      status: claims.status,
+      updatedAt: claims.updatedAt,
+      createdAt: claims.createdAt,
+      agentId: claims.agentId,
+      memberId: user.id,
+      memberName: user.name,
+      memberNumber: user.memberNumber,
+    })
+    .from(claims)
+    .leftJoin(user, eq(claims.userId, user.id))
+    .where(withTenant(tenantId, claims.tenantId, and(eq(claims.id, claimId))))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row || !row.memberId || !row.memberName) return null;
+
+  let agent: StaffClaimDetail['agent'];
+  if (row.agentId) {
+    const agentRows = await db
+      .select({ id: user.id, name: user.name })
+      .from(user)
+      .where(withTenant(tenantId, user.tenantId, eq(user.id, row.agentId)))
+      .limit(1);
+    const agentRow = agentRows[0];
+    if (agentRow?.id && agentRow.name) {
+      agent = { id: agentRow.id, name: agentRow.name };
+    }
+  }
+
+  return {
+    claim: {
+      id: row.claimId,
+      claimNumber: row.claimNumber,
+      status: row.status,
+      stageLabel: formatStageLabel(row.status),
+      submittedAt: normalizeDate(row.createdAt),
+      updatedAt: normalizeDate(row.updatedAt ?? row.createdAt),
+    },
+    member: {
+      id: row.memberId,
+      fullName: row.memberName,
+      membershipNumber: row.memberNumber ?? null,
+    },
+    agent,
+  };
+}

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const claimChain = {
+    from: vi.fn(),
+    leftJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit: vi.fn(),
+  };
+
+  const agentChain = {
+    from: vi.fn(),
+    where: vi.fn(),
+  };
+
+  return {
+    claimChain,
+    agentChain,
+    db: { select: vi.fn() },
+    claims: {
+      id: 'claims.id',
+      tenantId: 'claims.tenant_id',
+      claimNumber: 'claims.claim_number',
+      status: 'claims.status',
+      updatedAt: 'claims.updated_at',
+      agentId: 'claims.agent_id',
+      userId: 'claims.user_id',
+    },
+    user: {
+      id: 'user.id',
+      name: 'user.name',
+    },
+    eq: vi.fn((left, right) => ({ left, right, op: 'eq' })),
+    desc: vi.fn(value => ({ value, op: 'desc' })),
+    inArray: vi.fn((column, values) => ({ column, values, op: 'inArray' })),
+    withTenant: vi.fn((_tenantId, _column, condition) => ({ scoped: true, condition })),
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  db: mocks.db,
+  claims: mocks.claims,
+  user: mocks.user,
+  eq: mocks.eq,
+  desc: mocks.desc,
+  inArray: mocks.inArray,
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+import { getStaffClaimsList } from './get-staff-claims-list';
+
+describe('getStaffClaimsList', () => {
+  beforeEach(() => {
+    mocks.db.select.mockReset();
+    mocks.db.select.mockReturnValueOnce(mocks.claimChain).mockReturnValueOnce(mocks.agentChain);
+    mocks.claimChain.from.mockReturnValue(mocks.claimChain);
+    mocks.claimChain.leftJoin.mockReturnValue(mocks.claimChain);
+    mocks.claimChain.where.mockReturnValue(mocks.claimChain);
+    mocks.claimChain.orderBy.mockReturnValue(mocks.claimChain);
+    mocks.agentChain.from.mockReturnValue(mocks.agentChain);
+  });
+
+  it('returns claims scoped to tenant', async () => {
+    mocks.claimChain.limit.mockResolvedValue([
+      {
+        id: 'claim-1',
+        claimNumber: 'KS-0001',
+        status: 'submitted',
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+        agentId: 'agent-1',
+        agentName: 'Agent One',
+        memberName: 'Member One',
+      },
+    ]);
+    mocks.agentChain.where.mockResolvedValue([{ id: 'agent-1', name: 'Agent One' }]);
+
+    const result = await getStaffClaimsList({
+      staffId: 'staff-1',
+      tenantId: 'tenant-ks',
+      limit: 20,
+    });
+
+    expect(mocks.withTenant).toHaveBeenCalledWith('tenant-ks', mocks.claims.tenantId);
+    expect(result).toHaveLength(1);
+    expect(result[0].claimNumber).toBe('KS-0001');
+    expect(result[0].agentName).toBe('Agent One');
+  });
+
+  it('returns empty when no claims match tenant', async () => {
+    mocks.claimChain.limit.mockResolvedValue([]);
+
+    const result = await getStaffClaimsList({
+      staffId: 'staff-2',
+      tenantId: 'tenant-mk',
+      limit: 10,
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
@@ -1,0 +1,75 @@
+import { claims, db, desc, eq, inArray, user } from '@interdomestik/database';
+import { withTenant } from '@interdomestik/database/tenant-security';
+
+export type StaffClaimsListItem = {
+  id: string;
+  claimNumber: string | null;
+  status: string | null;
+  stageLabel: string;
+  updatedAt: string | null;
+  agentName?: string;
+  memberName?: string;
+};
+
+function formatStageLabel(status: string | null | undefined) {
+  if (!status) return 'Draft';
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function normalizeDate(value: Date | string | null | undefined) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export async function getStaffClaimsList(params: {
+  staffId: string;
+  tenantId: string;
+  limit: number;
+  cursor?: string | null;
+}): Promise<StaffClaimsListItem[]> {
+  const { tenantId, limit } = params;
+
+  const rows = await db
+    .select({
+      id: claims.id,
+      claimNumber: claims.claimNumber,
+      status: claims.status,
+      updatedAt: claims.updatedAt,
+      agentId: claims.agentId,
+      memberName: user.name,
+    })
+    .from(claims)
+    .leftJoin(user, eq(claims.userId, user.id))
+    .where(withTenant(tenantId, claims.tenantId))
+    .orderBy(desc(claims.updatedAt))
+    .limit(limit);
+
+  const agentIds = Array.from(
+    new Set(rows.map(row => row.agentId).filter((id): id is string => !!id))
+  );
+
+  const agentNames = new Map<string, string>();
+  if (agentIds.length > 0) {
+    const agents = await db
+      .select({ id: user.id, name: user.name })
+      .from(user)
+      .where(withTenant(tenantId, user.tenantId, inArray(user.id, agentIds)));
+
+    for (const agent of agents) {
+      if (agent.id && agent.name) {
+        agentNames.set(agent.id, agent.name);
+      }
+    }
+  }
+
+  return rows.map(row => ({
+    id: row.id,
+    claimNumber: row.claimNumber,
+    status: row.status,
+    stageLabel: formatStageLabel(row.status),
+    updatedAt: normalizeDate(row.updatedAt),
+    agentName: row.agentId ? agentNames.get(row.agentId) : undefined,
+    memberName: row.memberName ?? undefined,
+  }));
+}


### PR DESCRIPTION
## Summary\n- add staff read models for claims list and claim detail with tenant scoping\n- simplify staff dashboard and claims pages to read-only views with required test IDs\n- add staff claims read-only Playwright regression test\n\n## Testing\n- bash scripts/m4-gatekeeper.sh\n- cd apps/web && pnpm playwright test production.spec.ts --project=ks-sq --max-failures=1\n- cd apps/web && pnpm playwright test staff-claims-readonly.spec.ts --project=ks-sq --max-failures=1