### PR TITLE
fix(admin-claims): resolve review follow-ups for lifecycle guard and test isolation

### DIFF
--- a/apps/web/src/app/[locale]/admin/claims/[id]/_core.test.ts
+++ b/apps/web/src/app/[locale]/admin/claims/[id]/_core.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   claimsFindFirst: vi.fn(),
@@ -48,6 +48,13 @@ function createSelectChain(result: unknown) {
 }
 
 describe('getAdminClaimDetailsCore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.createSignedUrl.mockResolvedValue({
+      data: { signedUrl: 'https://signed.example.com/doc' },
+    });
+  });
+
   it('returns not_found when tenant context is missing', async () => {
     const result = await getAdminClaimDetailsCore({ claimId: 'c1' });
 

--- a/apps/web/src/features/admin/claims/server/getAdminClaimsV2.ts
+++ b/apps/web/src/features/admin/claims/server/getAdminClaimsV2.ts
@@ -36,12 +36,13 @@ function buildConditions(context: ClaimsVisibilityContext, filters: AdminClaimsV
 
   // Lifecycle filter
   const lifecycleStage =
-    typeof filters.lifecycleStage === 'string' && filters.lifecycleStage in LIFECYCLE_STATUS_MAP
+    typeof filters.lifecycleStage === 'string' &&
+    Object.prototype.hasOwnProperty.call(LIFECYCLE_STATUS_MAP, filters.lifecycleStage)
       ? (filters.lifecycleStage as LifecycleStage)
       : undefined;
   if (lifecycleStage) {
     const statuses = LIFECYCLE_STATUS_MAP[lifecycleStage];
-    if (statuses && statuses.length > 0) {
+    if (Array.isArray(statuses) && statuses.length > 0) {
       conditions.push(inArray(claims.status, statuses as any));
     }
   }


### PR DESCRIPTION
## Summary
- replaces `in` check with own-property guard for `lifecycleStage` lookup
- adds `Array.isArray` validation before using mapped lifecycle statuses
- adds `beforeEach(vi.clearAllMocks())` in admin claim detail core tests for per-test isolation
- re-establishes default signed URL mock in `beforeEach`

## Why
Addresses post-merge review feedback to avoid inherited-key edge cases and reduce false positives from shared mock call history between tests.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/features/admin/claims/server/getAdminClaimsV2.test.ts`
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/admin/claims/[id]/_core.test.ts'`
