### PR TITLE
fix(ci): avoid git dependency in standalone build stamp

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "NEXT_PUBLIC_FORCE_NIPIO_REDIRECT=1 DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres} BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-test-secret-for-local-dev-only-32chars-minimum} next dev --turbo --hostname 127.0.0.1 --port 3000",
-    "stamp:standalone": "node -e \"const fs=require('node:fs');const path=require('node:path');const cp=require('node:child_process');const gitSha=cp.execSync('git rev-parse HEAD',{encoding:'utf8'}).trim();const stamp={gitSha,builtAt:new Date().toISOString()};const outDir=path.resolve('.next/standalone');const outFile=path.join(outDir,'.build-stamp.json');fs.mkdirSync(outDir,{recursive:true});fs.writeFileSync(outFile,JSON.stringify(stamp,null,2)+'\\n');console.log('[build-stamp] '+outFile+' ('+gitSha+')');\"",
+    "stamp:standalone": "node scripts/stamp-standalone.mjs",
     "build": "next build && pnpm run stamp:standalone && pnpm check:size",
     "build:ci": "next build && pnpm run stamp:standalone",
     "check:size": "node scripts/check-size.mjs",

--- a/apps/web/scripts/stamp-standalone.mjs
+++ b/apps/web/scripts/stamp-standalone.mjs
@@ -1,0 +1,33 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function resolveGitSha() {
+  try {
+    const sha = execSync('git rev-parse HEAD', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (sha) return sha;
+  } catch {
+    // Fall back to env-based commit SHA in containerized CI contexts without git.
+  }
+
+  const envSha =
+    process.env.GITHUB_SHA ||
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.SOURCE_COMMIT ||
+    process.env.COMMIT_SHA;
+
+  return envSha?.trim() || 'unknown';
+}
+
+const gitSha = resolveGitSha();
+const stamp = { gitSha, builtAt: new Date().toISOString() };
+const outDir = path.resolve('.next/standalone');
+const outFile = path.join(outDir, '.build-stamp.json');
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(outFile, `${JSON.stringify(stamp, null, 2)}\n`);
+
+console.log(`[build-stamp] ${outFile} (${gitSha})`);


### PR DESCRIPTION
Fixes failing CD run: https://github.com/interdomestik/interdomestik/actions/runs/21763024835

## Root cause
`apps/web` build script `stamp:standalone` executed `git rev-parse HEAD` during Docker build. The builder image does not include `git`, so build failed with `/bin/sh: git: not found`.

## Changes
- Replace inline `stamp:standalone` command with `node scripts/stamp-standalone.mjs`
- New script behavior:
  - uses `git rev-parse HEAD` when available
  - gracefully falls back to CI env SHA (`GITHUB_SHA` / `VERCEL_GIT_COMMIT_SHA` / `SOURCE_COMMIT` / `COMMIT_SHA`)
  - defaults to `unknown` if no source is available

## Validation
- `pnpm --filter @interdomestik/web run stamp:standalone` (normal env)
- script run with empty PATH + `GITHUB_SHA=deadbeef` to simulate container without git
