### PR TITLE
chore(web): clear static warning annotations

### DIFF
--- a/apps/web/e2e/fixtures/auth.fixture.ts
+++ b/apps/web/e2e/fixtures/auth.fixture.ts
@@ -189,23 +189,10 @@ function credsFor(role: Role, tenant: Tenant): { email: string; password: string
   return { email: u.email, password: E2E_PASSWORD, name: u.name };
 }
 
-function getApiOrigin(baseURL: string): string {
-  return new URL(baseURL).origin;
-}
-
 function storageStateFile(role: Role, tenant: Tenant): string {
   // Keep legacy `admin_mk` file name for backwards-compat with existing state files.
   const filename = role === 'admin_mk' ? 'admin' : role;
   return path.join(__dirname, '..', '.auth', tenant, `${filename}.json`);
-}
-
-async function storageStateExists(filePath: string): Promise<boolean> {
-  try {
-    await fs.access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function storageStateUsable(filePath: string, expectedHost: string): Promise<boolean> {

--- a/apps/web/e2e/pilot/c1-01-pilot-ceremony-closed-loop.spec.ts
+++ b/apps/web/e2e/pilot/c1-01-pilot-ceremony-closed-loop.spec.ts
@@ -241,8 +241,8 @@ test('Pilot Ceremony: Closed Loop (Member -> Agent -> Staff -> Admin)', async ({
     });
 
     report.meta.outcome = 'PASS';
-  } catch (error: any) {
-    report.meta.error = error.message;
+  } catch (error: unknown) {
+    report.meta.error = error instanceof Error ? error.message : String(error);
 
     // Screenshot on failure
     try {

--- a/apps/web/e2e/utils/navigation.ts
+++ b/apps/web/e2e/utils/navigation.ts
@@ -82,14 +82,15 @@ export async function gotoApp(
     try {
       response = await page.goto(targetUrl, { waitUntil: 'domcontentloaded' });
       break;
-    } catch (e: any) {
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
       const isRetryable =
-        e.message.includes('net::ERR_ABORTED') ||
-        e.message.includes('net::ERR_CONNECTION_RESET') ||
-        e.message.includes('net::ERR_CONNECTION_REFUSED');
+        message.includes('net::ERR_ABORTED') ||
+        message.includes('net::ERR_CONNECTION_RESET') ||
+        message.includes('net::ERR_CONNECTION_REFUSED');
 
       if (attempt < maxRetries && isRetryable) {
-        console.warn(`[gotoApp] Retry ${attempt + 1}/${maxRetries} for ${targetUrl}: ${e.message}`);
+        console.warn(`[gotoApp] Retry ${attempt + 1}/${maxRetries} for ${targetUrl}: ${message}`);
         await page.waitForTimeout(1000);
         continue;
       }

--- a/apps/web/src/actions/agent-settings/access.wrapper.test.ts
+++ b/apps/web/src/actions/agent-settings/access.wrapper.test.ts
@@ -8,13 +8,15 @@ describe('agent-settings access.core', () => {
   });
 
   it('canReadAgentSettings logic', () => {
-    const adminSession = { user: { role: 'admin', id: 'a1' } };
-    const agentSession = { user: { role: 'agent', id: 'ag1' } };
-    const otherSession = { user: { role: 'agent', id: 'ag2' } };
+    type ReadParams = Parameters<typeof canReadAgentSettings>[0];
+    type AgentSettingsSession = NonNullable<ReadParams['session']>;
+    const adminSession = { user: { role: 'admin', id: 'a1' } } as AgentSettingsSession;
+    const agentSession = { user: { role: 'agent', id: 'ag1' } } as AgentSettingsSession;
+    const otherSession = { user: { role: 'agent', id: 'ag2' } } as AgentSettingsSession;
 
-    expect(canReadAgentSettings({ session: adminSession as any, agentId: 'ag1' })).toBe(true);
-    expect(canReadAgentSettings({ session: agentSession as any, agentId: 'ag1' })).toBe(true);
-    expect(canReadAgentSettings({ session: otherSession as any, agentId: 'ag1' })).toBe(false);
+    expect(canReadAgentSettings({ session: adminSession, agentId: 'ag1' })).toBe(true);
+    expect(canReadAgentSettings({ session: agentSession, agentId: 'ag1' })).toBe(true);
+    expect(canReadAgentSettings({ session: otherSession, agentId: 'ag1' })).toBe(false);
     expect(canReadAgentSettings({ session: null, agentId: 'ag1' })).toBe(false);
   });
 });


### PR DESCRIPTION
## What
- Removes the 10 static warning annotations reported in CI.
- Replaces explicit `any` with typed session/mock usage in agent-settings wrapper tests.
- Replaces `any` error catches with `unknown` + safe message extraction in e2e helpers/specs.
- Removes two unused helper functions in auth fixture (`getApiOrigin`, `storageStateExists`).

## Scope
- apps/web/src/actions/agent-settings/update-rates.wrapper.test.ts
- apps/web/src/actions/agent-settings/access.wrapper.test.ts
- apps/web/e2e/utils/navigation.ts
- apps/web/e2e/pilot/c1-01-pilot-ceremony-closed-loop.spec.ts
- apps/web/e2e/fixtures/auth.fixture.ts

## Validation
- `pnpm --filter @interdomestik/web exec eslint src/actions/agent-settings/update-rates.wrapper.test.ts src/actions/agent-settings/access.wrapper.test.ts e2e/utils/navigation.ts e2e/pilot/c1-01-pilot-ceremony-closed-loop.spec.ts e2e/fixtures/auth.fixture.ts`
- `pnpm --filter @interdomestik/web test:unit --run src/actions/agent-settings/update-rates.wrapper.test.ts src/actions/agent-settings/access.wrapper.test.ts`
