### PR TITLE
chore(rbac): centralize branch-required role rules

### DIFF
--- a/apps/web/src/app/[locale]/admin/users/[id]/_components/admin-user-roles-panel.tsx
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_components/admin-user-roles-panel.tsx
@@ -15,6 +15,7 @@ import {
   ROLE_PROMOTER,
   ROLE_TENANT_ADMIN,
 } from '@/lib/roles.core';
+import { isBranchRequiredRole } from '@interdomestik/domain-users/admin/role-rules';
 import { Button } from '@interdomestik/ui/components/button';
 import {
   Card,
@@ -56,16 +57,10 @@ const DEFAULT_ROLE_OPTIONS = [
   ROLE_PROMOTER,
 ];
 const TENANT_WIDE_BRANCH = '__tenant__';
-const BRANCH_REQUIRED_ROLES = new Set<string>([ROLE_AGENT, ROLE_BRANCH_MANAGER]);
 
 function formatBranchName(b: Branch | { name: string; code?: string | null }) {
   const codeSuffix = b.code ? ` (${b.code})` : '';
   return `${b.name}${codeSuffix}`;
-}
-
-function roleRequiresBranch(role: string | undefined) {
-  const normalizedRole = role?.trim();
-  return Boolean(normalizedRole && BRANCH_REQUIRED_ROLES.has(normalizedRole));
 }
 
 export function AdminUserRolesPanel({ userId }: { userId: string }) {
@@ -91,7 +86,7 @@ export function AdminUserRolesPanel({ userId }: { userId: string }) {
 
   const effectiveRoleValue = (grantRole === '__custom__' ? customRole : grantRole).trim();
   const isBranchMissingForRole =
-    roleRequiresBranch(effectiveRoleValue) && grantBranchId === TENANT_WIDE_BRANCH;
+    isBranchRequiredRole(effectiveRoleValue) && grantBranchId === TENANT_WIDE_BRANCH;
 
   const branchOptions = useMemo(() => {
     return [{ id: TENANT_WIDE_BRANCH, name: 'Tenant-wide', code: null }, ...branches];

--- a/packages/domain-users/package.json
+++ b/packages/domain-users/package.json
@@ -12,6 +12,7 @@
     "./admin/get-users": "./src/admin/get-users.ts",
     "./admin/get-agents": "./src/admin/get-agents.ts",
     "./admin/get-staff": "./src/admin/get-staff.ts",
+    "./admin/role-rules": "./src/admin/role-rules.ts",
     "./admin/schemas": "./src/admin/schemas.ts",
     "./admin/update-user-agent": "./src/admin/update-user-agent.ts",
     "./agent/get-users": "./src/agent/get-users.ts",

--- a/packages/domain-users/src/admin/role-rules.ts
+++ b/packages/domain-users/src/admin/role-rules.ts
@@ -1,0 +1,8 @@
+export const BRANCH_REQUIRED_ROLES = ['agent', 'branch_manager'] as const;
+
+const BRANCH_REQUIRED_ROLE_SET = new Set<string>(BRANCH_REQUIRED_ROLES);
+
+export function isBranchRequiredRole(role: string | null | undefined): boolean {
+  const normalizedRole = role?.trim();
+  return Boolean(normalizedRole && BRANCH_REQUIRED_ROLE_SET.has(normalizedRole));
+}

--- a/packages/domain-users/src/admin/roles.ts
+++ b/packages/domain-users/src/admin/roles.ts
@@ -4,6 +4,7 @@ import { hasPermission, PERMISSIONS, requirePermission } from '@interdomestik/sh
 import { isNull } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto'; // NOSONAR
 import type { ActionResult, UserDomainDeps, UserSession } from '../types';
+import { isBranchRequiredRole } from './role-rules';
 import { resolveTenantId } from './utils';
 
 export async function listUserRolesCore(params: {
@@ -56,7 +57,7 @@ export async function grantUserRoleCore(
   }
 
   // Branch Scoping Rules
-  if (role === 'branch_manager' || role === 'agent') {
+  if (isBranchRequiredRole(role)) {
     if (!branchId) return { error: `Branch is required for role: ${role}` };
   } else {
     // For non-branch roles (admin, staff), ensure branchId is null (unless we allow branch-staff later)


### PR DESCRIPTION
## What changed
- Added shared helper `isBranchRequiredRole` in `@interdomestik/domain-users/admin/role-rules` and exported it.
- Updated domain RBAC grant logic to use the shared helper.
- Updated admin roles panel UI to use the shared helper (removes local duplicate role list).
- Updated `grantUserRole` action to deterministically return `BRANCH_REQUIRED` before domain call when branch-scoped role is granted without a branch.
- Removed brittle message-substring classification path.

## Why
- Prevents drift between UI/server/domain branch-required role logic.
- Makes error classification deterministic and resilient to message text changes.

## Verification
- `pnpm --filter @interdomestik/web type-check`
- `pnpm --filter @interdomestik/web test:unit`
- `pnpm e2e:gate`
