### PR TITLE
feat(domain-claims): phase 3.4 staff-to-member update path reliability

### DIFF
--- a/packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts
+++ b/packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getMemberClaimDetail } from './get-member-claim-detail';
+
+const mocks = vi.hoisted(() => {
+  const selectChain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  };
+
+  return {
+    db: { select: vi.fn() },
+    claims: {
+      id: 'claims.id',
+      tenantId: 'claims.tenant_id',
+      userId: 'claims.user_id',
+      claimNumber: 'claims.claim_number',
+      status: 'claims.status',
+      createdAt: 'claims.created_at',
+      updatedAt: 'claims.updated_at',
+    },
+    eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
+    and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+    withTenant: vi.fn((_tenantId, _column, condition) => ({ scoped: true, condition })),
+    getClaimTimeline: vi.fn(),
+    getClaimStatus: vi.fn(),
+    selectChain,
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  db: mocks.db,
+  claims: mocks.claims,
+  eq: mocks.eq,
+  and: mocks.and,
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+vi.mock('../staff-claims/get-claim-timeline', () => ({
+  getClaimTimeline: mocks.getClaimTimeline,
+}));
+
+vi.mock('../staff-claims/get-claim-status', () => ({
+  getClaimStatus: mocks.getClaimStatus,
+}));
+
+describe('getMemberClaimDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.db.select.mockReturnValue(mocks.selectChain);
+    mocks.selectChain.from.mockReturnValue(mocks.selectChain);
+    mocks.selectChain.where.mockReturnValue(mocks.selectChain);
+  });
+
+  it('reflects updated status deterministically from ordered timeline events', async () => {
+    mocks.selectChain.limit.mockResolvedValue([
+      {
+        id: 'claim-1',
+        claimNumber: 'MK-100',
+        status: 'submitted',
+        createdAt: new Date('2026-02-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-02T00:00:00.000Z'),
+      },
+    ]);
+    mocks.getClaimTimeline.mockResolvedValue([{ id: 'e1' }]);
+    mocks.getClaimStatus.mockReturnValue({
+      status: 'evaluation',
+      lastTransitionAt: '2026-02-02T00:00:00.000Z',
+    });
+
+    const result = await getMemberClaimDetail({
+      tenantId: 'tenant-1',
+      memberId: 'member-1',
+      claimId: 'claim-1',
+    });
+
+    expect(mocks.getClaimTimeline).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      claimId: 'claim-1',
+    });
+    expect(mocks.getClaimStatus).toHaveBeenCalledTimes(1);
+    expect(result?.status).toBe('evaluation');
+  });
+
+  it('ignores unknown timeline events without corrupting member-visible status', async () => {
+    mocks.selectChain.limit.mockResolvedValue([
+      {
+        id: 'claim-1',
+        claimNumber: 'MK-101',
+        status: 'submitted',
+        createdAt: new Date('2026-02-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-03T00:00:00.000Z'),
+      },
+    ]);
+    mocks.getClaimTimeline.mockResolvedValue([
+      { id: 'e3', type: 'note_added', createdAt: '2026-02-03T00:00:00.000Z' },
+      {
+        id: 'e2',
+        type: 'status_changed',
+        toStatus: 'resolved',
+        createdAt: '2026-02-02T00:00:00.000Z',
+      },
+    ]);
+    mocks.getClaimStatus.mockReturnValue({
+      status: 'resolved',
+      lastTransitionAt: '2026-02-02T00:00:00.000Z',
+    });
+
+    const result = await getMemberClaimDetail({
+      tenantId: 'tenant-1',
+      memberId: 'member-1',
+      claimId: 'claim-1',
+    });
+
+    expect(result?.status).toBe('resolved');
+  });
+});

