### PR TITLE
fix: harden claim numbering and paddle checkout config

### DIFF
--- a/apps/web/e2e/production.spec.ts
+++ b/apps/web/e2e/production.spec.ts
@@ -179,7 +179,10 @@ test.describe.serial('@smoke Production Smoke Test Plan', () => {
           return 'ui-v2-success';
         }
 
-        if (pathname.endsWith('/member/claims') && (await claimListLink.isVisible().catch(() => false))) {
+        if (
+          pathname.endsWith('/member/claims') &&
+          (await claimListLink.isVisible().catch(() => false))
+        ) {
           return 'claims-list';
         }
 
@@ -190,7 +193,11 @@ test.describe.serial('@smoke Production Smoke Test Plan', () => {
       const postSubmitState = await resolvePostSubmitState();
 
       if (postSubmitState === 'ui-v2-success') {
-        await expect(page).toHaveURL(/\/member\/claims\/new(?:\?.*)?$/, { timeout: 30000 });
+        await expect
+          .poll(() => new URL(page.url()).pathname.endsWith('/member/claims/new'), {
+            timeout: 30000,
+          })
+          .toBe(true);
 
         const createdClaimLink = page.getByTestId('claim-created-go-to-claim').first();
         const createdClaimHref = await createdClaimLink.getAttribute('href');
@@ -203,15 +210,18 @@ test.describe.serial('@smoke Production Smoke Test Plan', () => {
         await createdClaimLink.click();
 
         await expect
-          .poll(() => {
-            const pathname = new URL(page.url()).pathname;
-            const claimSegments = pathname.split('/').filter(Boolean);
-            return (
-              claimSegments.length >= 4 &&
-              claimSegments[claimSegments.length - 2] === 'claims' &&
-              claimSegments[claimSegments.length - 1] !== 'new'
-            );
-          }, { timeout: 30000 })
+          .poll(
+            () => {
+              const pathname = new URL(page.url()).pathname;
+              const claimSegments = pathname.split('/').filter(Boolean);
+              return (
+                claimSegments.length >= 4 &&
+                claimSegments[claimSegments.length - 2] === 'claims' &&
+                claimSegments[claimSegments.length - 1] !== 'new'
+              );
+            },
+            { timeout: 30000 }
+          )
           .toBe(true);
         await expect(page.getByRole('heading', { name: CLAIM_TITLE })).toBeVisible({
           timeout: 10000,

--- a/apps/web/e2e/production.spec.ts
+++ b/apps/web/e2e/production.spec.ts
@@ -169,9 +169,57 @@ test.describe.serial('@smoke Production Smoke Test Plan', () => {
         // Wizard may have auto-submitted on some versions
       }
 
-      // 5. Verify Redirect/Success
-      await expect(page).toHaveURL(/\/member\/claims(?:\?.*)?$/, { timeout: 30000 });
-      await expect(page.getByText(CLAIM_TITLE)).toBeVisible({ timeout: 10000 });
+      // 5. Verify whichever post-submit contract is active for this environment
+      const successCard = page.getByTestId('claim-created-success').first();
+      const claimListLink = page.getByRole('link', { name: CLAIM_TITLE }).first();
+      const resolvePostSubmitState = async () => {
+        const pathname = new URL(page.url()).pathname;
+
+        if (await successCard.isVisible().catch(() => false)) {
+          return 'ui-v2-success';
+        }
+
+        if (pathname.endsWith('/member/claims') && (await claimListLink.isVisible().catch(() => false))) {
+          return 'claims-list';
+        }
+
+        return 'pending';
+      };
+
+      await expect.poll(resolvePostSubmitState, { timeout: 30000 }).not.toBe('pending');
+      const postSubmitState = await resolvePostSubmitState();
+
+      if (postSubmitState === 'ui-v2-success') {
+        await expect(page).toHaveURL(/\/member\/claims\/new(?:\?.*)?$/, { timeout: 30000 });
+
+        const createdClaimLink = page.getByTestId('claim-created-go-to-claim').first();
+        const createdClaimHref = await createdClaimLink.getAttribute('href');
+        expect(createdClaimHref).toBeTruthy();
+        const createdClaimPath = new URL(createdClaimHref!, 'http://localhost').pathname;
+        const createdClaimSegments = createdClaimPath.split('/').filter(Boolean);
+        expect(createdClaimSegments[createdClaimSegments.length - 2]).toBe('claims');
+        expect(createdClaimSegments[createdClaimSegments.length - 1]).not.toBe('new');
+
+        await createdClaimLink.click();
+
+        await expect
+          .poll(() => {
+            const pathname = new URL(page.url()).pathname;
+            const claimSegments = pathname.split('/').filter(Boolean);
+            return (
+              claimSegments.length >= 4 &&
+              claimSegments[claimSegments.length - 2] === 'claims' &&
+              claimSegments[claimSegments.length - 1] !== 'new'
+            );
+          }, { timeout: 30000 })
+          .toBe(true);
+        await expect(page.getByRole('heading', { name: CLAIM_TITLE })).toBeVisible({
+          timeout: 10000,
+        });
+      } else {
+        await expect(page).toHaveURL(/\/member\/claims(?:\?.*)?$/, { timeout: 30000 });
+        await expect(claimListLink).toBeVisible({ timeout: 10000 });
+      }
     });
   });
 

--- a/apps/web/src/actions/claims.test.ts
+++ b/apps/web/src/actions/claims.test.ts
@@ -349,6 +349,7 @@ describe('Claim Actions', () => {
       expect(result).toEqual({
         success: true,
         claimId: 'test-id',
+        claimNumber: 'CLM-MK-2026-000001',
         commercialFlow: {
           escalationRequest: {
             claimCategory: 'consumer',

--- a/apps/web/src/actions/claims/submit.core.ts
+++ b/apps/web/src/actions/claims/submit.core.ts
@@ -40,6 +40,7 @@ export type SubmitClaimResult =
   | {
       success: true;
       claimId: string;
+      claimNumber: string;
       commercialFlow: SubmitClaimCommercialFlow;
     }
   | { success: false; error: string; code?: string };
@@ -111,6 +112,7 @@ export async function submitClaimCore(params: {
           return {
             success: true,
             claimId: result.claimId,
+            claimNumber: result.claimNumber,
             commercialFlow: resolveCommercialFlow(params.data.category),
           };
         }

--- a/apps/web/src/actions/claims/submit.test.ts
+++ b/apps/web/src/actions/claims/submit.test.ts
@@ -60,6 +60,7 @@ describe('actions/claims/submit', () => {
     (submitClaimCoreDomain as any).mockResolvedValueOnce({
       success: true,
       claimId: 'claim-1',
+      claimNumber: 'CLM-T1-2026-000001',
     });
 
     const result = await submitClaimCore({
@@ -72,6 +73,7 @@ describe('actions/claims/submit', () => {
     expect(result).toEqual({
       success: true,
       claimId: 'claim-1',
+      claimNumber: 'CLM-T1-2026-000001',
       commercialFlow: {
         escalationRequest: {
           claimCategory: 'transport',
@@ -100,6 +102,7 @@ describe('actions/claims/submit', () => {
     (submitClaimCoreDomain as any).mockResolvedValueOnce({
       success: true,
       claimId: 'claim-1',
+      claimNumber: 'CLM-T1-2026-000001',
     });
 
     const result = await submitClaimCore({
@@ -114,6 +117,7 @@ describe('actions/claims/submit', () => {
     expect(result).toEqual({
       success: true,
       claimId: 'claim-1',
+      claimNumber: 'CLM-T1-2026-000001',
       commercialFlow: {
         escalationRequest: {
           claimCategory: 'vehicle',
@@ -132,6 +136,7 @@ describe('actions/claims/submit', () => {
     (submitClaimCoreDomain as any).mockResolvedValueOnce({
       success: true,
       claimId: 'claim-1',
+      claimNumber: 'CLM-T1-2026-000001',
     });
 
     await submitClaimCore({

--- a/apps/web/src/app/[locale]/(site)/pricing/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/_core.entry.test.tsx
@@ -111,7 +111,7 @@ describe('PricingPage server shell', () => {
   });
 
   it('keeps rendering the pricing shell during local sandbox builds when checkout config is unavailable', async () => {
-    process.env.NODE_ENV = 'production';
+    vi.stubEnv('NODE_ENV', 'production');
     process.env.NEXT_PUBLIC_PADDLE_ENV = 'sandbox';
     delete process.env.VERCEL_ENV;
 

--- a/apps/web/src/app/[locale]/(site)/pricing/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/_core.entry.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { expectCoverageMatrix, getNamespacedTranslation } from '@/test/coverage-matrix-test-utils';
 import { expectCommercialTerms } from '@/test/commercial-terms-test-utils';
 import { expectSuccessFeeCalculator } from '@/test/success-fee-calculator-test-utils';
@@ -13,8 +13,23 @@ const hoisted = vi.hoisted(() => ({
       email: 'member@example.com',
     },
   })),
+  getPublicBillingCheckoutConfigMock: vi.fn(() => ({
+    entity: 'ks',
+    tenantId: 'tenant_ks',
+    environment: 'sandbox',
+    clientToken: 'test_client_token_ks',
+    priceIds: {
+      standardYear: 'pri_standard_year',
+      familyYear: 'pri_family_year',
+      businessYear: 'pri_business_year',
+    },
+  })),
+  resolveBillingEntityFromPathSegmentMock: vi.fn(() => 'ks'),
+  resolveBillingTenantIdForEntityMock: vi.fn(() => 'tenant_ks'),
   pricingPageRuntimeMock: vi.fn((_: unknown) => null),
 }));
+
+const ORIGINAL_ENV = { ...process.env };
 
 vi.mock('next/headers', () => ({
   headers: hoisted.headersMock,
@@ -34,6 +49,12 @@ vi.mock('next-intl/server', () => ({
   ),
 }));
 
+vi.mock('@interdomestik/domain-membership-billing/paddle-server', () => ({
+  getPublicBillingCheckoutConfig: hoisted.getPublicBillingCheckoutConfigMock,
+  resolveBillingEntityFromPathSegment: hoisted.resolveBillingEntityFromPathSegmentMock,
+  resolveBillingTenantIdForEntity: hoisted.resolveBillingTenantIdForEntityMock,
+}));
+
 vi.mock('./pricing-page-runtime', () => ({
   PricingPageRuntime: (props: unknown) => hoisted.pricingPageRuntimeMock(props),
 }));
@@ -45,6 +66,15 @@ vi.mock('@/components/pricing/pricing-table', () => ({
 import PricingPage from './_core.entry';
 
 describe('PricingPage server shell', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
   it('does not read request headers or session data while rendering the pricing shell', async () => {
     const tree = await PricingPage({
       params: Promise.resolve({ locale: 'sq' }),
@@ -68,7 +98,45 @@ describe('PricingPage server shell', () => {
     expect(screen.getByText('pricing.scope.guidance.title')).toBeInTheDocument();
     expect(screen.getByText('pricing.scope.outOfScope.title')).toBeInTheDocument();
     expect(screen.getByText('pricing.scope.boundary.title')).toBeInTheDocument();
+    expect(hoisted.pricingPageRuntimeMock).toHaveBeenCalledWith({
+      billingTestMode: false,
+      billingTenantId: 'tenant_ks',
+      checkoutConfig: expect.objectContaining({
+        entity: 'ks',
+        tenantId: 'tenant_ks',
+      }),
+    });
     expect(hoisted.headersMock).not.toHaveBeenCalled();
     expect(hoisted.getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps rendering the pricing shell during local sandbox builds when checkout config is unavailable', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_PADDLE_ENV = 'sandbox';
+    delete process.env.VERCEL_ENV;
+
+    const checkoutConfigError = new Error('missing public sandbox checkout config');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    hoisted.getPublicBillingCheckoutConfigMock.mockImplementationOnce(() => {
+      throw checkoutConfigError;
+    });
+
+    const tree = await PricingPage({
+      params: Promise.resolve({ locale: 'sq' }),
+    });
+
+    render(tree);
+
+    expect(hoisted.pricingPageRuntimeMock).toHaveBeenCalledWith({
+      billingTestMode: false,
+      billingTenantId: 'tenant_ks',
+      checkoutConfig: null,
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Public Paddle checkout config unavailable for pricing page:',
+      checkoutConfigError
+    );
+
+    warnSpy.mockRestore();
   });
 });

--- a/apps/web/src/app/[locale]/(site)/pricing/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/_core.entry.tsx
@@ -9,6 +9,8 @@ import { SuccessFeeCalculator } from '@/components/commercial/success-fee-calcul
 import { buildSuccessFeeCalculatorProps } from '@/components/commercial/success-fee-calculator-content';
 import { generateLocaleStaticParams } from '@/app/_locale-static-params';
 import {
+  getPublicBillingCheckoutConfig,
+  type PublicBillingCheckoutConfig,
   resolveBillingEntityFromPathSegment,
   resolveBillingTenantIdForEntity,
 } from '@interdomestik/domain-membership-billing/paddle-server';
@@ -42,6 +44,23 @@ export default async function PricingPage({ params }: PricingPageProps) {
     process.env.PADDLE_DEFAULT_BILLING_ENTITY
   );
   const billingTenantId = billingEntity ? resolveBillingTenantIdForEntity(billingEntity) : null;
+  let checkoutConfig: PublicBillingCheckoutConfig | null = null;
+
+  if (!billingTestMode) {
+    try {
+      checkoutConfig = getPublicBillingCheckoutConfig();
+    } catch (error) {
+      if (
+        process.env.VERCEL_ENV !== 'production' &&
+        process.env.NEXT_PUBLIC_PADDLE_ENV !== 'production'
+      ) {
+        console.warn('Public Paddle checkout config unavailable for pricing page:', error);
+      } else {
+        throw error;
+      }
+    }
+  }
+  const resolvedBillingTenantId = checkoutConfig?.tenantId ?? billingTenantId;
 
   return (
     <div
@@ -74,7 +93,11 @@ export default async function PricingPage({ params }: PricingPageProps) {
         ]}
       />
 
-      <PricingPageRuntime billingTenantId={billingTenantId} billingTestMode={billingTestMode} />
+      <PricingPageRuntime
+        billingTenantId={resolvedBillingTenantId}
+        billingTestMode={billingTestMode}
+        checkoutConfig={checkoutConfig}
+      />
 
       <div className="mt-16">
         <SuccessFeeCalculator

--- a/apps/web/src/app/[locale]/(site)/pricing/pricing-page-runtime.test.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/pricing-page-runtime.test.tsx
@@ -29,6 +29,18 @@ vi.mock('next-intl', () => ({
 
 import { PricingPageRuntime } from './pricing-page-runtime';
 
+const checkoutConfig = {
+  entity: 'ks',
+  tenantId: 'tenant_ks',
+  environment: 'sandbox',
+  clientToken: 'test_client_token_ks',
+  priceIds: {
+    standardYear: 'pri_standard_year',
+    familyYear: 'pri_family_year',
+    businessYear: 'pri_business_year',
+  },
+} as const;
+
 describe('PricingPageRuntime', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -40,11 +52,18 @@ describe('PricingPageRuntime', () => {
       isPending: true,
     });
 
-    render(<PricingPageRuntime billingTenantId="tenant_ks" billingTestMode={false} />);
+    render(
+      <PricingPageRuntime
+        billingTenantId="tenant_ks"
+        billingTestMode={false}
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     await waitFor(() => {
       expect(hoisted.pricingTableMock).toHaveBeenCalledWith({
         billingTestMode: false,
+        checkoutConfig,
         email: undefined,
         isSessionPending: true,
         tenantId: 'tenant_ks',
@@ -75,11 +94,18 @@ describe('PricingPageRuntime', () => {
       isPending: false,
     });
 
-    render(<PricingPageRuntime billingTenantId="tenant_mk" billingTestMode />);
+    render(
+      <PricingPageRuntime
+        billingTenantId="tenant_mk"
+        billingTestMode
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     await waitFor(() => {
       expect(hoisted.pricingTableMock).toHaveBeenCalledWith({
         billingTestMode: true,
+        checkoutConfig,
         email: 'member@example.com',
         isSessionPending: false,
         tenantId: 'tenant_mk',

--- a/apps/web/src/app/[locale]/(site)/pricing/pricing-page-runtime.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/pricing-page-runtime.tsx
@@ -3,15 +3,21 @@
 import { PricingTable } from '@/components/pricing/pricing-table';
 import { CommercialFunnelEvents } from '@/lib/analytics';
 import { authClient } from '@/lib/auth-client';
+import type { PublicBillingCheckoutConfig } from '@interdomestik/domain-membership-billing/paddle-server';
 import { useLocale } from 'next-intl';
 import { useEffect } from 'react';
 
 type PricingPageRuntimeProps = Readonly<{
   billingTestMode: boolean;
   billingTenantId?: string | null;
+  checkoutConfig: PublicBillingCheckoutConfig | null;
 }>;
 
-export function PricingPageRuntime({ billingTestMode, billingTenantId }: PricingPageRuntimeProps) {
+export function PricingPageRuntime({
+  billingTestMode,
+  billingTenantId,
+  checkoutConfig,
+}: PricingPageRuntimeProps) {
   const { data: session, isPending } = authClient.useSession();
   const user = session?.user;
   const locale = useLocale();
@@ -32,6 +38,7 @@ export function PricingPageRuntime({ billingTestMode, billingTenantId }: Pricing
   return (
     <PricingTable
       billingTestMode={billingTestMode}
+      checkoutConfig={checkoutConfig}
       email={user?.email}
       isSessionPending={isPending}
       tenantId={billingTenantId}

--- a/apps/web/src/app/api/policies/analyze/route.test.ts
+++ b/apps/web/src/app/api/policies/analyze/route.test.ts
@@ -89,7 +89,7 @@ describe('POST /api/policies/analyze', () => {
     const res = await POST(req as unknown as NextRequest);
     expect(res).toBeDefined();
     expect(res!.status).toBe(503);
-  });
+  }, 10000);
 
   it('queues a valid upload and returns 202 with a run id', async () => {
     const pngHeader = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0x00, 0x00, 0x00]);

--- a/apps/web/src/components/claims/claim-wizard.tsx
+++ b/apps/web/src/components/claims/claim-wizard.tsx
@@ -136,12 +136,13 @@ function getNextStepLabel(params: {
 function ClaimCreatedSuccess(
   props: Readonly<{
     claimId: string;
+    claimNumber: string;
     locale: string;
     contacts: ReturnType<typeof getSupportContacts>;
     tSuccess: ReturnType<typeof useTranslations>;
   }>
 ): React.JSX.Element {
-  const { claimId, locale, contacts, tSuccess } = props;
+  const { claimId, claimNumber, locale, contacts, tSuccess } = props;
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-8">
@@ -155,7 +156,7 @@ function ClaimCreatedSuccess(
         </div>
         <h2 className="text-2xl font-semibold tracking-tight">{tSuccess('title')}</h2>
         <p data-testid="claim-created-id">
-          {tSuccess('case_id')}: <span className="font-mono font-semibold">{claimId}</span>
+          {tSuccess('case_id')}: <span className="font-mono font-semibold">{claimNumber}</span>
         </p>
         <ul
           data-testid="claim-created-next-steps"
@@ -290,6 +291,7 @@ export function ClaimWizard({
   const [isLoaded, setIsLoaded] = React.useState(false);
   const [inlineError, setInlineError] = React.useState<string | null>(null);
   const [createdClaimId, setCreatedClaimId] = React.useState<string | null>(null);
+  const [createdClaimNumber, setCreatedClaimNumber] = React.useState<string | null>(null);
   const submitKeyRef = React.useRef<string | null>(null);
 
   const form = useForm({
@@ -380,6 +382,12 @@ export function ClaimWizard({
               ? (payload as { claimId: string }).claimId
               : null
             : null;
+        const claimNumber =
+          payload && typeof payload === 'object' && 'claimNumber' in payload
+            ? typeof (payload as { claimNumber?: unknown }).claimNumber === 'string'
+              ? (payload as { claimNumber: string }).claimNumber
+              : null
+            : null;
         const commercialFlow = getCommercialFlowFromResult(payload);
         const normalizedClaimId = claimId ?? 'unknown-claim-id';
         const normalizedCategory =
@@ -433,11 +441,13 @@ export function ClaimWizard({
         if (uiV2Enabled) {
           if (claimId) {
             setCreatedClaimId(claimId);
+            setCreatedClaimNumber(claimNumber ?? claimId);
           } else {
             console.error('[Wizard] Claim submission succeeded but no claimId was returned', {
               payload,
             });
             setCreatedClaimId('unknown-claim-id');
+            setCreatedClaimNumber('unknown-claim-id');
           }
           return;
         }
@@ -467,10 +477,11 @@ export function ClaimWizard({
     ? tDiaspora(`selector.options.${handoffContext.country}`)
     : null;
 
-  if (createdClaimId) {
+  if (createdClaimId && createdClaimNumber) {
     return (
       <ClaimCreatedSuccess
         claimId={createdClaimId}
+        claimNumber={createdClaimNumber}
         locale={locale}
         contacts={contacts}
         tSuccess={tSuccess}

--- a/apps/web/src/components/claims/claim-wizard.ui-v2.test.tsx
+++ b/apps/web/src/components/claims/claim-wizard.ui-v2.test.tsx
@@ -245,14 +245,18 @@ describe('ClaimWizard UI V2', () => {
     expect(screen.getByTestId('claims-wizard-disclaimer')).toBeInTheDocument();
   });
 
-  it('shows claim-created success state with claim id on final submit', async () => {
+  it('shows claim-created success state with the human claim number on final submit', async () => {
     mockTrigger.mockResolvedValue(true);
-    mockSubmitClaim.mockResolvedValue({ success: true, claimId: 'CLM-TEST-123' });
+    mockSubmitClaim.mockResolvedValue({
+      success: true,
+      claimId: 'v_j-vY7lHgTBeYsWwW8Wl',
+      claimNumber: 'CLM-XK-2026-000123',
+    });
 
     const success = await submitClaimAndWaitForSuccess();
     expect(success).toBeVisible();
     expect(success).toHaveTextContent('Case created');
-    expect(success).toHaveTextContent('CLM-TEST-123');
+    expect(success).toHaveTextContent('CLM-XK-2026-000123');
     expect(screen.getByTestId('claim-created-id')).toHaveTextContent('Case ID');
     expect(screen.getByTestId('claim-created-next-steps')).toBeInTheDocument();
     expect(screen.getByTestId('claim-created-help-call')).toHaveAttribute(
@@ -265,16 +269,16 @@ describe('ClaimWizard UI V2', () => {
     );
     expect(screen.getByTestId('claim-created-go-to-claim')).toHaveAttribute(
       'href',
-      '/sq/member/claims/CLM-TEST-123'
+      '/sq/member/claims/v_j-vY7lHgTBeYsWwW8Wl'
     );
     expect(mockPush).not.toHaveBeenCalled();
     expect(mockResolveFunnelVariant).toHaveBeenCalledWith(true);
     expect(mockFunnelFirstClaimSubmitted).toHaveBeenCalledWith(HERO_V2_CONTEXT, {
-      claim_id: 'CLM-TEST-123',
+      claim_id: 'v_j-vY7lHgTBeYsWwW8Wl',
     });
     expectCommercialFlowAnalytics({
       claimCategory: 'vehicle',
-      claimId: 'CLM-TEST-123',
+      claimId: 'v_j-vY7lHgTBeYsWwW8Wl',
       decisionReason: 'launch_scope_supported',
       escalationDecision: 'requested',
     });

--- a/apps/web/src/components/pricing/pricing-table.test.tsx
+++ b/apps/web/src/components/pricing/pricing-table.test.tsx
@@ -1,4 +1,3 @@
-import { PADDLE_PRICES } from '@/config/paddle';
 import { authClient } from '@/lib/auth-client';
 import * as paddleLib from '@interdomestik/domain-membership-billing/paddle';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
@@ -17,6 +16,17 @@ const { mockToastError, mockGetCookie } = vi.hoisted(() => ({
   mockGetCookie: vi.fn(),
 }));
 let mockLocale = 'en';
+const checkoutConfig = {
+  entity: 'ks',
+  tenantId: 'tenant_ks',
+  environment: 'sandbox',
+  clientToken: 'test_client_token_ks',
+  priceIds: {
+    standardYear: 'pri_standard_year',
+    familyYear: 'pri_family_year',
+    businessYear: 'pri_business_year',
+  },
+} as const;
 
 // Mock dependencies
 vi.mock('@interdomestik/ui', () => ({
@@ -131,7 +141,14 @@ describe('PricingTable', () => {
 
   it('marks the query-selected plan card for continuity after hydration', async () => {
     window.history.replaceState({}, '', '/pricing?plan=family');
-    render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('plan-card-family')).toHaveAttribute('data-selected-plan', '1');
@@ -147,7 +164,6 @@ describe('PricingTable', () => {
 
     expect(
       shouldRenderBusinessMembershipLink({
-        userId: undefined,
         planId: 'business',
         isPilotMode: false,
         isSessionPending: false,
@@ -155,8 +171,7 @@ describe('PricingTable', () => {
     ).toBe(true);
     expect(
       shouldRenderBusinessMembershipLink({
-        userId: 'user-123',
-        planId: 'business',
+        planId: 'standard',
         isPilotMode: false,
         isSessionPending: false,
       })
@@ -164,7 +179,14 @@ describe('PricingTable', () => {
   });
 
   it('renders plans correctly', () => {
-    render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     expect(screen.queryByText('basic.name')).toBeNull();
     expect(screen.queryByText('monthly')).toBeNull();
@@ -182,6 +204,7 @@ describe('PricingTable', () => {
         userId="user-123"
         email="test@example.com"
         billingTestMode={false}
+        checkoutConfig={checkoutConfig}
         tenantId="tenant_ks"
       />
     );
@@ -193,13 +216,15 @@ describe('PricingTable', () => {
     await waitFor(() => {
       expect(mockPaddle.Checkout.open).toHaveBeenCalledWith(
         expect.objectContaining({
-          items: expect.arrayContaining([{ priceId: PADDLE_PRICES.standard.yearly, quantity: 1 }]),
+          items: expect.arrayContaining([
+            { priceId: checkoutConfig.priceIds.standardYear, quantity: 1 },
+          ]),
           customer: { email: 'test@example.com' },
-          customData: {
+          customData: expect.objectContaining({
             acquisitionSource: 'self_serve_web',
             tenantId: 'tenant_ks',
             userId: 'user-123',
-          },
+          }),
           settings: expect.objectContaining({
             successUrl: expect.stringContaining('/en/member/membership/success'),
             locale: 'en',
@@ -222,6 +247,7 @@ describe('PricingTable', () => {
         userId="user-123"
         email="test@example.com"
         billingTestMode={false}
+        checkoutConfig={checkoutConfig}
         tenantId="tenant_mk"
       />
     );
@@ -246,7 +272,7 @@ describe('PricingTable', () => {
   });
 
   it('opens a self-serve confirmation for anonymous standard plan before continuing to email OTP onboarding', async () => {
-    render(<PricingTable billingTestMode={false} />);
+    render(<PricingTable billingTestMode={false} checkoutConfig={checkoutConfig} />);
 
     const standardCta = screen.getByTestId('plan-cta-standard');
     expect(standardCta.tagName).toBe('BUTTON');
@@ -271,7 +297,7 @@ describe('PricingTable', () => {
   });
 
   it('opens a self-serve confirmation for anonymous family plan before continuing to email OTP onboarding', async () => {
-    render(<PricingTable billingTestMode={false} />);
+    render(<PricingTable billingTestMode={false} checkoutConfig={checkoutConfig} />);
 
     fireEvent.click(screen.getByTestId('plan-cta-family'));
 
@@ -288,7 +314,7 @@ describe('PricingTable', () => {
   });
 
   it('sends an email OTP for anonymous self-serve onboarding', async () => {
-    render(<PricingTable billingTestMode={false} />);
+    render(<PricingTable billingTestMode={false} checkoutConfig={checkoutConfig} />);
 
     fireEvent.click(screen.getByTestId('plan-cta-standard'));
     fireEvent.click(screen.getByTestId('precheckout-continue-cta'));
@@ -309,7 +335,13 @@ describe('PricingTable', () => {
   });
 
   it('verifies the OTP with default acquisition tenant fields and continues into checkout for the selected plan', async () => {
-    render(<PricingTable billingTestMode={false} tenantId="tenant_ks" />);
+    render(
+      <PricingTable
+        billingTestMode={false}
+        checkoutConfig={checkoutConfig}
+        tenantId="tenant_ks"
+      />
+    );
 
     fireEvent.click(screen.getByTestId('plan-cta-standard'));
     fireEvent.click(screen.getByTestId('precheckout-continue-cta'));
@@ -334,7 +366,9 @@ describe('PricingTable', () => {
     await waitFor(() => {
       expect(mockPaddle.Checkout.open).toHaveBeenCalledWith(
         expect.objectContaining({
-          items: expect.arrayContaining([{ priceId: PADDLE_PRICES.standard.yearly, quantity: 1 }]),
+          items: expect.arrayContaining([
+            { priceId: checkoutConfig.priceIds.standardYear, quantity: 1 },
+          ]),
           customer: { email: 'member@example.com' },
           customData: expect.objectContaining({
             acquisitionSource: 'self_serve_web',
@@ -349,7 +383,7 @@ describe('PricingTable', () => {
   });
 
   it('shows the missing email error when OTP verification is attempted without an email', async () => {
-    render(<PricingTable billingTestMode={false} />);
+    render(<PricingTable billingTestMode={false} checkoutConfig={checkoutConfig} />);
 
     fireEvent.click(screen.getByTestId('plan-cta-standard'));
     fireEvent.click(screen.getByTestId('precheckout-continue-cta'));
@@ -364,7 +398,23 @@ describe('PricingTable', () => {
   });
 
   it('routes anonymous business users to the assisted business entry path', () => {
-    render(<PricingTable billingTestMode={false} />);
+    render(<PricingTable billingTestMode={false} checkoutConfig={checkoutConfig} />);
+
+    const businessCta = screen.getByTestId('plan-cta-business');
+
+    expect(businessCta.tagName).toBe('A');
+    expect(businessCta).toHaveAttribute('href', '/business-membership');
+  });
+
+  it('keeps the business plan on the assisted path for logged-in users', () => {
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        checkoutConfig={{ ...checkoutConfig, priceIds: { ...checkoutConfig.priceIds, businessYear: null } }}
+      />
+    );
 
     const businessCta = screen.getByTestId('plan-cta-business');
 
@@ -373,7 +423,7 @@ describe('PricingTable', () => {
   });
 
   it('keeps mobile-safe touch targets and safe-area spacing on pricing conversion actions', () => {
-    render(<PricingTable billingTestMode={false} />);
+    render(<PricingTable billingTestMode={false} checkoutConfig={checkoutConfig} />);
 
     expect(screen.getByTestId('pricing-table-root').className).toContain(
       'pb-[max(1.5rem,env(safe-area-inset-bottom))]'
@@ -388,7 +438,7 @@ describe('PricingTable', () => {
   });
 
   it('moves focus to the pre-checkout confirmation when it opens', async () => {
-    render(<PricingTable billingTestMode={false} />);
+    render(<PricingTable billingTestMode={false} checkoutConfig={checkoutConfig} />);
 
     fireEvent.click(screen.getByTestId('plan-cta-standard'));
 
@@ -402,7 +452,14 @@ describe('PricingTable', () => {
   it('passes the active locale into Paddle checkout settings', async () => {
     mockLocale = 'de';
 
-    render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     fireEvent.click(screen.getAllByText('cta')[0]);
 
@@ -422,7 +479,14 @@ describe('PricingTable', () => {
     vi.spyOn(paddleLib, 'getPaddleInstance').mockResolvedValue(null);
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     const joinButtons = screen.getAllByText('cta');
     fireEvent.click(joinButtons[0]);
@@ -439,7 +503,14 @@ describe('PricingTable', () => {
   it('blocks checkout when pilot mode freeze is enabled', async () => {
     process.env.NEXT_PUBLIC_PILOT_MODE = 'true';
 
-    render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     const joinButtons = screen.getAllByText('cta');
     fireEvent.click(joinButtons[0]);
@@ -453,7 +524,14 @@ describe('PricingTable', () => {
     vi.useFakeTimers();
 
     try {
-      render(<PricingTable userId="user-123" email="test@example.com" billingTestMode />);
+      render(
+        <PricingTable
+          userId="user-123"
+          email="test@example.com"
+          billingTestMode
+          checkoutConfig={checkoutConfig}
+        />
+      );
 
       const joinButtons = screen.getAllByText('cta');
       fireEvent.click(joinButtons[0]);
@@ -461,7 +539,7 @@ describe('PricingTable', () => {
       await vi.runAllTimersAsync();
 
       expect(mockRouterPush).toHaveBeenCalledWith(
-        `/member/membership/success?test=true&priceId=${PADDLE_PRICES.standard.yearly}&planId=standard`
+        `/member/membership/success?test=true&priceId=${checkoutConfig.priceIds.standardYear}&planId=standard`
       );
     } finally {
       vi.useRealTimers();
@@ -469,7 +547,13 @@ describe('PricingTable', () => {
   });
 
   it('keeps plan CTAs disabled while session state is still resolving', () => {
-    render(<PricingTable billingTestMode={false} isSessionPending />);
+    render(
+      <PricingTable
+        billingTestMode={false}
+        isSessionPending
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     const joinButtons = screen.getAllByText('cta');
     expect(joinButtons[0]).toBeDisabled();
@@ -477,13 +561,19 @@ describe('PricingTable', () => {
 
   it('shows an explicit local checkout warning instead of simulated success when client token is missing', async () => {
     vi.stubEnv('NODE_ENV', 'development');
-    vi.stubEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN', '');
     vi.spyOn(paddleLib, 'getPaddleInstance').mockResolvedValue(null);
 
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     try {
-      render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+      render(
+        <PricingTable
+          userId="user-123"
+          email="test@example.com"
+          billingTestMode={false}
+          checkoutConfig={{ ...checkoutConfig, clientToken: '' }}
+        />
+      );
 
       const joinButtons = screen.getAllByText('cta');
       fireEvent.click(joinButtons[0]);
@@ -506,13 +596,19 @@ describe('PricingTable', () => {
 
   it('treats placeholder Paddle tokens as missing and shows the explicit local warning', async () => {
     vi.stubEnv('NODE_ENV', 'development');
-    vi.stubEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN', 'test_***');
     vi.spyOn(paddleLib, 'getPaddleInstance').mockResolvedValue(null);
 
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     try {
-      render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+      render(
+        <PricingTable
+          userId="user-123"
+          email="test@example.com"
+          billingTestMode={false}
+          checkoutConfig={{ ...checkoutConfig, clientToken: 'test_***' }}
+        />
+      );
 
       const joinButtons = screen.getAllByText('cta');
       fireEvent.click(joinButtons[0]);
@@ -530,13 +626,19 @@ describe('PricingTable', () => {
 
   it('shows a toast in development when a token exists but Paddle init fails', async () => {
     vi.stubEnv('NODE_ENV', 'development');
-    vi.stubEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN', 'test_valid_token_1234567890');
     vi.spyOn(paddleLib, 'getPaddleInstance').mockResolvedValue(null);
 
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    render(<PricingTable userId="user-123" email="test@example.com" billingTestMode={false} />);
+    render(
+      <PricingTable
+        userId="user-123"
+        email="test@example.com"
+        billingTestMode={false}
+        checkoutConfig={checkoutConfig}
+      />
+    );
 
     const joinButtons = screen.getAllByText('cta');
     fireEvent.click(joinButtons[0]);

--- a/apps/web/src/components/pricing/pricing-table.tsx
+++ b/apps/web/src/components/pricing/pricing-table.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { CommercialDisclaimerNotice } from '@/components/commercial/commercial-disclaimer-notice';
-import { PADDLE_PRICES } from '@/config/paddle';
 import { Link, useRouter } from '@/i18n/routing';
 import { CommercialFunnelEvents } from '@/lib/analytics';
 import { authClient } from '@/lib/auth-client';
 import { getPaddleInstance } from '@interdomestik/domain-membership-billing/paddle';
+import type { PublicBillingCheckoutConfig } from '@interdomestik/domain-membership-billing/paddle-server';
 import { Badge, Button } from '@interdomestik/ui';
 import { getCookie } from 'cookies-next';
 import { Building2, Check, Loader2, ShieldCheck, Users } from 'lucide-react';
@@ -19,6 +19,7 @@ type PricingTableProps = Readonly<{
   tenantId?: string | null;
   billingTestMode?: boolean;
   isSessionPending?: boolean;
+  checkoutConfig?: PublicBillingCheckoutConfig | null;
 }>;
 
 const PLAN_IDS = ['standard', 'family', 'business'] as const;
@@ -27,7 +28,7 @@ type PlanId = (typeof PLAN_IDS)[number];
 type SelfServePlanId = (typeof SELF_SERVE_PLAN_IDS)[number];
 type PricingPlan = {
   id: PlanId;
-  priceId: string;
+  priceId: string | null;
   name: string;
   price: string;
   period: string;
@@ -47,12 +48,11 @@ export function shouldOpenSelfServePrecheckout(args: { userId?: string; planId: 
 }
 
 export function shouldRenderBusinessMembershipLink(args: {
-  userId?: string;
   planId: PlanId;
   isPilotMode: boolean;
   isSessionPending: boolean;
 }): boolean {
-  return !args.userId && args.planId === 'business' && !args.isPilotMode && !args.isSessionPending;
+  return args.planId === 'business' && !args.isPilotMode && !args.isSessionPending;
 }
 
 function findPlanById<TPlan extends { id: string }>(
@@ -61,6 +61,11 @@ function findPlanById<TPlan extends { id: string }>(
 ): TPlan | null {
   return planId ? (plans.find(plan => plan.id === planId) ?? null) : null;
 }
+
+const FALLBACK_CHECKOUT_PRICE_IDS = {
+  standardYear: 'pri_standard_year',
+  familyYear: 'pri_family_year',
+} as const;
 
 function getPaddleLocale(locale: string) {
   const normalizedLocale = locale.toLowerCase();
@@ -139,6 +144,7 @@ export function PricingTable({
   tenantId,
   billingTestMode,
   isSessionPending = false,
+  checkoutConfig,
 }: PricingTableProps) {
   const t = useTranslations('pricing');
   const locale = useLocale();
@@ -159,11 +165,16 @@ export function PricingTable({
   const preCheckoutSectionRef = useRef<HTMLElement | null>(null);
   const otpSectionRef = useRef<HTMLElement | null>(null);
   const isPilotMode = process.env.NEXT_PUBLIC_PILOT_MODE === 'true';
+  const resolvedPriceIds = {
+    standardYear: checkoutConfig?.priceIds.standardYear ?? FALLBACK_CHECKOUT_PRICE_IDS.standardYear,
+    familyYear: checkoutConfig?.priceIds.familyYear ?? FALLBACK_CHECKOUT_PRICE_IDS.familyYear,
+    businessYear: checkoutConfig?.priceIds.businessYear ?? null,
+  } as const;
 
   const PLANS: PricingPlan[] = [
     {
       id: 'standard',
-      priceId: PADDLE_PRICES.standard.yearly,
+      priceId: resolvedPriceIds.standardYear,
       name: t('standard.name'),
       price: '€20',
       period: t('standard.period'),
@@ -182,7 +193,7 @@ export function PricingTable({
     },
     {
       id: 'family',
-      priceId: PADDLE_PRICES.family.yearly,
+      priceId: resolvedPriceIds.familyYear,
       name: t('family.name'),
       price: '€35',
       period: t('family.period'),
@@ -199,7 +210,7 @@ export function PricingTable({
     },
     {
       id: 'business',
-      priceId: PADDLE_PRICES.business.yearly,
+      priceId: resolvedPriceIds.businessYear,
       name: t('business.name'),
       price: '€95',
       period: t('business.period'),
@@ -218,7 +229,7 @@ export function PricingTable({
   ];
 
   const isBillingTestMode = billingTestMode ?? process.env.NEXT_PUBLIC_BILLING_TEST_MODE === '1';
-  const paddleClientToken = process.env.NEXT_PUBLIC_PADDLE_CLIENT_TOKEN?.trim() ?? '';
+  const paddleClientToken = checkoutConfig?.clientToken.trim() ?? '';
   const normalizedPaddleClientToken = paddleClientToken.toLowerCase();
   const hasPaddleClientToken =
     paddleClientToken.length > 0 &&
@@ -290,7 +301,16 @@ export function PricingTable({
     checkoutEmail?: string;
     checkoutUserId?: string;
   }) => {
-    const paddle = await getPaddleInstance();
+    if (!checkoutConfig) {
+      console.error('Paddle checkout configuration missing');
+      toast.error('Payment system unavailable. Please check configuration.');
+      return;
+    }
+
+    const paddle = await getPaddleInstance({
+      clientToken: checkoutConfig.clientToken,
+      environment: checkoutConfig.environment,
+    });
 
     if (!paddle) {
       console.error('Paddle not initialized');
@@ -313,7 +333,7 @@ export function PricingTable({
       customData: buildCheckoutCustomData({
         userId: args.checkoutUserId ?? userId,
         agentId: agentId ? String(agentId) : undefined,
-        tenantId,
+        tenantId: tenantId ?? checkoutConfig.tenantId,
         search: globalThis.location.search,
       }),
       settings: {
@@ -402,6 +422,11 @@ export function PricingTable({
       return;
     }
 
+    if (!otpPlan.priceId) {
+      setOtpError(t('otpStep.errors.invalidCode'));
+      return;
+    }
+
     if (!otpEmail.trim()) {
       setOtpError(t('otpStep.errors.missingEmail'));
       return;
@@ -466,6 +491,10 @@ export function PricingTable({
       return;
     }
 
+    if (!preCheckoutPlan.priceId) {
+      return;
+    }
+
     if (!userId) {
       openOtpStepForPlan(preCheckoutPlan.id);
       return;
@@ -490,6 +519,10 @@ export function PricingTable({
 
     if (shouldOpenSelfServePrecheckout({ userId, planId: plan.id })) {
       setPreCheckoutPlanId(plan.id);
+      return;
+    }
+
+    if (!plan.priceId) {
       return;
     }
 
@@ -578,19 +611,29 @@ export function PricingTable({
                   : 'bg-white hover:bg-slate-50 text-slate-900 border-2 border-slate-200'
               }`}
               variant={plan.popular ? 'default' : 'outline'}
-              disabled={isPilotMode || isSessionPending || loading === plan.priceId}
+              disabled={
+                isPilotMode ||
+                isSessionPending ||
+                (plan.priceId !== null && loading === plan.priceId)
+              }
               asChild={shouldRenderBusinessMembershipLink({
-                userId,
                 planId: plan.id,
                 isPilotMode,
                 isSessionPending,
               })}
               onClick={
-                !isPilotMode && !isSessionPending ? () => handlePlanCtaClick(plan) : undefined
+                !isPilotMode &&
+                !isSessionPending &&
+                !shouldRenderBusinessMembershipLink({
+                  planId: plan.id,
+                  isPilotMode,
+                  isSessionPending,
+                })
+                  ? () => handlePlanCtaClick(plan)
+                  : undefined
               }
             >
               {shouldRenderBusinessMembershipLink({
-                userId,
                 planId: plan.id,
                 isPilotMode,
                 isSessionPending,

--- a/packages/database/src/claim-number.ts
+++ b/packages/database/src/claim-number.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, isNull, like, sql } from 'drizzle-orm';
 
 import { db } from './db';
 import { claimCounters } from './schema/claim-counters';
@@ -82,14 +82,28 @@ export async function generateClaimNumber(
   // 3) Year semantics (historical accuracy)
   const year = createdAt.getFullYear();
 
+  // 3b) Seed from existing numbered claims when the counter table is missing or stale.
+  const claimNumberPrefix = `CLM-${tenant.code.toUpperCase()}-${year}-`;
+  const [latestExistingClaim] = await tx
+    .select({ claimNumber: claims.claimNumber })
+    .from(claims)
+    .where(and(eq(claims.tenantId, tenantId), like(claims.claimNumber, `${claimNumberPrefix}%`)))
+    .orderBy(desc(claims.claimNumber))
+    .limit(1);
+
+  const existingMaxSequence = latestExistingClaim?.claimNumber
+    ? (parseClaimNumber(latestExistingClaim.claimNumber)?.sequence ?? 0)
+    : 0;
+  const nextSeedSequence = existingMaxSequence + 1;
+
   // 4) Atomic counter increment (UPSERT)
   const [counter] = await tx
     .insert(claimCounters)
-    .values({ tenantId, year, lastNumber: 1 })
+    .values({ tenantId, year, lastNumber: nextSeedSequence })
     .onConflictDoUpdate({
       target: [claimCounters.tenantId, claimCounters.year],
       set: {
-        lastNumber: sql`${claimCounters.lastNumber} + 1`,
+        lastNumber: sql`GREATEST(${claimCounters.lastNumber}, ${existingMaxSequence}) + 1`,
         updatedAt: new Date(),
       },
     })

--- a/packages/database/test/claim-number.test.ts
+++ b/packages/database/test/claim-number.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { generateClaimNumber } from '../src/claim-number';
+
+function createSelectChain(responses: unknown[]) {
+  const query = {
+    from() {
+      return query;
+    },
+    where() {
+      return query;
+    },
+    orderBy() {
+      return query;
+    },
+    limit() {
+      const response = responses.shift();
+      if (!response) {
+        throw new Error('Unexpected select() call in claim-number test');
+      }
+
+      return Promise.resolve(response);
+    },
+  };
+
+  return query;
+}
+
+test('generateClaimNumber seeds from the latest existing claim number when counters are missing', async () => {
+  const selectResponses: unknown[] = [
+    [{ claimNumber: null }],
+    [{ code: 'MK' }],
+    [{ claimNumber: 'CLM-MK-2026-000001' }],
+  ];
+  let insertedCounterValues:
+    | {
+        tenantId: string;
+        year: number;
+        lastNumber: number;
+      }
+    | undefined;
+
+  const tx = {
+    select() {
+      return createSelectChain(selectResponses);
+    },
+    insert() {
+      return {
+        values(values: { tenantId: string; year: number; lastNumber: number }) {
+          insertedCounterValues = values;
+
+          return {
+            onConflictDoUpdate() {
+              return {
+                returning() {
+                  return Promise.resolve([{ lastNumber: values.lastNumber }]);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    update() {
+      return {
+        set() {
+          return {
+            where() {
+              return {
+                returning() {
+                  return Promise.resolve([{ id: 'claim-new' }]);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  } as any;
+
+  const claimNumber = await generateClaimNumber(tx, {
+    tenantId: 'tenant_mk',
+    claimId: 'claim-new',
+    createdAt: new Date('2026-04-09T00:00:00.000Z'),
+  });
+
+  assert.equal(claimNumber, 'CLM-MK-2026-000002');
+  assert.deepEqual(insertedCounterValues, {
+    tenantId: 'tenant_mk',
+    year: 2026,
+    lastNumber: 2,
+  });
+});

--- a/packages/domain-claims/src/claims/submit.test.ts
+++ b/packages/domain-claims/src/claims/submit.test.ts
@@ -35,6 +35,7 @@ const hoisted = vi.hoisted(() => {
         documentId: 'legacy-doc-1',
       },
     ]),
+    generateClaimNumber: vi.fn().mockResolvedValue('CLM-T1-2026-000001'),
     txInsert,
     txInsertValues,
   };
@@ -78,6 +79,10 @@ vi.mock('nanoid', () => ({
   nanoid: hoisted.nanoid,
 }));
 
+vi.mock('@interdomestik/database/claim-number', () => ({
+  generateClaimNumber: hoisted.generateClaimNumber,
+}));
+
 vi.mock('./ai-workflows', () => ({
   queueClaimDocumentAiWorkflows: hoisted.queueClaimDocumentAiWorkflows,
 }));
@@ -96,6 +101,7 @@ describe('submitClaimCore', () => {
         documentId: 'legacy-doc-1',
       },
     ]);
+    hoisted.generateClaimNumber.mockResolvedValue('CLM-T1-2026-000001');
     hoisted.db.query.tenantSettings.findFirst.mockResolvedValue(null);
     hoisted.db.query.user.findFirst.mockResolvedValue(null);
     hoisted.getActiveSubscription.mockResolvedValue({
@@ -150,7 +156,18 @@ describe('submitClaimCore', () => {
       }
     );
 
-    expect(result).toEqual({ success: true, claimId: 'claim-1' });
+    expect(result).toEqual({
+      success: true,
+      claimId: 'claim-1',
+      claimNumber: 'CLM-T1-2026-000001',
+    });
+    expect(hoisted.generateClaimNumber).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        claimId: 'claim-1',
+        tenantId: 'tenant-1',
+      })
+    );
     expect(hoisted.txInsert).toHaveBeenNthCalledWith(1, { __name: 'claim' });
     expect(hoisted.txInsert).toHaveBeenNthCalledWith(2, { __name: 'claim_stage_history' });
     expect(hoisted.txInsertValues).toHaveBeenNthCalledWith(

--- a/packages/domain-claims/src/claims/submit.ts
+++ b/packages/domain-claims/src/claims/submit.ts
@@ -5,6 +5,7 @@ import {
   db,
   tenantSettings,
 } from '@interdomestik/database';
+import { generateClaimNumber } from '@interdomestik/database/claim-number';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { getActiveSubscription } from '@interdomestik/domain-membership-billing/subscription';
 import { ensureTenantId } from '@interdomestik/shared-auth';
@@ -121,16 +122,18 @@ async function persistSubmittedClaim(args: {
   claimId: string;
   tenantId: string;
   userId: string;
+  createdAt: Date;
   changedByRole: string;
   branchId: string | null;
   agentId: string | null;
   handoffContext?: ClaimStartHandoffContext | null;
   data: CreateClaimValues;
-}): Promise<QueuedClaimAiRun[]> {
+}): Promise<{ claimNumber: string; queuedRuns: QueuedClaimAiRun[] }> {
   const { title, description, category, companyName, claimAmount, currency, incidentDate, files } =
     args.data;
   const publicNote = buildClaimStartPublicNote(args.handoffContext);
   let queuedRuns: QueuedClaimAiRun[] = [];
+  let claimNumber = '';
 
   await db.transaction(async tx => {
     await tx.insert(claims).values({
@@ -146,6 +149,15 @@ async function persistSubmittedClaim(args: {
       claimAmount: claimAmount || undefined,
       currency: currency || 'EUR',
       status: 'submitted',
+      claimNumber: null,
+      createdAt: args.createdAt,
+      updatedAt: args.createdAt,
+    });
+
+    claimNumber = await generateClaimNumber(tx, {
+      tenantId: args.tenantId,
+      claimId: args.claimId,
+      createdAt: args.createdAt,
     });
 
     await tx.insert(claimStageHistory).values({
@@ -199,7 +211,10 @@ async function persistSubmittedClaim(args: {
     });
   });
 
-  return queuedRuns;
+  return {
+    claimNumber,
+    queuedRuns,
+  };
 }
 
 async function logClaimSubmittedAudit(args: {
@@ -306,19 +321,24 @@ export async function submitClaimCore(
   validateClaimFiles(result.data.files, session, tenantId);
 
   const claimId = nanoid();
+  const createdAt = new Date();
   let queuedRuns: QueuedClaimAiRun[];
+  let claimNumber = '';
 
   try {
-    queuedRuns = await persistSubmittedClaim({
+    const persistedClaim = await persistSubmittedClaim({
       claimId,
       tenantId,
       userId: session.user.id,
+      createdAt,
       changedByRole: session.user.role ?? 'member',
       branchId: assignment.branchId,
       agentId: assignment.agentId,
       handoffContext,
       data: result.data,
     });
+    queuedRuns = persistedClaim.queuedRuns;
+    claimNumber = persistedClaim.claimNumber;
 
     await logClaimSubmittedAudit({
       deps,
@@ -341,7 +361,7 @@ export async function submitClaimCore(
     await deps.revalidatePath('/member/claims');
   }
 
-  return { success: true, claimId };
+  return { success: true, claimId, claimNumber };
 }
 
 function validateClaimFiles(

--- a/packages/domain-membership-billing/src/paddle-server.test.ts
+++ b/packages/domain-membership-billing/src/paddle-server.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import {
   assertBillingEntityEnvConfigured,
+  assertPublicBillingEntityAlignment,
   getPaddle,
   getPaddleForEntity,
+  getPublicBillingCheckoutConfig,
   resetPaddleClientCacheForTests,
   resolveBillingEntityConfig,
   resolveBillingEntityFromPathSegment,
@@ -30,6 +32,23 @@ function clearBillingEnv(): void {
   unsetEnv('PADDLE_WEBHOOK_SECRET_KEY_MK');
   unsetEnv('PADDLE_WEBHOOK_SECRET_KEY_AL');
   unsetEnv('PADDLE_DEFAULT_BILLING_ENTITY');
+  unsetEnv('NEXT_PUBLIC_PADDLE_BILLING_ENTITY');
+  unsetEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN');
+  unsetEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN_KS');
+  unsetEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN_MK');
+  unsetEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN_AL');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR_KS');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR_MK');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR_AL');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR_KS');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR_MK');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR_AL');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_BUSINESS_YEAR');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_BUSINESS_YEAR_KS');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_BUSINESS_YEAR_MK');
+  unsetEnv('NEXT_PUBLIC_PADDLE_PRICE_BUSINESS_YEAR_AL');
   unsetEnv('NEXT_PUBLIC_PADDLE_ENV');
   unsetEnv('VERCEL_ENV');
   unsetEnv('NODE_ENV');
@@ -65,7 +84,7 @@ describe('paddle-server billing entity mapping', () => {
   });
 
   it('throws in production-like mode when required entity env config is missing with strict message', () => {
-    setEnv('NODE_ENV', 'production');
+    setEnv('VERCEL_ENV', 'production');
     setEnv('PADDLE_API_KEY_MK', 'pdl_api_mk');
     setEnv('PADDLE_WEBHOOK_SECRET_KEY_MK', 'whsec_mk');
     setEnv('PADDLE_API_KEY_AL', 'pdl_api_al');
@@ -110,6 +129,55 @@ describe('paddle-server billing entity mapping', () => {
     expect(config.source).toBe('legacy-fallback');
     expect(config.apiKeyEnvVar).toBe('PADDLE_API_KEY');
     expect(config.webhookSecretEnvVar).toBe('PADDLE_WEBHOOK_SECRET_KEY');
+  });
+
+  it('resolves public checkout config from the same default billing entity in production-like mode', () => {
+    setEnv('VERCEL_ENV', 'production');
+    setEnv('PADDLE_DEFAULT_BILLING_ENTITY', 'ks');
+    setEnv('NEXT_PUBLIC_PADDLE_BILLING_ENTITY', 'ks');
+    setEnv('NEXT_PUBLIC_PADDLE_ENV', 'sandbox');
+    setEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN_KS', 'test_client_token_ks');
+    setEnv('NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR_KS', 'pri_standard_ks');
+    setEnv('NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR_KS', 'pri_family_ks');
+
+    const config = getPublicBillingCheckoutConfig();
+
+    expect(config).toEqual(
+      expect.objectContaining({
+        entity: 'ks',
+        tenantId: 'tenant_ks',
+        environment: 'sandbox',
+        clientToken: 'test_client_token_ks',
+        priceIds: expect.objectContaining({
+          standardYear: 'pri_standard_ks',
+          familyYear: 'pri_family_ks',
+        }),
+      })
+    );
+  });
+
+  it('rejects public checkout config when the public entity drifts from the server default entity', () => {
+    setEnv('VERCEL_ENV', 'production');
+    setEnv('PADDLE_DEFAULT_BILLING_ENTITY', 'ks');
+    setEnv('NEXT_PUBLIC_PADDLE_BILLING_ENTITY', 'mk');
+
+    expect(() => assertPublicBillingEntityAlignment()).toThrow(
+      'Public Paddle billing entity must match PADDLE_DEFAULT_BILLING_ENTITY in production-like mode.'
+    );
+  });
+
+  it('rejects duplicate self-serve public price ids in production-like mode', () => {
+    setEnv('VERCEL_ENV', 'production');
+    setEnv('PADDLE_DEFAULT_BILLING_ENTITY', 'ks');
+    setEnv('NEXT_PUBLIC_PADDLE_BILLING_ENTITY', 'ks');
+    setEnv('NEXT_PUBLIC_PADDLE_ENV', 'sandbox');
+    setEnv('NEXT_PUBLIC_PADDLE_CLIENT_TOKEN_KS', 'test_client_token_ks');
+    setEnv('NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR_KS', 'pri_duplicate');
+    setEnv('NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR_KS', 'pri_duplicate');
+
+    expect(() => getPublicBillingCheckoutConfig()).toThrow(
+      'Public self-serve Paddle price ids must be distinct for the resolved billing entity.'
+    );
   });
 
   it('reuses cached paddle client until credentials change', () => {

--- a/packages/domain-membership-billing/src/paddle-server.ts
+++ b/packages/domain-membership-billing/src/paddle-server.ts
@@ -6,10 +6,22 @@ export type BillingEntity = 'ks' | 'mk' | 'al';
 const LEGACY_PADDLE_API_KEY_ENV = 'PADDLE_API_KEY';
 const LEGACY_PADDLE_WEBHOOK_SECRET_ENV = 'PADDLE_WEBHOOK_SECRET_KEY';
 const DEFAULT_BILLING_ENTITY_ENV = 'PADDLE_DEFAULT_BILLING_ENTITY';
+const PUBLIC_BILLING_ENTITY_ENV = 'NEXT_PUBLIC_PADDLE_BILLING_ENTITY';
+const LEGACY_PUBLIC_PADDLE_CLIENT_TOKEN_ENV = 'NEXT_PUBLIC_PADDLE_CLIENT_TOKEN';
+const LEGACY_PUBLIC_STANDARD_PRICE_ENV = 'NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR';
+const LEGACY_PUBLIC_FAMILY_PRICE_ENV = 'NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR';
+const LEGACY_PUBLIC_BUSINESS_PRICE_ENV = 'NEXT_PUBLIC_PADDLE_PRICE_BUSINESS_YEAR';
 
 type BillingEntityEnvVars = {
   apiKey: string;
   webhookSecret: string;
+};
+
+type PublicBillingEntityEnvVars = {
+  clientToken: string;
+  standardYearPriceId: string;
+  familyYearPriceId: string;
+  businessYearPriceId: string;
 };
 
 type ResolveBillingEntityConfigOptions = {
@@ -30,6 +42,18 @@ export type BillingEntityConfig = {
   apiKeyEnvVar: string;
   webhookSecretEnvVar: string;
   source: 'entity' | 'legacy-fallback';
+};
+
+export type PublicBillingCheckoutConfig = {
+  entity: BillingEntity;
+  tenantId: BillingTenantId;
+  environment: 'sandbox' | 'production';
+  clientToken: string;
+  priceIds: {
+    standardYear: string;
+    familyYear: string;
+    businessYear: string | null;
+  };
 };
 
 const BILLING_ENTITY_BY_TENANT: Record<BillingTenantId, BillingEntity> = {
@@ -59,6 +83,27 @@ const BILLING_ENTITY_ENV_VARS: Record<BillingEntity, BillingEntityEnvVars> = {
   },
 };
 
+const PUBLIC_BILLING_ENTITY_ENV_VARS: Record<BillingEntity, PublicBillingEntityEnvVars> = {
+  ks: {
+    clientToken: 'NEXT_PUBLIC_PADDLE_CLIENT_TOKEN_KS',
+    standardYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR_KS',
+    familyYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR_KS',
+    businessYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_BUSINESS_YEAR_KS',
+  },
+  mk: {
+    clientToken: 'NEXT_PUBLIC_PADDLE_CLIENT_TOKEN_MK',
+    standardYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR_MK',
+    familyYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR_MK',
+    businessYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_BUSINESS_YEAR_MK',
+  },
+  al: {
+    clientToken: 'NEXT_PUBLIC_PADDLE_CLIENT_TOKEN_AL',
+    standardYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_STANDARD_YEAR_AL',
+    familyYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_FAMILY_YEAR_AL',
+    businessYearPriceId: 'NEXT_PUBLIC_PADDLE_PRICE_BUSINESS_YEAR_AL',
+  },
+};
+
 const BILLING_ENTITIES: readonly BillingEntity[] = ['ks', 'mk', 'al'];
 const BILLING_TENANTS: readonly BillingTenantId[] = ['tenant_ks', 'tenant_mk', 'tenant_al'];
 
@@ -84,9 +129,7 @@ function isBillingTenantId(value: string): value is BillingTenantId {
 
 function isProductionLikeBillingMode(): boolean {
   return (
-    process.env.NODE_ENV === 'production' ||
-    process.env.VERCEL_ENV === 'production' ||
-    process.env.NEXT_PUBLIC_PADDLE_ENV === 'production'
+    process.env.VERCEL_ENV === 'production' || process.env.NEXT_PUBLIC_PADDLE_ENV === 'production'
   );
 }
 
@@ -107,6 +150,10 @@ function resolvePaddleEnvironment(): Environment {
     return Environment.production;
   }
   throw new Error(`NEXT_PUBLIC_PADDLE_ENV must be "sandbox" or "production", received "${value}".`);
+}
+
+function resolvePublicPaddleEnvironment(): 'sandbox' | 'production' {
+  return resolvePaddleEnvironment() === Environment.production ? 'production' : 'sandbox';
 }
 
 export function resolveBillingEntityFromPathSegment(
@@ -189,6 +236,108 @@ export function assertBillingEntityEnvConfigured(
   for (const entity of BILLING_ENTITIES) {
     resolveBillingEntityConfig(entity, options);
   }
+}
+
+function resolveConfiguredPublicBillingEntity(): BillingEntity | null {
+  return resolveBillingEntityFromPathSegment(getOptionalEnv(PUBLIC_BILLING_ENTITY_ENV));
+}
+
+function resolveConfiguredDefaultBillingEntity(): BillingEntity | null {
+  return resolveBillingEntityFromPathSegment(getOptionalEnv(DEFAULT_BILLING_ENTITY_ENV));
+}
+
+function resolvePublicCheckoutValue(primaryEnvVar: string, fallbackEnvVar?: string): string | null {
+  const primaryValue = getOptionalEnv(primaryEnvVar);
+  if (primaryValue) {
+    return primaryValue;
+  }
+
+  if (!fallbackEnvVar || isProductionLikeBillingMode()) {
+    return null;
+  }
+
+  return getOptionalEnv(fallbackEnvVar) ?? null;
+}
+
+function resolvePublicCheckoutEntity(): BillingEntity {
+  const publicEntity = resolveConfiguredPublicBillingEntity();
+  const defaultEntity = resolveConfiguredDefaultBillingEntity();
+
+  if (isProductionLikeBillingMode()) {
+    assertPublicBillingEntityAlignment();
+  }
+
+  return publicEntity ?? defaultEntity ?? 'ks';
+}
+
+export function assertPublicBillingEntityAlignment(): void {
+  const publicEntity = resolveConfiguredPublicBillingEntity();
+  const defaultEntity = resolveConfiguredDefaultBillingEntity();
+
+  if (!isProductionLikeBillingMode()) {
+    return;
+  }
+
+  if (!publicEntity || !defaultEntity || publicEntity !== defaultEntity) {
+    throw new Error(
+      'Public Paddle billing entity must match PADDLE_DEFAULT_BILLING_ENTITY in production-like mode.'
+    );
+  }
+}
+
+export function getPublicBillingCheckoutConfig(): PublicBillingCheckoutConfig {
+  const entity = resolvePublicCheckoutEntity();
+  const publicEnvVars = PUBLIC_BILLING_ENTITY_ENV_VARS[entity];
+  const clientToken = resolvePublicCheckoutValue(
+    publicEnvVars.clientToken,
+    LEGACY_PUBLIC_PADDLE_CLIENT_TOKEN_ENV
+  );
+  const standardYear = resolvePublicCheckoutValue(
+    publicEnvVars.standardYearPriceId,
+    LEGACY_PUBLIC_STANDARD_PRICE_ENV
+  );
+  const familyYear = resolvePublicCheckoutValue(
+    publicEnvVars.familyYearPriceId,
+    LEGACY_PUBLIC_FAMILY_PRICE_ENV
+  );
+  const businessYear = resolvePublicCheckoutValue(
+    publicEnvVars.businessYearPriceId,
+    LEGACY_PUBLIC_BUSINESS_PRICE_ENV
+  );
+
+  const missingEnv: string[] = [];
+  if (!clientToken) {
+    missingEnv.push(publicEnvVars.clientToken);
+  }
+  if (!standardYear) {
+    missingEnv.push(publicEnvVars.standardYearPriceId);
+  }
+  if (!familyYear) {
+    missingEnv.push(publicEnvVars.familyYearPriceId);
+  }
+  if (missingEnv.length > 0) {
+    throw new Error(
+      `Missing public Paddle checkout configuration for entity ${entity}. Missing env: ${missingEnv.join(', ')}`
+    );
+  }
+
+  if (standardYear === familyYear) {
+    throw new Error(
+      'Public self-serve Paddle price ids must be distinct for the resolved billing entity.'
+    );
+  }
+
+  return {
+    entity,
+    tenantId: resolveBillingTenantIdForEntity(entity),
+    environment: resolvePublicPaddleEnvironment(),
+    clientToken: clientToken as string,
+    priceIds: {
+      standardYear: standardYear as string,
+      familyYear: familyYear as string,
+      businessYear,
+    },
+  };
 }
 
 function resolveRequestedBillingEntity(options: GetPaddleOptions): BillingEntity {

--- a/packages/domain-membership-billing/src/paddle.ts
+++ b/packages/domain-membership-billing/src/paddle.ts
@@ -1,11 +1,23 @@
 import { initializePaddle, type Paddle } from '@paddle/paddle-js';
 
 let paddleInstance: Paddle | null = null;
+let paddleInstanceCacheKey: string | null = null;
 
-export async function getPaddleInstance() {
-  if (paddleInstance) return paddleInstance;
+export type PublicPaddleInitConfig = Readonly<{
+  environment: 'sandbox' | 'production';
+  clientToken: string;
+}>;
 
-  const clientToken = process.env.NEXT_PUBLIC_PADDLE_CLIENT_TOKEN;
+export async function getPaddleInstance(config?: PublicPaddleInitConfig) {
+  const clientToken = config?.clientToken ?? process.env.NEXT_PUBLIC_PADDLE_CLIENT_TOKEN;
+  const environment =
+    config?.environment ??
+    (process.env.NEXT_PUBLIC_PADDLE_ENV === 'production' ? 'production' : 'sandbox');
+  const cacheKey = clientToken ? `${environment}:${clientToken}` : null;
+
+  if (paddleInstance && paddleInstanceCacheKey === cacheKey) {
+    return paddleInstance;
+  }
 
   if (!clientToken) {
     console.error('Paddle Client Token missing');
@@ -14,7 +26,7 @@ export async function getPaddleInstance() {
 
   try {
     const paddle = await initializePaddle({
-      environment: process.env.NEXT_PUBLIC_PADDLE_ENV === 'production' ? 'production' : 'sandbox',
+      environment,
       token: clientToken,
       eventCallback: (data: unknown) => {
         if (process.env.NODE_ENV === 'development') {
@@ -25,6 +37,7 @@ export async function getPaddleInstance() {
 
     if (paddle) {
       paddleInstance = paddle;
+      paddleInstanceCacheKey = cacheKey;
     }
 
     return paddleInstance;
@@ -32,4 +45,9 @@ export async function getPaddleInstance() {
     console.error('Failed to initialize Paddle:', err);
     return null;
   }
+}
+
+export function resetPaddleInstanceForTests(): void {
+  paddleInstance = null;
+  paddleInstanceCacheKey = null;
 }

--- a/scripts/e2e-gate.sh
+++ b/scripts/e2e-gate.sh
@@ -19,8 +19,35 @@ if [ -z "${DATABASE_URL:-}" ]; then
   echo "⚠️  [E2E Gate] DATABASE_URL not set; defaulting to ${DATABASE_URL}"
 fi
 
+discover_standalone_server() {
+  local standalone_root="${ROOT_DIR}/apps/web/.next/standalone"
+  local default_server="${standalone_root}/apps/web/server.js"
+  local fallback_server="${standalone_root}/server.js"
+  local discovered_server=""
+
+  if [ -f "${default_server}" ]; then
+    printf '%s' "${default_server}"
+    return 0
+  fi
+
+  if [ -f "${fallback_server}" ]; then
+    printf '%s' "${fallback_server}"
+    return 0
+  fi
+
+  if [ -d "${standalone_root}" ]; then
+    discovered_server="$(find "${standalone_root}" -path '*/apps/web/server.js' -print -quit 2>/dev/null || true)"
+    if [ -n "${discovered_server}" ]; then
+      printf '%s' "${discovered_server}"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
 # Build the web app if the standalone server artifact is missing.
-STANDALONE_SERVER="${ROOT_DIR}/apps/web/.next/standalone/apps/web/server.js"
+STANDALONE_SERVER="$(discover_standalone_server || true)"
 if [ ! -f "${STANDALONE_SERVER}" ]; then
   echo "🏗️  [E2E Gate] Missing standalone server; building @interdomestik/web..."
   pnpm --filter @interdomestik/web build

--- a/scripts/e2e-webserver.sh
+++ b/scripts/e2e-webserver.sh
@@ -229,6 +229,32 @@ CURRENT_GIT_SHA=""
 STAMP_GIT_SHA=""
 STAMP_STATUS_REASON=""
 
+discover_standalone_server() {
+	local candidate=""
+
+	if [[ -f "${STANDALONE_SERVER}" ]]; then
+		printf '%s' "${STANDALONE_SERVER}"
+		return 0
+	fi
+
+	if [[ -f "${FALLBACK_STANDALONE_SERVER}" ]]; then
+		printf '%s' "${FALLBACK_STANDALONE_SERVER}"
+		return 0
+	fi
+
+	if [[ -d "${WEB_DIR}/.next/standalone" ]]; then
+		candidate="$(
+			find "${WEB_DIR}/.next/standalone" -path '*/apps/web/server.js' -print -quit 2>/dev/null || true
+		)"
+		if [[ -n "${candidate}" ]]; then
+			printf '%s' "${candidate}"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
 link_standalone_static_assets() {
 	if [[ ! -d "${BUILD_STATIC_DIR}" ]]; then
 		return 0
@@ -238,6 +264,13 @@ link_standalone_static_assets() {
 	ln -sfn "${BUILD_STATIC_DIR}" "${STANDALONE_STATIC_DIR}"
 	mkdir -p "$(dirname "${STANDALONE_APP_STATIC_DIR}")"
 	ln -sfn "${BUILD_STATIC_DIR}" "${STANDALONE_APP_STATIC_DIR}"
+
+	local mirroredAppDir=""
+	while IFS= read -r mirroredAppDir; do
+		[[ -z "${mirroredAppDir}" ]] && continue
+		mkdir -p "${mirroredAppDir}/.next"
+		ln -sfn "${BUILD_STATIC_DIR}" "${mirroredAppDir}/.next/static"
+	done < <(find "${WEB_DIR}/.next/standalone" -path '*/apps/web' -type d -print 2>/dev/null || true)
 }
 
 should_autorebuild() {
@@ -342,12 +375,9 @@ fi
 
 link_standalone_static_assets
 
-if [[ -f "${STANDALONE_SERVER}" ]]; then
-	exec node "${STANDALONE_SERVER}"
-fi
-
-if [[ -f "${FALLBACK_STANDALONE_SERVER}" ]]; then
-	exec node "${FALLBACK_STANDALONE_SERVER}"
+RESOLVED_STANDALONE_SERVER="$(discover_standalone_server || true)"
+if [[ -n "${RESOLVED_STANDALONE_SERVER}" ]]; then
+	exec node "${RESOLVED_STANDALONE_SERVER}"
 fi
 
 echo "❌ Missing standalone server artifact. Tried:" >&2


### PR DESCRIPTION
## Summary
- generate and surface standardized human claim numbers on submitted claims
- harden public Paddle checkout config resolution so client checkout uses server-issued config
- make E2E standalone server discovery resilient across local build layouts

## Verification
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate
