### PR TITLE
Phase 2.4: Lock agent KPI numeric contracts

### DIFF
--- a/apps/web/src/app/[locale]/(agent)/agent/crm/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/_core.test.ts
@@ -54,12 +54,12 @@ describe('getAgentCrmStatsCore', () => {
     });
   });
 
-  it('maps counts and totals to a stable DTO', async () => {
+  it('maps counts and totals to a stable numeric DTO', async () => {
     hoisted.dbSelect
-      .mockReturnValueOnce(createSelectChain([{ count: 3 }]))
-      .mockReturnValueOnce(createSelectChain([{ count: 7 }]))
-      .mockReturnValueOnce(createSelectChain([{ count: 2 }]))
-      .mockReturnValueOnce(createSelectChain([{ total: 123.45 }]));
+      .mockReturnValueOnce(createSelectChain([{ count: '3' }]))
+      .mockReturnValueOnce(createSelectChain([{ count: '7' }]))
+      .mockReturnValueOnce(createSelectChain([{ count: '2' }]))
+      .mockReturnValueOnce(createSelectChain([{ total: '123.45' }]));
 
     const stats = await getAgentCrmStatsCore({ agentId: 'agent-1' });
 
@@ -69,5 +69,9 @@ describe('getAgentCrmStatsCore', () => {
       closedWonDealsCount: 2,
       paidCommissionTotal: 123.45,
     });
+    expect(typeof stats.newLeadsCount).toBe('number');
+    expect(typeof stats.contactedLeadsCount).toBe('number');
+    expect(typeof stats.closedWonDealsCount).toBe('number');
+    expect(typeof stats.paidCommissionTotal).toBe('number');
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/crm/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/_core.ts
@@ -36,9 +36,9 @@ export async function getAgentCrmStatsCore(args: { agentId: string }): Promise<A
   ]);
 
   return {
-    newLeadsCount: newLeads?.count ?? 0,
-    contactedLeadsCount: contactedLeads?.count ?? 0,
-    closedWonDealsCount: wonDeals?.count ?? 0,
+    newLeadsCount: Number(newLeads?.count ?? 0),
+    contactedLeadsCount: Number(contactedLeads?.count ?? 0),
+    closedWonDealsCount: Number(wonDeals?.count ?? 0),
     paidCommissionTotal: Number(totalCommission?.total ?? 0),
   };
 }


### PR DESCRIPTION
## Phase 2.4 Scope
- lock agent KPI read-model DTO numeric contracts for dashboard + CRM
- add deterministic unit tests for numeric coercion and field type stability
- no UI/nav/i18n/testid/gotoApp/proxy changes

## Changes
- apps/web/src/app/[locale]/(agent)/agent/_core.test.ts
- apps/web/src/app/[locale]/(agent)/agent/crm/_core.test.ts
- apps/web/src/app/[locale]/(agent)/agent/crm/_core.ts

## Checklist
- [x] RED test added for numeric DTO type contract
- [x] GREEN implementation keeps behavior unchanged except type stabilization
- [x] pnpm pr:verify
- [x] pnpm security:guard
- [x] bash scripts/m4-gatekeeper.sh
- [x] pnpm e2e:gate
- [x] No changes to apps/web/src/proxy.ts
- [x] No UI redesign/polish changes

## Notes
- Ensures KPI DTO fields remain numbers even when DB aggregates return strings.
