### PR TITLE
fix(admin-users): avoid server call into client-only status mapper

### DIFF
--- a/apps/web/src/app/[locale]/admin/users/[id]/_components/recent-claims-card.tsx
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_components/recent-claims-card.tsx
@@ -1,4 +1,5 @@
-import { OpsStatusBadge, OpsTable, toOpsBadgeVariant } from '@/components/ops';
+import { OpsStatusBadge, OpsTable } from '@/components/ops';
+import { toOpsBadgeVariant } from '@/components/ops/adapters/status';
 import { Link } from '@/i18n/routing';
 import { Button } from '@interdomestik/ui/components/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@interdomestik/ui/components/card';


### PR DESCRIPTION
## Summary
- fix admin user profile recent claims rendering by using server-safe toOpsBadgeVariant mapper
- stop calling toOpsBadgeVariant from OpsStatusBadge client module inside a server component

## Why
Production logs show repeated errors on /sq/admin/users/*:
Error: Attempted to call toOpsBadgeVariant() from the server ...

## Verification
- pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/admin/users/[id]/_components/recent-claims-card.test.tsx'
- pnpm --filter @interdomestik/web type-check
