### PR TITLE
fix(agent-claims): route claim rows to workspace with deterministic preselect

### DIFF
--- a/apps/web/src/app/[locale]/(agent)/agent/claims/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/claims/_core.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { getAgentClaimsCore } from './_core';
+import { buildAgentWorkspaceClaimHref, getAgentClaimsCore } from './_core';
 
 describe('getAgentClaimsCore', () => {
   const mockParams = {
@@ -55,5 +55,13 @@ describe('getAgentClaimsCore', () => {
       expect(result.data[0].memberId).toBe('m1');
       expect(result.data[0].claims.length).toBe(2);
     }
+  });
+});
+
+describe('buildAgentWorkspaceClaimHref', () => {
+  it('builds locale-agnostic workspace claim deep-link with claimId query param', () => {
+    expect(buildAgentWorkspaceClaimHref('claim-123')).toBe(
+      '/agent/workspace/claims?claimId=claim-123'
+    );
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/claims/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/claims/_core.ts
@@ -19,6 +19,10 @@ export type AgentClaimsResult =
   | { ok: true; data: AgentMemberClaimsDTO[] }
   | { ok: false; code: 'UNAUTHORIZED' | 'FORBIDDEN' | 'INTERNAL' };
 
+export function buildAgentWorkspaceClaimHref(claimId: string): string {
+  return `/agent/workspace/claims?claimId=${encodeURIComponent(claimId)}`;
+}
+
 /**
  * Pure core logic for the Agent Claims Page.
  * Fetches members managed by the agent and their claims, grouped by member.

--- a/apps/web/src/app/[locale]/(agent)/agent/claims/page.tsx
+++ b/apps/web/src/app/[locale]/(agent)/agent/claims/page.tsx
@@ -1,11 +1,11 @@
 import { ClaimStatusBadge } from '@/features/claims/tracking/components/ClaimStatusBadge';
+import { Link } from '@/i18n/routing';
 import { db } from '@/lib/db.server';
 import { Avatar, AvatarFallback } from '@interdomestik/ui/avatar';
 import { Card, CardContent, CardHeader, CardTitle } from '@interdomestik/ui/card';
 import { headers } from 'next/headers';
-import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
-import { getAgentClaimsCore } from './_core';
+import { buildAgentWorkspaceClaimHref, getAgentClaimsCore } from './_core';
 
 // Helper for initials
 function getInitials(name: string) {
@@ -82,7 +82,7 @@ export default async function AgentClaimsPage({ params, searchParams }: Props) {
                 <div className="divide-y">
                   {group.claims.map(claim => (
                     <Link
-                      href={`/${locale}/agent/claims/${claim.id}`}
+                      href={buildAgentWorkspaceClaimHref(claim.id)}
                       key={claim.id}
                       className="flex items-center justify-between p-4 hover:bg-muted/20 transition-colors"
                       data-testid="agent-claim-row"

--- a/apps/web/src/features/agent/claims/components/AgentClaimsProPage.tsx
+++ b/apps/web/src/features/agent/claims/components/AgentClaimsProPage.tsx
@@ -17,6 +17,7 @@ import { Link } from '@/i18n/routing';
 import { Button } from '@interdomestik/ui';
 import { format } from 'date-fns';
 import { ArrowLeft } from 'lucide-react';
+import { getSelectedClaimId } from './claim-selection';
 
 // Define minimal Claim type for Pro table
 export type AgentProClaim = {
@@ -57,7 +58,7 @@ export function AgentClaimsProPage({ claims, currentUser }: AgentClaimsProPagePr
   const searchParams = useSearchParams();
 
   // URL Selection for Drawer
-  const selectedId = searchParams.get('selected');
+  const selectedId = getSelectedClaimId(searchParams);
   // Drawer View Mode
   const [viewMode, setViewMode] = useState<'details' | 'messaging'>('details');
 

--- a/apps/web/src/features/agent/claims/components/claim-selection.test.ts
+++ b/apps/web/src/features/agent/claims/components/claim-selection.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getSelectedClaimId } from './claim-selection';
+
+describe('getSelectedClaimId', () => {
+  it('uses claimId when selected is missing', () => {
+    const params = new URLSearchParams('claimId=claim-42');
+    expect(getSelectedClaimId(params)).toBe('claim-42');
+  });
+
+  it('prefers selected when both selected and claimId are present', () => {
+    const params = new URLSearchParams('selected=claim-2&claimId=claim-1');
+    expect(getSelectedClaimId(params)).toBe('claim-2');
+  });
+
+  it('returns null when no valid id is provided', () => {
+    const params = new URLSearchParams();
+    expect(getSelectedClaimId(params)).toBeNull();
+  });
+});

--- a/apps/web/src/features/agent/claims/components/claim-selection.ts
+++ b/apps/web/src/features/agent/claims/components/claim-selection.ts
@@ -1,0 +1,9 @@
+export function getSelectedClaimId(searchParams: URLSearchParams): string | null {
+  const selected = searchParams.get('selected');
+  if (selected) return selected;
+
+  const claimId = searchParams.get('claimId');
+  if (claimId) return claimId;
+
+  return null;
+}


### PR DESCRIPTION
Context
Agent claim rows previously linked to /agent/claims/:id, but no such route exists -> direct 404 risk.

What changed
- Deep-linked agent claim row click-through to the existing Agent Workspace -> Claims view using:
- /{locale}/agent/workspace/claims?claimId=<id>
- Implemented deterministic query parsing + selection fallback so the same claimId yields the same selected claim every run.
- Added minimal unit coverage for:
- URL contract generation
- selection behavior / fallback determinism

Why this is safe for Phase 5
- No new routes/pages added.
- No changes to proxy/auth/RBAC/tenancy.
- No readiness marker or testid renames.
- Pure navigation + deterministic selection behavior within existing workspace flow.

Validation
- Targeted unit tests: ✅
- pnpm security:guard: ✅
- pnpm pr:verify: ✅
- pnpm e2e:gate: ✅

Risk / rollback
- If workspace preselect is not deterministic in production, rollback is to make claim rows non-clickable (Phase 5.3 Option A).
