### PR TITLE
fix(domain-claims): harden phase 3.4 scoped status updates

### DIFF
--- a/packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts
+++ b/packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts
@@ -118,4 +118,29 @@ describe('getMemberClaimDetail', () => {
 
     expect(result?.status).toBe('resolved');
   });
+
+  it('falls back to claim row status when timeline is empty', async () => {
+    mocks.selectChain.limit.mockResolvedValue([
+      {
+        id: 'claim-1',
+        claimNumber: 'MK-102',
+        status: 'submitted',
+        createdAt: new Date('2026-02-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-03T00:00:00.000Z'),
+      },
+    ]);
+    mocks.getClaimTimeline.mockResolvedValue([]);
+    mocks.getClaimStatus.mockReturnValue({
+      status: 'draft',
+      lastTransitionAt: null,
+    });
+
+    const result = await getMemberClaimDetail({
+      tenantId: 'tenant-1',
+      memberId: 'member-1',
+      claimId: 'claim-1',
+    });
+
+    expect(result?.status).toBe('submitted');
+  });
 });

--- a/packages/domain-claims/src/member-claims/get-member-claim-detail.ts
+++ b/packages/domain-claims/src/member-claims/get-member-claim-detail.ts
@@ -46,11 +46,12 @@ export async function getMemberClaimDetail(params: {
   if (!row) return null;
   const timeline = await getClaimTimeline({ tenantId, claimId });
   const projected = getClaimStatus(timeline);
+  const status = timeline.length > 0 ? projected.status : (row.status ?? null);
 
   return {
     id: row.id,
     claimNumber: row.claimNumber,
-    status: projected.status,
+    status,
     createdAt: normalizeDate(row.createdAt),
     updatedAt: normalizeDate(row.updatedAt),
   };


### PR DESCRIPTION
## What
- Move updateClaimStatus read + write into a single transaction for scoped atomicity.
- Guard the update with returning and deny when zero rows are affected.
- Set statusUpdatedAt only when status actually changes.
- Add member-detail fallback to claim row status when timeline is empty.
- Expand unit coverage for tenant scoping assertion, zero-row update denial, and empty-timeline fallback.

## Why
- Addresses Copilot review findings without widening scope.
- Preserves deterministic/status projection behavior for Phase 3.4 while tightening reliability.

## Scope
- packages/domain-claims/src/update-claim-status.ts
- packages/domain-claims/src/update-claim-status.test.ts
- packages/domain-claims/src/member-claims/get-member-claim-detail.ts
- packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts

## Validation
- pnpm --filter @interdomestik/domain-claims test:unit --run src/update-claim-status.test.ts
- pnpm --filter @interdomestik/domain-claims test:unit --run src/member-claims/get-member-claim-detail.test.ts
- pnpm pr:verify
- pnpm security:guard
- bash scripts/m4-gatekeeper.sh
- pnpm e2e:gate
