### PR TITLE
fix(auth): reduce staff auth request volume on staff surfaces

### DIFF
--- a/apps/web/src/app/[locale]/(staff)/staff/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/_core.entry.tsx
@@ -39,7 +39,7 @@ export default async function StaffLayout({
       <SidebarProvider defaultOpen={true}>
         <StaffSidebar user={shellUser} />
         <SidebarInset className="bg-mesh flex flex-col min-h-screen">
-          <DashboardHeader user={shellUser} />
+          <DashboardHeader user={shellUser} adminAccess={false} prefetchNotifications={false} />
           <div className="px-6 pt-4 md:px-8">
             <LegacyBanner role={shellUser.role} />
           </div>

--- a/apps/web/src/app/[locale]/(staff)/staff/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/_core.entry.tsx
@@ -1,3 +1,4 @@
+import { requireTenantAdminSession } from '@interdomestik/domain-users/admin/access';
 import { DashboardHeader } from '@/components/dashboard/dashboard-header';
 import { LegacyBanner } from '@/components/dashboard/legacy-banner';
 import { AuthenticatedShell } from '@/components/shell/authenticated-shell';
@@ -33,13 +34,20 @@ export default async function StaffLayout({
     ...pickMessages(allMessages, STAFF_NAMESPACES),
   };
   const shellUser = toClientShellUser(sessionNonNull.user);
+  const adminAccess = await requireTenantAdminSession(sessionNonNull)
+    .then(() => true)
+    .catch(() => false);
 
   return (
     <AuthenticatedShell locale={locale} messages={messages}>
       <SidebarProvider defaultOpen={true}>
         <StaffSidebar user={shellUser} />
         <SidebarInset className="bg-mesh flex flex-col min-h-screen">
-          <DashboardHeader user={shellUser} adminAccess={false} prefetchNotifications={false} />
+          <DashboardHeader
+            user={shellUser}
+            adminAccess={adminAccess}
+            prefetchNotifications={false}
+          />
           <div className="px-6 pt-4 md:px-8">
             <LegacyBanner role={shellUser.role} />
           </div>

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.test.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.test.tsx
@@ -60,20 +60,24 @@ const hoisted = vi.hoisted(() => ({
   })),
   getLatestPublicStatusNoteCoreMock: vi.fn(async () => null),
   getStaffAssignmentOptionsMock: vi.fn(async () => []),
+  getMessagesForClaimCoreMock: vi.fn(async () => ({ success: true, messages: [] })),
   messagingPanelMock: vi.fn(
     ({
       allowInternal,
       claimId,
       currentUser,
+      fetchOnMount,
     }: {
       allowInternal?: boolean;
       claimId: string;
       currentUser: { role: string };
+      fetchOnMount?: boolean;
     }) => (
       <div
         data-testid="staff-claim-messaging-panel"
         data-allow-internal={String(Boolean(allowInternal))}
         data-claim-id={claimId}
+        data-fetch-on-mount={String(fetchOnMount ?? true)}
         data-role={currentUser.role}
       />
     )
@@ -117,6 +121,10 @@ vi.mock('./_core', () => ({
 
 vi.mock('@/features/staff/claims/assignment-options', () => ({
   getStaffAssignmentOptions: hoisted.getStaffAssignmentOptionsMock,
+}));
+
+vi.mock('@/actions/messages/get.core', () => ({
+  getMessagesForClaimCore: hoisted.getMessagesForClaimCoreMock,
 }));
 
 vi.mock('@/components/staff/claim-action-panel', () => ({
@@ -166,6 +174,7 @@ describe('StaffClaimDetailsPage', () => {
       expect.objectContaining({
         claimId: 'claim-1',
         allowInternal: true,
+        fetchOnMount: false,
         currentUser: expect.objectContaining({
           role: 'staff',
         }),

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
@@ -7,6 +7,7 @@ import { notFound } from 'next/navigation';
 import { ClaimActionPanel } from '@/components/staff/claim-action-panel';
 import { MessagingPanel } from '@/components/messaging/messaging-panel';
 import { getSessionSafe, requireSessionOrRedirect } from '@/components/shell/session';
+import { getMessagesForClaimCore } from '@/actions/messages/get.core';
 import { getStaffAssignmentOptions } from '@/features/staff/claims/assignment-options';
 import { getLatestPublicStatusNoteCore } from './_core';
 
@@ -32,7 +33,7 @@ export default async function StaffClaimDetailsPage({ params }: PageProps) {
     return notFound();
   }
 
-  const [detail, latestStatusNote, assignmentOptions] = await Promise.all([
+  const [detail, latestStatusNote, assignmentOptions, initialMessagesResult] = await Promise.all([
     getStaffClaimDetail({
       claimId: id,
       staffId: session.user.id,
@@ -48,12 +49,21 @@ export default async function StaffClaimDetailsPage({ params }: PageProps) {
           tenantId: session.user.tenantId,
         })
       : Promise.resolve([]),
+    session.user.role === 'staff'
+      ? getMessagesForClaimCore({
+          session,
+          claimId: id,
+        })
+      : Promise.resolve({ success: true as const, messages: [] }),
   ]);
 
   if (!detail) return notFound();
 
   const currentAssigneeLabel =
     assignmentOptions.find(option => option.id === detail.claim.staffId)?.label ?? null;
+  const initialMessages = initialMessagesResult.success
+    ? (initialMessagesResult.messages ?? [])
+    : [];
   const claimStatus = toClaimStatus(detail.claim.status);
   const slaPhase = deriveClaimSlaPhase(claimStatus);
 
@@ -224,6 +234,8 @@ export default async function StaffClaimDetailsPage({ params }: PageProps) {
                 role: session.user.role || 'staff',
               }}
               allowInternal={true}
+              initialMessages={initialMessages}
+              fetchOnMount={false}
             />
           </div>
         </section>

--- a/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/claims/[id]/page.tsx
@@ -18,8 +18,25 @@ interface PageProps {
   }>;
 }
 
+type LatestStatusNote = Awaited<ReturnType<typeof getLatestPublicStatusNoteCore>>;
+
 function toClaimStatus(value: unknown): ClaimStatus {
   return CLAIM_STATUSES.includes(value as ClaimStatus) ? (value as ClaimStatus) : 'draft';
+}
+
+function LatestStatusNoteContent({ latestStatusNote }: { latestStatusNote: LatestStatusNote }) {
+  if (!latestStatusNote?.note) {
+    return <p className="text-muted-foreground">No public status notes yet.</p>;
+  }
+
+  return (
+    <>
+      <p className="whitespace-pre-wrap text-slate-900">{latestStatusNote.note}</p>
+      <p className="text-xs text-muted-foreground">
+        {latestStatusNote.createdAt ? new Date(latestStatusNote.createdAt).toLocaleString() : ''}
+      </p>
+    </>
+  );
 }
 
 export default async function StaffClaimDetailsPage({ params }: PageProps) {
@@ -192,18 +209,7 @@ export default async function StaffClaimDetailsPage({ params }: PageProps) {
           Latest status note
         </h2>
         <div className="mt-3 space-y-1 text-sm">
-          {latestStatusNote?.note ? (
-            <>
-              <p className="whitespace-pre-wrap text-slate-900">{latestStatusNote.note}</p>
-              <p className="text-xs text-muted-foreground">
-                {latestStatusNote.createdAt
-                  ? new Date(latestStatusNote.createdAt).toLocaleString()
-                  : ''}
-              </p>
-            </>
-          ) : (
-            <p className="text-muted-foreground">No public status notes yet.</p>
-          )}
+          <LatestStatusNoteContent latestStatusNote={latestStatusNote} />
         </div>
       </section>
 

--- a/apps/web/src/components/dashboard/dashboard-header.tsx
+++ b/apps/web/src/components/dashboard/dashboard-header.tsx
@@ -14,7 +14,15 @@ type DashboardHeaderUser = Readonly<{
   role?: string;
 }>;
 
-export function DashboardHeader({ user }: Readonly<{ user?: DashboardHeaderUser | null }>) {
+export function DashboardHeader({
+  user,
+  adminAccess,
+  prefetchNotifications = true,
+}: Readonly<{
+  user?: DashboardHeaderUser | null;
+  adminAccess?: boolean;
+  prefetchNotifications?: boolean;
+}>) {
   return (
     <header className="sticky top-0 z-30 flex h-16 shrink-0 items-center gap-2 border-b border-white/10 bg-background/60 px-4 transition-all backdrop-blur-xl supports-[backdrop-filter]:bg-background/60">
       <div className="flex items-center gap-2">
@@ -28,8 +36,8 @@ export function DashboardHeader({ user }: Readonly<{ user?: DashboardHeaderUser 
         </div>
         <div className="flex items-center gap-4">
           <PortalSurfaceIndicator role={user?.role} />
-          <NotificationBell subscriberId={user?.id} />
-          <UserNav user={user} />
+          <NotificationBell subscriberId={user?.id} prefetchNotifications={prefetchNotifications} />
+          <UserNav user={user} adminAccess={adminAccess} />
         </div>
       </div>
     </header>

--- a/apps/web/src/components/dashboard/user-nav.test.tsx
+++ b/apps/web/src/components/dashboard/user-nav.test.tsx
@@ -127,6 +127,28 @@ describe('UserNav', () => {
     expect(mockUseSession).not.toHaveBeenCalled();
   });
 
+  it('skips admin access action when admin access is provided by the shell', async () => {
+    render(
+      <UserNav
+        user={{
+          id: 'staff-1',
+          name: 'Staff User',
+          email: 'staff@example.com',
+          image: null,
+          role: 'staff',
+        }}
+        adminAccess={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-nav')).toBeInTheDocument();
+    });
+
+    expect(mockUseSession).not.toHaveBeenCalled();
+    expect(mockCanAccessAdmin).not.toHaveBeenCalled();
+  });
+
   it('signs out with a localized hard redirect', async () => {
     mockUseSession.mockReturnValue({
       data: {

--- a/apps/web/src/components/dashboard/user-nav.tsx
+++ b/apps/web/src/components/dashboard/user-nav.tsx
@@ -31,10 +31,21 @@ type UserNavUser = Readonly<{
   role?: string;
 }>;
 
-function UserNavInner({ user }: Readonly<{ user: UserNavUser | null | undefined }>) {
+type UserNavProps = Readonly<{
+  user?: UserNavUser | null;
+  adminAccess?: boolean;
+}>;
+
+function UserNavInner({
+  user,
+  adminAccessOverride,
+}: Readonly<{
+  user: UserNavUser | null | undefined;
+  adminAccessOverride?: boolean;
+}>) {
   const locale = useLocale();
   const [mounted, setMounted] = useState(false);
-  const [adminAccess, setAdminAccess] = useState(false);
+  const [adminAccess, setAdminAccess] = useState(adminAccessOverride ?? false);
   const t = useTranslations('nav');
 
   useEffect(() => {
@@ -42,6 +53,11 @@ function UserNavInner({ user }: Readonly<{ user: UserNavUser | null | undefined 
   }, []);
 
   useEffect(() => {
+    if (adminAccessOverride !== undefined) {
+      setAdminAccess(adminAccessOverride);
+      return;
+    }
+
     if (!user) return;
 
     const role = user.role ?? null;
@@ -62,7 +78,7 @@ function UserNavInner({ user }: Readonly<{ user: UserNavUser | null | undefined 
     return () => {
       cancelled = true;
     };
-  }, [user]);
+  }, [adminAccessOverride, user]);
 
   const handleSignOut = async () => {
     await signOutAndRedirectToLogin({
@@ -157,9 +173,9 @@ function UserNavFromSession() {
   return <UserNavInner user={(session?.user as UserNavUser | undefined) ?? null} />;
 }
 
-export function UserNav({ user }: Readonly<{ user?: UserNavUser | null }>) {
+export function UserNav({ user, adminAccess }: UserNavProps) {
   if (user !== undefined) {
-    return <UserNavInner user={user} />;
+    return <UserNavInner user={user} adminAccessOverride={adminAccess} />;
   }
 
   return <UserNavFromSession />;

--- a/apps/web/src/components/messaging/messaging-panel.test.tsx
+++ b/apps/web/src/components/messaging/messaging-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MessagingPanel } from './messaging-panel';
 
@@ -13,6 +13,8 @@ vi.mock('@/actions/messages', () => ({
 
 import { getMessagesForClaim } from '@/actions/messages';
 const mockGetMessages = vi.mocked(getMessagesForClaim);
+import { markMessagesAsRead } from '@/actions/messages';
+const mockMarkMessagesAsRead = vi.mocked(markMessagesAsRead);
 
 // Mock child components
 vi.mock('./message-thread', () => ({
@@ -39,6 +41,7 @@ describe('MessagingPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetMessages.mockResolvedValue({ success: true, messages: [] });
+    mockMarkMessagesAsRead.mockResolvedValue({ success: true } as never);
   });
 
   it('renders the messaging panel', async () => {
@@ -125,6 +128,54 @@ describe('MessagingPanel', () => {
     );
 
     expect(mockGetMessages).not.toHaveBeenCalled();
+  });
+
+  it('marks initial unread messages as read when mount fetch is disabled', async () => {
+    render(
+      <MessagingPanel
+        claimId="claim-1"
+        currentUser={{ id: 'user-1', name: 'User', image: null, role: 'user' }}
+        fetchOnMount={false}
+        initialMessages={[
+          {
+            id: 'msg-2',
+            claimId: 'claim-1',
+            senderId: 'user-2',
+            content: 'Unread',
+            isInternal: false,
+            readAt: null,
+            createdAt: new Date(),
+            sender: { id: 'user-2', name: 'Other', image: null, role: 'staff' },
+          },
+        ]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockMarkMessagesAsRead).toHaveBeenCalledWith(['msg-2']);
+    });
+  });
+
+  it('continues polling when mount fetch is disabled', async () => {
+    vi.useFakeTimers();
+
+    render(
+      <MessagingPanel
+        claimId="claim-1"
+        currentUser={{ id: 'user-1', name: 'User', image: null, role: 'user' }}
+        fetchOnMount={false}
+      />
+    );
+
+    expect(mockGetMessages).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+    });
+
+    expect(mockGetMessages).toHaveBeenCalledWith('claim-1');
+
+    vi.useRealTimers();
   });
 
   it('shows message count in title', async () => {

--- a/apps/web/src/components/messaging/messaging-panel.test.tsx
+++ b/apps/web/src/components/messaging/messaging-panel.test.tsx
@@ -115,6 +115,18 @@ describe('MessagingPanel', () => {
     expect(screen.getByText('Thread (1 messages)')).toBeInTheDocument();
   });
 
+  it('does not fetch messages on mount when fetchOnMount is disabled', () => {
+    render(
+      <MessagingPanel
+        claimId="claim-1"
+        currentUser={{ id: 'user-1', name: 'User', image: null, role: 'user' }}
+        fetchOnMount={false}
+      />
+    );
+
+    expect(mockGetMessages).not.toHaveBeenCalled();
+  });
+
   it('shows message count in title', async () => {
     const initialMessages = [
       {

--- a/apps/web/src/components/messaging/messaging-panel.tsx
+++ b/apps/web/src/components/messaging/messaging-panel.tsx
@@ -29,6 +29,7 @@ interface MessagingPanelProps {
   readonly isAgent?: boolean;
   readonly allowInternal?: boolean;
   readonly initialMessages?: MessageWithSender[];
+  readonly fetchOnMount?: boolean;
 }
 
 export function MessagingPanel({
@@ -37,11 +38,12 @@ export function MessagingPanel({
   isAgent = false,
   allowInternal = false,
   initialMessages = [],
+  fetchOnMount = true,
 }: MessagingPanelProps) {
   const t = useTranslations('messaging');
   const [messages, setMessages] = useState<MessageWithSender[]>(initialMessages);
   const [optimisticMessages, setOptimisticMessages] = useState<OptimisticMessage[]>([]);
-  const [isLoading, setIsLoading] = useState(initialMessages.length === 0);
+  const [isLoading, setIsLoading] = useState(fetchOnMount && initialMessages.length === 0);
   const [isPending, startTransition] = useTransition();
 
   const fetchMessages = useCallback(async () => {
@@ -70,12 +72,17 @@ export function MessagingPanel({
   }, [claimId, currentUser.id]);
 
   useEffect(() => {
+    if (!fetchOnMount) {
+      setIsLoading(false);
+      return;
+    }
+
     fetchMessages();
 
     // Poll for new messages every 30 seconds
     const interval = setInterval(fetchMessages, 30000);
     return () => clearInterval(interval);
-  }, [fetchMessages]);
+  }, [fetchMessages, fetchOnMount]);
 
   const handleRefresh = useCallback(() => {
     startTransition(async () => {

--- a/apps/web/src/components/messaging/messaging-panel.tsx
+++ b/apps/web/src/components/messaging/messaging-panel.tsx
@@ -72,17 +72,24 @@ export function MessagingPanel({
   }, [claimId, currentUser.id]);
 
   useEffect(() => {
-    if (!fetchOnMount) {
-      setIsLoading(false);
-      return;
-    }
+    if (fetchOnMount) {
+      fetchMessages();
+    } else {
+      const unreadIds = initialMessages
+        .filter(message => message.senderId !== currentUser.id && !message.readAt)
+        .map(message => message.id);
 
-    fetchMessages();
+      if (unreadIds.length > 0) {
+        void markMessagesAsRead(unreadIds);
+      }
+
+      setIsLoading(false);
+    }
 
     // Poll for new messages every 30 seconds
     const interval = setInterval(fetchMessages, 30000);
     return () => clearInterval(interval);
-  }, [fetchMessages, fetchOnMount]);
+  }, [currentUser.id, fetchMessages, fetchOnMount, initialMessages]);
 
   const handleRefresh = useCallback(() => {
     startTransition(async () => {

--- a/apps/web/src/components/notifications/notification-bell.test.tsx
+++ b/apps/web/src/components/notifications/notification-bell.test.tsx
@@ -15,8 +15,16 @@ vi.mock('better-auth/react', () => ({
 
 // Mock NotificationCenter
 vi.mock('./notification-center', () => ({
-  NotificationCenter: ({ subscriberId }: { subscriberId: string }) => (
-    <div data-testid="notification-center">Notifications for {subscriberId}</div>
+  NotificationCenter: ({
+    subscriberId,
+    fetchOnMount,
+  }: {
+    subscriberId: string;
+    fetchOnMount?: boolean;
+  }) => (
+    <div data-testid="notification-center">
+      Notifications for {subscriberId} ({fetchOnMount === false ? 'lazy' : 'eager'})
+    </div>
   ),
 }));
 
@@ -29,10 +37,24 @@ describe('NotificationBell', () => {
     const { getByTestId } = render(<NotificationBell subscriberId="staff-1" />);
 
     await waitFor(() => {
-      expect(getByTestId('notification-center')).toHaveTextContent('Notifications for staff-1');
+      expect(getByTestId('notification-center')).toHaveTextContent(
+        'Notifications for staff-1 (eager)'
+      );
     });
 
     expect(hoisted.mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('can opt into lazy notification fetching when the shell already has route context', async () => {
+    const { getByTestId } = render(
+      <NotificationBell subscriberId="staff-1" prefetchNotifications={false} />
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('notification-center')).toHaveTextContent(
+        'Notifications for staff-1 (lazy)'
+      );
+    });
   });
 
   it('returns null while loading', () => {

--- a/apps/web/src/components/notifications/notification-bell.tsx
+++ b/apps/web/src/components/notifications/notification-bell.tsx
@@ -11,7 +11,10 @@ const authClient = createAuthClient();
  * when available, or falls back to fetching the user session to determine the subscriber.
  * Renders the NotificationCenter only when a valid subscriber/user id is available.
  */
-export function NotificationBell({ subscriberId }: Readonly<{ subscriberId?: string | null }>) {
+export function NotificationBell({
+  subscriberId,
+  prefetchNotifications = true,
+}: Readonly<{ subscriberId?: string | null; prefetchNotifications?: boolean }>) {
   const [userId, setUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState(!subscriberId);
 
@@ -43,5 +46,5 @@ export function NotificationBell({ subscriberId }: Readonly<{ subscriberId?: str
     return null;
   }
 
-  return <NotificationCenter subscriberId={userId} />;
+  return <NotificationCenter subscriberId={userId} fetchOnMount={prefetchNotifications} />;
 }

--- a/apps/web/src/components/notifications/notification-center.test.tsx
+++ b/apps/web/src/components/notifications/notification-center.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationCenter } from './notification-center';
 
@@ -46,7 +46,18 @@ vi.mock('@interdomestik/ui', () => ({
   }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
     <button {...props}>{children}</button>
   ),
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenu: ({
+    children,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <div>
+      <button onClick={() => onOpenChange?.(true)}>Open menu</button>
+      {children}
+    </div>
+  ),
   DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
@@ -88,5 +99,29 @@ describe('NotificationCenter', () => {
     render(<NotificationCenter subscriberId="user-123" fetchOnMount={false} />);
 
     expect(mocks.getNotifications).not.toHaveBeenCalled();
+  });
+
+  it('shows a loading state when opened after lazy mount', async () => {
+    let resolveNotifications: ((value: unknown[]) => void) | undefined;
+    mocks.getNotifications.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveNotifications = resolve;
+        })
+    );
+
+    render(<NotificationCenter subscriberId="user-123" fetchOnMount={false} />);
+
+    expect(screen.getByText('All caught up!')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Open menu'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('All caught up!')).not.toBeInTheDocument();
+    });
+
+    resolveNotifications?.([]);
+
+    expect(await screen.findByText('All caught up!')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/notifications/notification-center.test.tsx
+++ b/apps/web/src/components/notifications/notification-center.test.tsx
@@ -83,4 +83,10 @@ describe('NotificationCenter', () => {
     expect(await screen.findByText('New message')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();
   });
+
+  it('does not fetch notifications on mount when fetchOnMount is disabled', () => {
+    render(<NotificationCenter subscriberId="user-123" fetchOnMount={false} />);
+
+    expect(mocks.getNotifications).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/notifications/notification-center.tsx
+++ b/apps/web/src/components/notifications/notification-center.tsx
@@ -47,6 +47,7 @@ export function NotificationCenter({ subscriberId, fetchOnMount = true }: Notifi
   const [isOpen, setIsOpen] = useState(false);
 
   const fetchInitialNotifications = useCallback(async () => {
+    setLoading(true);
     try {
       const data = await getNotifications();
       setNotifications(data as unknown as Notification[]);
@@ -70,7 +71,7 @@ export function NotificationCenter({ subscriberId, fetchOnMount = true }: Notifi
 
   useEffect(() => {
     if (!isOpen) return;
-    fetchInitialNotifications();
+    void fetchInitialNotifications();
   }, [isOpen, fetchInitialNotifications]);
 
   const handleMarkAsRead = async (id: string, e?: React.MouseEvent) => {

--- a/apps/web/src/components/notifications/notification-center.tsx
+++ b/apps/web/src/components/notifications/notification-center.tsx
@@ -37,12 +37,13 @@ interface Notification {
 
 interface NotificationCenterProps {
   readonly subscriberId: string;
+  readonly fetchOnMount?: boolean;
 }
 
-export function NotificationCenter({ subscriberId }: NotificationCenterProps) {
+export function NotificationCenter({ subscriberId, fetchOnMount = true }: NotificationCenterProps) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(fetchOnMount);
   const [isOpen, setIsOpen] = useState(false);
 
   const fetchInitialNotifications = useCallback(async () => {
@@ -59,8 +60,13 @@ export function NotificationCenter({ subscriberId }: NotificationCenterProps) {
   }, []);
 
   useEffect(() => {
+    if (!fetchOnMount) {
+      setLoading(false);
+      return;
+    }
+
     fetchInitialNotifications();
-  }, [subscriberId, fetchInitialNotifications]);
+  }, [subscriberId, fetchInitialNotifications, fetchOnMount]);
 
   useEffect(() => {
     if (!isOpen) return;


### PR DESCRIPTION
## Summary
- reduce avoidable auth-driven server action traffic on staff surfaces
- stop staff shell widgets from fetching admin access or notifications on mount when the server shell already knows that state
- stop staff claim detail from eagerly fetching messages on mount by server-loading initial messages and disabling the mount fetch path

## What changed
- pass `adminAccess={false}` and `prefetchNotifications={false}` through the canonical staff shell
- let `UserNav` skip `canAccessAdmin()` when admin access is already known
- let `NotificationBell` and `NotificationCenter` skip eager notification fetch on staff shell mount
- server-load initial claim messages on the canonical staff claim detail page and render `MessagingPanel` with `fetchOnMount={false}`

## Verification
- `pnpm --filter @interdomestik/web test:unit --run 'src/components/dashboard/user-nav.test.tsx' 'src/components/dashboard/dashboard-header.test.tsx' 'src/components/notifications/notification-center.test.tsx' 'src/components/notifications/notification-bell.test.tsx' 'src/components/messaging/messaging-panel.test.tsx' 'src/app/[locale]/(staff)/staff/claims/[id]/page.test.tsx'`
- `pnpm --filter @interdomestik/web type-check`

## Runtime evidence
- focused detail-page capture after the messaging change became `GET`-only; the old staff detail `POST` server action from `getMessagesForClaim` disappeared
- paced staff queue/detail walkthrough on the updated branch completed with `GET /api/auth/get-session?disableCookieCache=true&disableRefresh=true => 200` throughout the normal flow
- no `session_introspection_throttled` was emitted during the paced operator-style queue/detail run on the updated branch

## Acceptance target
- no `429` on normal queue/detail navigation during a 5-10 minute staff walkthrough

## Out of scope
- CSS preload warning cleanup
- HMR / Fast Refresh dev chatter cleanup
- separate investigation into why the local `next dev --turbo` process can disappear between passes
