### PR TITLE
chore(db): add member_activities migration (0032)

### DIFF
--- a/packages/database/drizzle/0032_member_activities_backfill.sql
+++ b/packages/database/drizzle/0032_member_activities_backfill.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS "member_activities" (
+  "id" text PRIMARY KEY NOT NULL,
+  "tenant_id" text NOT NULL REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action,
+  "agent_id" text NOT NULL REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action,
+  "member_id" text NOT NULL REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action,
+  "type" text NOT NULL,
+  "subject" text NOT NULL,
+  "description" text,
+  "occurred_at" timestamp DEFAULT now(),
+  "created_at" timestamp DEFAULT now(),
+  "updated_at" timestamp
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "member_activities_tenant_member_occurred_idx"
+  ON "member_activities" USING btree ("tenant_id", "member_id", "occurred_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "member_activities_tenant_agent_occurred_idx"
+  ON "member_activities" USING btree ("tenant_id", "agent_id", "occurred_at");
+--> statement-breakpoint
+ALTER TABLE public."member_activities" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'member_activities'
+      AND policyname = 'tenant_isolation_member_activities'
+  ) THEN
+    CREATE POLICY "tenant_isolation_member_activities" ON public."member_activities"
+      USING (tenant_id = current_setting('app.current_tenant_id', true)::text);
+  END IF;
+END
+$$;

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1770936797388,
       "tag": "0031_enable_claim_rls",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1771200000000,
+      "tag": "0032_member_activities_backfill",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add idempotent migration `0032_member_activities_backfill.sql`
- create `member_activities` table + indexes + RLS policy
- add migration journal entry

## Scope
- only DB migration + drizzle journal

## Why
- fix prod/repo schema drift causing missing relation `member_activities` (`42P01`) on agent member/client detail pages
