### PR TITLE
test(e2e): avoid re-reading response body in production spec

### DIFF
--- a/apps/web/e2e/production.spec.ts
+++ b/apps/web/e2e/production.spec.ts
@@ -189,9 +189,8 @@ test.describe.serial('@smoke Production Smoke Test Plan', () => {
       });
 
       expect(res.status()).toBe(401);
-      await expect
-        .poll(async () => await res.text(), { message: 'Expected tenant guard denial payload' })
-        .toContain('WRONG_TENANT_CONTEXT');
+      const bodyText = await res.text();
+      expect(bodyText).toContain('WRONG_TENANT_CONTEXT');
     });
   });
 


### PR DESCRIPTION
## Why
The production E2E isolation assertion was re-reading the same Playwright Response body via repeated res.text() calls. Response bodies are single-consume streams, so this caused intermittent body-consumed failures.

## Scope
- Update apps/web/e2e/production.spec.ts to read response text once and assert on the cached value.

## Safety
- Test-only change.
- No runtime product behavior changes.

## Verification
- pnpm --filter @interdomestik/web exec playwright test apps/web/e2e/production.spec.ts --project=ks-sq --grep "Admin \(MK\) CANNOT view KS claims" --reporter=line
