### PR TITLE
fix(e2e): repair nightly RBAC member-number path

### DIFF
--- a/apps/web/e2e/golden/rbac-scope.spec.ts
+++ b/apps/web/e2e/golden/rbac-scope.spec.ts
@@ -17,7 +17,7 @@ test.describe('RBAC Scope Guards (Golden)', () => {
   }, testInfo) => {
     test.skip(testInfo.project.name.includes('mk'), 'KS-only check');
 
-    const targetPath = `${routes.admin(testInfo)}/members/number/${MK_MEMBER_NUMBER}`;
+    const targetPath = `/${routes.getLocale(testInfo)}/admin/members/number/${MK_MEMBER_NUMBER}`;
 
     // We expect access denied, so we use a generic marker or body
     await gotoApp(page, targetPath, testInfo, { marker: 'body' });


### PR DESCRIPTION
## What\n- fix RBAC golden test path construction for member-number resolution\n- avoid appending to /admin/overview route, which produced /admin/overview/members/number/... and deterministic 404\n\n## Why\n- nightly run 21773994987 failed in E2E Phase 5 deterministic batch on rbac-scope.spec.ts due to invalid URL construction\n\n## Validation\n- pnpm --filter @interdomestik/web run build:ci\n- pnpm --filter @interdomestik/web exec playwright test apps/web/e2e/golden/rbac-scope.spec.ts --project=smoke