### PR TITLE
fix: enforce mandatory RLS integration execution for RC (A08)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -140,8 +140,6 @@ jobs:
           set +e
           REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test 2>&1 | tee "${log_file}"
           exit_code=${PIPESTATUS[0]}
-          # Required by write-rc-manifest.mjs to prove the RLS integration check ran.
-          echo "RLS_INTEGRATION_RAN=1" | tee -a "${log_file}"
           set -e
           printf '%s\n' "${exit_code}" > "${RC_LOGS_DIR}/rls.exit"
           exit "${exit_code}"

--- a/docs/plans/2026-02-22-v1-bulletproof-tracker.md
+++ b/docs/plans/2026-02-22-v1-bulletproof-tracker.md
@@ -1,6 +1,6 @@
 # V1.0.0 Bulletproof Tracker
 
-Last updated: 2026-02-22
+Last updated: 2026-02-23
 Current phase: M0-A (Gate Foundation)
 Plan reference: docs/plans/2026-02-22-v1-bulletproof-program.md
 Status command: pnpm v1:status
@@ -26,11 +26,11 @@ Status command: pnpm v1:status
 - [x] A05 - Playwright gate reporters emit JUnit/XML and JSON outputs at `apps/web/test-results/junit.xml` and `apps/web/test-results/report.json` | Date: 2026-02-22 | Evidence: `pnpm --filter @interdomestik/web exec playwright test e2e/gate --project=gate-ks-sq --workers=1` + `test -f apps/web/test-results/junit.xml` + `test -f apps/web/test-results/report.json`
 - [x] A06 - Release-candidate workflow added at `.github/workflows/release-candidate.yml` | Date: 2026-02-22 | Evidence: `https://github.com/interdomestik/interdomestik/actions/runs/22286625815` + artifact `release-candidate-artifacts-22286625815-1`
 - [x] A07 - Secret scan blocking on `release/*` and `rc/*` in security workflows | Date: 2026-02-22 | Evidence: `rg -n "continue-on-error:\\s*true|gitleaks|secret" .github/workflows/security.yml .github/workflows/secret-scan.yml` + PR runs `22287449326` (Security) / `22287449314` (Secret Scan) + RC smoke runs `22287448408` (Security) / `22287448415` (Secret Scan)
+- [x] A08 - Enforce mandatory RLS integration for RC (`REQUIRE_RLS_INTEGRATION=1`) | Date: 2026-02-23 | Evidence: `REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test` exits non-zero when `DATABASE_URL` is missing; `pnpm db:rls:test` preserves local skip ergonomics when DB env is absent; `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test` prints `RLS_INTEGRATION_RAN=1`
 
 ## Next Up (work top-down)
 
-1. A08 - Enforce mandatory RLS integration for RC (`REQUIRE_RLS_INTEGRATION=1`)
-2. A09 - Unify tenant resolver usage in sensitive surfaces
+1. A09 - Unify tenant resolver usage in sensitive surfaces
 
 ## Milestone Actions
 
@@ -46,7 +46,7 @@ Status command: pnpm v1:status
 
 ### M0-B Security and Isolation Closure (2026-02-28 to 2026-03-08)
 
-- [ ] A08 - Enforce mandatory RLS integration for RC (`REQUIRE_RLS_INTEGRATION=1`). Verify: `REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test`
+- [x] A08 - Enforce mandatory RLS integration for RC (`REQUIRE_RLS_INTEGRATION=1`). Verify: `REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test` | Date: 2026-02-23 | Evidence: required mode hard-fails on missing `DATABASE_URL` and missing RLS/policy prerequisites; RC marker is emitted only by integration run path (`RLS_INTEGRATION_RAN=1`)
 - [ ] A09 - Unify tenant resolver usage in sensitive surfaces. Verify: targeted unit tests + isolation scenario
 - [ ] A10 - Enforce member upload ownership. Verify: upload/member action unit tests
 - [ ] A11 - Implement fail-closed rate limits on sensitive endpoints. Verify: rate-limit core unit tests
@@ -87,6 +87,7 @@ Status command: pnpm v1:status
 
 ## Notes Log (append newest first)
 
+- 2026-02-23: A08 handoff status: Atlas confirmed boundary-impacting scope (`packages/database/test/rls-engaged.test.ts` + RC workflow marker path), Forge implemented required-mode hard-fail behavior and integration-only marker emission, Sentinel pre-review completed for `packages/database` changes, Gatekeeper verified required/non-required/integration-capable command evidence (`REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test`, `pnpm db:rls:test`, `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test`); Sentinel post-review pending before merge.
 - 2026-02-22: A07 handoff completed: Atlas confirmed A07 scope/touched files (`.github/workflows/security.yml`, `.github/workflows/secret-scan.yml`), Runway implemented rc/release triggers + blocking gitleaks CLI with SARIF artifact uploads, Gatekeeper verified `rg` policy check and PR/RC workflow evidence (`22287449326`, `22287449314`, `22287448408`, `22287448415`); Sentinel review not required (no boundary-owned product paths touched).
 - 2026-02-22: A06 handoff completed: Atlas confirmed A06 slice/dependencies (`.github/workflows/release-candidate.yml` + tracker evidence update; A04/A05 present), Runway implemented RC orchestration, Gatekeeper verified formatting + RC branch run `22286625815` and artifact upload `release-candidate-artifacts-22286625815-1`; Sentinel review not required (no boundary-owned product paths touched).
 - 2026-02-22: A05 handoff completed: Atlas confirmed scope/path (`apps/web/playwright.config.ts` only, no boundary-owned paths), Forge implemented reporter outputs, Gatekeeper verified gate command + reporter artifacts; Sentinel review not required.


### PR DESCRIPTION
## Summary
- enforce `REQUIRE_RLS_INTEGRATION=1` hard-fail behavior in `packages/database/test/rls-engaged.test.ts`
- keep non-required local mode skip ergonomics when DB env/prereqs are absent
- emit `RLS_INTEGRATION_RAN=1` only from the real integration test path
- remove unconditional marker append from RC workflow RLS step to prevent false positives
- update A08 completion evidence in tracker

## Verification
- `REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test` (fails non-zero when `DATABASE_URL` is absent)
- `pnpm db:rls:test` (passes with skip when DB env is absent)
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres REQUIRE_RLS_INTEGRATION=1 pnpm db:rls:test` (prints `RLS_INTEGRATION_RAN=1`)
