### PR TITLE
fix(nav): correct dashboard links + role-aware settings + a11y

### DIFF
--- a/apps/web/src/components/dashboard/member-dashboard-view.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view.tsx
@@ -385,7 +385,7 @@ export async function MemberDashboardView({ data, locale }: MemberDashboardViewP
                 className="w-full rounded-2xl border-blue-500/20 hover:bg-blue-500/5 hover:border-blue-500/40 transition-all font-bold group/pulse"
               >
                 <Link href="/member/help" className="flex items-center justify-center gap-2">
-                  <span>View Full Audit</span>
+                  <span>Get Help & Support</span>
                   <ArrowRight className="w-4 h-4 group-hover/pulse:translate-x-1 transition-transform" />
                 </Link>
               </Button>

--- a/apps/web/src/components/dashboard/user-nav.tsx
+++ b/apps/web/src/components/dashboard/user-nav.tsx
@@ -74,6 +74,12 @@ export function UserNav() {
 
   const { user } = session;
   const role = (user as { role?: string }).role;
+  const settingsHref =
+    role === 'agent'
+      ? '/agent/settings'
+      : isAdmin(role) || adminAccess
+        ? '/admin/settings'
+        : '/member/settings';
 
   return (
     <DropdownMenu>
@@ -102,7 +108,7 @@ export function UserNav() {
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
-            <Link href="/settings" className="w-full cursor-pointer">
+            <Link href={settingsHref} className="w-full cursor-pointer">
               <Settings className="mr-2 h-4 w-4" />
               <span>{t('settings')}</span>
               <DropdownMenuShortcut>⌘S</DropdownMenuShortcut>

--- a/apps/web/src/features/agent/leads/components/AgentLeadsProPage.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadsProPage.tsx
@@ -160,8 +160,10 @@ export function AgentLeadsProPage({ leads }: { leads: any[] }) {
               size="icon"
               className="h-8 w-8"
               data-testid="agent-pro-back-button"
+              aria-label="Back to members"
             >
               <ArrowLeft className="h-4 w-4" />
+              <span className="sr-only">Back to members</span>
             </Button>
           </Link>
           <div>

--- a/apps/web/src/features/member/policies/components/MemberPoliciesV2Page.tsx
+++ b/apps/web/src/features/member/policies/components/MemberPoliciesV2Page.tsx
@@ -67,7 +67,7 @@ export async function MemberPoliciesV2Page() {
             Upload your insurance policy to unlock AI-powered insights, hidden perks, and advocacy
             tools.
           </p>
-          <Link href="/dashboard/policies/upload">
+          <Link href="/member/policies/upload">
             <Button variant="outline">Upload First Policy</Button>
           </Link>
         </Card>


### PR DESCRIPTION
## Summary\n- fix member policies empty-state upload link to existing member upload route\n- make UserNav settings destination role-aware (member/agent/admin) instead of generic /settings\n- rename member dashboard CTA text from "View Full Audit" to help-oriented copy while keeping destination unchanged\n- add accessible name for icon-only back button on Agent Leads Pro page\n\n## Scope\n- navigation/labels/accessibility only\n- no auth/proxy/RBAC/middleware changes\n- no readiness marker or data-testid contract changes\n- intentionally excludes agent claim-row destination decision\n\n## Validation\n- pnpm pr:verify\n- pnpm security:guard\n- pnpm e2e:gate:ks:fast\n