### PR TITLE
ci(security): override undici to ^7.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "overrides": {
       "fast-xml-parser": ">=5.3.4",
       "lodash": "^4.17.23",
-      "undici": ">=6.19.2",
+      "undici": "^7.20.0",
       "seroval": ">=1.4.1",
       "tar": "^7.5.7",
       "@isaacs/brace-expansion": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   fast-xml-parser: '>=5.3.4'
   lodash: ^4.17.23
-  undici: '>=6.19.2'
+  undici: ^7.20.0
   seroval: '>=1.4.1'
   tar: ^7.5.7
   '@isaacs/brace-expansion': ^5.0.1
@@ -16576,12 +16576,12 @@ packages:
         integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
       }
 
-  undici@6.22.0:
+  undici@7.20.0:
     resolution:
       {
-        integrity: sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==,
+        integrity: sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==,
       }
-    engines: { node: '>=18.17' }
+    engines: { node: '>=20.18.1' }
 
   unicorn-magic@0.1.0:
     resolution:
@@ -22952,7 +22952,7 @@ snapshots:
       '@types/express': 5.0.6
       commander: 14.0.2
       express: 5.2.1
-      undici: 6.22.0
+      undici: 7.20.0
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -27703,7 +27703,7 @@ snapshots:
       proxy-agent: 6.5.0
       semver: 7.7.3
       tinyglobby: 0.2.15
-      undici: 6.22.0
+      undici: 7.20.0
       url-join: 5.0.0
       wildcard-match: 5.1.4
       yargs-parser: 21.1.1
@@ -28654,7 +28654,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@6.22.0: {}
+  undici@7.20.0: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
• Scope: undici override (transitive dependency hardening)
• Change: pnpm.overrides forces undici@^7.20.0
• Impact: Updates fetch/http stack transitive dependencies to resolved security versions.
• Verification:
  • pnpm -r lint ✅
  • pnpm -r test ✅
  • m4-gatekeeper.sh ✅
  • pnpm pr:verify ✅