### PR TITLE
feat(admin-claims): couple side effects to real mutations

### DIFF
--- a/apps/web/src/actions/admin-claims/assign.core.ts
+++ b/apps/web/src/actions/admin-claims/assign.core.ts
@@ -66,7 +66,11 @@ export async function assignClaimCore(params: {
       },
     });
 
-    const persistedStaffId = updatedClaim?.staffId ?? null;
+    if (!updatedClaim) {
+      return result;
+    }
+
+    const persistedStaffId = updatedClaim.staffId ?? null;
     if (persistedStaffId !== claim.staffId) {
       revalidatePathForAllLocales('/member/claims');
       revalidatePathForAllLocales(`/member/claims/${params.claimId}`);

--- a/apps/web/src/actions/admin-claims/assign.wrapper.test.ts
+++ b/apps/web/src/actions/admin-claims/assign.wrapper.test.ts
@@ -223,4 +223,26 @@ describe('assignClaimCore (Wrapper Means)', () => {
     expect(domainAssign.assignClaimCore).toHaveBeenCalledTimes(1);
     expect(nextCache.revalidatePath).not.toHaveBeenCalled();
   });
+
+  it('does not revalidate when post-mutation claim re-read is missing', async () => {
+    dbMocks.claimFindFirst
+      .mockResolvedValueOnce({ id: 'claim1', staffId: 'staff-old' })
+      .mockResolvedValueOnce(null);
+
+    vi.spyOn(domainAssign, 'assignClaimCore').mockResolvedValueOnce({
+      success: true,
+      error: undefined,
+    });
+
+    const result = await assignClaimCore({
+      claimId: 'claim1',
+      staffId: 'staff1',
+      session: mockSession,
+      requestHeaders: mockHeaders,
+    });
+
+    expect(result).toEqual({ success: true, error: undefined });
+    expect(domainAssign.assignClaimCore).toHaveBeenCalledTimes(1);
+    expect(nextCache.revalidatePath).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/actions/admin-claims/update-status.core.ts
+++ b/apps/web/src/actions/admin-claims/update-status.core.ts
@@ -109,7 +109,11 @@ export async function updateClaimStatusCore(params: {
     },
   });
 
-  const persistedStatus = updatedClaim?.status ?? 'draft';
+  if (!updatedClaim) {
+    return;
+  }
+
+  const persistedStatus = updatedClaim.status ?? 'draft';
   if (persistedStatus !== currentStatus) {
     revalidatePath(`/${locale}/admin/claims`);
     revalidatePath(`/${locale}/admin/claims/${claimId}`);

--- a/apps/web/src/actions/admin-claims/update-status.test.ts
+++ b/apps/web/src/actions/admin-claims/update-status.test.ts
@@ -146,4 +146,24 @@ describe('updateClaimStatusCore', () => {
     expect(hoisted.domainUpdateStatus).toHaveBeenCalledTimes(1);
     expect(hoisted.revalidatePath).not.toHaveBeenCalled();
   });
+
+  it('does not revalidate when post-mutation claim re-read is missing', async () => {
+    hoisted.claimFindFirst
+      .mockResolvedValueOnce({ id: 'claim-1', status: 'submitted' })
+      .mockResolvedValueOnce(null);
+
+    const formData = new FormData();
+    formData.set('claimId', 'claim-1');
+    formData.set('status', 'resolved');
+    formData.set('locale', 'en');
+
+    await updateClaimStatusCore({
+      formData,
+      session,
+      requestHeaders: new Headers(),
+    });
+
+    expect(hoisted.domainUpdateStatus).toHaveBeenCalledTimes(1);
+    expect(hoisted.revalidatePath).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
Hardens admin claim write action side effects so revalidation runs only when a real persisted mutation occurred.

## Policy Contract
- Tenant predicate remains enforced at mutation/read boundaries
- No-op and denied/not-found paths perform no side effects
- Side effects are coupled to persisted state change
- Return/DTO shapes unchanged

## Touched Files
- apps/web/src/actions/admin-claims/update-status.core.ts
- apps/web/src/actions/admin-claims/update-status.test.ts
- apps/web/src/actions/admin-claims/assign.core.ts
- apps/web/src/actions/admin-claims/assign.wrapper.test.ts

## RED -> GREEN Evidence
- RED commit: 139ecfe70
- GREEN commit: 4840124c7

## Tests Run
- pnpm --filter @interdomestik/web test:unit --run src/actions/admin-claims/update-status.test.ts
- pnpm --filter @interdomestik/web test:unit --run src/actions/admin-claims/assign.wrapper.test.ts

## Gate Results
- pnpm pr:verify ✅
- pnpm security:guard ✅
- bash scripts/m4-gatekeeper.sh ✅
- pnpm e2e:gate ✅