--- a/packages/domain-claims/src/member-claims/get-member-claim-detail.ts
+++ b/packages/domain-claims/src/member-claims/get-member-claim-detail.ts
@@ -1,0 +1,57 @@
+import { and, claims, db, eq } from '@interdomestik/database';
+import { withTenant } from '@interdomestik/database/tenant-security';
+import { getClaimStatus } from '../staff-claims/get-claim-status';
+import { getClaimTimeline } from '../staff-claims/get-claim-timeline';
+
+export type MemberClaimDetail = {
+  id: string;
+  claimNumber: string | null;
+  status: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+function normalizeDate(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+export async function getMemberClaimDetail(params: {
+  tenantId: string;
+  memberId: string;
+  claimId: string;
+}): Promise<MemberClaimDetail | null> {
+  const { tenantId, memberId, claimId } = params;
+
+  const [row] = await db
+    .select({
+      id: claims.id,
+      claimNumber: claims.claimNumber,
+      status: claims.status,
+      createdAt: claims.createdAt,
+      updatedAt: claims.updatedAt,
+    })
+    .from(claims)
+    .where(
+      withTenant(
+        tenantId,
+        claims.tenantId,
+        and(eq(claims.id, claimId), eq(claims.userId, memberId))
+      )
+    )
+    .limit(1);
+
+  if (!row) return null;
+  const timeline = await getClaimTimeline({ tenantId, claimId });
+  const projected = getClaimStatus(timeline);
+
+  return {
+    id: row.id,
+    claimNumber: row.claimNumber,
+    status: projected.status,
+    createdAt: normalizeDate(row.createdAt),
+    updatedAt: normalizeDate(row.updatedAt),
+  };
+}

--- a/packages/domain-claims/src/update-claim-status.test.ts
+++ b/packages/domain-claims/src/update-claim-status.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ClaimsSession } from './claims/types';
+import { updateClaimStatus } from './update-claim-status';
+
+const mocks = vi.hoisted(() => {
+  const selectChain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  };
+
+  const txUpdateWhere = vi.fn();
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
+  const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
+  const txInsertValues = vi.fn();
+  const txInsert = vi.fn(() => ({ values: txInsertValues }));
+  const transaction = vi.fn(async cb => cb({ update: txUpdate, insert: txInsert }));
+
+  return {
+    db: {
+      select: vi.fn(),
+      transaction,
+    },
+    selectChain,
+    claims: {
+      id: 'claims.id',
+      tenantId: 'claims.tenant_id',
+      branchId: 'claims.branch_id',
+      staffId: 'claims.staff_id',
+      status: 'claims.status',
+      updatedAt: 'claims.updated_at',
+    },
+    claimStageHistory: {
+      id: 'claim_stage_history.id',
+      tenantId: 'claim_stage_history.tenant_id',
+      claimId: 'claim_stage_history.claim_id',
+      fromStatus: 'claim_stage_history.from_status',
+      toStatus: 'claim_stage_history.to_status',
+      changedById: 'claim_stage_history.changed_by_id',
+      changedByRole: 'claim_stage_history.changed_by_role',
+      note: 'claim_stage_history.note',
+      isPublic: 'claim_stage_history.is_public',
+      createdAt: 'claim_stage_history.created_at',
+    },
+    eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
+    and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+    withTenant: vi.fn((_tenantId, _column, condition) => ({ scoped: true, condition })),
+    ensureTenantId: vi.fn(() => 'tenant-1'),
+    txUpdate,
+    txUpdateSet,
+    txUpdateWhere,
+    txInsert,
+    txInsertValues,
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  db: mocks.db,
+  claims: mocks.claims,
+  claimStageHistory: mocks.claimStageHistory,
+  eq: mocks.eq,
+  and: mocks.and,
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: mocks.ensureTenantId,
+}));
+
+function createSession(options: {
+  userId: string;
+  role?: string;
+  tenantId?: string;
+  branchId?: string | null;
+}): ClaimsSession {
+  return {
+    user: {
+      id: options.userId,
+      role: options.role ?? 'staff',
+      tenantId: options.tenantId ?? 'tenant-1',
+      ...(options.branchId !== undefined ? { branchId: options.branchId } : {}),
+    },
+  } as unknown as ClaimsSession;
+}
+
+describe('updateClaimStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.db.select.mockReturnValue(mocks.selectChain);
+    mocks.selectChain.from.mockReturnValue(mocks.selectChain);
+    mocks.selectChain.where.mockReturnValue(mocks.selectChain);
+  });
+
+  it('denies cross-tenant update', async () => {
+    mocks.selectChain.limit.mockResolvedValue([]);
+
+    const result = await updateClaimStatus({
+      claimId: 'claim-1',
+      newStatus: 'evaluation',
+      session: createSession({ userId: 'staff-1', tenantId: 'tenant-1', branchId: 'branch-1' }),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Claim not found or access denied',
+      data: undefined,
+    });
+    expect(mocks.db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('denies out-of-scope update when staff branch is present and mismatched', async () => {
+    mocks.selectChain.limit.mockResolvedValue([]);
+
+    await updateClaimStatus({
+      claimId: 'claim-1',
+      newStatus: 'evaluation',
+      session: createSession({ userId: 'staff-1', branchId: 'branch-1' }),
+    });
+
+    expect(mocks.eq).toHaveBeenCalledWith('claims.branch_id', 'branch-1');
+    expect(mocks.db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('denies out-of-scope update when branchless staff is not claim owner', async () => {
+    mocks.selectChain.limit.mockResolvedValue([]);
+
+    await updateClaimStatus({
+      claimId: 'claim-1',
+      newStatus: 'evaluation',
+      session: createSession({ userId: 'staff-1', branchId: null }),
+    });
+
+    expect(mocks.eq).toHaveBeenCalledWith('claims.staff_id', 'staff-1');
+    expect(mocks.eq).not.toHaveBeenCalledWith('claims.branch_id', expect.anything());
+    expect(mocks.db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('persists status transition and timeline event in one transaction for in-scope update', async () => {
+    mocks.selectChain.limit.mockResolvedValue([
+      { id: 'claim-1', status: 'submitted', staffId: 'staff-1', branchId: 'branch-1' },
+    ]);
+
+    const result = await updateClaimStatus({
+      claimId: 'claim-1',
+      newStatus: 'evaluation',
+      note: 'picked for review',
+      session: createSession({ userId: 'staff-1', branchId: 'branch-1' }),
+    });
+
+    expect(result).toEqual({ success: true, error: undefined });
+    expect(mocks.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mocks.txUpdate).toHaveBeenCalledWith(mocks.claims);
+    expect(mocks.txInsert).toHaveBeenCalledWith(mocks.claimStageHistory);
+    expect(mocks.txInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        claimId: 'claim-1',
+        fromStatus: 'submitted',
+        toStatus: 'evaluation',
+        changedById: 'staff-1',
+      })
+    );
+  });
+});

--- a/packages/domain-claims/src/update-claim-status.ts
+++ b/packages/domain-claims/src/update-claim-status.ts
@@ -1,0 +1,72 @@
+import { and, claimStageHistory, claims, db, eq } from '@interdomestik/database';
+import { withTenant } from '@interdomestik/database/tenant-security';
+import { ensureTenantId } from '@interdomestik/shared-auth';
+
+import type { ActionResult, ClaimsSession } from './claims/types';
+import { claimStatusSchema } from './validators/claims';
+
+type StaffUser = ClaimsSession['user'] & { branchId?: string | null };
+
+export async function updateClaimStatus(params: {
+  claimId: string;
+  newStatus: string;
+  note?: string;
+  session: ClaimsSession | null;
+}): Promise<ActionResult> {
+  const { claimId, newStatus, note, session } = params;
+  if (session?.user?.role !== 'staff') {
+    return { success: false, error: 'Unauthorized', data: undefined };
+  }
+
+  const parsed = claimStatusSchema.safeParse({ status: newStatus });
+  if (!parsed.success) {
+    return { success: false, error: 'Invalid status', data: undefined };
+  }
+
+  const user = session.user as StaffUser;
+  const tenantId = ensureTenantId(session);
+  const branchId = user.branchId ?? null;
+  const scope =
+    branchId != null
+      ? and(eq(claims.id, claimId), eq(claims.branchId, branchId))
+      : and(eq(claims.id, claimId), eq(claims.staffId, user.id));
+  const scopedWhere = withTenant(tenantId, claims.tenantId, scope);
+
+  const [existingClaim] = await db
+    .select({
+      id: claims.id,
+      status: claims.status,
+      staffId: claims.staffId,
+      branchId: claims.branchId,
+    })
+    .from(claims)
+    .where(scopedWhere)
+    .limit(1);
+
+  if (!existingClaim) {
+    return { success: false, error: 'Claim not found or access denied', data: undefined };
+  }
+
+  if (existingClaim.status === parsed.data.status && !note) {
+    return { success: true, error: undefined };
+  }
+
+  const now = new Date();
+  await db.transaction(async tx => {
+    await tx.update(claims).set({ status: parsed.data.status, updatedAt: now }).where(scopedWhere);
+    await tx.insert(claimStageHistory).values({
+      id: crypto.randomUUID(),
+      tenantId,
+      claimId,
+      fromStatus: existingClaim.status,
+      toStatus: parsed.data.status,
+      changedById: user.id,
+      changedByRole: 'staff',
+      note: note ?? null,
+      isPublic: true,
+      createdAt: now,
+    });
+  });
+
+  return { success: true, error: undefined };
+}


### PR DESCRIPTION
## Phase 3.4 — Staff → Member Update Path Reliability

### Scope
- `packages/domain-claims/src/update-claim-status.ts`
- `packages/domain-claims/src/update-claim-status.test.ts`
- `packages/domain-claims/src/member-claims/get-member-claim-detail.ts`
- `packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts`

### What changed
- Added strict tenant-scoped status update action with staff scope policy at query + mutation boundary:
  - `branchId` present: require claim branch match.
  - `branchId` null: require claim `staffId` = session user.
- Added atomic write path (single transaction) for status update + timeline insert.
- Added member claim detail read model that derives member-visible status deterministically from ordered timeline projection.
- Unknown timeline event handling remains safe through projection layer (ignored, no throw).

### RED -> GREEN coverage
- deny cross-tenant update
- deny out-of-scope update (branch mismatch + branchless non-owner)
- in-scope success writes status + timeline in one transaction
- member detail reflects timeline-projected status deterministically
- unknown event does not corrupt member-visible status

### Validation
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/update-claim-status.test.ts`
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/member-claims/get-member-claim-detail.test.ts`
- `pnpm pr:verify`
- `pnpm security:guard`
- `bash scripts/m4-gatekeeper.sh`
- `pnpm e2e:gate`
