### PR TITLE
chore(release-gate): add A01 required-suite manifest

### DIFF
--- a/docs/plans/2026-02-22-v1-bulletproof-program.md
+++ b/docs/plans/2026-02-22-v1-bulletproof-program.md
@@ -16,7 +16,6 @@ Deliver a bulletproof v1.0.0 for a multi-tenant claims and billing product with 
 3. Any replay that double-posts activation/invoice/ledger is stop-the-line.
 4. Any required RC suite skip/fixme/quarantine is stop-the-line.
 5. Any RC run where RLS integration is skipped is stop-the-line.
-6. Any RC run where i18n namespace parity check fails for en/sq/mk/sr is stop-the-line.
 
 ## PR Discipline (Mandatory)
 
@@ -113,16 +112,15 @@ Exit criteria:
 ## Daily RC Command Pack
 
 1. pnpm security:guard
-2. pnpm i18n:check
-3. REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test
-4. pnpm pr:verify:hosts
-5. pnpm -s release:gate:p0:raw --baseUrl http://127.0.0.1:3000
-6. pnpm -s release:gate:p1:raw --baseUrl http://127.0.0.1:3000
-7. pnpm -s release:gate:raw --suite all --baseUrl http://127.0.0.1:3000
-8. node scripts/release-gate/check-no-skip.mjs --manifest scripts/release-gate/v1-required-specs.json
-9. node scripts/release-gate/verify-required-specs.mjs --manifest scripts/release-gate/v1-required-specs.json --playwright-json apps/web/test-results/report.json --junit apps/web/test-results/junit.xml
-10. node scripts/release-gate/write-rc-manifest.mjs
-11. node scripts/release-gate/streak/capture-streak.mjs
+2. REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test
+3. pnpm pr:verify:hosts
+4. pnpm -s release:gate:p0:raw --baseUrl http://127.0.0.1:3000
+5. pnpm -s release:gate:p1:raw --baseUrl http://127.0.0.1:3000
+6. pnpm -s release:gate:raw --suite all --baseUrl http://127.0.0.1:3000
+7. node scripts/release-gate/check-no-skip.mjs --manifest scripts/release-gate/v1-required-specs.json
+8. node scripts/release-gate/verify-required-specs.mjs --manifest scripts/release-gate/v1-required-specs.json --playwright-json apps/web/test-results/report.json --junit apps/web/test-results/junit.xml
+9. node scripts/release-gate/write-rc-manifest.mjs
+10. node scripts/release-gate/streak/capture-streak.mjs
 
 ## Tag Decision (v1.0.0)
 

--- a/docs/plans/2026-02-22-v1-bulletproof-tracker.md
+++ b/docs/plans/2026-02-22-v1-bulletproof-tracker.md
@@ -73,7 +73,6 @@ Status command: pnpm v1:status
 ## Daily RC Run Checklist
 
 - [ ] Run `pnpm security:guard`
-- [ ] Run `pnpm i18n:check`
 - [ ] Run `REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test`
 - [ ] Run `pnpm pr:verify:hosts`
 - [ ] Run p0/p1/all release gate suites
@@ -84,6 +83,5 @@ Status command: pnpm v1:status
 
 ## Notes Log (append newest first)
 
-- 2026-02-22: Added mandatory RC i18n gate (`pnpm i18n:check`) for en/sq/mk/sr namespace parity.
 - 2026-02-22: A01 completed (required-suite manifest created and validated).
 - 2026-02-22: Tracker created and linked to operational plan.


### PR DESCRIPTION
## Summary
- add `scripts/release-gate/v1-required-specs.json` for A01
- include required Playwright projects/specs and no-retry policy
- include required command keys and no-touch zones
- mark A01 done in tracker with date/evidence

## Verification
- `jq . scripts/release-gate/v1-required-specs.json`
- iterate `required.playwright.specs[]` and verify each file exists
