### PR TITLE
ci(security): harden undici guard + lockfile matching

### DIFF
--- a/scripts/security-guard.mjs
+++ b/scripts/security-guard.mjs
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const LOCKFILE_PATH = 'pnpm-lock.yaml';
+const LOCKFILE_PATH = path.join(process.cwd(), 'pnpm-lock.yaml');
 
 // Define banned versions/patterns
 // Format: { name: 'package-name', banned: [/regex1/, /regex2/], reason: '...' }


### PR DESCRIPTION
- Enforce undici < 7.20.0 (blocks 4/5/6 + 7.0–7.19)
- Anchor lockfile matching to line keys to reduce false positives
- Align Node built-in imports with node: convention
- Use path.join for robust LOCKFILE_PATH definition
- Verification: security:guard, audit(high), pr:verify