### PR TITLE
PR-13 A13: add AL dark tenant config and KS/MK/AL isolation matrix

### DIFF
--- a/apps/web/e2e/pilot/_host.ts
+++ b/apps/web/e2e/pilot/_host.ts
@@ -1,0 +1,29 @@
+import type { TestInfo } from '@playwright/test';
+
+const DEFAULT_MK_HOST = 'mk.127.0.0.1.nip.io:3000';
+
+export function resolveActorHost(testInfo: TestInfo): string {
+  if (process.env.C2_ACTOR_HOST) {
+    return process.env.C2_ACTOR_HOST;
+  }
+
+  const forwardedHost = testInfo.project.use.extraHTTPHeaders?.['x-forwarded-host'];
+  if (typeof forwardedHost === 'string' && forwardedHost.trim().length > 0) {
+    return forwardedHost;
+  }
+
+  const baseURL = testInfo.project.use.baseURL?.toString();
+  if (baseURL) {
+    try {
+      return new URL(baseURL).host;
+    } catch {
+      // Ignore malformed baseURL and fall through to env/default fallback.
+    }
+  }
+
+  return process.env.MK_HOST ?? DEFAULT_MK_HOST;
+}
+
+export function isAlActorHost(host: string): boolean {
+  return host.toLowerCase().startsWith('al.');
+}

--- a/apps/web/src/lib/proxy-logic.ts
+++ b/apps/web/src/lib/proxy-logic.ts
@@ -12,7 +12,9 @@ const SESSION_COOKIE_NAMES = [
   '__Host-better-auth.session_token',
 ] as const;
 
-function resolveTenantFromHost(host: string): 'tenant_mk' | 'tenant_ks' | 'pilot-mk' | null {
+function resolveTenantFromHost(
+  host: string
+): 'tenant_mk' | 'tenant_ks' | 'tenant_al' | 'pilot-mk' | null {
   const canonicalTenant = resolveTenantFromCanonicalHost(host);
   if (canonicalTenant) return canonicalTenant;
 


### PR DESCRIPTION
## Summary
- add `tenant_al` dark-tenant host resolution support in tenant host mapping (`AL_HOST`, canonical/local/nip.io matching) without changing canonical route/proxy authority
- add AL gate project wiring (`gate-al-sq`) and pilot matrix-aware gate project test selection so the requested pilot isolation command executes deterministically
- add AL-focused test delta:
  - unit: tenant host resolver coverage for AL
  - e2e: AL-host execution proof in C2-03 via resolved project host (`C2_03_ACTOR_HOST=al...`)
- fix latent pilot scenario wiring uncovered by gate execution:
  - persist `SCENARIO_S1_CLAIM_ID` between serial tests
  - run S1 isolation with explicit MK-admin context (matches test intent)

## Handoff checkpoints
- Atlas: scope/acceptance criteria confirmed for A13-only slice
- Forge: implementation + test wiring completed
- Sentinel pre-review: completed for tenant/proxy boundary files (`tenant-hosts.ts`, `proxy-logic.ts`) with additive-only review
- Gatekeeper: verification commands executed (see below)
- Sentinel post-review: required before merge (boundary-impacting changes)

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/lib/tenant/tenant-hosts.test.ts`
- `KS_HOST=ks.127.0.0.1.nip.io:3000 MK_HOST=mk.127.0.0.1.nip.io:3000 AL_HOST=al.127.0.0.1.nip.io:3000 PILOT_HOST=pilot.127.0.0.1.nip.io:3000 pnpm --filter @interdomestik/web exec playwright test e2e/pilot/scenario-01-ks-e2e.spec.ts e2e/pilot/c2-02-cross-tenant-artifact-isolation.spec.ts e2e/pilot/c2-03-cross-tenant-write-isolation.spec.ts e2e/pilot/c2-04-cross-tenant-staff-member-write-isolation.spec.ts --project=gate-ks-sq --project=gate-mk-mk --project=gate-al-sq --workers=1 --max-failures=1`
- `pnpm pr:finalize` (currently blocked until PR context existed; rerunning now that PR is opened)
