### PR TITLE
fix(rbac): require branch for branch-scoped role grants

### DIFF
--- a/apps/web/src/actions/admin-rbac.core.ts
+++ b/apps/web/src/actions/admin-rbac.core.ts
@@ -179,6 +179,13 @@ export async function grantUserRole({
     });
 
     if ('error' in result) {
+      if (result.error.includes('Branch is required for role')) {
+        return {
+          success: false,
+          error: result.error,
+          code: 'BRANCH_REQUIRED',
+        } as never;
+      }
       throw new Error(result.error);
     }
 

--- a/apps/web/src/actions/admin-rbac.wrapper.test.ts
+++ b/apps/web/src/actions/admin-rbac.wrapper.test.ts
@@ -195,5 +195,21 @@ describe('admin-rbac.core', () => {
         expect(result.error).toContain('Tenant context is required');
       }
     });
+
+    it('returns BRANCH_REQUIRED when grant role is branch-scoped without branch', async () => {
+      mockGrantUserRoleCore.mockResolvedValueOnce({ error: 'Branch is required for role: agent' });
+
+      const result = await grantUserRole({
+        userId: '123e4567-e89b-12d3-a456-426614174000',
+        role: 'agent',
+        tenantId: 'tenant-1',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe('BRANCH_REQUIRED');
+        expect(result.error).toBe('Branch is required for role: agent');
+      }
+    });
   });
 });

--- a/apps/web/src/app/[locale]/admin/users/[id]/_components/admin-user-roles-panel.test.tsx
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_components/admin-user-roles-panel.test.tsx
@@ -164,4 +164,23 @@ describe('AdminUserRolesPanel', () => {
       expect(rbacMocks.revokeUserRole).not.toHaveBeenCalled();
     });
   });
+
+  it('disables grant when selected role requires branch and branch is tenant-wide', async () => {
+    render(<AdminUserRolesPanel userId="user-1" />);
+
+    await waitFor(() => {
+      expect(rbacMocks.listUserRoles).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByTestId('role-select-trigger'));
+    fireEvent.click(screen.getByTestId('role-option-agent'));
+
+    const grantButton = screen.getByRole('button', { name: 'Grant role' });
+    expect(grantButton).toBeDisabled();
+    fireEvent.click(grantButton);
+
+    await waitFor(() => {
+      expect(rbacMocks.grantUserRole).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary\n- block invalid role grants in admin user roles UI when selected role is branch-scoped and branch is tenant-wide\n- return  from admin RBAC server action instead of generic  for branch-required validation failures\n- add/extend unit tests for UI guard and action error mapping\n\n## Validation\n- pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/admin/users/[id]/_components/admin-user-roles-panel.test.tsx'\n- pnpm --filter @interdomestik/web test:unit --run src/actions/admin-rbac.wrapper.test.ts\n- pnpm --filter @interdomestik/web type-check\n- pnpm --filter @interdomestik/web test:unit\n- pnpm e2e:gate