### PR TITLE
fix: reduce staff auth session probe volume

### DIFF
--- a/apps/web/src/app/[locale]/(staff)/staff/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/_core.entry.tsx
@@ -1,6 +1,7 @@
 import { DashboardHeader } from '@/components/dashboard/dashboard-header';
 import { LegacyBanner } from '@/components/dashboard/legacy-banner';
 import { AuthenticatedShell } from '@/components/shell/authenticated-shell';
+import { toClientShellUser } from '@/components/shell/client-shell-user';
 import { getSessionSafe, requireSessionOrRedirect } from '@/components/shell/session';
 import { StaffSidebar } from '@/components/staff/staff-sidebar';
 import { BASE_NAMESPACES, STAFF_NAMESPACES, pickMessages } from '@/i18n/messages';
@@ -31,15 +32,16 @@ export default async function StaffLayout({
     ...pickMessages(allMessages, BASE_NAMESPACES),
     ...pickMessages(allMessages, STAFF_NAMESPACES),
   };
+  const shellUser = toClientShellUser(sessionNonNull.user);
 
   return (
     <AuthenticatedShell locale={locale} messages={messages}>
       <SidebarProvider defaultOpen={true}>
-        <StaffSidebar user={sessionNonNull.user} />
+        <StaffSidebar user={shellUser} />
         <SidebarInset className="bg-mesh flex flex-col min-h-screen">
-          <DashboardHeader user={sessionNonNull.user} />
+          <DashboardHeader user={shellUser} />
           <div className="px-6 pt-4 md:px-8">
-            <LegacyBanner role={sessionNonNull.user.role} />
+            <LegacyBanner role={shellUser.role} />
           </div>
           <main className="flex-1 p-6 md:p-8 pt-6">{children}</main>
         </SidebarInset>

--- a/apps/web/src/app/[locale]/(staff)/staff/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/_core.entry.tsx
@@ -35,11 +35,11 @@ export default async function StaffLayout({
   return (
     <AuthenticatedShell locale={locale} messages={messages}>
       <SidebarProvider defaultOpen={true}>
-        <StaffSidebar />
+        <StaffSidebar user={sessionNonNull.user} />
         <SidebarInset className="bg-mesh flex flex-col min-h-screen">
-          <DashboardHeader />
+          <DashboardHeader user={sessionNonNull.user} />
           <div className="px-6 pt-4 md:px-8">
-            <LegacyBanner />
+            <LegacyBanner role={sessionNonNull.user.role} />
           </div>
           <main className="flex-1 p-6 md:p-8 pt-6">{children}</main>
         </SidebarInset>

--- a/apps/web/src/components/dashboard/dashboard-header.tsx
+++ b/apps/web/src/components/dashboard/dashboard-header.tsx
@@ -6,15 +6,15 @@ import { CommandMenuTrigger } from './command-menu-trigger';
 import { PortalSurfaceIndicator } from './portal-surface-indicator';
 import { UserNav } from './user-nav';
 
-type DashboardHeaderUser = {
+type DashboardHeaderUser = Readonly<{
   id?: string;
   name?: string | null;
   email?: string | null;
   image?: string | null;
   role?: string;
-};
+}>;
 
-export function DashboardHeader({ user }: { user?: DashboardHeaderUser | null }) {
+export function DashboardHeader({ user }: Readonly<{ user?: DashboardHeaderUser | null }>) {
   return (
     <header className="sticky top-0 z-30 flex h-16 shrink-0 items-center gap-2 border-b border-white/10 bg-background/60 px-4 transition-all backdrop-blur-xl supports-[backdrop-filter]:bg-background/60">
       <div className="flex items-center gap-2">

--- a/apps/web/src/components/dashboard/dashboard-header.tsx
+++ b/apps/web/src/components/dashboard/dashboard-header.tsx
@@ -6,7 +6,15 @@ import { CommandMenuTrigger } from './command-menu-trigger';
 import { PortalSurfaceIndicator } from './portal-surface-indicator';
 import { UserNav } from './user-nav';
 
-export function DashboardHeader() {
+type DashboardHeaderUser = {
+  id?: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  role?: string;
+};
+
+export function DashboardHeader({ user }: { user?: DashboardHeaderUser | null }) {
   return (
     <header className="sticky top-0 z-30 flex h-16 shrink-0 items-center gap-2 border-b border-white/10 bg-background/60 px-4 transition-all backdrop-blur-xl supports-[backdrop-filter]:bg-background/60">
       <div className="flex items-center gap-2">
@@ -19,9 +27,9 @@ export function DashboardHeader() {
           <CommandMenuTrigger />
         </div>
         <div className="flex items-center gap-4">
-          <PortalSurfaceIndicator />
-          <NotificationBell />
-          <UserNav />
+          <PortalSurfaceIndicator role={user?.role} />
+          <NotificationBell subscriberId={user?.id} />
+          <UserNav user={user} />
         </div>
       </div>
     </header>

--- a/apps/web/src/components/dashboard/legacy-banner.tsx
+++ b/apps/web/src/components/dashboard/legacy-banner.tsx
@@ -16,16 +16,14 @@ function roleFromPathname(pathname: string | null) {
   return parts[legacyIndex + 1] ?? null;
 }
 
-export function LegacyBanner() {
+function LegacyBannerInner({ role }: { role?: string }) {
   const pathname = usePathname();
-  const { data: session } = authClient.useSession();
-  const sessionRole = (session?.user as { role?: string })?.role;
   const isLegacy = pathname?.includes('/legacy/') ?? false;
 
   if (!isLegacy) return null;
 
   const locale = getValidatedLocaleFromPathname(pathname);
-  const canonical = getCanonicalRouteForRole(sessionRole ?? roleFromPathname(pathname), locale);
+  const canonical = getCanonicalRouteForRole(role ?? roleFromPathname(pathname), locale);
   const linkHref = stripLocalePrefixFromCanonicalRoute(canonical, locale);
   if (!linkHref) return null;
 
@@ -48,4 +46,19 @@ export function LegacyBanner() {
       </div>
     </div>
   );
+}
+
+function LegacyBannerFromSession() {
+  const { data: session } = authClient.useSession();
+  const role = (session?.user as { role?: string } | undefined)?.role;
+
+  return <LegacyBannerInner role={role} />;
+}
+
+export function LegacyBanner({ role }: { role?: string }) {
+  if (typeof role !== 'undefined') {
+    return <LegacyBannerInner role={role} />;
+  }
+
+  return <LegacyBannerFromSession />;
 }

--- a/apps/web/src/components/dashboard/legacy-banner.tsx
+++ b/apps/web/src/components/dashboard/legacy-banner.tsx
@@ -16,7 +16,7 @@ function roleFromPathname(pathname: string | null) {
   return parts[legacyIndex + 1] ?? null;
 }
 
-function LegacyBannerInner({ role }: { role?: string }) {
+function LegacyBannerInner({ role }: Readonly<{ role?: string }>) {
   const pathname = usePathname();
   const isLegacy = pathname?.includes('/legacy/') ?? false;
 
@@ -55,8 +55,8 @@ function LegacyBannerFromSession() {
   return <LegacyBannerInner role={role} />;
 }
 
-export function LegacyBanner({ role }: { role?: string }) {
-  if (typeof role !== 'undefined') {
+export function LegacyBanner({ role }: Readonly<{ role?: string }>) {
+  if (role !== undefined) {
     return <LegacyBannerInner role={role} />;
   }
 

--- a/apps/web/src/components/dashboard/portal-surface-indicator.test.tsx
+++ b/apps/web/src/components/dashboard/portal-surface-indicator.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { authClient } from '@/lib/auth-client';
+
 vi.mock('@/lib/auth-client', () => ({
   authClient: {
     useSession: vi.fn(() => ({
@@ -37,6 +39,15 @@ vi.mock('next-intl', () => ({
 import { PortalSurfaceIndicator } from './portal-surface-indicator';
 
 describe('PortalSurfaceIndicator', () => {
+  it('renders from a provided role without consulting the auth session hook', () => {
+    const useSessionSpy = vi.mocked(authClient.useSession);
+
+    render(<PortalSurfaceIndicator role="staff" />);
+
+    expect(screen.getByTestId('portal-surface-indicator')).toHaveTextContent('Portal: Staff');
+    expect(useSessionSpy).not.toHaveBeenCalled();
+  });
+
   it('prefers the canonical staff route over a branch-manager session role', () => {
     render(<PortalSurfaceIndicator />);
 

--- a/apps/web/src/components/dashboard/portal-surface-indicator.tsx
+++ b/apps/web/src/components/dashboard/portal-surface-indicator.tsx
@@ -39,7 +39,7 @@ function inferPortalKeyFromRole(role: string | undefined): PortalKey | null {
   return null;
 }
 
-function PortalSurfaceIndicatorInner({ role }: { role?: string }) {
+function PortalSurfaceIndicatorInner({ role }: Readonly<{ role?: string }>) {
   const pathname = usePathname();
   const t = useTranslations('dashboard.shell');
   const pathPortalKey = inferPortalKeyFromPath(pathname);
@@ -62,8 +62,8 @@ function PortalSurfaceIndicatorInner({ role }: { role?: string }) {
   );
 }
 
-export function PortalSurfaceIndicator({ role }: { role?: string }) {
-  if (typeof role !== 'undefined') {
+export function PortalSurfaceIndicator({ role }: Readonly<{ role?: string }>) {
+  if (role !== undefined) {
     return <PortalSurfaceIndicatorInner role={role} />;
   }
 

--- a/apps/web/src/components/dashboard/portal-surface-indicator.tsx
+++ b/apps/web/src/components/dashboard/portal-surface-indicator.tsx
@@ -39,11 +39,9 @@ function inferPortalKeyFromRole(role: string | undefined): PortalKey | null {
   return null;
 }
 
-export function PortalSurfaceIndicator() {
+function PortalSurfaceIndicatorInner({ role }: { role?: string }) {
   const pathname = usePathname();
   const t = useTranslations('dashboard.shell');
-  const { data: session } = authClient.useSession();
-  const role = (session?.user as { role?: string })?.role;
   const pathPortalKey = inferPortalKeyFromPath(pathname);
   const portalKey = pathPortalKey ?? inferPortalKeyFromRole(role) ?? 'member';
   const isLegacy = pathname?.includes('/legacy/') ?? false;
@@ -62,4 +60,15 @@ export function PortalSurfaceIndicator() {
       ) : null}
     </div>
   );
+}
+
+export function PortalSurfaceIndicator({ role }: { role?: string }) {
+  if (typeof role !== 'undefined') {
+    return <PortalSurfaceIndicatorInner role={role} />;
+  }
+
+  const { data: session } = authClient.useSession();
+  const sessionRole = (session?.user as { role?: string } | undefined)?.role;
+
+  return <PortalSurfaceIndicatorInner role={sessionRole} />;
 }

--- a/apps/web/src/components/dashboard/user-nav.test.tsx
+++ b/apps/web/src/components/dashboard/user-nav.test.tsx
@@ -107,6 +107,26 @@ describe('UserNav', () => {
     mockCanAccessAdmin.mockResolvedValue(false);
   });
 
+  it('renders from a provided user without consulting the auth session hook', async () => {
+    render(
+      <UserNav
+        user={{
+          id: 'staff-1',
+          name: 'Staff User',
+          email: 'staff@example.com',
+          image: null,
+          role: 'staff',
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-nav')).toBeInTheDocument();
+    });
+
+    expect(mockUseSession).not.toHaveBeenCalled();
+  });
+
   it('signs out with a localized hard redirect', async () => {
     mockUseSession.mockReturnValue({
       data: {

--- a/apps/web/src/components/dashboard/user-nav.tsx
+++ b/apps/web/src/components/dashboard/user-nav.tsx
@@ -23,15 +23,15 @@ import { Briefcase, LayoutTemplate, LogOut, Settings, User } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 
-type UserNavUser = {
+type UserNavUser = Readonly<{
   id?: string;
   name?: string | null;
   email?: string | null;
   image?: string | null;
   role?: string;
-};
+}>;
 
-function UserNavInner({ user }: { user: UserNavUser | null | undefined }) {
+function UserNavInner({ user }: Readonly<{ user: UserNavUser | null | undefined }>) {
   const locale = useLocale();
   const [mounted, setMounted] = useState(false);
   const [adminAccess, setAdminAccess] = useState(false);
@@ -157,8 +157,8 @@ function UserNavFromSession() {
   return <UserNavInner user={(session?.user as UserNavUser | undefined) ?? null} />;
 }
 
-export function UserNav({ user }: { user?: UserNavUser | null }) {
-  if (typeof user !== 'undefined') {
+export function UserNav({ user }: Readonly<{ user?: UserNavUser | null }>) {
+  if (user !== undefined) {
     return <UserNavInner user={user} />;
   }
 

--- a/apps/web/src/components/dashboard/user-nav.tsx
+++ b/apps/web/src/components/dashboard/user-nav.tsx
@@ -23,11 +23,18 @@ import { Briefcase, LayoutTemplate, LogOut, Settings, User } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 
-export function UserNav() {
+type UserNavUser = {
+  id?: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  role?: string;
+};
+
+function UserNavInner({ user }: { user: UserNavUser | null | undefined }) {
   const locale = useLocale();
   const [mounted, setMounted] = useState(false);
   const [adminAccess, setAdminAccess] = useState(false);
-  const { data: session } = authClient.useSession();
   const t = useTranslations('nav');
 
   useEffect(() => {
@@ -35,9 +42,9 @@ export function UserNav() {
   }, []);
 
   useEffect(() => {
-    if (!session) return;
+    if (!user) return;
 
-    const role = (session.user as unknown as { role?: string })?.role ?? null;
+    const role = user.role ?? null;
     if (isAdmin(role)) {
       setAdminAccess(true);
       return;
@@ -55,7 +62,7 @@ export function UserNav() {
     return () => {
       cancelled = true;
     };
-  }, [session]);
+  }, [user]);
 
   const handleSignOut = async () => {
     await signOutAndRedirectToLogin({
@@ -65,7 +72,7 @@ export function UserNav() {
   };
 
   // Avoid SSR/CSR id mismatches from Radix by rendering menu only after mount.
-  if (!mounted || !session) {
+  if (!mounted || !user) {
     return (
       <Button variant="ghost" className="relative h-9 w-9 rounded-full" disabled>
         <Avatar className="h-9 w-9">
@@ -75,8 +82,7 @@ export function UserNav() {
     );
   }
 
-  const { user } = session;
-  const role = (user as { role?: string }).role;
+  const role = user.role;
   let settingsHref = '/member/settings';
   if (isAdmin(role) || adminAccess) {
     settingsHref = '/admin/settings';
@@ -90,7 +96,7 @@ export function UserNav() {
         <Button variant="ghost" className="relative h-9 w-9 rounded-full" data-testid="user-nav">
           <Avatar className="h-9 w-9">
             <AvatarImage src={user.image || ''} alt={user.name || 'User'} />
-            <AvatarFallback>{user.name?.charAt(0).toUpperCase() || 'U'}</AvatarFallback>
+            <AvatarFallback>{user.name?.charAt(0)?.toUpperCase() || 'U'}</AvatarFallback>
           </Avatar>
         </Button>
       </DropdownMenuTrigger>
@@ -143,4 +149,18 @@ export function UserNav() {
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+function UserNavFromSession() {
+  const { data: session } = authClient.useSession();
+
+  return <UserNavInner user={(session?.user as UserNavUser | undefined) ?? null} />;
+}
+
+export function UserNav({ user }: { user?: UserNavUser | null }) {
+  if (typeof user !== 'undefined') {
+    return <UserNavInner user={user} />;
+  }
+
+  return <UserNavFromSession />;
 }

--- a/apps/web/src/components/notifications/notification-bell.test.tsx
+++ b/apps/web/src/components/notifications/notification-bell.test.tsx
@@ -2,10 +2,14 @@ import { render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationBell } from './notification-bell';
 
+const hoisted = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+}));
+
 // Mock better-auth
 vi.mock('better-auth/react', () => ({
   createAuthClient: () => ({
-    getSession: vi.fn(),
+    getSession: hoisted.mockGetSession,
   }),
 }));
 
@@ -19,6 +23,16 @@ vi.mock('./notification-center', () => ({
 describe('NotificationBell', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('renders from a provided subscriber id without fetching session', async () => {
+    const { getByTestId } = render(<NotificationBell subscriberId="staff-1" />);
+
+    await waitFor(() => {
+      expect(getByTestId('notification-center')).toHaveTextContent('Notifications for staff-1');
+    });
+
+    expect(hoisted.mockGetSession).not.toHaveBeenCalled();
   });
 
   it('returns null while loading', () => {

--- a/apps/web/src/components/notifications/notification-bell.tsx
+++ b/apps/web/src/components/notifications/notification-bell.tsx
@@ -11,7 +11,7 @@ const authClient = createAuthClient();
  * when available, or falls back to fetching the user session to determine the subscriber.
  * Renders the NotificationCenter only when a valid subscriber/user id is available.
  */
-export function NotificationBell({ subscriberId }: { subscriberId?: string | null }) {
+export function NotificationBell({ subscriberId }: Readonly<{ subscriberId?: string | null }>) {
   const [userId, setUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState(!subscriberId);
 

--- a/apps/web/src/components/notifications/notification-bell.tsx
+++ b/apps/web/src/components/notifications/notification-bell.tsx
@@ -10,11 +10,17 @@ const authClient = createAuthClient();
  * NotificationBell - A self-contained notification bell that fetches user session
  * and renders the NotificationCenter if the user is authenticated.
  */
-export function NotificationBell() {
+export function NotificationBell({ subscriberId }: { subscriberId?: string | null }) {
   const [userId, setUserId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!subscriberId);
 
   useEffect(() => {
+    if (subscriberId) {
+      setUserId(subscriberId);
+      setLoading(false);
+      return;
+    }
+
     async function fetchSession() {
       try {
         const session = await authClient.getSession();
@@ -29,7 +35,7 @@ export function NotificationBell() {
     }
 
     fetchSession();
-  }, []);
+  }, [subscriberId]);
 
   // Don't render anything while loading or if not authenticated
   if (loading || !userId) {

--- a/apps/web/src/components/notifications/notification-bell.tsx
+++ b/apps/web/src/components/notifications/notification-bell.tsx
@@ -7,8 +7,9 @@ import { NotificationCenter } from './notification-center';
 const authClient = createAuthClient();
 
 /**
- * NotificationBell - A self-contained notification bell that fetches user session
- * and renders the NotificationCenter if the user is authenticated.
+ * NotificationBell - A self-contained notification bell that uses a provided subscriberId
+ * when available, or falls back to fetching the user session to determine the subscriber.
+ * Renders the NotificationCenter only when a valid subscriber/user id is available.
  */
 export function NotificationBell({ subscriberId }: { subscriberId?: string | null }) {
   const [userId, setUserId] = useState<string | null>(null);

--- a/apps/web/src/components/shell/client-shell-user.test.ts
+++ b/apps/web/src/components/shell/client-shell-user.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { toClientShellUser } from './client-shell-user';
+
+describe('toClientShellUser', () => {
+  it('picks only the primitive fields needed by authenticated shell widgets', () => {
+    const result = toClientShellUser({
+      id: 'staff-1',
+      name: 'Drita Gashi',
+      email: 'staff.ks@interdomestik.com',
+      image: null,
+      role: 'staff',
+      tenantId: 'tenant-ks',
+      branchId: 'branch-1',
+      createdAt: new Date('2026-03-26T00:00:00.000Z'),
+      updatedAt: new Date('2026-03-26T00:00:00.000Z'),
+    });
+
+    expect(result).toEqual({
+      id: 'staff-1',
+      name: 'Drita Gashi',
+      email: 'staff.ks@interdomestik.com',
+      image: null,
+      role: 'staff',
+    });
+  });
+});

--- a/apps/web/src/components/shell/client-shell-user.ts
+++ b/apps/web/src/components/shell/client-shell-user.ts
@@ -1,0 +1,19 @@
+export type ClientShellUser = {
+  id?: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  role?: string;
+};
+
+export function toClientShellUser(
+  user: Partial<ClientShellUser> & Record<string, unknown>
+): ClientShellUser {
+  return {
+    id: typeof user.id === 'string' ? user.id : undefined,
+    name: typeof user.name === 'string' || user.name === null ? user.name : undefined,
+    email: typeof user.email === 'string' || user.email === null ? user.email : undefined,
+    image: typeof user.image === 'string' || user.image === null ? user.image : undefined,
+    role: typeof user.role === 'string' ? user.role : undefined,
+  };
+}

--- a/apps/web/src/components/shell/client-shell-user.ts
+++ b/apps/web/src/components/shell/client-shell-user.ts
@@ -1,13 +1,13 @@
-export type ClientShellUser = {
+export type ClientShellUser = Readonly<{
   id?: string;
   name?: string | null;
   email?: string | null;
   image?: string | null;
   role?: string;
-};
+}>;
 
 export function toClientShellUser(
-  user: Partial<ClientShellUser> & Record<string, unknown>
+  user: Readonly<Partial<ClientShellUser> & Record<string, unknown>>
 ): ClientShellUser {
   return {
     id: typeof user.id === 'string' ? user.id : undefined,

--- a/apps/web/src/components/staff/staff-sidebar.test.tsx
+++ b/apps/web/src/components/staff/staff-sidebar.test.tsx
@@ -75,6 +75,20 @@ vi.mock('lucide-react', () => ({
 }));
 
 describe('StaffSidebar', () => {
+  it('renders from a provided user without consulting the auth session hook', () => {
+    const useSessionSpy = vi.mocked(authClient.useSession);
+
+    render(
+      <StaffSidebar
+        user={{ name: 'Provided Staff', email: 'provided.staff@example.com', image: null }}
+      />
+    );
+
+    expect(screen.getByText('Provided Staff')).toBeInTheDocument();
+    expect(screen.getByText('provided.staff@example.com')).toBeInTheDocument();
+    expect(useSessionSpy).not.toHaveBeenCalled();
+  });
+
   it('does not render a redundant /staff overview link', () => {
     render(<StaffSidebar />);
 

--- a/apps/web/src/components/staff/staff-sidebar.tsx
+++ b/apps/web/src/components/staff/staff-sidebar.tsx
@@ -23,12 +23,17 @@ import { Avatar, AvatarFallback, AvatarImage } from '@interdomestik/ui/component
 import { ChevronUp, FileText, LogOut, Shield } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 
-export function StaffSidebar() {
+type StaffSidebarUser = {
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+};
+
+function StaffSidebarInner({ user }: { user: StaffSidebarUser | null | undefined }) {
   const pathname = usePathname();
   const locale = useLocale();
   const tNav = useTranslations('nav');
   const tClaims = useTranslations('agent-claims.claims');
-  const { data: session } = authClient.useSession();
 
   const navItems = [{ title: tClaims('claims_queue'), href: '/staff/claims', icon: FileText }];
 
@@ -92,14 +97,14 @@ export function StaffSidebar() {
                   className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                 >
                   <Avatar className="h-8 w-8 rounded-lg">
-                    <AvatarImage src={session?.user?.image || ''} alt={session?.user?.name || ''} />
+                    <AvatarImage src={user?.image || ''} alt={user?.name || ''} />
                     <AvatarFallback className="rounded-lg">
-                      {session?.user?.name?.[0]?.toUpperCase() || 'S'}
+                      {user?.name?.[0]?.toUpperCase() || 'S'}
                     </AvatarFallback>
                   </Avatar>
                   <div className="grid flex-1 text-left text-sm leading-tight">
-                    <span className="truncate font-semibold">{session?.user?.name || 'Staff'}</span>
-                    <span className="truncate text-xs">{session?.user?.email}</span>
+                    <span className="truncate font-semibold">{user?.name || 'Staff'}</span>
+                    <span className="truncate text-xs">{user?.email}</span>
                   </div>
                   <ChevronUp className="ml-auto size-4" />
                 </SidebarMenuButton>
@@ -122,4 +127,18 @@ export function StaffSidebar() {
       </SidebarFooter>
     </Sidebar>
   );
+}
+
+function StaffSidebarFromSession() {
+  const { data: session } = authClient.useSession();
+
+  return <StaffSidebarInner user={(session?.user as StaffSidebarUser | undefined) ?? null} />;
+}
+
+export function StaffSidebar({ user }: { user?: StaffSidebarUser | null }) {
+  if (typeof user !== 'undefined') {
+    return <StaffSidebarInner user={user} />;
+  }
+
+  return <StaffSidebarFromSession />;
 }

--- a/apps/web/src/components/staff/staff-sidebar.tsx
+++ b/apps/web/src/components/staff/staff-sidebar.tsx
@@ -23,13 +23,13 @@ import { Avatar, AvatarFallback, AvatarImage } from '@interdomestik/ui/component
 import { ChevronUp, FileText, LogOut, Shield } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 
-type StaffSidebarUser = {
+type StaffSidebarUser = Readonly<{
   name?: string | null;
   email?: string | null;
   image?: string | null;
-};
+}>;
 
-function StaffSidebarInner({ user }: { user: StaffSidebarUser | null | undefined }) {
+function StaffSidebarInner({ user }: Readonly<{ user: StaffSidebarUser | null | undefined }>) {
   const pathname = usePathname();
   const locale = useLocale();
   const tNav = useTranslations('nav');
@@ -135,8 +135,8 @@ function StaffSidebarFromSession() {
   return <StaffSidebarInner user={(session?.user as StaffSidebarUser | undefined) ?? null} />;
 }
 
-export function StaffSidebar({ user }: { user?: StaffSidebarUser | null }) {
-  if (typeof user !== 'undefined') {
+export function StaffSidebar({ user }: Readonly<{ user?: StaffSidebarUser | null }>) {
+  if (user !== undefined) {
     return <StaffSidebarInner user={user} />;
   }
 


### PR DESCRIPTION
## Summary
- pass the already-validated staff session user from the server layout into the staff header, sidebar, legacy banner, and notification bell
- stop those staff shell widgets from independently fetching client session state when server session data is already available
- add focused regression tests covering prop-driven rendering paths that avoid extra auth probes

## Verification
- pnpm --filter @interdomestik/web type-check
- pnpm --filter @interdomestik/web test:unit --run src/components/notifications/notification-bell.test.tsx src/components/staff/staff-sidebar.test.tsx src/components/dashboard/portal-surface-indicator.test.tsx src/components/dashboard/user-nav.test.tsx src/components/dashboard/dashboard-header.test.tsx
- live browser sanity pass on /sq/staff/claims queue/detail navigation after the change; no 429 reproduced in the spot check

## Follow-up Acceptance Target
- no 429 on normal queue/detail navigation during a 5-10 minute staff walkthrough.

## Out of Scope
- CSS preload warning cleanup
- HMR/dev console noise cleanup