### PR TITLE
test(e2e): preserve pilot baseURL in status loop spec

### DIFF
--- a/apps/web/e2e/pilot/c1-05-pilot-staff-member-status-loop.spec.ts
+++ b/apps/web/e2e/pilot/c1-05-pilot-staff-member-status-loop.spec.ts
@@ -14,7 +14,6 @@ test.describe('C1 Pilot: Staff to member status loop', () => {
     if (!baseUrl) {
       throw new Error('Expected project baseURL for pilot host resolution');
     }
-    const pilotHost = new URL(baseUrl).host;
 
     const seededAgent = await db.query.user.findFirst({
       where: eq(user.email, 'agent.pilot@interdomestik.com'),
@@ -80,7 +79,7 @@ test.describe('C1 Pilot: Staff to member status loop', () => {
 
     try {
       memberContext = await browser.newContext({
-        baseURL: `http://${pilotHost}/en`,
+        baseURL: baseUrl,
         extraHTTPHeaders: testInfo.project.use.extraHTTPHeaders,
         locale: 'en-US',
       });
@@ -140,7 +139,7 @@ test.describe('C1 Pilot: Staff to member status loop', () => {
       expect(createdClaim.staffId).toBeNull();
 
       staffContext = await browser.newContext({
-        baseURL: `http://${pilotHost}/en`,
+        baseURL: baseUrl,
         extraHTTPHeaders: testInfo.project.use.extraHTTPHeaders,
         locale: 'en-US',
       });


### PR DESCRIPTION
## What
- preserve the configured Playwright project `baseURL` for staff/member browser contexts in the pilot status-loop E2E
- remove manual host/protocol reconstruction

## Why
- avoids dropping protocol/locale/path from project config
- keeps the test compatible with HTTPS and env-specific host settings

## Scope
- apps/web/e2e/pilot/c1-05-pilot-staff-member-status-loop.spec.ts

## Validation
- pnpm --filter @interdomestik/web exec playwright test e2e/pilot/c1-05-pilot-staff-member-status-loop.spec.ts --project=pilot-mk --reporter=list
