### PR TITLE
feat: expand membership checkout reconciliation contract

### DIFF
--- a/apps/web/src/app/[locale]/(site)/pricing/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/_core.entry.tsx
@@ -8,6 +8,10 @@ import { buildClaimScopeTreeProps } from '@/components/commercial/claim-scope-tr
 import { SuccessFeeCalculator } from '@/components/commercial/success-fee-calculator';
 import { buildSuccessFeeCalculatorProps } from '@/components/commercial/success-fee-calculator-content';
 import { generateLocaleStaticParams } from '@/app/_locale-static-params';
+import {
+  resolveBillingEntityFromPathSegment,
+  resolveBillingTenantIdForEntity,
+} from '@interdomestik/domain-membership-billing/paddle-server';
 import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { PricingPageRuntime } from './pricing-page-runtime';
@@ -34,6 +38,10 @@ export default async function PricingPage({ params }: PricingPageProps) {
   ]);
 
   const billingTestMode = process.env.NEXT_PUBLIC_BILLING_TEST_MODE === '1';
+  const billingEntity = resolveBillingEntityFromPathSegment(
+    process.env.PADDLE_DEFAULT_BILLING_ENTITY
+  );
+  const billingTenantId = billingEntity ? resolveBillingTenantIdForEntity(billingEntity) : null;
 
   return (
     <div
@@ -66,7 +74,7 @@ export default async function PricingPage({ params }: PricingPageProps) {
         ]}
       />
 
-      <PricingPageRuntime billingTestMode={billingTestMode} />
+      <PricingPageRuntime billingTenantId={billingTenantId} billingTestMode={billingTestMode} />
 
       <div className="mt-16">
         <SuccessFeeCalculator

--- a/apps/web/src/app/[locale]/(site)/pricing/pricing-page-runtime.test.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/pricing-page-runtime.test.tsx
@@ -40,13 +40,14 @@ describe('PricingPageRuntime', () => {
       isPending: true,
     });
 
-    render(<PricingPageRuntime billingTestMode={false} />);
+    render(<PricingPageRuntime billingTenantId="tenant_ks" billingTestMode={false} />);
 
     await waitFor(() => {
       expect(hoisted.pricingTableMock).toHaveBeenCalledWith({
         billingTestMode: false,
         email: undefined,
         isSessionPending: true,
+        tenantId: 'tenant_ks',
         userId: undefined,
       });
     });
@@ -74,13 +75,14 @@ describe('PricingPageRuntime', () => {
       isPending: false,
     });
 
-    render(<PricingPageRuntime billingTestMode />);
+    render(<PricingPageRuntime billingTenantId="tenant_mk" billingTestMode />);
 
     await waitFor(() => {
       expect(hoisted.pricingTableMock).toHaveBeenCalledWith({
         billingTestMode: true,
         email: 'member@example.com',
         isSessionPending: false,
+        tenantId: 'tenant_mk',
         userId: 'user-1',
       });
     });

--- a/apps/web/src/app/[locale]/(site)/pricing/pricing-page-runtime.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/pricing-page-runtime.tsx
@@ -8,9 +8,10 @@ import { useEffect } from 'react';
 
 type PricingPageRuntimeProps = Readonly<{
   billingTestMode: boolean;
+  billingTenantId?: string | null;
 }>;
 
