### PR TITLE
fix(member): locale-aware links + locale login redirect

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/claims/new/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/new/_core.entry.tsx
@@ -17,20 +17,22 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 type Props = {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{ category?: string }>;
 };
 
-export default async function NewClaimPage({ searchParams }: Props) {
+export default async function NewClaimPage({ params, searchParams }: Props) {
+  const { locale } = await params;
   const t = await getTranslations('claims');
-  const params = await searchParams;
-  const preselectedCategory = params.category;
+  const query = await searchParams;
+  const preselectedCategory = query.category;
 
   const session = await auth.api.getSession({
     headers: await headers(),
   });
 
   if (!session) {
-    redirect('/auth/sign-in');
+    redirect(`/${locale}/login`);
   }
 
   const tenantId = ensureTenantId(session);

--- a/apps/web/src/components/member-dashboard/active-claim-focus.tsx
+++ b/apps/web/src/components/member-dashboard/active-claim-focus.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@/i18n/routing';
 import type { ReactElement } from 'react';
 
 export type ActiveClaimFocusProps = {
@@ -25,7 +26,7 @@ export function ActiveClaimFocus({
       <p>{stageLabel}</p>
       <p>{status}</p>
       <p>{updatedAt ?? '—'}</p>
-      {nextMemberAction ? <a href={nextMemberAction.href}>{nextMemberAction.label}</a> : null}
+      {nextMemberAction ? <Link href={nextMemberAction.href}>{nextMemberAction.label}</Link> : null}
     </section>
   );
 }

--- a/apps/web/src/components/member-dashboard/claims-overview-list.tsx
+++ b/apps/web/src/components/member-dashboard/claims-overview-list.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@/i18n/routing';
 import type { ReactElement } from 'react';
 
 export type ClaimsOverviewItem = {
@@ -31,7 +32,7 @@ export function ClaimsOverviewList({ claims }: ClaimsOverviewListProps): ReactEl
             <span>{claim.submittedAt ?? '—'}</span>
             <span>{claim.updatedAt ?? '—'}</span>
             {claim.requiresMemberAction && claim.nextMemberAction ? (
-              <a href={claim.nextMemberAction.href}>{claim.nextMemberAction.label}</a>
+              <Link href={claim.nextMemberAction.href}>{claim.nextMemberAction.label}</Link>
             ) : null}
           </li>
         ))}


### PR DESCRIPTION
## Summary
- Locale-aware navigation (`Link`) in member claim blocks
- Locale login redirect fix for `/member/claims/new`

## Changes
- Replace internal raw anchors with locale-aware `Link` in:
  - `apps/web/src/components/member-dashboard/active-claim-focus.tsx`
  - `apps/web/src/components/member-dashboard/claims-overview-list.tsx`
- Normalize unauthenticated redirect in:
  - `apps/web/src/app/[locale]/(app)/member/claims/new/_core.entry.tsx`
  - from `/auth/sign-in` to `/${locale}/login`

## Validation Checklist
- [x] Gatekeeper passes
- [x] `pnpm e2e:gate` passes
- [x] `production.spec.ts --project=ks-sq` passes
- [x] Member golden specs (empty + has-claims) pass
- [x] Verified redirect goes to `/${locale}/login`
