### PR TITLE
fix(staff-claims): tighten scope contract follow-up

### DIFF
--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
@@ -61,7 +61,7 @@ describe('getStaffClaimsList', () => {
     mocks.claimChain.orderBy.mockReturnValue(mocks.claimChain);
   });
 
-  it('returns claims scoped to tenant', async () => {
+  it('returns claims scoped to tenant and branch when branchId exists', async () => {
     mocks.claimChain.limit.mockResolvedValue([
       {
         id: 'claim-1',

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
@@ -28,7 +28,6 @@ export async function getStaffClaimsList(params: {
   tenantId: string;
   branchId?: string | null;
   limit: number;
-  cursor?: string | null;
 }): Promise<StaffClaimsListItem[]> {
   const { staffId, tenantId, branchId, limit } = params;
   const scopeCondition =


### PR DESCRIPTION
## What\n- rename the branch-scoped unit test to match its actual assertion\n- remove unused  from  params to keep the API contract honest\n\n## Why\n- addresses Copilot review feedback with no behavior change\n- keeps Phase 3.1 scope enforcement clear and deterministic\n\n## Scope\n- packages/domain-claims/src/staff-claims/get-staff-claims-list.ts\n- packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts\n\n## Validation\n- pnpm --filter @interdomestik/domain-claims test:unit --run src/staff-claims/get-staff-claims-list.test.ts\n- pnpm pr:verify\n- pnpm security:guard