### PR TITLE
fix(domain-claims): address phase 3.4 copilot follow-up comments

### DIFF
--- a/packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts
+++ b/packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts
@@ -142,5 +142,6 @@ describe('getMemberClaimDetail', () => {
     });
 
     expect(result?.status).toBe('submitted');
+    expect(mocks.getClaimStatus).not.toHaveBeenCalled();
   });
 });

--- a/packages/domain-claims/src/member-claims/get-member-claim-detail.ts
+++ b/packages/domain-claims/src/member-claims/get-member-claim-detail.ts
@@ -45,8 +45,7 @@ export async function getMemberClaimDetail(params: {
 
   if (!row) return null;
   const timeline = await getClaimTimeline({ tenantId, claimId });
-  const projected = getClaimStatus(timeline);
-  const status = timeline.length > 0 ? projected.status : (row.status ?? null);
+  const status = timeline.length > 0 ? getClaimStatus(timeline).status : (row.status ?? null);
 
   return {
     id: row.id,

--- a/packages/domain-claims/src/update-claim-status.ts
+++ b/packages/domain-claims/src/update-claim-status.ts
@@ -50,6 +50,7 @@ export async function updateClaimStatus(params: {
     }
 
     const now = new Date();
+    const previousStatus = existingClaim.status as NonNullable<typeof existingClaim.status>;
     const nextStatus = parsed.data.status as NonNullable<typeof existingClaim.status>;
     const updateData: {
       status: NonNullable<typeof existingClaim.status>;
@@ -66,7 +67,7 @@ export async function updateClaimStatus(params: {
     const updatedClaims = await tx
       .update(claims)
       .set(updateData)
-      .where(scopedWhere)
+      .where(and(scopedWhere, eq(claims.status, previousStatus)))
       .returning({ id: claims.id });
 
     if (updatedClaims.length === 0) {
@@ -77,7 +78,7 @@ export async function updateClaimStatus(params: {
       id: crypto.randomUUID(),
       tenantId,
       claimId,
-      fromStatus: existingClaim.status,
+      fromStatus: previousStatus,
       toStatus: nextStatus,
       changedById: user.id,
       changedByRole: 'staff',


### PR DESCRIPTION
## What
- Add optimistic stale-status guard on status update (`WHERE ... AND claim.status = previousStatus`) to prevent inconsistent timeline writes under races.
- Keep update and timeline write transactional and scoped.
- Add note-only update test to ensure `statusUpdatedAt` is not set when status does not change.
- Avoid calling `getClaimStatus` when timeline is empty; continue falling back to claim row status.
- Assert empty-timeline path does not invoke projection helper.

## Scope
- packages/domain-claims/src/update-claim-status.ts
- packages/domain-claims/src/update-claim-status.test.ts
- packages/domain-claims/src/member-claims/get-member-claim-detail.ts
- packages/domain-claims/src/member-claims/get-member-claim-detail.test.ts

## Validation
- pnpm --filter @interdomestik/domain-claims test:unit --run src/update-claim-status.test.ts
- pnpm --filter @interdomestik/domain-claims test:unit --run src/member-claims/get-member-claim-detail.test.ts
- pnpm pr:verify
- pnpm security:guard
- bash scripts/m4-gatekeeper.sh
- pnpm e2e:gate
