### PR TITLE
fix(member): persist uploads in claim_documents

### DIFF
--- a/apps/web/src/features/member/claims/actions.ts
+++ b/apps/web/src/features/member/claims/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { auth } from '@/lib/auth';
-import { claims, db, documents } from '@interdomestik/database';
+import { claimDocuments, claims, db } from '@interdomestik/database';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
@@ -133,15 +133,14 @@ export async function confirmUpload(
   }
 
   try {
-    await db.insert(documents).values({
+    await db.insert(claimDocuments).values({
       id: fileId,
       tenantId: tenantId,
-      entityType: 'claim',
-      entityId: claimId,
-      fileName: originalName,
-      mimeType: mimeType,
-      fileSize: fileSize,
-      storagePath: storagePath,
+      claimId,
+      name: originalName,
+      filePath: storagePath,
+      fileType: mimeType,
+      fileSize,
       category: 'evidence',
       uploadedBy: session.user.id,
     });


### PR DESCRIPTION
## Summary
- write member evidence metadata to  instead of 
- keep signed upload generation path unchanged

## Why
The member documents page reads from , so uploads looked successful but were not visible after refresh/relogin.

## Verification
- pnpm --filter @interdomestik/web type-check