-export function PricingPageRuntime({ billingTestMode }: PricingPageRuntimeProps) {
+export function PricingPageRuntime({ billingTestMode, billingTenantId }: PricingPageRuntimeProps) {
   const { data: session, isPending } = authClient.useSession();
   const user = session?.user;
   const locale = useLocale();
@@ -33,6 +34,7 @@ export function PricingPageRuntime({ billingTestMode }: PricingPageRuntimeProps)
       billingTestMode={billingTestMode}
       email={user?.email}
       isSessionPending={isPending}
+      tenantId={billingTenantId}
       userId={user?.id}
     />
   );

--- a/apps/web/src/components/pricing/pricing-table.test.tsx
+++ b/apps/web/src/components/pricing/pricing-table.test.tsx
@@ -7,8 +7,9 @@ import { PricingTable } from './pricing-table';
 // Mock dependencies
 import { cloneElement, isValidElement, MouseEventHandler, ReactElement, ReactNode } from 'react';
 const mockRouterPush = vi.fn();
-const { mockToastError } = vi.hoisted(() => ({
+const { mockToastError, mockGetCookie } = vi.hoisted(() => ({
   mockToastError: vi.fn(),
+  mockGetCookie: vi.fn(),
 }));
 let mockLocale = 'en';
 
@@ -78,6 +79,10 @@ vi.mock('sonner', () => ({
   },
 }));
 
+vi.mock('cookies-next', () => ({
+  getCookie: mockGetCookie,
+}));
+
 describe('PricingTable', () => {
   const mockPaddle = {
     Checkout: {
@@ -91,6 +96,7 @@ describe('PricingTable', () => {
     vi.unstubAllEnvs();
     mockRouterPush.mockReset();
     mockToastError.mockReset();
+    mockGetCookie.mockReset();
     mockLocale = 'en';
     process.env.NEXT_PUBLIC_PILOT_MODE = originalPilotMode;
     window.history.replaceState({}, '', '/pricing');
@@ -123,7 +129,14 @@ describe('PricingTable', () => {
   });
 
   it('initiates checkout on button click', async () => {
-    render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        tenantId="tenant_ks"
+      />
+    );
 
     // Find the Join Now button for standard plan (now at index 0)
     const joinButtons = screen.getAllByText('cta');
@@ -134,10 +147,50 @@ describe('PricingTable', () => {
         expect.objectContaining({
           items: expect.arrayContaining([{ priceId: PADDLE_PRICES.standard.yearly, quantity: 1 }]),
           customer: { email: 'test@example.com' },
-          customData: { userId: 'user-123' },
+          customData: {
+            acquisitionSource: 'self_serve_web',
+            tenantId: 'tenant_ks',
+            userId: 'user-123',
+          },
           settings: expect.objectContaining({
             successUrl: expect.stringContaining('/en/member/membership/success'),
             locale: 'en',
+          }),
+        })
+      );
+    });
+  });
+
+  it('preserves agent and marketing attribution in checkout customData when available', async () => {
+    mockGetCookie.mockReturnValue('agent-42');
+    window.history.replaceState(
+      {},
+      '',
+      '/pricing?utm_source=google&utm_medium=cpc&utm_campaign=funnel&utm_content=hero'
+    );
+
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        tenantId="tenant_mk"
+      />
+    );
+
+    fireEvent.click(screen.getAllByText('cta')[0]);
+
+    await waitFor(() => {
+      expect(mockPaddle.Checkout.open).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customData: expect.objectContaining({
+            acquisitionSource: 'self_serve_web',
+            agentId: 'agent-42',
+            tenantId: 'tenant_mk',
+            utmSource: 'google',
+            utmMedium: 'cpc',
+            utmCampaign: 'funnel',
+            utmContent: 'hero',
           }),
         })
       );

--- a/apps/web/src/components/pricing/pricing-table.test.tsx
+++ b/apps/web/src/components/pricing/pricing-table.test.tsx
@@ -163,7 +163,7 @@ describe('PricingTable', () => {
 
   it('preserves agent and marketing attribution in checkout customData when available', async () => {
     mockGetCookie.mockReturnValue('agent-42');
-    window.history.replaceState(
+    globalThis.history.replaceState(
       {},
       '',
       '/pricing?utm_source=google&utm_medium=cpc&utm_campaign=funnel&utm_content=hero'

--- a/apps/web/src/components/pricing/pricing-table.tsx
+++ b/apps/web/src/components/pricing/pricing-table.tsx
@@ -15,6 +15,7 @@ import { toast } from 'sonner';
 type PricingTableProps = Readonly<{
   userId?: string;
   email?: string;
+  tenantId?: string | null;
   billingTestMode?: boolean;
   isSessionPending?: boolean;
 }>;
@@ -57,16 +58,46 @@ function trackMembershipCheckoutOpened(args: { locale: string; planId: string; u
   );
 }
 
-function buildCheckoutCustomData(args: { userId?: string; agentId?: string }) {
+function getCheckoutAttribution(search: string) {
+  const params = new URLSearchParams(search);
+
+  const normalize = (key: string) => {
+    const value = params.get(key)?.trim();
+    return value ? value : undefined;
+  };
+
   return {
+    utmSource: normalize('utm_source'),
+    utmMedium: normalize('utm_medium'),
+    utmCampaign: normalize('utm_campaign'),
+    utmContent: normalize('utm_content'),
+  };
+}
+
+function buildCheckoutCustomData(args: {
+  userId?: string;
+  agentId?: string;
+  tenantId?: string | null;
+  search?: string;
+}) {
+  const attribution = getCheckoutAttribution(args.search ?? '');
+
+  return {
+    acquisitionSource: 'self_serve_web',
     ...(args.userId ? { userId: args.userId } : {}),
     ...(args.agentId ? { agentId: args.agentId } : {}),
+    ...(args.tenantId ? { tenantId: args.tenantId } : {}),
+    ...(attribution.utmSource ? { utmSource: attribution.utmSource } : {}),
+    ...(attribution.utmMedium ? { utmMedium: attribution.utmMedium } : {}),
+    ...(attribution.utmCampaign ? { utmCampaign: attribution.utmCampaign } : {}),
+    ...(attribution.utmContent ? { utmContent: attribution.utmContent } : {}),
   };
 }
 
 export function PricingTable({
   userId,
   email,
+  tenantId,
   billingTestMode,
   isSessionPending = false,
 }: PricingTableProps) {
@@ -221,6 +252,8 @@ export function PricingTable({
       customData: buildCheckoutCustomData({
         userId,
         agentId: agentId ? String(agentId) : undefined,
+        tenantId,
+        search: window.location.search,
       }),
       settings: {
         displayMode: 'overlay',

--- a/apps/web/src/components/pricing/pricing-table.tsx
+++ b/apps/web/src/components/pricing/pricing-table.tsx
@@ -63,7 +63,7 @@ function getCheckoutAttribution(search: string) {
 
   const normalize = (key: string) => {
     const value = params.get(key)?.trim();
-    return value ? value : undefined;
+    return value || undefined;
   };
 
   return {
@@ -229,7 +229,6 @@ export function PricingTable({
   };
 
   const openPaddleCheckout = async (args: { planId: string; priceId: string }) => {
-    console.log('🏷️ Opening Paddle checkout with Price ID:', args.priceId);
     const paddle = await getPaddleInstance();
 
     if (!paddle) {
@@ -253,13 +252,13 @@ export function PricingTable({
         userId,
         agentId: agentId ? String(agentId) : undefined,
         tenantId,
-        search: window.location.search,
+        search: globalThis.location.search,
       }),
       settings: {
         displayMode: 'overlay',
         theme: 'light',
         locale: getPaddleLocale(locale),
-        successUrl: `${window.location.origin}/${locale}/member/membership/success`,
+        successUrl: `${globalThis.location.origin}/${locale}/member/membership/success`,
       },
     });
   };

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -116,6 +116,8 @@ describe('Paddle Webhook Handlers', () => {
     });
 
     it('uses customData tenant and attribution metadata for anonymous transactions', async () => {
+      hoisted.db.query.subscriptions.findFirst.mockResolvedValue(undefined);
+
       const payload = {
         id: 'tx_anon',
         status: 'completed',
@@ -148,6 +150,32 @@ describe('Paddle Webhook Handlers', () => {
             utmSource: 'google',
             utmCampaign: 'diaspora',
           }),
+        })
+      );
+      expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('prefers persisted subscription tenant over client-provided tenant metadata', async () => {
+      hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+        tenantId: 'tenant_real',
+      });
+
+      const payload = {
+        id: 'tx_existing',
+        status: 'completed',
+        subscriptionId: 'sub_existing',
+        customData: {
+          tenantId: 'tenant_bad',
+          acquisitionSource: 'self_serve_web',
+        },
+        details: { totals: { total: '2000', currencyCode: 'EUR' } },
+      };
+
+      await handleTransactionCompleted({ data: payload }, { logAuditEvent });
+
+      expect(logAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: 'tenant_real',
         })
       );
       expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -114,5 +114,43 @@ describe('Paddle Webhook Handlers', () => {
         })
       );
     });
+
+    it('uses customData tenant and attribution metadata for anonymous transactions', async () => {
+      const payload = {
+        id: 'tx_anon',
+        status: 'completed',
+        subscriptionId: 'sub_anon',
+        customerId: 'ctm_123',
+        customerEmail: 'buyer@example.com',
+        customData: {
+          tenantId: 'tenant_mk',
+          acquisitionSource: 'self_serve_web',
+          agentId: 'agent_9',
+          utmSource: 'google',
+          utmCampaign: 'diaspora',
+        },
+        details: { totals: { total: '3500', currencyCode: 'EUR' } },
+      };
+
+      await handleTransactionCompleted({ data: payload }, { logAuditEvent });
+
+      expect(logAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'payment.processed',
+          entityId: 'tx_anon',
+          tenantId: 'tenant_mk',
+          metadata: expect.objectContaining({
+            acquisitionSource: 'self_serve_web',
+            agentId: 'agent_9',
+            customerEmail: 'buyer@example.com',
+            customerId: 'ctm_123',
+            subscriptionId: 'sub_anon',
+            utmSource: 'google',
+            utmCampaign: 'diaspora',
+          }),
+        })
+      );
+      expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
@@ -15,29 +15,42 @@ export async function handleTransactionCompleted(
 
   const customData = tx.customData || tx.custom_data;
   const userId = customData?.userId;
+  const tenantIdFromCustomData = customData?.tenantId;
   const subscriptionId = tx.subscriptionId || tx.subscription_id;
+  const customerId = tx.customerId || tx.customer_id;
+  const customerEmail = tx.customerEmail || tx.customer_email;
+  let tenantId = tenantIdFromCustomData ?? null;
 
-  if (userId && subscriptionId) {
-    // Resolve Tenant for Audit Log
+  if (userId) {
     const user = await db.query.user.findFirst({
       where: (t, { eq }) => eq(t.id, userId),
       columns: { tenantId: true },
     });
+    tenantId = user?.tenantId ?? tenantId;
+  }
 
-    if (deps.logAuditEvent && user?.tenantId) {
-      await deps.logAuditEvent({
-        actorRole: 'system',
-        action: 'payment.processed',
-        entityType: 'transaction',
-        entityId: tx.id,
-        tenantId: user.tenantId,
-        metadata: {
-          subscriptionId,
-          status: tx.status,
-          currency: tx.details?.totals?.currencyCode,
-          amount: tx.details?.totals?.total,
-        },
-      });
-    }
+  if (deps.logAuditEvent && tenantId) {
+    await deps.logAuditEvent({
+      actorRole: 'system',
+      action: 'payment.processed',
+      entityType: 'transaction',
+      entityId: tx.id,
+      tenantId,
+      metadata: {
+        subscriptionId,
+        status: tx.status,
+        currency: tx.details?.totals?.currencyCode,
+        amount: tx.details?.totals?.total,
+        acquisitionSource: customData?.acquisitionSource,
+        agentId: customData?.agentId,
+        customerEmail,
+        customerId,
+        userId: userId ?? null,
+        utmSource: customData?.utmSource,
+        utmMedium: customData?.utmMedium,
+        utmCampaign: customData?.utmCampaign,
+        utmContent: customData?.utmContent,
+      },
+    });
   }
 }

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
@@ -19,7 +19,15 @@ export async function handleTransactionCompleted(
   const subscriptionId = tx.subscriptionId || tx.subscription_id;
   const customerId = tx.customerId || tx.customer_id;
   const customerEmail = tx.customerEmail || tx.customer_email;
-  let tenantId = tenantIdFromCustomData ?? null;
+  let tenantId: string | null = null;
+
+  if (subscriptionId) {
+    const subscription = await db.query.subscriptions.findFirst({
+      where: (subs, { eq }) => eq(subs.id, subscriptionId),
+      columns: { tenantId: true },
+    });
+    tenantId = subscription?.tenantId ?? null;
+  }
 
   if (userId) {
     const user = await db.query.user.findFirst({
@@ -28,6 +36,8 @@ export async function handleTransactionCompleted(
     });
     tenantId = user?.tenantId ?? tenantId;
   }
+
+  tenantId ??= tenantIdFromCustomData ?? null;
 
   if (deps.logAuditEvent && tenantId) {
     await deps.logAuditEvent({

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.test.ts
@@ -163,6 +163,30 @@ describe('context utils', () => {
       );
     });
 
+    it('should prefer canonical tenant over mismatched customData tenant', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const sub = { id: 's_existing', customData: { userId: 'u_1', tenantId: 'tenant_bad' } };
+
+      (db.query.subscriptions.findFirst as any).mockImplementation(
+        mockDbResponse({ tenantId: 'tenant_real', userId: 'u_1' })
+      );
+      (db.query.user.findFirst as any).mockImplementation(
+        mockDbResponse({ tenantId: 'tenant_real', email: 'member@example.com' })
+      );
+      (db.query.tenantSettings.findFirst as any).mockImplementation(
+        mockDbResponse({ value: { branchId: 'br_def' } })
+      );
+
+      const result = await resolveSubscriptionContext(sub);
+
+      expect(result?.tenantId).toBe('tenant_real');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Ignoring mismatched customData.tenantId')
+      );
+
+      warnSpy.mockRestore();
+    });
+
     it('should return null if tenant cannot be resolved', async () => {
       const sub = { id: 's_bad', customData: { userId: 'u_1' } };
       (db.query.subscriptions.findFirst as any).mockImplementation(mockDbResponse(undefined));

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.test.ts
@@ -109,7 +109,7 @@ describe('context utils', () => {
       const sub = { id: 's_1', customData: { userId: 'u_1' } };
 
       (db.query.subscriptions.findFirst as any).mockImplementation(
-        mockDbResponse({ tenantId: 'tn_ex' })
+        mockDbResponse({ tenantId: 'tn_ex', userId: 'u_1' })
       );
       (db.query.user.findFirst as any).mockImplementation(mockDbResponse({ email: 'e@mail.com' }));
       (db.query.tenantSettings.findFirst as any).mockImplementation(
@@ -138,6 +138,29 @@ describe('context utils', () => {
 
       const result = await resolveSubscriptionContext(sub);
       expect(result?.tenantId).toBe('tn_usr');
+    });
+
+    it('should reuse existing subscription user when customData omits userId', async () => {
+      const sub = { id: 's_existing', customData: { tenantId: 'tenant_mk', agentId: 'ag_1' } };
+
+      (db.query.subscriptions.findFirst as any).mockImplementation(
+        mockDbResponse({ tenantId: 'tenant_mk', userId: 'user_existing' })
+      );
+      (db.query.user.findFirst as any).mockImplementation(
+        mockDbResponse({ tenantId: 'tenant_mk', email: 'member@example.com' })
+      );
+      (db.query.tenantSettings.findFirst as any).mockImplementation(
+        mockDbResponse({ value: { branchId: 'br_agent' } })
+      );
+
+      const result = await resolveSubscriptionContext(sub);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          userId: 'user_existing',
+          tenantId: 'tenant_mk',
+        })
+      );
     });
 
     it('should return null if tenant cannot be resolved', async () => {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
@@ -39,26 +39,35 @@ export async function resolveBranchId(args: {
 
 export async function resolveSubscriptionContext(sub: any) {
   const customData = (sub.customData || sub.custom_data) as
-    | { userId?: string; agentId?: string }
+    | {
+        userId?: string;
+        agentId?: string;
+        tenantId?: string;
+        acquisitionSource?: string;
+        utmSource?: string;
+        utmMedium?: string;
+        utmCampaign?: string;
+        utmContent?: string;
+      }
     | undefined;
-  const userId = customData?.userId;
+
+  const existingSub = await db.query.subscriptions.findFirst({
+    where: (subs, { eq }) => eq(subs.id, sub.id),
+    columns: { tenantId: true, userId: true },
+  });
+  const userId = customData?.userId ?? existingSub?.userId;
 
   if (!userId) {
     console.warn(`[Webhook] No userId found in customData for subscription ${sub.id}`);
     return null;
   }
 
-  const existingSub = await db.query.subscriptions.findFirst({
-    where: (subs, { eq }) => eq(subs.id, sub.id),
-    columns: { tenantId: true },
-  });
-
   const userRecord = await db.query.user.findFirst({
     where: (users, { eq }) => eq(users.id, userId),
     columns: { tenantId: true, email: true, name: true, memberNumber: true },
   });
 
-  const tenantId = existingSub?.tenantId ?? userRecord?.tenantId;
+  const tenantId = existingSub?.tenantId ?? customData?.tenantId ?? userRecord?.tenantId;
 
   if (!tenantId) {
     console.warn(

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
@@ -67,7 +67,14 @@ export async function resolveSubscriptionContext(sub: any) {
     columns: { tenantId: true, email: true, name: true, memberNumber: true },
   });
 
-  const tenantId = existingSub?.tenantId ?? customData?.tenantId ?? userRecord?.tenantId;
+  const canonicalTenantId = existingSub?.tenantId ?? userRecord?.tenantId;
+  const tenantId = canonicalTenantId ?? customData?.tenantId;
+
+  if (canonicalTenantId && customData?.tenantId && customData.tenantId !== canonicalTenantId) {
+    console.warn(
+      `[Webhook] Ignoring mismatched customData.tenantId for subscription ${sub.id} userId=${userId}; canonical tenant=${canonicalTenantId} customData tenant=${customData.tenantId}`
+    );
+  }
 
   if (!tenantId) {
     console.warn(

--- a/packages/domain-membership-billing/src/paddle-webhooks/schemas.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/schemas.ts
@@ -5,6 +5,12 @@ const customDataSchema = z
   .object({
     userId: z.string().optional(),
     agentId: z.string().optional(),
+    tenantId: z.string().optional(),
+    acquisitionSource: z.string().optional(),
+    utmSource: z.string().optional(),
+    utmMedium: z.string().optional(),
+    utmCampaign: z.string().optional(),
+    utmContent: z.string().optional(),
   })
   .passthrough(); // NOSONAR
 
@@ -65,6 +71,10 @@ export const transactionEventDataSchema = z
   .object({
     id: z.string(),
     status: z.string(),
+    customerId: z.string().optional().nullable(),
+    customer_id: z.string().optional().nullable(),
+    customerEmail: z.string().email().optional().nullable(),
+    customer_email: z.string().email().optional().nullable(),
 
     subscriptionId: z.string().optional().nullable(),
     subscription_id: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary
- carry trusted checkout metadata from pricing into Paddle custom data
- expand Paddle webhook schemas and transaction audit metadata for anonymous self-serve attribution
- reuse existing subscription context when webhook custom data omits a user id

## Verification
- pnpm --filter @interdomestik/web test:unit --run src/components/pricing/pricing-table.test.tsx 'src/app/[locale]/(site)/pricing/pricing-page-runtime.test.tsx'
- pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/paddle-webhooks/handlers.test.ts src/paddle-webhooks/handlers/utils/context.test.ts
- pnpm --filter @interdomestik/web type-check
- pnpm --filter @interdomestik/domain-membership-billing type-check
- pnpm security:guard
- NODE20_BIN=$(dirname "$(npx -y node@20 -p 'process.execPath')"); PATH="$NODE20_BIN:$PATH" pnpm pr:verify
