### PR TITLE
fix(nav): resolve locale-aware link drift follow-up from #96

### DIFF
--- a/apps/web/src/features/admin/claims/components/ops/ClaimHeader.tsx
+++ b/apps/web/src/features/admin/claims/components/ops/ClaimHeader.tsx
@@ -44,7 +44,7 @@ export function ClaimHeader({ claim, allStaff, locale }: Omit<ClaimHeaderProps, 
     const params = new URLSearchParams(searchParams.toString());
     params.delete('poolAnchor');
     const queryString = params.toString();
-    return queryString ? `/${locale}/admin/claims?${queryString}` : `/${locale}/admin/claims`;
+    return queryString ? `/admin/claims?${queryString}` : '/admin/claims';
   };
 
   const copyToClipboard = (text: string, label: string) => {
@@ -75,7 +75,7 @@ export function ClaimHeader({ claim, allStaff, locale }: Omit<ClaimHeaderProps, 
 
           {/* Level 2: Lifecycle Stage */}
           <Link
-            href={`/${locale}/admin/claims?lifecycle=${claim.lifecycleStage}`}
+            href={`/admin/claims?lifecycle=${claim.lifecycleStage}`}
             className="text-muted-foreground hover:text-foreground transition-colors"
           >
             {tLifecycle(claim.lifecycleStage)}

--- a/packages/domain-member/src/get-member-dashboard-data.test.ts
+++ b/packages/domain-member/src/get-member-dashboard-data.test.ts
@@ -78,7 +78,7 @@ describe('getMemberDashboardData', () => {
     expect(data.claims[0].stageLabel).toBe('Submitted');
     expect(data.claims[0].requiresMemberAction).toBe(false);
     expect(data.claims[0].nextMemberAction).toBeUndefined();
-    expect(data.supportHref).toBe('/sq/member/help');
+    expect(data.supportHref).toBe('/member/help');
   });
 
   it('returns empty-state friendly data when there are no claims', async () => {

--- a/packages/domain-member/src/get-member-dashboard-data.ts
+++ b/packages/domain-member/src/get-member-dashboard-data.ts
@@ -62,7 +62,7 @@ export async function getMemberDashboardData(params: {
   tenantId?: string | null;
   locale: string;
 }): Promise<MemberDashboardData> {
-  const { memberId, tenantId, locale } = params;
+  const { memberId, tenantId } = params;
 
   const memberWhere = tenantId
     ? withTenant(tenantId, user.tenantId, eq(user.id, memberId))
@@ -124,6 +124,6 @@ export async function getMemberDashboardData(params: {
     },
     claims: claimsData,
     activeClaimId: activeClaim?.id ?? null,
-    supportHref: `/${locale}/member/help`,
+    supportHref: '/member/help',
   };
 }


### PR DESCRIPTION
## Summary
Follow-up to merged PR #96 to resolve unresolved review concerns and keep locale-aware routing behavior consistent.

### Included (navigation-only)
- `ClaimHeader` breadcrumbs now pass locale-agnostic hrefs to `@/i18n/routing` `Link` (no manual `/${locale}` prefix).
- Member dashboard support href contract is now locale-agnostic (`/member/help`) to prevent double-prefix URLs (`/sq/sq/member/help`).
- Updated corresponding unit expectation.

## Files changed
- `apps/web/src/features/admin/claims/components/ops/ClaimHeader.tsx`
- `packages/domain-member/src/get-member-dashboard-data.ts`
- `packages/domain-member/src/get-member-dashboard-data.test.ts`

## Validation
- `pnpm --filter @interdomestik/domain-member test:unit --run src/get-member-dashboard-data.test.ts`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate:ks:fast`
- `pnpm e2e:gate`

All passed locally.

## Scope guard
- No auth/proxy/RBAC changes
- No readiness marker/data-testid changes
- No new routes/workflows
