### PR TITLE
docs(pilot): operationalize Sat/Sun cadence evidence

### DIFF
--- a/docs/PHASE_5_6_SPECS.md
+++ b/docs/PHASE_5_6_SPECS.md
@@ -31,7 +31,7 @@ Operationalize the Mon–Sun pilot cadence with deterministic weekend execution 
 - Operating window: `08:00–17:00 Europe/Pristina`.
 - Saturday/Sunday default mode: monitor + log.
 - Change policy: hotfixes allowed only for Sev1 conditions.
-- Sev2/Sev3 on weekends: log, assign owner, defer to weekday ops huddle unless promoted to Sev1 or stop criteria is met.
+- Sev2/Sev3 on weekends: log, assign owner, defer to weekday ops huddle unless promoted to Sev1 or stop criteria are met.
 
 ## Deterministic Ceremony Commands
 
@@ -48,7 +48,7 @@ git status --porcelain
 pnpm security:guard
 ```
 
-If Sev1 incident requires hotfix gating evidence:
+If Sev1 incident requires hotfix gating evidence, execute the Phase 5.1 ceremony after the hotfix is merged to clean, synced `main`:
 
 ```bash
 # Canonical
@@ -62,7 +62,7 @@ bash ./phase-5-1.sh
 
 - Phase 5.1 gate bundle path:
   - `tmp/pilot-evidence/phase-5.1/<YYYY-MM-DDTHH-MM-SS+ZZZZ>/`
-- Pilot ops evidence index:
+- Pilot ops evidence index template (copy per pilot):
   - `docs/pilot/PILOT_EVIDENCE_INDEX_TEMPLATE.md`
 - Weekend daily entry format:
   - `Day <N> | <YYYY-MM-DD> | <owner> | <status> | <bundle-path-or-n/a> | <incident-count> | <highest-sev> | <decision>`

--- a/docs/pilot/PILOT_EVIDENCE_INDEX_TEMPLATE.md
+++ b/docs/pilot/PILOT_EVIDENCE_INDEX_TEMPLATE.md
@@ -1,10 +1,11 @@
 # Pilot Evidence Index Template (14 Days, Mon–Sun)
 
-Use this table as the single source of truth for daily pilot ops evidence.
+For each pilot, copy this template to a per-pilot evidence index file (for example, `PILOT_EVIDENCE_INDEX.md`) and use that copied file as the single source of truth for daily pilot ops evidence.
 
 - Keep one row per operating day.
 - Use absolute or repo-relative bundle paths exactly as generated.
 - If no gate bundle was generated that day, set bundle path to `n/a`.
+- Do not edit this template directly; always work in your copied per-pilot evidence index file.
 
 | Day | Date (YYYY-MM-DD) | Owner | Status (`green`/`amber`/`red`) | Evidence Bundle Path | Incidents (count) | Highest Sev (`none`/`sev3`/`sev2`/`sev1`) | Decision (`continue`/`defer`/`hotfix`/`stop`) |
 | --- | ----------------- | ----- | ------------------------------ | -------------------- | ----------------- | ----------------------------------------- | --------------------------------------------- |

--- a/docs/pilot/PILOT_GO_NO_GO.md
+++ b/docs/pilot/PILOT_GO_NO_GO.md
@@ -37,7 +37,7 @@
   - Closed-loop path operational end-to-end.
 - No-Go:
   - Any Sev1 incident unresolved.
-  - Weekend defer policy does not apply when stop criteria are met; treat as immediate no-go.
+  - When stop criteria are met, they trigger an immediate stop/rollback decision; weekend defer policy cannot override or delay this.
   - Repeated guardrail failures (`security:guard`, `m4-gatekeeper.sh`, or `e2e:gate`) without fix.
   - Repeated authentication/login failures for pilot users that block operations.
   - Closed-loop path broken for more than 1 operating day.

--- a/docs/pilot/PILOT_RUNBOOK.md
+++ b/docs/pilot/PILOT_RUNBOOK.md
@@ -71,10 +71,10 @@ git status --porcelain
 pnpm security:guard
 ```
 
-- Record results in `docs/pilot/PILOT_EVIDENCE_INDEX_TEMPLATE.md`.
+- Record results in a per-pilot evidence index copied from `docs/pilot/PILOT_EVIDENCE_INDEX_TEMPLATE.md` (for example, `docs/pilot/PILOT_EVIDENCE_INDEX_<PILOT_ID>.md`).
 - If Sev1 requires hotfix workflow evidence, run:
-  - `./phase-5-1.sh`
-  - Fallback: `bash ./phase-5-1.sh`
+  - after hotfix merge to clean, synced `main`: `./phase-5-1.sh`
+  - fallback on clean, synced `main`: `bash ./phase-5-1.sh`
 - Evidence bundle path convention for full gate runs:
   - `tmp/pilot-evidence/phase-5.1/<YYYY-MM-DDTHH-MM-SS+ZZZZ>/`
 - If no full gate run is required, use `n/a` for bundle path in the evidence index row.


### PR DESCRIPTION
## Summary
Operationalizes Phase 5.6 weekend (Sat/Sun) pilot cadence as docs-only, with deterministic execution/evidence standards and no runtime behavior changes.

## What changed
- Added `docs/PHASE_5_6_SPECS.md` with locked scope, commands, acceptance criteria, and evidence conventions.
- Updated `docs/pilot/PILOT_RUNBOOK.md` with:
  - weekend ceremony checklist (explicit command lines),
  - evidence bundle location convention,
  - escalation decision table (Sev1 immediate hotfix; Sev2/Sev3 defer unless promoted/stop criteria).
- Updated `docs/pilot/PILOT_GO_NO_GO.md` for weekend policy clarity (defer does not override stop criteria).
- Added `docs/pilot/PILOT_EVIDENCE_INDEX_TEMPLATE.md` (14-day day/date/owner/status/bundle/incidents/sev/decision template).

## Validation
- `./phase-5-1.sh` on clean `main`: ✅
  - Evidence bundle: `tmp/pilot-evidence/phase-5.1/2026-02-08T19-29-41+0100`
- `pnpm security:guard`: ✅
- `pnpm docs:verify` (existing docs check): ✅

## Scope Safety
- Docs-only diff.
- No app/runtime/proxy/auth/RBAC/tenancy/routing changes.
- Pilot duration unchanged (14 days).
