### PR TITLE
fix(claims): allow .txt evidence uploads

### DIFF
--- a/apps/web/src/app/api/uploads/_core.ts
+++ b/apps/web/src/app/api/uploads/_core.ts
@@ -11,7 +11,12 @@ type Session = {
   };
 };
 
-export const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'application/pdf'] as const;
+export const ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'application/pdf',
+  'text/plain',
+] as const;
 export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 export const DEFAULT_BUCKET = 'claim-evidence';
 export const DEFAULT_CLASSIFICATION = 'pii' as const;

--- a/apps/web/src/app/api/uploads/route.test.ts
+++ b/apps/web/src/app/api/uploads/route.test.ts
@@ -214,4 +214,27 @@ describe('POST /api/uploads', () => {
     );
     expect(hoisted.createSignedUploadUrl).toHaveBeenCalled();
   });
+
+  it('allows text files for claim evidence uploads', async () => {
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'user-1', role: 'user', tenantId: 'tenant_mk' },
+    });
+
+    const req = new Request('http://localhost:3000/api/uploads', {
+      method: 'POST',
+      body: JSON.stringify({
+        fileName: 'notes.txt',
+        fileType: 'text/plain',
+        fileSize: 120,
+        claimId: 'claim-1',
+      }),
+    });
+
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.upload.path).toContain('.txt');
+    expect(hoisted.createSignedUploadUrl).toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/claims/wizard-step-evidence.tsx
+++ b/apps/web/src/components/claims/wizard-step-evidence.tsx
@@ -18,7 +18,7 @@ import {
 } from '@interdomestik/ui/components/tooltip';
 import { useTranslations } from 'next-intl';
 
-const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'application/pdf'];
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'application/pdf', 'text/plain'];
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
 
 const CATEGORY_PROMPTS: Record<string, string[]> = {

--- a/apps/web/src/features/member/claims/components/ClaimEvidenceUploadDialog.tsx
+++ b/apps/web/src/features/member/claims/components/ClaimEvidenceUploadDialog.tsx
@@ -103,7 +103,13 @@ export function ClaimEvidenceUploadDialog({ claimId, trigger }: ClaimEvidenceUpl
         <div className="grid w-full items-center gap-4">
           <div className="flex flex-col space-y-1.5">
             <Label htmlFor="file">File</Label>
-            <Input id="file" type="file" onChange={handleFileChange} disabled={uploading} />
+            <Input
+              id="file"
+              type="file"
+              accept="application/pdf,image/jpeg,image/png,text/plain"
+              onChange={handleFileChange}
+              disabled={uploading}
+            />
           </div>
         </div>
         <DialogFooter className="sm:justify-start">

--- a/packages/domain-claims/src/claims/submit.ts
+++ b/packages/domain-claims/src/claims/submit.ts
@@ -170,6 +170,7 @@ function validateClaimFiles(
   const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB - aligned with upload API
   const ALLOWED_TYPES = new Set([
     'application/pdf',
+    'text/plain',
     'image/jpeg',
     'image/png',
     'image/webp',
@@ -202,7 +203,7 @@ function validateClaimFiles(
     }
     if (!ALLOWED_TYPES.has(file.type)) {
       throw new ClaimValidationError(
-        `Unsupported file type: ${file.type}. Allowed: PDF, Images, Audio.`,
+        `Unsupported file type: ${file.type}. Allowed: PDF, TXT, Images, Audio.`,
         'INVALID_TYPE'
       );
     }


### PR DESCRIPTION
## What changed
- Added `text/plain` to claim evidence upload allowlist in `POST /api/uploads`
- Added `text/plain` to claim wizard client-side MIME validation
- Added `text/plain` to member claim submit server-side validation (`domain-claims`)
- Updated member evidence upload dialog input `accept` types to include text files
- Added unit coverage to verify `.txt` files are accepted by upload API

## Why
Members were blocked from uploading `.txt` evidence files in claim flows.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/app/api/uploads/route.test.ts`
- `pnpm --filter @interdomestik/web type-check`
