### PR TITLE
fix: harden staff claims queue usability

### DIFF
--- a/apps/web/e2e/staff-claims-queue.spec.ts
+++ b/apps/web/e2e/staff-claims-queue.spec.ts
@@ -30,6 +30,12 @@ test.describe('Staff Claims Queue MVP', () => {
     await expect(page.getByTestId('staff-claims-row')).toHaveCount(1);
     await expect(page.getByTestId('staff-claim-title')).toHaveText([firstTitle]);
 
+    const cookieBanner = page.getByTestId('cookie-consent-banner');
+    if (await cookieBanner.isVisible().catch(() => false)) {
+      await page.getByTestId('cookie-consent-decline').click();
+      await expect(cookieBanner).toHaveCount(0);
+    }
+
     await page.getByTestId('staff-claims-view').first().click();
     await expect(page).toHaveURL(/\/staff\/claims\/[^/]+$/);
     await expect(page.getByTestId('staff-claim-detail-ready')).toBeVisible();

--- a/apps/web/e2e/staff.spec.ts
+++ b/apps/web/e2e/staff.spec.ts
@@ -6,67 +6,62 @@ function getLocaleForProject(projectName: string): string {
   return projectName.includes('mk') ? 'mk' : 'sq';
 }
 
-test.describe('@legacy Staff Claim Management', () => {
-  test('Staff can view dashboard stats and recent claims', async ({
+test.describe('Staff Claim Management', () => {
+  test('Staff lands on the canonical queue-first staff surface', async ({
     staffPage: page,
   }, testInfo) => {
     const locale = getLocaleForProject(testInfo.project.name);
-    await gotoApp(page, routes.staff(locale), testInfo, { marker: 'domcontentloaded' });
+    await gotoApp(page, routes.staff(locale), testInfo, { marker: 'staff-page-ready' });
 
-    // Logged-in marker(s) that are not localized.
-    const authMarker = page
-      .getByTestId('user-nav')
-      .or(page.getByTestId('sidebar-user-menu-button'));
-    await expect(authMarker.first()).toBeVisible({ timeout: 15000 });
-
-    // Stable staff dashboard structure (avoid translated strings).
-    await expect(page.locator('h1').first()).toBeVisible({ timeout: 15000 });
-    await expect(page.locator('a[href$="/staff/claims"]').first()).toBeVisible({ timeout: 15000 });
-    await expect(page.getByTestId('agent-stats-cards')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('staff-page-ready')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('page-title')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('staff-claims-queue')).toBeVisible({ timeout: 15000 });
   });
 
   test('Staff can view and navigate claims queue', async ({ staffPage: page }, testInfo) => {
     const locale = getLocaleForProject(testInfo.project.name);
-    await gotoApp(page, routes.staffClaims(locale), testInfo, { marker: 'domcontentloaded' });
+    await gotoApp(page, routes.staffClaims(locale), testInfo, { marker: 'staff-page-ready' });
 
     await expect(page.getByTestId('page-title')).toBeVisible({ timeout: 15000 });
-    await expect(page.getByTestId('ops-table')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('staff-claims-queue')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('staff-claims-assignment-filters')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId('staff-claims-status-filters')).toBeVisible({ timeout: 15000 });
 
     // Seeded data can be empty in some environments; accept either rows or empty state.
     const rowOrEmpty = page
-      .getByTestId('ops-table-row')
+      .getByTestId('staff-claims-row')
       .first()
-      .or(page.getByTestId('ops-table-empty'));
+      .or(page.getByTestId('staff-claims-empty'));
     await expect(rowOrEmpty).toBeVisible({ timeout: 15000 });
   });
 
   test('Staff can view claim details', async ({ staffPage: page }, testInfo) => {
     const locale = getLocaleForProject(testInfo.project.name);
-    await gotoApp(page, routes.staffClaims(locale), testInfo, { marker: 'domcontentloaded' });
+    await gotoApp(page, routes.staffClaims(locale), testInfo, { marker: 'staff-page-ready' });
 
-    await expect(page.getByTestId('ops-table')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('staff-claims-queue')).toBeVisible({ timeout: 15000 });
 
     // If there are no claims, assert empty and exit.
-    if (await page.getByTestId('ops-table-empty').isVisible()) {
-      await expect(page.getByTestId('ops-table-empty')).toBeVisible({ timeout: 15000 });
+    if (await page.getByTestId('staff-claims-empty').isVisible()) {
+      await expect(page.getByTestId('staff-claims-empty')).toBeVisible({ timeout: 15000 });
       return;
     }
 
-    const firstRow = page.getByTestId('ops-table-row').first();
+    const firstRow = page.getByTestId('staff-claims-row').first();
     await expect(firstRow).toBeVisible({ timeout: 15000 });
 
-    // Click the first action link (Review / View Status / Message alert).
-    const firstActionLink = firstRow.getByTestId('ops-table-actions').getByRole('link').first();
+    const firstActionLink = firstRow.getByTestId('staff-claims-view').first();
     await expect(firstActionLink).toBeVisible({ timeout: 15000 });
     await firstActionLink.click();
 
     await expect(page).toHaveURL(/\/staff\/claims\//, { timeout: 15000 });
 
-    // Details page: structural assertions (avoid translated strings).
     await expect(page.locator('a[href$="/staff/claims"]').first()).toBeVisible({ timeout: 15000 });
-    await expect(page.locator('h1').first()).toBeVisible({ timeout: 15000 });
-    const tabs = page.getByRole('tab');
-    await expect(tabs).toHaveCount(3, { timeout: 15000 });
+    await expect(page.getByTestId('staff-claim-detail-ready')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('staff-claim-detail-member')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('staff-claim-detail-agent')).toBeVisible({ timeout: 15000 });
   });
 
   // Skip this test - it modifies data and may fail due to toast timing

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.test.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.test.tsx
@@ -92,6 +92,8 @@ vi.mock('next-intl/server', () => ({
       'details.sla_phase.running': 'Running',
       'details.sla_phase.incomplete': 'Waiting for member information',
       'details.sla_phase.not_applicable': 'Not active',
+      'details.branch_manager_readonly_notice':
+        'Branch managers can review claim status and member context here, but assignment, messaging, and claim actions remain staff-only in the pilot.',
     };
 
     return translations[key] || key;
@@ -177,5 +179,29 @@ describe('StaffClaimDetailsPage', () => {
         }),
       })
     );
+  });
+
+  it('shows a read-only operator notice for branch managers', async () => {
+    hoisted.getSessionMock.mockResolvedValueOnce({
+      user: {
+        id: 'manager-1',
+        tenantId: 'tenant-ks',
+        role: 'branch_manager',
+        branchId: 'branch-a',
+      },
+    });
+
+    const tree = await StaffClaimDetailsPage({
+      params: Promise.resolve({
+        locale: 'en',
+        id: 'claim-1',
+      }),
+    });
+
+    render(tree);
+
+    expect(screen.getByTestId('staff-claim-readonly-notice')).toBeInTheDocument();
+    expect(screen.queryByTestId('staff-claim-messaging-panel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('staff-claim-action-panel')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
@@ -199,6 +199,15 @@ export default async function StaffClaimDetailsPage({ params }: PageProps) {
         </div>
       </section>
 
+      {session.user.role === 'branch_manager' ? (
+        <section
+          className="rounded-lg border border-sky-200 bg-sky-50 p-4 text-sm text-sky-950"
+          data-testid="staff-claim-readonly-notice"
+        >
+          {tClaims('details.branch_manager_readonly_notice')}
+        </section>
+      ) : null}
+
       {session.user.role === 'staff' ? (
         <section
           className="rounded-lg border bg-white p-4"

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/_core.entry.test.tsx
@@ -51,6 +51,29 @@ vi.mock('@/components/dashboard/claims/claim-status-badge', () => ({
 }));
 
 vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn(async () => (key: string, values?: Record<string, string | number>) => {
+    const translations: Record<string, string> = {
+      'staff_queue.subtitle': 'What needs action today.',
+      'staff_queue.results_count': values?.count === 1 ? '1 claim' : `${values?.count} claims`,
+      'staff_queue.search_placeholder': 'Search claim, member, company, or number',
+      'staff_queue.search': 'Search',
+      'staff_queue.clear_search': 'Clear',
+      'staff_queue.assignment_filter_label': 'Assignment filter',
+      'staff_queue.status_filter_label': 'Status filter',
+      'staff_queue.all_actionable': 'All actionable',
+      'staff_queue.empty_filtered': 'No claims match the current filters',
+      'staff_queue.empty_default': 'No claims in queue',
+      'staff_queue.assignment_state.unassigned': 'Unassigned',
+      'staff_queue.assignment_state.assigned_to_you': 'Assigned to you',
+      'staff_queue.assignment_state.assigned': 'Assigned',
+    };
+
+    if (key === 'staff_queue.assignment_state.assigned_to_named') {
+      return `Assigned to ${values?.name}`;
+    }
+
+    return translations[key] || key;
+  }),
   setRequestLocale: vi.fn(),
 }));
 
@@ -93,7 +116,85 @@ describe('StaffClaimsPage', () => {
       staffId: 'manager-1',
       status: 'verification',
       tenantId: 'tenant-ks',
+      viewerRole: 'branch_manager',
     });
     expect(screen.getByTestId('staff-page-ready')).toBeInTheDocument();
+  });
+
+  it('shows assignment state labels in the queue for staff operators', async () => {
+    hoisted.getSessionMock.mockResolvedValueOnce({
+      user: {
+        id: 'staff-1',
+        role: 'staff',
+        tenantId: 'tenant-ks',
+        branchId: 'branch-1',
+      },
+    });
+    hoisted.getStaffClaimsListMock.mockResolvedValueOnce([
+      {
+        id: 'claim-mine',
+        claimNumber: 'KS-0001',
+        companyName: 'Acme',
+        title: 'Mine',
+        status: 'verification',
+        stageLabel: 'Verification',
+        updatedAt: '2026-03-01T00:00:00.000Z',
+        memberName: 'Member One',
+        memberNumber: 'M-001',
+        staffId: 'staff-1',
+      },
+      {
+        id: 'claim-open',
+        claimNumber: 'KS-0002',
+        companyName: 'Acme',
+        title: 'Open',
+        status: 'submitted',
+        stageLabel: 'Submitted',
+        updatedAt: '2026-03-01T00:00:00.000Z',
+        memberName: 'Member Two',
+        memberNumber: 'M-002',
+        staffId: null,
+      },
+      {
+        id: 'claim-other',
+        claimNumber: 'KS-0003',
+        companyName: 'Acme',
+        title: 'Other',
+        status: 'evaluation',
+        stageLabel: 'Evaluation',
+        updatedAt: '2026-03-01T00:00:00.000Z',
+        memberName: 'Member Three',
+        memberNumber: 'M-003',
+        staffId: 'staff-99',
+        assigneeName: 'Agim Ramadani',
+        assigneeEmail: 'agim@example.com',
+      },
+    ] as any);
+
+    const tree = await StaffClaimsPage({
+      params: Promise.resolve({ locale: 'en' }),
+      searchParams: Promise.resolve({}),
+    });
+
+    render(tree);
+
+    expect(
+      screen.getAllByTestId('staff-claim-assignment-state').map(node => node.textContent)
+    ).toEqual(['Assigned to you', 'Unassigned', 'Assigned to Agim Ramadani']);
+    expect(screen.getByTestId('staff-claims-results-count')).toHaveTextContent('3 claims');
+  });
+
+  it('labels the filter groups as filters instead of tabs', async () => {
+    const tree = await StaffClaimsPage({
+      params: Promise.resolve({ locale: 'en' }),
+      searchParams: Promise.resolve({}),
+    });
+
+    render(tree);
+
+    expect(screen.getByTestId('staff-claims-assignment-filters')).toHaveTextContent(
+      'Assignment filter'
+    );
+    expect(screen.getByTestId('staff-claims-status-filters')).toHaveTextContent('Status filter');
   });
 });

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/_core.entry.tsx
@@ -3,7 +3,7 @@ import { Link } from '@/i18n/routing';
 import { auth } from '@/lib/auth';
 import { ACTIONABLE_CLAIM_STATUSES, getStaffClaimsList } from '@interdomestik/domain-claims';
 import { Button, Input } from '@interdomestik/ui';
-import { setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 
@@ -78,9 +78,31 @@ function buildStaffClaimsHref(args: {
   return query ? `/${args.locale}/staff/claims?${query}` : `/${args.locale}/staff/claims`;
 }
 
+function getAssignmentStateLabel(args: {
+  assigneeId: string | null;
+  assigneeName?: string | null;
+  assigneeEmail?: string | null;
+  currentStaffId: string;
+  t: (key: string, values?: Record<string, string | number>) => string;
+}) {
+  if (args.assigneeId == null) {
+    return args.t('staff_queue.assignment_state.unassigned');
+  }
+
+  if (args.assigneeId === args.currentStaffId) {
+    return args.t('staff_queue.assignment_state.assigned_to_you');
+  }
+
+  const assigneeLabel = args.assigneeName || args.assigneeEmail;
+  return assigneeLabel
+    ? args.t('staff_queue.assignment_state.assigned_to_named', { name: assigneeLabel })
+    : args.t('staff_queue.assignment_state.assigned');
+}
+
 export default async function StaffClaimsPage({ params, searchParams }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
+  const tClaims = await getTranslations('agent-claims.claims');
 
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) return notFound();
@@ -105,6 +127,7 @@ export default async function StaffClaimsPage({ params, searchParams }: Props) {
     search: currentSearch,
     status: currentStatus,
     tenantId: session.user.tenantId,
+    viewerRole: session.user.role,
   });
 
   const assignmentOptions =
@@ -124,10 +147,16 @@ export default async function StaffClaimsPage({ params, searchParams }: Props) {
     <div className="space-y-6" data-testid="staff-page-ready">
       <div>
         <h1 className="text-3xl font-bold tracking-tight" data-testid="page-title">
-          Claims Queue
+          {tClaims('claims_queue')}
         </h1>
 
-        <p className="text-muted-foreground">What needs action today.</p>
+        <p className="text-muted-foreground">{tClaims('staff_queue.subtitle')}</p>
+        <p
+          className="mt-2 text-sm font-medium text-slate-700"
+          data-testid="staff-claims-results-count"
+        >
+          {tClaims('staff_queue.results_count', { count: claims.length })}
+        </p>
       </div>
 
       <section
@@ -145,12 +174,12 @@ export default async function StaffClaimsPage({ params, searchParams }: Props) {
           <Input
             name="search"
             defaultValue={currentSearch}
-            placeholder="Search claim, member, company, or number"
+            placeholder={tClaims('staff_queue.search_placeholder')}
             data-testid="staff-claims-search-input"
           />
           <div className="flex items-center gap-2">
             <Button type="submit" data-testid="staff-claims-search-submit">
-              Search
+              {tClaims('staff_queue.search')}
             </Button>
             {currentSearch && (
               <Button asChild type="button" variant="ghost">
@@ -162,73 +191,83 @@ export default async function StaffClaimsPage({ params, searchParams }: Props) {
                   })}
                   prefetch={false}
                 >
-                  Clear
+                  {tClaims('staff_queue.clear_search')}
                 </Link>
               </Button>
             )}
           </div>
         </form>
 
-        <div className="mt-4 flex flex-wrap gap-2">
-          {assignmentOptions.map(option => {
-            const isActive = currentAssignment === option.value;
-            return (
-              <Button
-                asChild
-                key={option.value}
-                size="sm"
-                variant={isActive ? 'default' : 'outline'}
-              >
-                <Link
-                  href={buildStaffClaimsHref({
-                    assigned: option.value,
-                    locale,
-                    search: currentSearch,
-                    status: currentStatus,
-                  })}
-                  prefetch={false}
-                  data-testid={`staff-claims-assigned-filter-${option.value}`}
+        <div className="mt-4 space-y-2" data-testid="staff-claims-assignment-filters">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {tClaims('staff_queue.assignment_filter_label')}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {assignmentOptions.map(option => {
+              const isActive = currentAssignment === option.value;
+              return (
+                <Button
+                  asChild
+                  key={option.value}
+                  size="sm"
+                  variant={isActive ? 'default' : 'outline'}
                 >
-                  {option.label}
-                </Link>
-              </Button>
-            );
-          })}
+                  <Link
+                    href={buildStaffClaimsHref({
+                      assigned: option.value,
+                      locale,
+                      search: currentSearch,
+                      status: currentStatus,
+                    })}
+                    prefetch={false}
+                    data-testid={`staff-claims-assigned-filter-${option.value}`}
+                  >
+                    {option.label}
+                  </Link>
+                </Button>
+              );
+            })}
+          </div>
         </div>
 
-        <div className="mt-3 flex flex-wrap gap-2">
-          <Button asChild size="sm" variant={currentStatus ? 'outline' : 'default'}>
-            <Link
-              href={buildStaffClaimsHref({
-                assigned: currentAssignment,
-                locale,
-                search: currentSearch,
-              })}
-              prefetch={false}
-              data-testid="staff-claims-status-filter-all"
-            >
-              All actionable
-            </Link>
-          </Button>
-          {ACTIONABLE_CLAIM_STATUSES.map(status => {
-            const isActive = currentStatus === status;
-            return (
-              <Button asChild key={status} size="sm" variant={isActive ? 'default' : 'outline'}>
-                <Link
-                  href={buildStaffClaimsHref({
-                    assigned: currentAssignment,
-                    locale,
-                    search: currentSearch,
-                    status,
-                  })}
-                  prefetch={false}
-                  data-testid={`staff-claims-status-filter-${status}`}
-                >
-                  {toLabel(status)}
-                </Link>
-              </Button>
-            );
-          })}
+        <div className="mt-3 space-y-2" data-testid="staff-claims-status-filters">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {tClaims('staff_queue.status_filter_label')}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild size="sm" variant={currentStatus ? 'outline' : 'default'}>
+              <Link
+                href={buildStaffClaimsHref({
+                  assigned: currentAssignment,
+                  locale,
+                  search: currentSearch,
+                })}
+                prefetch={false}
+                data-testid="staff-claims-status-filter-all"
+              >
+                {tClaims('staff_queue.all_actionable')}
+              </Link>
+            </Button>
+            {ACTIONABLE_CLAIM_STATUSES.map(status => {
+              const isActive = currentStatus === status;
+              return (
+                <Button asChild key={status} size="sm" variant={isActive ? 'default' : 'outline'}>
+                  <Link
+                    href={buildStaffClaimsHref({
+                      assigned: currentAssignment,
+                      locale,
+                      search: currentSearch,
+                      status,
+                    })}
+                    prefetch={false}
+                    data-testid={`staff-claims-status-filter-${status}`}
+                  >
+                    {toLabel(status)}
+                  </Link>
+                </Button>
+              );
+            })}
+          </div>
         </div>
       </section>
 
@@ -267,6 +306,18 @@ export default async function StaffClaimsPage({ params, searchParams }: Props) {
               <div>
                 <ClaimStatusBadge status={claim.status} />
                 <div className="mt-1 text-xs text-muted-foreground">{claim.stageLabel}</div>
+                <div
+                  className="mt-1 text-xs font-medium text-slate-700"
+                  data-testid="staff-claim-assignment-state"
+                >
+                  {getAssignmentStateLabel({
+                    assigneeId: claim.staffId,
+                    assigneeName: claim.assigneeName,
+                    assigneeEmail: claim.assigneeEmail,
+                    currentStaffId: session.user.id,
+                    t: tClaims,
+                  })}
+                </div>
               </div>
               <div>
                 {claim.updatedAt ? new Date(claim.updatedAt).toLocaleDateString(locale) : '-'}
@@ -278,7 +329,7 @@ export default async function StaffClaimsPage({ params, searchParams }: Props) {
                     prefetch={false}
                     data-testid="staff-claims-view"
                   >
-                    Open
+                    {tClaims('actions.open')}
                   </Link>
                 </Button>
               </div>
@@ -289,7 +340,9 @@ export default async function StaffClaimsPage({ params, searchParams }: Props) {
               className="px-4 py-10 text-center text-muted-foreground"
               data-testid="staff-claims-empty"
             >
-              {hasActiveFilters ? 'No claims match the current filters' : 'No claims in queue'}
+              {hasActiveFilters
+                ? tClaims('staff_queue.empty_filtered')
+                : tClaims('staff_queue.empty_default')}
             </div>
           )}
         </div>

--- a/apps/web/src/lib/paddle-webhooks/subscriptions-handler.test.ts
+++ b/apps/web/src/lib/paddle-webhooks/subscriptions-handler.test.ts
@@ -43,7 +43,7 @@ vi.mock('@interdomestik/database', () => ({
   },
 }));
 
-vi.mock('@interdomestik/domain-referrals', () => ({
+vi.mock('@interdomestik/domain-referrals/member-referrals/rewards', () => ({
   createMemberReferralRewardCore: mocks.createMemberReferralReward,
 }));
 

--- a/apps/web/src/messages/en/agent-claims.json
+++ b/apps/web/src/messages/en/agent-claims.json
@@ -1,6 +1,24 @@
 {
   "agent-claims": {
     "claims": {
+      "staff_queue": {
+        "subtitle": "What needs action today.",
+        "results_count": "{count, plural, one {# claim} other {# claims}}",
+        "search_placeholder": "Search claim, member, company, or number",
+        "search": "Search",
+        "clear_search": "Clear",
+        "assignment_filter_label": "Assignment filter",
+        "status_filter_label": "Status filter",
+        "all_actionable": "All actionable",
+        "empty_filtered": "No claims match the current filters",
+        "empty_default": "No claims in queue",
+        "assignment_state": {
+          "unassigned": "Unassigned",
+          "assigned_to_you": "Assigned to you",
+          "assigned": "Assigned",
+          "assigned_to_named": "Assigned to {name}"
+        }
+      },
       "queue": "Claims Queue",
       "claims_queue": "Claims Queue",
       "manage_triage": "Manage and triage all submitted claims.",
@@ -21,7 +39,8 @@
         "approve": "Approve",
         "reject": "Reject",
         "requestInfo": "Request Info",
-        "review": "Review Case"
+        "review": "Review Case",
+        "open": "Open"
       },
       "details": {
         "title": "Claim Details",
@@ -53,7 +72,8 @@
         "messages": "Messages",
         "documents": "Documents",
         "no_documents": "No documents uploaded",
-        "unknown_date": "Unknown date"
+        "unknown_date": "Unknown date",
+        "branch_manager_readonly_notice": "Branch managers can review claim status and member context here, but assignment, messaging, and claim actions remain staff-only in the pilot."
       },
       "triage": {
         "title": "Triage Actions",

--- a/apps/web/src/messages/mk/agent-claims.json
+++ b/apps/web/src/messages/mk/agent-claims.json
@@ -1,6 +1,24 @@
 {
   "agent-claims": {
     "claims": {
+      "staff_queue": {
+        "subtitle": "Што бара дејство денес.",
+        "results_count": "{count, plural, one {# барање} other {# барања}}",
+        "search_placeholder": "Пребарај барање, член, компанија или број",
+        "search": "Барај",
+        "clear_search": "Исчисти",
+        "assignment_filter_label": "Филтер за доделување",
+        "status_filter_label": "Филтер за статус",
+        "all_actionable": "Сите активни барања",
+        "empty_filtered": "Ниту едно барање не одговара на тековните филтри",
+        "empty_default": "Нема барања во редицата",
+        "assignment_state": {
+          "unassigned": "Недоделено",
+          "assigned_to_you": "Доделено на вас",
+          "assigned": "Доделено",
+          "assigned_to_named": "Доделено на {name}"
+        }
+      },
       "queue": "Редица на барања",
       "manage_triage": "Управувајте и тријажирајте ги сите поднесени барања.",
       "table": {
@@ -20,7 +38,8 @@
         "approve": "Одобри",
         "reject": "Одбиј",
         "requestInfo": "Побарај инфо",
-        "review": "Прегледај случај"
+        "review": "Прегледај случај",
+        "open": "Отвори"
       },
       "details": {
         "title": "Детали за барањето",
@@ -52,7 +71,8 @@
         "messages": "Пораки",
         "documents": "Документи",
         "no_documents": "Нема прикачени документи",
-        "unknown_date": "Непознат датум"
+        "unknown_date": "Непознат датум",
+        "branch_manager_readonly_notice": "Менаџерите на филијали можат да ги прегледуваат статусот на барањето и контекстот на членот овде, но доделувањето, пораките и дејствијата по барањето остануваат само за персоналот во пилотот."
       },
       "triage": {
         "title": "Тријажа дејствија",

--- a/apps/web/src/messages/sq/agent-claims.json
+++ b/apps/web/src/messages/sq/agent-claims.json
@@ -1,6 +1,24 @@
 {
   "agent-claims": {
     "claims": {
+      "staff_queue": {
+        "subtitle": "Çfarë ka nevojë për veprim sot.",
+        "results_count": "{count, plural, one {# rast} other {# raste}}",
+        "search_placeholder": "Kërko rast, anëtar, kompani ose numër",
+        "search": "Kërko",
+        "clear_search": "Pastro",
+        "assignment_filter_label": "Filtri i caktimit",
+        "status_filter_label": "Filtri i statusit",
+        "all_actionable": "Të gjitha rastet vepruese",
+        "empty_filtered": "Asnjë rast nuk përputhet me filtrat aktualë",
+        "empty_default": "Nuk ka raste në radhë",
+        "assignment_state": {
+          "unassigned": "Pa përgjegjës",
+          "assigned_to_you": "Caktuar te ju",
+          "assigned": "I caktuar",
+          "assigned_to_named": "Caktuar te {name}"
+        }
+      },
       "queue": "Radha Operative e Kërkesave",
       "claims_queue": "Radha Operative e Kërkesave",
       "manage_triage": "Triage dhe verifiko kërkesat e dorëzuara përpara alokimit.",
@@ -21,7 +39,8 @@
         "approve": "Aprovo",
         "reject": "Refuzo",
         "requestInfo": "Kërko sqarim",
-        "review": "Rishiko Rastin"
+        "review": "Rishiko Rastin",
+        "open": "Hap"
       },
       "details": {
         "title": "Detajet Operative të Rastit",
@@ -53,7 +72,8 @@
         "messages": "Mesazhet",
         "documents": "Dokumentet",
         "no_documents": "Nuk ka dokumente të ngarkuara",
-        "unknown_date": "Datë e panjohur"
+        "unknown_date": "Datë e panjohur",
+        "branch_manager_readonly_notice": "Menaxherët e degës mund të rishikojnë statusin e rastit dhe kontekstin e anëtarit këtu, por caktimi, mesazhet dhe veprimet mbi rastin mbeten vetëm për stafin në pilot."
       },
       "triage": {
         "title": "Veprimet e Triage",

--- a/apps/web/src/messages/sr/agent-claims.json
+++ b/apps/web/src/messages/sr/agent-claims.json
@@ -1,6 +1,24 @@
 {
   "agent-claims": {
     "claims": {
+      "staff_queue": {
+        "subtitle": "Šta danas traži akciju.",
+        "results_count": "{count, plural, one {# zahtev} other {# zahteva}}",
+        "search_placeholder": "Pretraži zahtev, člana, kompaniju ili broj",
+        "search": "Pretraži",
+        "clear_search": "Obriši",
+        "assignment_filter_label": "Filter dodele",
+        "status_filter_label": "Filter statusa",
+        "all_actionable": "Svi aktivni zahtevi",
+        "empty_filtered": "Nijedan zahtev ne odgovara trenutnim filterima",
+        "empty_default": "Nema zahteva u redu",
+        "assignment_state": {
+          "unassigned": "Nedodeljeno",
+          "assigned_to_you": "Dodeljeno vama",
+          "assigned": "Dodeljeno",
+          "assigned_to_named": "Dodeljeno za {name}"
+        }
+      },
       "queue": "Red zahteva",
       "manage_triage": "Upravljajte i trijaživajte sve podnete zahteve.",
       "table": {
@@ -20,7 +38,8 @@
         "approve": "Odobri",
         "reject": "Odbij",
         "requestInfo": "Zatraži info",
-        "review": "Pregledaj slučaj"
+        "review": "Pregledaj slučaj",
+        "open": "Otvori"
       },
       "details": {
         "title": "Detalji zahteva",
@@ -52,7 +71,8 @@
         "messages": "Poruke",
         "documents": "Dokumenti",
         "no_documents": "Nema otpremljenih dokumenata",
-        "unknown_date": "Nepoznat datum"
+        "unknown_date": "Nepoznat datum",
+        "branch_manager_readonly_notice": "Menadžeri filijala ovde mogu da pregledaju status zahteva i kontekst člana, ali dodela, poruke i radnje nad zahtevom ostaju samo za osoblje u pilotu."
       },
       "triage": {
         "title": "Trijaža radnje",

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
       '@interdomestik/ui': path.resolve(__dirname, '../../packages/ui/src'),
       '@interdomestik/database': path.resolve(__dirname, '../../packages/database/src'),
       '@interdomestik/domain-ai': path.resolve(__dirname, '../../packages/domain-ai/src'),
+      '@interdomestik/domain-membership-billing': path.resolve(
+        __dirname,
+        '../../packages/domain-membership-billing/src'
+      ),
+      '@interdomestik/domain-referrals': path.resolve(
+        __dirname,
+        '../../packages/domain-referrals/src'
+      ),
       'server-only': path.resolve(__dirname, './src/test/__mocks__/server-only.ts'),
     },
   },

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
@@ -27,8 +27,15 @@ const mocks = vi.hoisted(() => {
     user: {
       id: 'user.id',
       name: 'user.name',
+      email: 'user.email',
       memberNumber: 'user.member_number',
     },
+    aliasedTable: vi.fn((table, alias) => ({
+      ...table,
+      email: `${alias}.email`,
+      id: `${alias}.id`,
+      name: `${alias}.name`,
+    })),
     eq: vi.fn((left, right) => ({ left, right, op: 'eq' })),
     and: vi.fn((...conditions) => ({ conditions, op: 'and' })),
     desc: vi.fn(value => ({ value, op: 'desc' })),
@@ -56,6 +63,7 @@ vi.mock('@interdomestik/database/tenant-security', () => ({
 }));
 
 vi.mock('drizzle-orm', () => ({
+  aliasedTable: mocks.aliasedTable,
   or: mocks.or,
   isNull: mocks.isNull,
 }));
@@ -80,11 +88,14 @@ describe('getStaffClaimsList', () => {
     mocks.claimChain.orderBy.mockReturnValue(mocks.claimChain);
   });
 
-  it('returns claims scoped to tenant and branch when branchId exists', async () => {
+  it('returns all branch claims for branch managers when branchId exists', async () => {
     mocks.claimChain.limit.mockResolvedValue([
       {
         id: 'claim-1',
         claimNumber: 'KS-0001',
+        assigneeEmail: 'staff@example.com',
+        assigneeName: 'Staff User',
+        staffId: null,
         status: 'submitted',
         updatedAt: new Date('2026-01-01T00:00:00Z'),
         memberName: 'Member One',
@@ -97,6 +108,7 @@ describe('getStaffClaimsList', () => {
       tenantId: 'tenant-ks',
       branchId: 'branch-1',
       limit: 20,
+      viewerRole: 'branch_manager',
     });
 
     expect(mocks.withTenant).toHaveBeenCalledTimes(1);
@@ -114,6 +126,66 @@ describe('getStaffClaimsList', () => {
     expect(result).toHaveLength(1);
     expect(result[0].claimNumber).toBe('KS-0001');
     expect(result[0].memberNumber).toBe('M-0001');
+  });
+
+  it('maps assignee details for queue operator context', async () => {
+    mocks.claimChain.limit.mockResolvedValue([
+      {
+        id: 'claim-1',
+        claimNumber: 'KS-0001',
+        companyName: 'Acme',
+        title: 'Claim',
+        status: 'verification',
+        staffId: 'staff-2',
+        assigneeName: 'Drita Gashi',
+        assigneeEmail: 'drita@example.com',
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+        memberName: 'Member One',
+        memberNumber: 'M-0001',
+      },
+    ]);
+
+    const [result] = await getStaffClaimsList({
+      staffId: 'staff-1',
+      tenantId: 'tenant-ks',
+      branchId: 'branch-1',
+      limit: 20,
+      viewerRole: 'branch_manager',
+    });
+
+    expect(result.assigneeName).toBe('Drita Gashi');
+    expect(result.assigneeEmail).toBe('drita@example.com');
+  });
+
+  it('limits the default staff queue to assigned-to-me and unassigned claims even when branchId exists', async () => {
+    mocks.claimChain.limit.mockResolvedValue([]);
+
+    await getStaffClaimsList({
+      staffId: 'staff-1',
+      tenantId: 'tenant-ks',
+      branchId: 'branch-1',
+      limit: 20,
+      viewerRole: 'staff',
+    });
+
+    expect(mocks.withTenant).toHaveBeenCalledWith(
+      'tenant-ks',
+      mocks.claims.tenantId,
+      expect.objectContaining({
+        op: 'and',
+        conditions: expect.arrayContaining([
+          expect.objectContaining({ op: 'inArray' }),
+          expect.objectContaining({ op: 'eq', left: 'claims.branch_id', right: 'branch-1' }),
+          expect.objectContaining({
+            op: 'or',
+            conditions: expect.arrayContaining([
+              expect.objectContaining({ op: 'eq', left: 'claims.staff_id', right: 'staff-1' }),
+              expect.objectContaining({ op: 'isNull', column: 'claims.staff_id' }),
+            ]),
+          }),
+        ]),
+      })
+    );
   });
 
   it('returns empty when no claims match tenant', async () => {

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
@@ -128,6 +128,36 @@ describe('getStaffClaimsList', () => {
     expect(result[0].memberNumber).toBe('M-0001');
   });
 
+  it('falls back to own and unassigned claims when branch manager branch context is missing', async () => {
+    mocks.claimChain.limit.mockResolvedValue([]);
+
+    await getStaffClaimsList({
+      staffId: 'staff-1',
+      tenantId: 'tenant-ks',
+      branchId: null,
+      limit: 20,
+      viewerRole: 'branch_manager',
+    });
+
+    expect(mocks.withTenant).toHaveBeenCalledWith(
+      'tenant-ks',
+      mocks.claims.tenantId,
+      expect.objectContaining({
+        op: 'and',
+        conditions: expect.arrayContaining([
+          expect.objectContaining({ op: 'inArray' }),
+          expect.objectContaining({
+            op: 'or',
+            conditions: expect.arrayContaining([
+              expect.objectContaining({ op: 'eq', left: 'claims.staff_id', right: 'staff-1' }),
+              expect.objectContaining({ op: 'isNull', column: 'claims.staff_id' }),
+            ]),
+          }),
+        ]),
+      })
+    );
+  });
+
   it('maps assignee details for queue operator context', async () => {
     mocks.claimChain.limit.mockResolvedValue([
       {

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
@@ -70,6 +70,26 @@ vi.mock('drizzle-orm', () => ({
 
 import { getStaffClaimsList } from './get-staff-claims-list';
 
+function expectOwnOrUnassignedQueueScope(args: { staffId: string; tenantId: string }) {
+  expect(mocks.withTenant).toHaveBeenCalledWith(
+    args.tenantId,
+    mocks.claims.tenantId,
+    expect.objectContaining({
+      op: 'and',
+      conditions: expect.arrayContaining([
+        expect.objectContaining({ op: 'inArray' }),
+        expect.objectContaining({
+          op: 'or',
+          conditions: expect.arrayContaining([
+            expect.objectContaining({ op: 'eq', left: 'claims.staff_id', right: args.staffId }),
+            expect.objectContaining({ op: 'isNull', column: 'claims.staff_id' }),
+          ]),
+        }),
+      ]),
+    })
+  );
+}
+
 describe('getStaffClaimsList', () => {
   beforeEach(() => {
     mocks.and.mockClear();
@@ -139,23 +159,7 @@ describe('getStaffClaimsList', () => {
       viewerRole: 'branch_manager',
     });
 
-    expect(mocks.withTenant).toHaveBeenCalledWith(
-      'tenant-ks',
-      mocks.claims.tenantId,
-      expect.objectContaining({
-        op: 'and',
-        conditions: expect.arrayContaining([
-          expect.objectContaining({ op: 'inArray' }),
-          expect.objectContaining({
-            op: 'or',
-            conditions: expect.arrayContaining([
-              expect.objectContaining({ op: 'eq', left: 'claims.staff_id', right: 'staff-1' }),
-              expect.objectContaining({ op: 'isNull', column: 'claims.staff_id' }),
-            ]),
-          }),
-        ]),
-      })
-    );
+    expectOwnOrUnassignedQueueScope({ staffId: 'staff-1', tenantId: 'tenant-ks' });
   });
 
   it('maps assignee details for queue operator context', async () => {
@@ -241,23 +245,7 @@ describe('getStaffClaimsList', () => {
       limit: 10,
     });
 
-    expect(mocks.withTenant).toHaveBeenCalledWith(
-      'tenant-ks',
-      mocks.claims.tenantId,
-      expect.objectContaining({
-        op: 'and',
-        conditions: expect.arrayContaining([
-          expect.objectContaining({ op: 'inArray' }),
-          expect.objectContaining({
-            op: 'or',
-            conditions: expect.arrayContaining([
-              expect.objectContaining({ op: 'eq', left: 'claims.staff_id', right: 'staff-3' }),
-              expect.objectContaining({ op: 'isNull', column: 'claims.staff_id' }),
-            ]),
-          }),
-        ]),
-      })
-    );
+    expectOwnOrUnassignedQueueScope({ staffId: 'staff-3', tenantId: 'tenant-ks' });
   });
 
   it('applies assignment, status, and search filters within the actionable queue scope', async () => {

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
@@ -79,11 +79,14 @@ export async function getStaffClaimsList(params: {
     conditions.push(eq(claims.branchId, branchId));
   }
 
+  const shouldUseOwnOrUnassignedFallback =
+    viewerRole !== 'branch_manager' || (viewerRole === 'branch_manager' && branchId == null);
+
   if (assignment === 'mine') {
     conditions.push(eq(claims.staffId, staffId));
   } else if (assignment === 'unassigned') {
     conditions.push(isNull(claims.staffId));
-  } else if (viewerRole !== 'branch_manager') {
+  } else if (shouldUseOwnOrUnassignedFallback) {
     const ownOrUnassigned = or(eq(claims.staffId, staffId), isNull(claims.staffId));
     if (ownOrUnassigned) {
       conditions.push(ownOrUnassigned);

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
@@ -1,6 +1,6 @@
 import { and, claims, db, desc, eq, ilike, inArray, user } from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
-import { isNull, or, type SQL } from 'drizzle-orm';
+import { aliasedTable, isNull, or, type SQL } from 'drizzle-orm';
 import { ACTIONABLE_CLAIM_STATUSES } from '../claims/constants';
 
 export type StaffClaimsAssignmentFilter = 'all' | 'mine' | 'unassigned';
@@ -11,6 +11,9 @@ export type StaffClaimsListItem = {
   companyName: string | null;
   title: string | null;
   status: string | null;
+  staffId: string | null;
+  assigneeName?: string | null;
+  assigneeEmail?: string | null;
   stageLabel: string;
   updatedAt: string | null;
   memberName?: string;
@@ -58,8 +61,18 @@ export async function getStaffClaimsList(params: {
   limit: number;
   search?: string;
   status?: string;
+  viewerRole?: string | null;
 }): Promise<StaffClaimsListItem[]> {
-  const { staffId, tenantId, branchId, assignment = 'all', limit, search, status } = params;
+  const {
+    staffId,
+    tenantId,
+    branchId,
+    assignment = 'all',
+    limit,
+    search,
+    status,
+    viewerRole,
+  } = params;
   const conditions: SQL<unknown>[] = [inArray(claims.status, ACTIONABLE_CLAIM_STATUSES)];
 
   if (branchId != null) {
@@ -70,7 +83,7 @@ export async function getStaffClaimsList(params: {
     conditions.push(eq(claims.staffId, staffId));
   } else if (assignment === 'unassigned') {
     conditions.push(isNull(claims.staffId));
-  } else if (branchId == null) {
+  } else if (viewerRole !== 'branch_manager') {
     const ownOrUnassigned = or(eq(claims.staffId, staffId), isNull(claims.staffId));
     if (ownOrUnassigned) {
       conditions.push(ownOrUnassigned);
@@ -90,6 +103,7 @@ export async function getStaffClaimsList(params: {
   }
 
   const scopedWhere = withTenant(tenantId, claims.tenantId, and(...conditions));
+  const assignee = aliasedTable(user, 'assignee');
 
   const rows = await db
     .select({
@@ -98,12 +112,16 @@ export async function getStaffClaimsList(params: {
       companyName: claims.companyName,
       title: claims.title,
       status: claims.status,
+      staffId: claims.staffId,
+      assigneeName: assignee.name,
+      assigneeEmail: assignee.email,
       updatedAt: claims.updatedAt,
       memberName: user.name,
       memberNumber: user.memberNumber,
     })
     .from(claims)
     .leftJoin(user, eq(claims.userId, user.id))
+    .leftJoin(assignee, eq(claims.staffId, assignee.id))
     .where(scopedWhere)
     .orderBy(desc(claims.updatedAt), desc(claims.id))
     .limit(limit);
@@ -114,6 +132,9 @@ export async function getStaffClaimsList(params: {
     companyName: row.companyName,
     title: row.title,
     status: row.status,
+    staffId: row.staffId ?? null,
+    assigneeName: row.assigneeName ?? null,
+    assigneeEmail: row.assigneeEmail ?? null,
     stageLabel: formatStageLabel(row.status),
     updatedAt: normalizeDate(row.updatedAt),
     memberName: row.memberName ?? undefined,

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
@@ -1,6 +1,6 @@
 import { db } from '@interdomestik/database';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMemberReferralRewardCore } from '@interdomestik/domain-referrals';
+import { createMemberReferralRewardCore } from '@interdomestik/domain-referrals/member-referrals/rewards';
 import { createCommissionCore } from '../../../commissions/create';
 import { createRenewalCommissionCore } from '../../../commissions/create-renewal';
 import {
@@ -23,7 +23,7 @@ vi.mock('@interdomestik/database', () => ({
   },
 }));
 
-vi.mock('@interdomestik/domain-referrals', () => ({
+vi.mock('@interdomestik/domain-referrals/member-referrals/rewards', () => ({
   createMemberReferralRewardCore: vi.fn(),
 }));
 

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
@@ -1,7 +1,7 @@
 import { db } from '@interdomestik/database';
 import { referrals } from '@interdomestik/database/schema';
 import { and, eq } from 'drizzle-orm';
-import { createMemberReferralRewardCore } from '@interdomestik/domain-referrals';
+import { createMemberReferralRewardCore } from '@interdomestik/domain-referrals/member-referrals/rewards';
 import { createCommissionCore } from '../../../commissions/create';
 import { createRenewalCommissionCore } from '../../../commissions/create-renewal';
 import { calculateCommission } from '../../../commissions/types';

--- a/packages/domain-membership-billing/vitest.config.ts
+++ b/packages/domain-membership-billing/vitest.config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/packages/domain-membership-billing/vitest.config.ts
+++ b/packages/domain-membership-billing/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@interdomestik/domain-referrals': path.resolve(__dirname, '../domain-referrals/src'),
+    },
+  },
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- harden the canonical staff claims queue for pilot-safe operator use
- replace stale staff Playwright expectations and localize the new queue/detail copy
- fix Vitest workspace alias drift so Paddle/referrals tests pass in both `apps/web` and `domain-membership-billing`

## What changed
- corrected default staff queue scoping to show own plus unassigned claims by default while preserving branch-manager visibility
- added result counts, clearer filter labeling, and assignee state/name visibility on the staff claims queue
- added an explicit read-only notice for branch managers on staff claim detail
- updated stale staff E2E coverage and hardened queue navigation against the cookie banner
- aligned Vitest resolver aliases for workspace package imports used by Paddle webhook tests

## Verification
- `pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/paddle-webhooks/handlers.test.ts`
- `pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/paddle-webhooks/handlers/utils/extras.test.ts`
- `pnpm --filter @interdomestik/web test:unit --run src/lib/paddle-webhooks/subscriptions-handler.test.ts`
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/api/webhooks/paddle/[entity]/_core.test.ts'`
- `pnpm security:guard`
- `source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && pnpm pr:verify`

## Notes
- left unrelated local changes in `apps/web/src/components/auth/register-form.tsx` and `apps/web/src/components/auth/register-form.test.tsx` out of this PR
- did not modify `apps/web/src/proxy.ts`
