### PR TITLE
fix: fallback pricing checkout in local development

### DIFF
--- a/apps/web/src/components/pricing/pricing-table.test.tsx
+++ b/apps/web/src/components/pricing/pricing-table.test.tsx
@@ -163,6 +163,25 @@ describe('PricingTable', () => {
     });
   });
 
+  it('keeps billing test success URL contract with test flag first', async () => {
+    vi.useFakeTimers();
+
+    try {
+      render(<PricingTable userId="user-123" email="test@example.com" billingTestMode />);
+
+      const joinButtons = screen.getAllByText('cta');
+      fireEvent.click(joinButtons[0]);
+
+      await vi.runAllTimersAsync();
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        `/member/membership/success?test=true&priceId=${PADDLE_PRICES.standard.yearly}&planId=standard`
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('falls back to simulated checkout in development when client token is missing', async () => {
     vi.stubEnv('NODE_ENV', 'development');
     vi.stubEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN', '');

--- a/apps/web/src/components/pricing/pricing-table.tsx
+++ b/apps/web/src/components/pricing/pricing-table.tsx
@@ -107,10 +107,12 @@ export function PricingTable({ userId, email, billingTestMode }: PricingTablePro
     includeBillingTestFlag: boolean
   ) => {
     await new Promise(resolve => setTimeout(resolve, 1000));
-    const params = new URLSearchParams({ priceId, planId });
+    const params = new URLSearchParams();
     if (includeBillingTestFlag) {
       params.set('test', 'true');
     }
+    params.set('priceId', priceId);
+    params.set('planId', planId);
     router.push(`/member/membership/success?${params.toString()}`);
   };
 


### PR DESCRIPTION
## Summary\n- add a development-only checkout fallback when Paddle client token is missing/uninitialized\n- preserve strict behavior in non-development environments by keeping the payment-unavailable alert\n- add regression test coverage for the dev fallback path\n\n## Verification\n- pnpm --filter @interdomestik/web test:unit --run src/components/pricing/pricing-table.test.tsx\n- pnpm --filter @interdomestik/web type-check