### PR TITLE
feat: complete A05 Playwright gate reporters

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -23,6 +23,9 @@ const MK_MEMBER_STATE = path.join(AUTH_DIR, 'mk', 'member.json');
 const GATE_STATE_DIR = path.resolve(__dirname, '.playwright', 'state');
 const GATE_KS_STATE = path.join(GATE_STATE_DIR, 'ks.json');
 const GATE_MK_STATE = path.join(GATE_STATE_DIR, 'mk.json');
+const TEST_RESULTS_DIR = path.resolve(__dirname, 'test-results');
+const JUNIT_REPORT_FILE = path.join(TEST_RESULTS_DIR, 'junit.xml');
+const JSON_REPORT_FILE = path.join(TEST_RESULTS_DIR, 'report.json');
 
 function requireState(statePath: string) {
   if (fs.existsSync(statePath)) return;
@@ -69,6 +72,8 @@ function loadEnvManual(envPath: string) {
 
 envPaths.forEach(loadEnvManual);
 
+fs.mkdirSync(TEST_RESULTS_DIR, { recursive: true });
+
 if (!process.env.DATABASE_URL) {
   console.log('⚠️ DATABASE_URL not found, using default local fallback.');
   process.env.DATABASE_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
@@ -80,7 +85,18 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 4 : '50%',
-  reporter: process.env.CI ? [['html'], ['list']] : [['list']],
+  reporter: process.env.CI
+    ? [
+        ['html'],
+        ['list'],
+        ['junit', { outputFile: JUNIT_REPORT_FILE }],
+        ['json', { outputFile: JSON_REPORT_FILE }],
+      ]
+    : [
+        ['list'],
+        ['junit', { outputFile: JUNIT_REPORT_FILE }],
+        ['json', { outputFile: JSON_REPORT_FILE }],
+      ],
   timeout: 60 * 1000,
   snapshotDir: './e2e/snapshots',
   expect: {

--- a/docs/plans/2026-02-22-v1-bulletproof-tracker.md
+++ b/docs/plans/2026-02-22-v1-bulletproof-tracker.md
@@ -23,12 +23,13 @@ Status command: pnpm v1:status
 - [x] A02 - Required-suite no-skip checker added at `scripts/release-gate/check-no-skip.mjs` | Date: 2026-02-22 | Evidence: `node scripts/release-gate/check-no-skip.mjs --manifest scripts/release-gate/v1-required-specs.json` + temp-manifest injected `test.skip` exits 1
 - [x] A03 - RC evidence manifest writer added at `scripts/release-gate/write-rc-manifest.mjs` | Date: 2026-02-22 | Evidence: `node scripts/release-gate/write-rc-manifest.mjs --manifest scripts/release-gate/v1-required-specs.json --run-id test-run --results-dir tmp/release-rc/test-run/results --logs-dir tmp/release-rc/test-run/logs` + `jq . tmp/release-rc/test-run/rc.json` + `tmp/release-rc/test-run/rc.json.sha256`
 - [x] A04 - Streak anchor/capture scripts added at `scripts/release-gate/streak/compute-anchor.mjs` and `scripts/release-gate/streak/capture-streak.mjs` | Date: 2026-02-22 | Evidence: `node scripts/release-gate/streak/compute-anchor.mjs` + `node scripts/release-gate/streak/capture-streak.mjs` + `tmp/release-streak/2026-02-22/run-2026-02-22T21-19-34-841Z-e012d7af/pack.sha256`
+- [x] A05 - Playwright gate reporters emit JUnit/XML and JSON outputs at `apps/web/test-results/junit.xml` and `apps/web/test-results/report.json` | Date: 2026-02-22 | Evidence: `pnpm --filter @interdomestik/web exec playwright test e2e/gate --project=gate-ks-sq --workers=1` + `test -f apps/web/test-results/junit.xml` + `test -f apps/web/test-results/report.json`
 
 ## Next Up (work top-down)
 
-1. A05 - Update Playwright to emit JUnit and JSON reports
-2. A06 - Add release-candidate workflow
-3. A07 - Make secret scan blocking on `release/*` and `rc/*`
+1. A06 - Add release-candidate workflow
+2. A07 - Make secret scan blocking on `release/*` and `rc/*`
+3. A08 - Enforce mandatory RLS integration for RC (`REQUIRE_RLS_INTEGRATION=1`)
 
 ## Milestone Actions
 
@@ -38,7 +39,7 @@ Status command: pnpm v1:status
 - [x] A02 - Enforce no skip/fixme/quarantine in required suites. Verify: `node scripts/release-gate/check-no-skip.mjs --manifest scripts/release-gate/v1-required-specs.json` | Date: 2026-02-22 | Evidence: emits `file:line: matched_token` and exits non-zero on violations
 - [x] A03 - Write rc.json evidence contract. Verify: `node scripts/release-gate/write-rc-manifest.mjs --manifest scripts/release-gate/v1-required-specs.json --run-id test-run --results-dir tmp/release-rc/test-run/results --logs-dir tmp/release-rc/test-run/logs` | Date: 2026-02-22 | Evidence: `tmp/release-rc/test-run/rc.json` + `tmp/release-rc/test-run/rc.json.sha256` + `checks.rls_integration_ran=true`
 - [x] A04 - Add streak anchor and daily capture scripts. Verify: `node scripts/release-gate/streak/compute-anchor.mjs && node scripts/release-gate/streak/capture-streak.mjs` | Date: 2026-02-22 | Evidence: `anchor_sha=bccc12e6333ebb0f8d916d483d3c4f529ff45ac4` + `tmp/release-streak/2026-02-22/run-2026-02-22T21-19-34-841Z-e012d7af/pack.sha256`
-- [ ] A05 - Update Playwright to emit JUnit and JSON reports. Verify: `pnpm --filter @interdomestik/web exec playwright test e2e/gate --project=gate-ks-sq --workers=1`
+- [x] A05 - Update Playwright to emit JUnit and JSON reports. Verify: `pnpm --filter @interdomestik/web exec playwright test e2e/gate --project=gate-ks-sq --workers=1` | Date: 2026-02-22 | Evidence: `apps/web/playwright.config.ts` reporter includes `junit` + `json` outputFile settings and gate run emits both files in `apps/web/test-results/`
 - [ ] A06 - Add release-candidate workflow. Verify: run `.github/workflows/release-candidate.yml` on `rc/*` branch
 - [ ] A07 - Make secret scan blocking on `release/*` and `rc/*`. Verify: security workflow fails on seeded secret
 
@@ -85,6 +86,7 @@ Status command: pnpm v1:status
 
 ## Notes Log (append newest first)
 
+- 2026-02-22: A05 handoff completed: Atlas confirmed scope/path (`apps/web/playwright.config.ts` only, no boundary-owned paths), Forge implemented reporter outputs, Gatekeeper verified gate command + reporter artifacts; Sentinel review not required.
 - 2026-02-22: A04 handoff completed: Atlas confirmed A04 scope/dependencies (`scripts/release-gate/streak/*` + tracker evidence update), Runway implemented, Gatekeeper verified via required local commands; Sentinel review not required (no boundary-owned paths touched).
 - 2026-02-22: A04 completed (added streak anchor/capture scripts with repo-relative path handling, immutable run directory policy, and pack-level SHA256 checksums).
 - 2026-02-22: A03 completed (RC evidence manifest writer added; emits `rc.json` and `rc.json.sha256`, with `checks.rls_integration_ran=true` from `rls.log` marker).


### PR DESCRIPTION
## Summary
- update apps/web/playwright.config.ts to emit junit and json reporter outputs into apps/web/test-results
- preserve existing list/html reporter behavior for current gate lanes
- update A05 completion and handoff evidence in tracker

## Verification
- pnpm --filter @interdomestik/web exec playwright test e2e/gate --project=gate-ks-sq --workers=1
- test -f apps/web/test-results/junit.xml
- test -f apps/web/test-results/report.json
