### PR TITLE
fix(release-gate): prevent double-locale staff claim URL

### DIFF
--- a/scripts/release-gate/run.test.ts
+++ b/scripts/release-gate/run.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 const {
+  buildRouteAllowingLocalePath,
   computeRetryDelayMs,
   parseRetryAfterSeconds,
   sessionCacheKeyForAccount,
@@ -39,4 +40,16 @@ test('computeRetryDelayMs keeps jitter within expected bounds', () => {
 test('sessionCacheKeyForAccount keys cache by account label', () => {
   assert.equal(sessionCacheKeyForAccount('admin_ks'), 'Admin-(KS)');
   assert.equal(sessionCacheKeyForAccount('member'), 'Member-only');
+});
+
+test('buildRouteAllowingLocalePath avoids duplicate locale prefixes', () => {
+  const baseUrl = 'https://interdomestik-web.vercel.app';
+  assert.equal(
+    buildRouteAllowingLocalePath(baseUrl, 'en', '/en/staff/claims/claim_123'),
+    'https://interdomestik-web.vercel.app/en/staff/claims/claim_123'
+  );
+  assert.equal(
+    buildRouteAllowingLocalePath(baseUrl, 'en', '/staff/claims/claim_123'),
+    'https://interdomestik-web.vercel.app/en/staff/claims/claim_123'
+  );
 });

--- a/scripts/release-gate/run.ts
+++ b/scripts/release-gate/run.ts
@@ -1383,7 +1383,7 @@ async function runP13(browser, runCtx) {
     if (claimUrlFromEnv && String(claimUrlFromEnv).trim() !== '') {
       detailUrl = claimUrlFromEnv.startsWith('http')
         ? claimUrlFromEnv
-        : buildRoute(runCtx.baseUrl, runCtx.locale, claimUrlFromEnv);
+        : buildRouteAllowingLocalePath(runCtx.baseUrl, runCtx.locale, claimUrlFromEnv);
       evidence.push('claim_source=STAFF_CLAIM_URL');
     } else {
       if (requireClaimUrl) {
@@ -1413,7 +1413,7 @@ async function runP13(browser, runCtx) {
       }
       detailUrl = hrefs[0].startsWith('http')
         ? hrefs[0]
-        : buildRoute(runCtx.baseUrl, runCtx.locale, hrefs[0]);
+        : buildRouteAllowingLocalePath(runCtx.baseUrl, runCtx.locale, hrefs[0]);
       evidence.push('claim_source=staff_claims_list');
     }
 
@@ -1775,6 +1775,7 @@ async function main() {
 }
 
 module.exports = {
+  buildRouteAllowingLocalePath,
   computeRetryDelayMs,
   parseRetryAfterSeconds,
   sessionCacheKeyForAccount,


### PR DESCRIPTION
Harness-only fix for P1.3 fallback URL composition in release gate.

- Use locale-aware route composition for STAFF_CLAIM_URL and fallback href-derived claim URLs.
- Prevents malformed /en/en/... detail URLs that caused P1.3_MISCONFIG_STAFF_CLAIM_URL_UNREACHABLE skips.
- Adds regression test covering duplicate-locale prevention.

No runtime app/proxy/auth behavior changes.