### PR TITLE
feat(pilot): c1-04 staff triage self-assign (mk-pilot)

### DIFF
--- a/apps/web/e2e/pilot/c1-04-pilot-staff-triage.spec.ts
+++ b/apps/web/e2e/pilot/c1-04-pilot-staff-triage.spec.ts
@@ -1,0 +1,178 @@
+import { E2E_PASSWORD, claims, db, eq, user } from '@interdomestik/database';
+import { expect, test } from '../fixtures/auth.fixture';
+import { gotoApp } from '../utils/navigation';
+
+const PILOT_TENANT_ID = 'pilot-mk';
+const PILOT_HOST = 'pilot.127.0.0.1.nip.io:3000';
+const KS_HOST = 'ks.127.0.0.1.nip.io:3000';
+
+test.describe('C1 Pilot: Staff claim triage', () => {
+  test('member submits claim, pilot staff sees it and self-assigns, KS host remains isolated', async ({
+    agentPage,
+    browser,
+  }, testInfo) => {
+    const seededAgent = await db.query.user.findFirst({
+      where: eq(user.email, 'agent.pilot@interdomestik.com'),
+      columns: { id: true, tenantId: true, branchId: true },
+    });
+
+    if (!seededAgent?.id || !seededAgent.tenantId || !seededAgent.branchId) {
+      throw new Error('Expected seeded pilot agent with tenantId and branchId');
+    }
+
+    const seededPilotStaff = await db.query.user.findFirst({
+      where: eq(user.email, 'staff.pilot@interdomestik.com'),
+      columns: { id: true, tenantId: true },
+    });
+
+    if (!seededPilotStaff?.id || seededPilotStaff.tenantId !== PILOT_TENANT_ID) {
+      throw new Error('Expected seeded pilot staff user in pilot-mk tenant');
+    }
+
+    const timestamp = Date.now();
+    const memberEmail = `member.mk.pilot.c104.${timestamp}@interdomestik.com`;
+    const memberName = `Pilot Member C104 ${timestamp}`;
+    const claimTitle = `Pilot Staff Claim ${timestamp}`;
+
+    await gotoApp(agentPage, '/en/agent/clients/new', testInfo, { marker: 'dashboard-page-ready' });
+    await expect(agentPage.getByTestId('agent-register-member-form')).toBeVisible();
+
+    await agentPage.getByTestId('agent-register-member-full-name').fill(memberName);
+    await agentPage.getByTestId('agent-register-member-email').fill(memberEmail);
+    await agentPage.getByTestId('agent-register-member-phone').fill('+38970111222');
+    await agentPage.getByTestId('agent-register-member-password').fill(E2E_PASSWORD);
+    await agentPage.getByTestId('agent-register-member-plan-trigger').click();
+    await agentPage.getByTestId('agent-register-member-plan-standard').click();
+    await agentPage.getByTestId('agent-register-member-submit').click();
+
+    await expect(agentPage).toHaveURL(/\/(?:en\/)?agent\/clients$/);
+
+    await expect
+      .poll(
+        async () => {
+          const createdMember = await db.query.user.findFirst({
+            where: eq(user.email, memberEmail),
+            columns: { id: true },
+          });
+          return createdMember?.id ?? null;
+        },
+        { timeout: 15_000 }
+      )
+      .not.toBeNull();
+
+    const createdMember = await db.query.user.findFirst({
+      where: eq(user.email, memberEmail),
+      columns: { id: true, tenantId: true, branchId: true },
+    });
+
+    if (!createdMember?.id) {
+      throw new Error('Created pilot member not found');
+    }
+
+    const memberContext = await browser.newContext({
+      baseURL: `http://${PILOT_HOST}/en`,
+      extraHTTPHeaders: testInfo.project.use.extraHTTPHeaders,
+      locale: 'en-US',
+    });
+    const memberPage = await memberContext.newPage();
+
+    await memberPage.goto('/en/login');
+    await memberPage.getByTestId('login-email').fill(memberEmail);
+    await memberPage.getByTestId('login-password').fill(E2E_PASSWORD);
+    await memberPage.getByTestId('login-submit').click();
+
+    await expect(memberPage).toHaveURL(/\/(?:en\/)?member$/);
+    await gotoApp(memberPage, '/en/member/claims/new', testInfo);
+    await memberPage.getByTestId('category-vehicle').click();
+    await memberPage.getByTestId('wizard-next').click();
+
+    await memberPage.getByTestId('claim-title-input').fill(claimTitle);
+    await memberPage.getByTestId('claim-company-input').fill('Pilot MK');
+    await memberPage.getByTestId('claim-description-input').fill('C1-04 staff triage pilot proof');
+    await memberPage.getByTestId('claim-amount-input').fill('450');
+    await memberPage.getByTestId('claim-date-input').fill(new Date().toISOString().split('T')[0]);
+    await memberPage.getByTestId('wizard-next').click();
+    await memberPage.getByTestId('wizard-next').click();
+    await memberPage.getByTestId('wizard-submit').click();
+
+    await expect(memberPage).toHaveURL(/\/(?:en\/)?member\/claims$/);
+
+    await expect
+      .poll(
+        async () => {
+          const createdClaim = await db.query.claims.findFirst({
+            where: eq(claims.title, claimTitle),
+            columns: { id: true },
+          });
+          return createdClaim?.id ?? null;
+        },
+        { timeout: 20_000 }
+      )
+      .not.toBeNull();
+
+    const createdClaim = await db.query.claims.findFirst({
+      where: eq(claims.title, claimTitle),
+      columns: { id: true, tenantId: true, branchId: true, staffId: true, userId: true },
+    });
+
+    if (!createdClaim?.id) {
+      throw new Error('Created pilot claim not found');
+    }
+
+    expect(createdClaim.tenantId).toBe(PILOT_TENANT_ID);
+    expect(createdClaim.branchId).toBe(seededAgent.branchId);
+    expect(createdClaim.userId).toBe(createdMember.id);
+    expect(createdClaim.staffId).toBeNull();
+
+    const staffContext = await browser.newContext({
+      baseURL: `http://${PILOT_HOST}/en`,
+      extraHTTPHeaders: testInfo.project.use.extraHTTPHeaders,
+      locale: 'en-US',
+    });
+    const staffPage = await staffContext.newPage();
+
+    await staffPage.goto('/en/login');
+    await staffPage.getByTestId('login-email').fill('staff.pilot@interdomestik.com');
+    await staffPage.getByTestId('login-password').fill(E2E_PASSWORD);
+    await staffPage.getByTestId('login-submit').click();
+
+    await expect(staffPage).toHaveURL(/\/(?:en\/)?staff(?:\/claims)?$/);
+    await gotoApp(staffPage, '/en/staff/claims', testInfo, { marker: 'staff-page-ready' });
+
+    const reviewLink = staffPage.locator(`a[href$="/staff/claims/${createdClaim.id}"]`);
+    await expect(reviewLink).toBeVisible();
+    await gotoApp(staffPage, `/en/staff/claims/${createdClaim.id}`, testInfo);
+    await expect(staffPage).toHaveURL(new RegExp(`/staff/claims/${createdClaim.id}$`));
+    await expect(staffPage.getByTestId('staff-claim-detail-ready')).toBeVisible();
+    await staffPage.getByTestId('staff-assign-claim-button').click();
+
+    await expect
+      .poll(
+        async () => {
+          const assigned = await db.query.claims.findFirst({
+            where: eq(claims.id, createdClaim.id),
+            columns: { staffId: true, tenantId: true },
+          });
+          return assigned?.staffId ?? null;
+        },
+        { timeout: 15_000 }
+      )
+      .toBe(seededPilotStaff.id);
+
+    const ksContext = await browser.newContext({
+      baseURL: `http://${KS_HOST}/en`,
+      extraHTTPHeaders: { 'x-forwarded-host': KS_HOST },
+      locale: 'en-US',
+      storageState: await staffContext.storageState(),
+    });
+    const ksPage = await ksContext.newPage();
+
+    await ksPage.goto('/en/staff/claims', { waitUntil: 'domcontentloaded' });
+    await expect(ksPage).not.toHaveURL(/\/(?:en\/)?staff\/claims$/);
+    await expect(ksPage).toHaveURL(/\/(?:en\/)?login/);
+
+    await ksContext.close();
+    await staffContext.close();
+    await memberContext.close();
+  });
+});

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
@@ -4,6 +4,7 @@ import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 
 import { auth } from '@/lib/auth';
