### PR TITLE
fix: guard e2e standalone resolver edge cases

### DIFF
--- a/scripts/ci/e2e-standalone-contracts.test.mjs
+++ b/scripts/ci/e2e-standalone-contracts.test.mjs
@@ -23,7 +23,7 @@ test('e2e launchers resolve standalone server artifacts dynamically for worktree
   );
   assert.match(webServerScript, /dynamic find under \$\{STANDALONE_ROOT\}/);
   assert.match(webServerScript, /\[\[ ! -d "\$\{STANDALONE_ROOT\}" \]\] && return 1/);
-  assert.match(webServerScript, /\[\[ -n "\$\{discoveredServer\}" \]\] \|\| return 1/);
+  assert.match(webServerScript, /\[\[ -n "\$\{discovered_server\}" \]\] \|\| return 1/);
 
   assert.match(gateScript, /resolve_standalone_server\(\)/);
   assert.match(
@@ -31,5 +31,6 @@ test('e2e launchers resolve standalone server artifacts dynamically for worktree
     /find "\$\{STANDALONE_ROOT\}" -path '\*\/node_modules\/\*' -prune -o -type f -name server\.js -print/
   );
   assert.match(gateScript, /\[\[ ! -d "\$\{STANDALONE_ROOT\}" \]\] && return 1/);
-  assert.match(gateScript, /\[\[ -n "\$\{discoveredServer\}" \]\] \|\| return 1/);
+  assert.match(gateScript, /\[\[ -n "\$\{discovered_server\}" \]\] \|\| return 1/);
+  assert.match(gateScript, /if ! resolve_standalone_server >\/dev\/null; then/);
 });

--- a/scripts/ci/e2e-standalone-contracts.test.mjs
+++ b/scripts/ci/e2e-standalone-contracts.test.mjs
@@ -22,10 +22,14 @@ test('e2e launchers resolve standalone server artifacts dynamically for worktree
     /find "\$\{STANDALONE_ROOT\}" -path '\*\/node_modules\/\*' -prune -o -type f -name server\.js -print/
   );
   assert.match(webServerScript, /dynamic find under \$\{STANDALONE_ROOT\}/);
+  assert.match(webServerScript, /\[\[ ! -d "\$\{STANDALONE_ROOT\}" \]\] && return 1/);
+  assert.match(webServerScript, /\[\[ -n "\$\{discoveredServer\}" \]\] \|\| return 1/);
 
   assert.match(gateScript, /resolve_standalone_server\(\)/);
   assert.match(
     gateScript,
     /find "\$\{STANDALONE_ROOT\}" -path '\*\/node_modules\/\*' -prune -o -type f -name server\.js -print/
   );
+  assert.match(gateScript, /\[\[ ! -d "\$\{STANDALONE_ROOT\}" \]\] && return 1/);
+  assert.match(gateScript, /\[\[ -n "\$\{discoveredServer\}" \]\] \|\| return 1/);
 });

--- a/scripts/e2e-gate.sh
+++ b/scripts/e2e-gate.sh
@@ -52,6 +52,8 @@ LEGACY_STANDALONE_SERVER="${STANDALONE_ROOT}/apps/web/server.js"
 FALLBACK_STANDALONE_SERVER="${STANDALONE_ROOT}/server.js"
 
 resolve_standalone_server() {
+  local discoveredServer=""
+
   if [ -f "${LEGACY_STANDALONE_SERVER}" ]; then
     printf '%s' "${LEGACY_STANDALONE_SERVER}"
     return 0
@@ -62,10 +64,17 @@ resolve_standalone_server() {
     return 0
   fi
 
-  find "${STANDALONE_ROOT}" -path '*/node_modules/*' -prune -o -type f -name server.js -print | sort | head -n 1
+  [[ ! -d "${STANDALONE_ROOT}" ]] && return 1
+
+  discoveredServer="$(
+    find "${STANDALONE_ROOT}" -path '*/node_modules/*' -prune -o -type f -name server.js -print | sort | head -n 1
+  )"
+  [[ -n "${discoveredServer}" ]] || return 1
+
+  printf '%s' "${discoveredServer}"
 }
 
