### PR TITLE
fix(db): cap vercel prod pool to avoid session mode exhaustion

### DIFF
--- a/packages/database/src/db.ts
+++ b/packages/database/src/db.ts
@@ -4,6 +4,7 @@ import * as schema from './schema';
 
 const globalQueryClient = global as unknown as { queryClient: postgres.Sql };
 const isProduction = process.env.NODE_ENV === 'production';
+const isVercelRuntime = process.env.VERCEL === '1';
 
 function parseEnvInt(value: string | undefined, fallback: number): number {
   const parsed = Number.parseInt(value ?? '', 10);
@@ -18,19 +19,24 @@ if (!process.env.DATABASE_URL) {
 
 const queryClient =
   globalQueryClient.queryClient ||
-  postgres(process.env.DATABASE_URL!, {
+  (() => {
     // Session-mode pooled DBs can exhaust quickly in serverless if max is too high.
-    max: parseEnvInt(process.env.DB_MAX_CONNECTIONS, isProduction ? 5 : 10),
-    idle_timeout: parseEnvInt(process.env.DB_IDLE_TIMEOUT, isProduction ? 10 : 20),
-    connect_timeout: parseEnvInt(process.env.DB_CONNECT_TIMEOUT, 10),
-    max_lifetime: parseEnvInt(process.env.DB_MAX_LIFETIME, 1800),
-    // Add connection monitoring
-    onnotice: notice => {
-      if (isProduction) {
-        console.warn('Database notice:', notice);
-      }
-    },
-  });
+    const configuredMax = parseEnvInt(process.env.DB_MAX_CONNECTIONS, isProduction ? 5 : 10);
+    const safeMax = isProduction && isVercelRuntime ? Math.min(configuredMax, 1) : configuredMax;
+
+    return postgres(process.env.DATABASE_URL!, {
+      max: safeMax,
+      idle_timeout: parseEnvInt(process.env.DB_IDLE_TIMEOUT, isProduction ? 10 : 20),
+      connect_timeout: parseEnvInt(process.env.DB_CONNECT_TIMEOUT, 10),
+      max_lifetime: parseEnvInt(process.env.DB_MAX_LIFETIME, 1800),
+      // Add connection monitoring
+      onnotice: notice => {
+        if (isProduction) {
+          console.warn('Database notice:', notice);
+        }
+      },
+    });
+  })();
 
 // Reuse per-runtime client in all environments to reduce connection churn.
 globalQueryClient.queryClient = queryClient;


### PR DESCRIPTION
## Summary
- hard-cap Postgres pool size to 1 on Vercel production runtime
- keep env-configurable values for non-Vercel/local runtimes
- reduce risk of Supabase session-mode MaxClientsInSessionMode auth failures

## Why
Production requests are intermittently failing Better Auth session reads with MaxClientsInSessionMode, causing redirects/logouts and blocking P1 flows.

## Verification
- pnpm --filter @interdomestik/database type-check
- pnpm --filter @interdomestik/web type-check
- production logs reproduced before patch with MaxClientsInSessionMode