### PR TITLE
fix(nav): locale-aware admin claim breadcrumbs (pre-Phase 5 drift)

### DIFF
--- a/apps/web/src/features/admin/claims/components/ops/ClaimHeader.tsx
+++ b/apps/web/src/features/admin/claims/components/ops/ClaimHeader.tsx
@@ -14,7 +14,7 @@ import {
   UserX,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
+import { Link } from '@/i18n/routing';
 import { useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 
@@ -44,7 +44,7 @@ export function ClaimHeader({ claim, allStaff, locale }: Omit<ClaimHeaderProps, 
     const params = new URLSearchParams(searchParams.toString());
     params.delete('poolAnchor');
     const queryString = params.toString();
-    return queryString ? `/admin/claims?${queryString}` : '/admin/claims';
+    return queryString ? `/${locale}/admin/claims?${queryString}` : `/${locale}/admin/claims`;
   };
 
   const copyToClipboard = (text: string, label: string) => {
@@ -75,7 +75,7 @@ export function ClaimHeader({ claim, allStaff, locale }: Omit<ClaimHeaderProps, 
 
           {/* Level 2: Lifecycle Stage */}
           <Link
-            href={`/admin/claims?lifecycle=${claim.lifecycleStage}`}
+            href={`/${locale}/admin/claims?lifecycle=${claim.lifecycleStage}`}
             className="text-muted-foreground hover:text-foreground transition-colors"
           >
             {tLifecycle(claim.lifecycleStage)}


### PR DESCRIPTION
## Summary
- make admin claim breadcrumbs locale-aware in `ClaimHeader`
- keep navigation/label scope only (no auth/proxy/RBAC/readiness marker/data-testid changes)
- preserve existing labels and behavior while fixing locale prefix drift

## File changed
- `apps/web/src/features/admin/claims/components/ops/ClaimHeader.tsx`

## Validation
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate:ks:fast`
- `pnpm e2e:gate`

All commands passed locally.

## Deferred (out of scope)
- agent claim detail destination decision for `/agent/claims/[id]` remains deferred pending product direction; no route/workflow changes included in this PR.
