### PR TITLE
fix(upload): harden member signed upload url + admin member link

### DIFF
--- a/apps/web/src/features/admin/claims/components/ops/ClaimHeader.tsx
+++ b/apps/web/src/features/admin/claims/components/ops/ClaimHeader.tsx
@@ -244,7 +244,7 @@ export function ClaimHeader({ claim, allStaff, locale }: Omit<ClaimHeaderProps, 
                   </div>
                   <div className="w-[1px] h-3 self-center bg-sky-200" />
                   <Link
-                    href={`/${locale}/admin/users/${claim.memberId}`}
+                    href={`/admin/users/${claim.memberId}`}
                     className="flex items-center gap-1 px-2 py-0.5 hover:underline decoration-sky-700/50"
                   >
                     <span className="text-[10px] font-medium max-w-[150px] truncate">


### PR DESCRIPTION
## What
- fix duplicated locale in admin claim header member link (`/sq/sq/admin/users/...`)
- harden member `generateUploadUrl` by auto-creating missing storage bucket and retrying once when Supabase returns missing-resource

## Why
- prevents prod 404 link regressions from claims detail
- avoids intermittent `Supabase signed URL error: The related resource does not exist` from blocking member upload flow

## Validation
- `pnpm --filter @interdomestik/web type-check`
- `pnpm --filter @interdomestik/web test:unit --run src/features/member/claims src/features/admin/claims/components/ops`
