### PR TITLE
feat(staff-claims): lock deterministic timeline and status projection contracts (Phase 3.3)

### DIFF
--- a/packages/domain-claims/src/staff-claims/get-claim-status.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-claim-status.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { getClaimStatus } from './get-claim-status';
+
+describe('getClaimStatus', () => {
+  it('returns deterministic default for empty timeline', () => {
+    const result = getClaimStatus([]);
+
+    expect(result).toEqual({
+      status: 'draft',
+      lastTransitionAt: null,
+    });
+  });
+
+  it('ignores unknown event types and projects from known status events', () => {
+    const result = getClaimStatus([
+      {
+        id: 'e3',
+        claimId: 'claim-1',
+        type: 'note_added',
+        fromStatus: null,
+        toStatus: null,
+        createdAt: '2026-01-03T00:00:00.000Z',
+      },
+      {
+        id: 'e2',
+        claimId: 'claim-1',
+        type: 'status_changed',
+        fromStatus: 'submitted',
+        toStatus: 'in_review',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      },
+      {
+        id: 'e1',
+        claimId: 'claim-1',
+        type: 'status_changed',
+        fromStatus: 'draft',
+        toStatus: 'submitted',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    expect(result).toEqual({
+      status: 'in_review',
+      lastTransitionAt: '2026-01-02T00:00:00.000Z',
+    });
+  });
+
+  it('returns deterministic status for same ordered timeline input', () => {
+    const events = [
+      {
+        id: 'e2',
+        claimId: 'claim-1',
+        type: 'status_changed',
+        fromStatus: 'submitted',
+        toStatus: 'in_review',
+        createdAt: '2026-01-02T00:00:00.000Z',
+      },
+      {
+        id: 'e1',
+        claimId: 'claim-1',
+        type: 'status_changed',
+        fromStatus: 'draft',
+        toStatus: 'submitted',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+
+    const first = getClaimStatus(events);
+    const second = getClaimStatus(events);
+
+    expect(first).toEqual(second);
+    expect(first).toEqual({
+      status: 'in_review',
+      lastTransitionAt: '2026-01-02T00:00:00.000Z',
+    });
+  });
+});

--- a/packages/domain-claims/src/staff-claims/get-claim-status.ts
+++ b/packages/domain-claims/src/staff-claims/get-claim-status.ts
@@ -1,0 +1,24 @@
+import type { ClaimTimelineEvent } from './get-claim-timeline';
+
+export type ClaimStatusProjection = {
+  status: string;
+  lastTransitionAt: string | null;
+};
+
+export function getClaimStatus(events: ClaimTimelineEvent[]): ClaimStatusProjection {
+  const statusEvents = events.filter(event => event.type === 'status_changed');
+
+  if (statusEvents.length === 0) {
+    return {
+      status: 'draft',
+      lastTransitionAt: null,
+    };
+  }
+
+  const latest = statusEvents[0];
+
+  return {
+    status: latest.toStatus ?? latest.fromStatus ?? 'draft',
+    lastTransitionAt: latest.createdAt,
+  };
+}

--- a/packages/domain-claims/src/staff-claims/get-claim-timeline.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-claim-timeline.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const selectChain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+  };
+
+  return {
+    selectChain,
+    db: { select: vi.fn() },
+    claimStageHistory: {
+      id: 'claim_stage_history.id',
+      tenantId: 'claim_stage_history.tenant_id',
+      claimId: 'claim_stage_history.claim_id',
+      fromStatus: 'claim_stage_history.from_status',
+      toStatus: 'claim_stage_history.to_status',
+      createdAt: 'claim_stage_history.created_at',
+    },
+    eq: vi.fn((left, right) => ({ left, right, op: 'eq' })),
+    and: vi.fn((...conditions) => ({ conditions, op: 'and' })),
+    desc: vi.fn(column => ({ column, op: 'desc' })),
+    withTenant: vi.fn((_tenantId, _column, condition) => ({ scoped: true, condition })),
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  db: mocks.db,
+  claimStageHistory: mocks.claimStageHistory,
+  eq: mocks.eq,
+  and: mocks.and,
+  desc: mocks.desc,
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+import { getClaimTimeline } from './get-claim-timeline';
+
+describe('getClaimTimeline', () => {
+  beforeEach(() => {
+    mocks.db.select.mockReset();
+    mocks.db.select.mockReturnValue(mocks.selectChain);
+    mocks.selectChain.from.mockReturnValue(mocks.selectChain);
+    mocks.selectChain.where.mockReturnValue(mocks.selectChain);
+    mocks.selectChain.orderBy.mockReset();
+  });
+
+  it('returns empty array when claim is outside tenant scope', async () => {
+    mocks.selectChain.orderBy.mockResolvedValue([]);
+
+    const result = await getClaimTimeline({ tenantId: 'tenant-ks', claimId: 'claim-1' });
+
+    expect(result).toEqual([]);
+    expect(mocks.withTenant).toHaveBeenCalledWith(
+      'tenant-ks',
+      mocks.claimStageHistory.tenantId,
+      expect.any(Object)
+    );
+  });
+
+  it('enforces deterministic ordering with createdAt desc and id desc tie-breaker', async () => {
+    mocks.selectChain.orderBy.mockResolvedValue([]);
+
+    await getClaimTimeline({ tenantId: 'tenant-ks', claimId: 'claim-1' });
+
+    expect(mocks.selectChain.orderBy).toHaveBeenCalledWith(
+      { column: mocks.claimStageHistory.createdAt, op: 'desc' },
+      { column: mocks.claimStageHistory.id, op: 'desc' }
+    );
+  });
+});

--- a/packages/domain-claims/src/staff-claims/get-claim-timeline.ts
+++ b/packages/domain-claims/src/staff-claims/get-claim-timeline.ts
@@ -1,0 +1,54 @@
+import { and, claimStageHistory, db, desc, eq } from '@interdomestik/database';
+import { withTenant } from '@interdomestik/database/tenant-security';
+
+export type ClaimTimelineEvent = {
+  id: string;
+  claimId: string;
+  type: string;
+  fromStatus: string | null;
+  toStatus: string | null;
+  createdAt: string;
+};
+
+function toIso(value: Date | string | null | undefined): string {
+  if (!value) {
+    return new Date(0).toISOString();
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return new Date(0).toISOString();
+  }
+
+  return date.toISOString();
+}
+
+export async function getClaimTimeline(params: {
+  tenantId: string;
+  claimId: string;
+}): Promise<ClaimTimelineEvent[]> {
+  const { tenantId, claimId } = params;
+
+  const rows = await db
+    .select({
+      id: claimStageHistory.id,
+      claimId: claimStageHistory.claimId,
+      fromStatus: claimStageHistory.fromStatus,
+      toStatus: claimStageHistory.toStatus,
+      createdAt: claimStageHistory.createdAt,
+    })
+    .from(claimStageHistory)
+    .where(
+      withTenant(tenantId, claimStageHistory.tenantId, and(eq(claimStageHistory.claimId, claimId)))
+    )
+    .orderBy(desc(claimStageHistory.createdAt), desc(claimStageHistory.id));
+
+  return rows.map(row => ({
+    id: row.id,
+    claimId: row.claimId,
+    type: 'status_changed',
+    fromStatus: row.fromStatus ?? null,
+    toStatus: row.toStatus ?? null,
+    createdAt: toIso(row.createdAt),
+  }));
+}


### PR DESCRIPTION
## What
- Add get-claim-timeline with tenant-scoped query boundary and deterministic ordering (createdAt DESC, id DESC).
- Add deterministic status projection from ordered timeline events.
- Ignore unknown event types safely (no throw, no status drift).
- Add explicit deterministic empty-timeline behavior.

## Files
- packages/domain-claims/src/staff-claims/get-claim-timeline.ts
- packages/domain-claims/src/staff-claims/get-claim-timeline.test.ts
- packages/domain-claims/src/staff-claims/get-claim-status.ts
- packages/domain-claims/src/staff-claims/get-claim-status.test.ts

## Validation
- pnpm --filter @interdomestik/domain-claims test:unit --run src/staff-claims/get-claim-timeline.test.ts
- pnpm --filter @interdomestik/domain-claims test:unit --run src/staff-claims/get-claim-status.test.ts
- pnpm pr:verify
- pnpm security:guard
- bash scripts/m4-gatekeeper.sh
- pnpm e2e:gate

## Scope
- No UI/routing/proxy/auth/RBAC/i18n/testid/readiness marker changes.
- Phase 3.3 single-task scope only.
