### PR TITLE
fix: narrow multi-agent hardening triggers

### DIFF
--- a/scripts/ci/multi-agent-policy-lib.mjs
+++ b/scripts/ci/multi-agent-policy-lib.mjs
@@ -3,12 +3,11 @@ const HIGH_RISK_LABELS = new Set(['ci:multi-agent', 'release-hardening', 'securi
 const HIGH_RISK_PATTERNS = [
   /^scripts\/multi-agent\//,
   /^scripts\/release-gate\//,
-  /^scripts\/(?:security-guard|pr-verify-hosts|m4-gatekeeper|docker-gate|sentry-seer-sweep|sonar-gate|sonar-scan(?:-lib)?)\.(?:mjs|sh)$/,
+  /^scripts\/(?:security-guard|pr-verify-hosts|m4-gatekeeper|sentry-seer-sweep|sonar-gate|sonar-scan(?:-lib)?)\.(?:mjs|sh)$/,
   /^apps\/web\/src\/proxy\.ts$/,
   /^packages\/database\/drizzle\//,
   /^packages\/database\/src\//,
   /^packages\/shared-auth\//,
-  /^pnpm-lock\.yaml$/,
   /^turbo\.json$/,
 ];
 
@@ -35,7 +34,6 @@ const HIGH_RISK_PACKAGE_JSON_SECTIONS = [
 ];
 
 const HIGH_RISK_PACKAGE_JSON_PNPM_KEYS = [
-  'overrides',
   'patchedDependencies',
   'onlyBuiltDependencies',
   'neverBuiltDependencies',

--- a/scripts/ci/multi-agent-policy.test.mjs
+++ b/scripts/ci/multi-agent-policy.test.mjs
@@ -105,6 +105,36 @@ test('routing authority changes trigger full multi-agent hardening', () => {
   );
 });
 
+test('local docker workflow changes skip full multi-agent hardening', () => {
+  assert.deepEqual(
+    evaluateMultiAgentPolicy({
+      eventName: 'pull_request',
+      labels: [],
+      changedFiles: ['scripts/docker-gate.sh', 'docker-compose.yml'],
+    }),
+    {
+      shouldRun: false,
+      reason: 'default_skip_non_risky_pr',
+      matchedPaths: [],
+    }
+  );
+});
+
+test('lockfile-only changes skip full multi-agent hardening', () => {
+  assert.deepEqual(
+    evaluateMultiAgentPolicy({
+      eventName: 'pull_request',
+      labels: [],
+      changedFiles: ['pnpm-lock.yaml'],
+    }),
+    {
+      shouldRun: false,
+      reason: 'default_skip_non_risky_pr',
+      matchedPaths: [],
+    }
+  );
+});
+
 test('normal product changes skip full multi-agent hardening', () => {
   assert.deepEqual(
     evaluateMultiAgentPolicy({
@@ -114,6 +144,39 @@ test('normal product changes skip full multi-agent hardening', () => {
         'apps/web/src/features/member/home.tsx',
         'apps/web/src/features/member/home.test.tsx',
       ],
+    }),
+    {
+      shouldRun: false,
+      reason: 'default_skip_non_risky_pr',
+      matchedPaths: [],
+    }
+  );
+});
+
+test('root package.json pnpm override changes skip full multi-agent hardening', () => {
+  const packageJsonRisk = evaluatePackageJsonRisk({
+    beforeContent: JSON.stringify({
+      pnpm: {
+        overrides: {
+          axios: '^1.0.0',
+        },
+      },
+    }),
+    afterContent: JSON.stringify({
+      pnpm: {
+        overrides: {
+          axios: '^1.1.0',
+        },
+      },
+    }),
+  });
+
+  assert.deepEqual(
+    evaluateMultiAgentPolicy({
+      eventName: 'pull_request',
+      labels: [],
+      changedFiles: ['package.json'],
+      packageJsonRisk,
     }),
     {
       shouldRun: false,


### PR DESCRIPTION
## Summary
- stop full multi-agent hardening from triggering on local docker workflow changes
- stop lockfile-only and pnpm override-only changes from forcing full hardening
- add policy tests covering the narrowed trigger rules

## Verification
- node --test scripts/ci/multi-agent-policy.test.mjs