-if [ -z "$(resolve_standalone_server)" ]; then
+if ! resolve_standalone_server >/dev/null; then
   echo "🏗️  [E2E Gate] Missing standalone server; building @interdomestik/web..."
   pnpm --filter @interdomestik/web build
 fi

--- a/scripts/e2e-gate.sh
+++ b/scripts/e2e-gate.sh
@@ -52,7 +52,7 @@ LEGACY_STANDALONE_SERVER="${STANDALONE_ROOT}/apps/web/server.js"
 FALLBACK_STANDALONE_SERVER="${STANDALONE_ROOT}/server.js"
 
 resolve_standalone_server() {
-  local discoveredServer=""
+  local discovered_server=""
 
   if [ -f "${LEGACY_STANDALONE_SERVER}" ]; then
     printf '%s' "${LEGACY_STANDALONE_SERVER}"
@@ -66,12 +66,12 @@ resolve_standalone_server() {
 
   [[ ! -d "${STANDALONE_ROOT}" ]] && return 1
 
-  discoveredServer="$(
+  discovered_server="$(
     find "${STANDALONE_ROOT}" -path '*/node_modules/*' -prune -o -type f -name server.js -print | sort | head -n 1
   )"
-  [[ -n "${discoveredServer}" ]] || return 1
+  [[ -n "${discovered_server}" ]] || return 1
 
-  printf '%s' "${discoveredServer}"
+  printf '%s' "${discovered_server}"
 }
 
 if ! resolve_standalone_server >/dev/null; then

--- a/scripts/e2e-webserver.sh
+++ b/scripts/e2e-webserver.sh
@@ -237,7 +237,7 @@ link_static_dir() {
 }
 
 resolve_standalone_server() {
-	local discoveredServer=""
+	local discovered_server=""
 
 	if [[ -f "${LEGACY_STANDALONE_SERVER}" ]]; then
 		printf '%s' "${LEGACY_STANDALONE_SERVER}"
@@ -251,12 +251,12 @@ resolve_standalone_server() {
 
 	[[ ! -d "${STANDALONE_ROOT}" ]] && return 1
 
-	discoveredServer="$(
+	discovered_server="$(
 		find "${STANDALONE_ROOT}" -path '*/node_modules/*' -prune -o -type f -name server.js -print | sort | head -n 1
 	)"
-	[[ -n "${discoveredServer}" ]] || return 1
+	[[ -n "${discovered_server}" ]] || return 1
 
-	printf '%s' "${discoveredServer}"
+	printf '%s' "${discovered_server}"
 }
 
 resolve_standalone_app_root() {

--- a/scripts/e2e-webserver.sh
+++ b/scripts/e2e-webserver.sh
@@ -237,6 +237,8 @@ link_static_dir() {
 }
 
 resolve_standalone_server() {
+	local discoveredServer=""
+
 	if [[ -f "${LEGACY_STANDALONE_SERVER}" ]]; then
 		printf '%s' "${LEGACY_STANDALONE_SERVER}"
 		return 0
@@ -247,7 +249,14 @@ resolve_standalone_server() {
 		return 0
 	fi
 
-	find "${STANDALONE_ROOT}" -path '*/node_modules/*' -prune -o -type f -name server.js -print | sort | head -n 1
+	[[ ! -d "${STANDALONE_ROOT}" ]] && return 1
+
+	discoveredServer="$(
+		find "${STANDALONE_ROOT}" -path '*/node_modules/*' -prune -o -type f -name server.js -print | sort | head -n 1
+	)"
+	[[ -n "${discoveredServer}" ]] || return 1
+
+	printf '%s' "${discoveredServer}"
 }
 
 resolve_standalone_app_root() {


### PR DESCRIPTION
## Summary
- make standalone resolver helpers return non-zero when the artifact directory is missing
- require a non-empty discovered server path before treating resolution as successful
- extend the standalone launcher contract test to lock both guard behaviors

## Test Plan
- [x] `pnpm exec node --test scripts/ci/e2e-standalone-contracts.test.mjs`
- [x] `bash -n scripts/e2e-webserver.sh scripts/e2e-gate.sh`
- [x] `pnpm pr:verify`
- [x] `pnpm security:guard`