### PR TITLE
fix: security + test hardening for lead conversion

### DIFF
--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   findFirst: vi.fn(),
   transaction: vi.fn(),
+  eq: vi.fn((left, right) => ({ left, right, op: 'eq' })),
   db: {
     query: {
       memberLeads: {
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@interdomestik/database', () => ({
   db: mocks.db,
+  eq: mocks.eq,
 }));
 
 vi.mock('@interdomestik/database/member-number', () => ({

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -1,4 +1,4 @@
-import { db } from '@interdomestik/database';
+import { db, eq } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
 import {
   memberLeads,
@@ -6,7 +6,6 @@ import {
   subscriptions,
   user as userTable,
 } from '@interdomestik/database/schema';
-import { eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
 export interface ConvertLeadResult {
@@ -15,10 +14,9 @@ export interface ConvertLeadResult {
   subscriptionId: string;
 }
 
-export function isLeadAlreadyConverted(lead: {
-  status: string;
-  convertedUserId?: string | null;
-}): boolean {
+type LeadConversionState = Pick<typeof memberLeads.$inferSelect, 'status' | 'convertedUserId'>;
+
+function isLeadAlreadyConverted(lead: LeadConversionState): boolean {
   return lead.convertedUserId != null || lead.status === 'converted';
 }
 


### PR DESCRIPTION
## Scope
Security + test hardening only for lead conversion and related tests. No behavior expansion.

## Changes
- Scope DB authorization query in `convertLeadToClient` by tenant + agent + branch (when session branch exists)
- Return generic scoped-miss error (`Lead not found or access denied`) to avoid enumeration
- Remove duplicate auth/session + DB lookup between `convertLeadToClient` and `updateLeadStatus` by sharing internal helpers
- Make `isLeadAlreadyConverted` internal and strongly typed from DB lead infer type
- Add missing web unit tests for unauthenticated and lead-not-found paths (no mutation assertions)
- Use Drizzle helpers re-exported from `@interdomestik/database` and stabilize `eq` mocks

## Files
- apps/web/src/features/agent/leads/actions.ts
- apps/web/src/features/agent/leads/actions.test.ts
- packages/domain-leads/src/convert.ts
- packages/domain-leads/src/convert.test.ts

## Validation
- [x] `pnpm --filter @interdomestik/domain-leads test:unit --run src/convert.test.ts`
- [x] `pnpm --filter @interdomestik/web test:unit --run src/features/agent/leads/actions.test.ts`
- [x] `pnpm pr:verify`
- [x] `pnpm security:guard`
- [x] `bash scripts/m4-gatekeeper.sh`
- [x] `pnpm e2e:gate`

## Constraints honored
- [x] No UI/nav/i18n/testid/gotoApp/proxy changes
- [x] No RBAC model changes
- [x] No scope widening