+import { ClaimActionPanel } from '@/components/staff/claim-action-panel';
 
 interface PageProps {
   params: Promise<{
@@ -95,6 +96,20 @@ export default async function StaffClaimDetailsPage({ params }: PageProps) {
           )}
         </div>
       </section>
+
+      {session.user.role === 'staff' && (
+        <section
+          className="rounded-lg border bg-white p-4"
+          data-testid="staff-claim-detail-actions"
+        >
+          <ClaimActionPanel
+            claimId={detail.claim.id}
+            currentStatus={detail.claim.status || 'draft'}
+            staffId={session.user.id}
+            assigneeId={detail.claim.staffId}
+          />
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/staff/claim-action-panel.tsx
+++ b/apps/web/src/components/staff/claim-action-panel.tsx
@@ -76,7 +76,10 @@ export function ClaimActionPanel({
   }
 
   return (
-    <div className="bg-white rounded-lg border shadow-sm p-6 space-y-6">
+    <div
+      className="bg-white rounded-lg border shadow-sm p-6 space-y-6"
+      data-testid="staff-claim-action-panel"
+    >
       <h3 className="font-semibold text-lg">Staff Actions</h3>
 
       {/* Assignment Section */}
@@ -86,7 +89,12 @@ export function ClaimActionPanel({
           <p className="text-xs text-muted-foreground">{assignmentLabel}</p>
         </div>
         {!isAssignedToMe && (
-          <Button size="sm" onClick={handleAssign} disabled={isPending}>
+          <Button
+            size="sm"
+            onClick={handleAssign}
+            disabled={isPending}
+            data-testid="staff-assign-claim-button"
+          >
             {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {assigneeId ? 'Reassign to Me' : 'Assign to Me'}
           </Button>

--- a/packages/database/src/e2e-users.ts
+++ b/packages/database/src/e2e-users.ts
@@ -65,6 +65,12 @@ export const E2E_USERS = {
     dbRole: 'agent',
     tenantId: 'pilot-mk',
   },
+  PILOT_MK_STAFF: {
+    email: 'staff.pilot@interdomestik.com',
+    name: 'Pilot Staff',
+    dbRole: 'staff',
+    tenantId: 'pilot-mk',
+  },
 
   // KS USERS
   KS_ADMIN: {

--- a/packages/database/src/seed-golden.ts
+++ b/packages/database/src/seed-golden.ts
@@ -111,6 +111,13 @@ export async function seedGolden(config: SeedConfig) {
       branchId: 'mk_branch_a',
     },
     {
+      id: goldenId('pilot_mk_staff'),
+      name: E2E_USERS.PILOT_MK_STAFF.name,
+      email: E2E_USERS.PILOT_MK_STAFF.email,
+      role: E2E_USERS.PILOT_MK_STAFF.dbRole,
+      tenantId: TENANTS.PILOT,
+    },
+    {
       id: goldenId('mk_bm_a'),
       name: E2E_USERS.MK_BRANCH_MANAGER.name,
       email: E2E_USERS.MK_BRANCH_MANAGER.email,

--- a/packages/domain-claims/src/staff-claims/get-staff-claim-detail.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claim-detail.ts
@@ -6,6 +6,7 @@ export type StaffClaimDetail = {
     id: string;
     claimNumber: string | null;
     status: string | null;
+    staffId: string | null;
     stageLabel: string;
     submittedAt: string | null;
     updatedAt: string | null;
@@ -44,6 +45,7 @@ export async function getStaffClaimDetail(params: {
       claimId: claims.id,
       claimNumber: claims.claimNumber,
       status: claims.status,
+      staffId: claims.staffId,
       updatedAt: claims.updatedAt,
       createdAt: claims.createdAt,
       agentId: claims.agentId,
@@ -77,6 +79,7 @@ export async function getStaffClaimDetail(params: {
       id: row.claimId,
       claimNumber: row.claimNumber,
       status: row.status,
+      staffId: row.staffId ?? null,
       stageLabel: formatStageLabel(row.status),
       submittedAt: normalizeDate(row.createdAt),
       updatedAt: normalizeDate(row.updatedAt ?? row.createdAt),


### PR DESCRIPTION
## Phase C1 – Command #4 Evidence

### Goal
Prove the Staff triage workflow under `MK-PILOT`:
1. Member submits claim in pilot tenant
2. Staff sees claim in canonical `/staff/claims`
3. Staff self-assigns from claim detail
4. Cross-tenant isolation is enforced (`MK ≠ KS`)

### What this PR includes
- Seeded pilot staff identity for deterministic pilot triage:
  - `packages/database/src/e2e-users.ts`
  - `packages/database/src/seed-golden.ts`
- Canonical staff claim detail exposes self-assign action (localized UI change only):
  - `apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx`
  - `apps/web/src/components/staff/claim-action-panel.tsx`
- Domain detail payload includes `staffId` to support assignment state in canonical staff detail:
  - `packages/domain-claims/src/staff-claims/get-staff-claim-detail.ts`
- Pilot E2E proof:
  - `apps/web/e2e/pilot/c1-04-pilot-staff-triage.spec.ts`

### Command #4 Pilot Proof (`c1-04-pilot-staff-triage.spec.ts`)
- Agent on `pilot.127.0.0.1.nip.io:3000` creates a new member
- Member submits a claim
- DB assertion: claim is persisted with:
  - `tenantId = pilot-mk`
  - `branchId = agent branch` (inherited scope)
- Pilot staff logs in, opens canonical `/staff/claims/[id]`, self-assigns
- DB assertion: `staffId` is set to pilot staff user
- Isolation assertion: same staff session on `ks.127.0.0.1.nip.io:3000` is blocked/redirected to login

### Verification
Executed and passed:
1. `pnpm check:fast`
2. `pnpm pr:verify`
3. `pnpm security:guard`
4. `pnpm e2e:gate`

All commands exited with `0`.

### Invariants respected
- No `proxy.ts` changes
- No canonical route changes (`/member`, `/agent`, `/staff`, `/admin`)
- No auth layering refactor
- No Stripe usage changes
- No docs/architecture edits
