### PR TITLE
fix(admin): avoid client barrel import in user claims card

### DIFF
--- a/apps/web/src/app/[locale]/admin/users/[id]/_components/recent-claims-card.tsx
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_components/recent-claims-card.tsx
@@ -1,4 +1,5 @@
-import { OpsStatusBadge, OpsTable } from '@/components/ops';
+import { OpsStatusBadge } from '@/components/ops/OpsStatusBadge';
+import { OpsTable } from '@/components/ops/OpsTable';
 import { toOpsBadgeVariant } from '@/components/ops/adapters/status';
 import { Link } from '@/i18n/routing';
 import { Button } from '@interdomestik/ui/components/button';


### PR DESCRIPTION
## What changed
- Updated admin user detail recent-claims card to import `OpsStatusBadge` and `OpsTable` directly instead of the `@/components/ops` barrel.

## Why
- Fixes production server render error: "Attempted to call toOpsBadgeVariant() from the server" triggered on `/[locale]/admin/users/[id]` for certain profile IDs.
- Keeps change surgical with no behavior changes outside this route.

## Validation
- `pnpm --filter @interdomestik/web type-check`
- `pnpm --filter @interdomestik/web test:unit --run src/app/[locale]/admin/users/[id]/_components/admin-user-roles-panel.test.tsx`
