### PR TITLE
[codex] keep member follow-up links locale-aware

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/claims/new/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/new/_core.entry.tsx
@@ -1,12 +1,12 @@
 import { ClaimWizard } from '@/components/claims/claim-wizard';
 import { getSessionSafe } from '@/components/shell/session';
+import { Link } from '@/i18n/routing';
 import { hasActiveMembership } from '@interdomestik/domain-membership-billing/subscription';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { Button } from '@interdomestik/ui';
 import { ShieldAlert } from 'lucide-react';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { Link } from '@/i18n/routing';
 import { redirect } from 'next/navigation';
 
 const DIASPORA_CLAIM_SOURCES = ['diaspora-green-card'] as const;

--- a/apps/web/src/app/[locale]/(app)/member/claims/new/page.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/new/page.test.tsx
@@ -49,12 +49,6 @@ vi.mock('@/components/shell/session', () => ({
   getSessionSafe: hoisted.getSessionSafeMock,
 }));
 
-vi.mock('@/i18n/routing', () => ({
-  Link: ({ children, href = '#' }: { children: React.ReactNode; href?: string }) => (
-    <a href={href}>{children}</a>
-  ),
-}));
-
 vi.mock('@interdomestik/domain-membership-billing/subscription', () => ({
   hasActiveMembership: hoisted.hasActiveMembershipMock,
 }));
@@ -65,6 +59,21 @@ vi.mock('@interdomestik/shared-auth', () => ({
 
 vi.mock('@interdomestik/ui', () => ({
   Button: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({ children, href = '#' }: { children: React.ReactNode; href?: string }) => {
+    const localizedHref =
+      typeof href === 'string' && href.startsWith('/') ? `/en${href}` : String(href);
+
+    return <a href={localizedHref}>{children}</a>;
+  },
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href = '#' }: { children: React.ReactNode; href?: string }) => (
+    <a href={href}>{children}</a>
+  ),
 }));
 
 import NewClaimPage from './page';
@@ -119,5 +128,21 @@ describe('NewClaimPage diaspora claim handoff', () => {
       },
     });
     expect(screen.getByTestId('claim-wizard-props')).toBeInTheDocument();
+  });
+
+  it('routes inactive members to the localized pricing page', async () => {
+    hoisted.hasActiveMembershipMock.mockResolvedValueOnce(false);
+
+    const tree = await NewClaimPage({
+      params: Promise.resolve({ locale: 'en' }),
+      searchParams: Promise.resolve({}),
+    });
+
+    render(tree);
+
+    expect(screen.getByRole('link', { name: 'gate.view_plans' })).toHaveAttribute(
+      'href',
+      '/en/pricing'
+    );
   });
 });

--- a/apps/web/src/app/[locale]/(app)/member/policies/page.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/policies/page.tsx
@@ -1,5 +1,7 @@
 import { MemberPoliciesV2Page } from '@/features/member/policies/components/MemberPoliciesV2Page';
 
-export default async function PoliciesPage() {
-  return <MemberPoliciesV2Page />;
+export default async function PoliciesPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+
+  return <MemberPoliciesV2Page locale={locale} />;
 }

--- a/apps/web/src/features/member/membership/components/MembershipV2Page.test.tsx
+++ b/apps/web/src/features/member/membership/components/MembershipV2Page.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getSessionMock: vi.fn(async () => ({
+    user: {
+      id: 'member-1',
+      tenantId: 'tenant-ks',
+    },
+  })),
+  getMembershipPageModelCoreMock: vi.fn(async () => ({
+    subscription: null,
+    dunning: {
+      isPastDue: false,
+      isInGracePeriod: false,
+      isGraceExpired: false,
+      daysRemaining: 0,
+    },
+  })),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: hoisted.getSessionMock,
+    },
+  },
+}));
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers()),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: hoisted.redirectMock,
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn(async () => (key: string) => key),
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={`/en${href}`}>{children}</a>
+  ),
+}));
+
+vi.mock('@/app/[locale]/(app)/member/membership/_core', () => ({
+  getMembershipPageModelCore: hoisted.getMembershipPageModelCoreMock,
+}));
+
+vi.mock('@/app/[locale]/(app)/member/membership/components/grace-period-banner', () => ({
+  GracePeriodBanner: () => null,
+}));
+
+vi.mock('@/app/[locale]/(app)/member/membership/components/locked-state-banner', () => ({
+  LockedStateBanner: () => null,
+}));
+
+vi.mock('@/app/[locale]/(app)/member/membership/components/manage-subscription-button', () => ({
+  ManageSubscriptionButton: () => null,
+}));
+
+import { MembershipV2Page } from './MembershipV2Page';
+
+describe('MembershipV2Page', () => {
+  it('routes members without a subscription to the localized pricing page', async () => {
+    const tree = await MembershipV2Page({ locale: 'en' });
+
+    render(tree);
+
+    expect(hoisted.getMembershipPageModelCoreMock).toHaveBeenCalledWith({
+      userId: 'member-1',
+      tenantId: 'tenant-ks',
+    });
+    expect(screen.getByRole('link', { name: 'plan.view_plans_button' })).toHaveAttribute(
+      'href',
+      '/en/pricing'
+    );
+  });
+});

--- a/apps/web/src/features/member/membership/components/MembershipV2Page.tsx
+++ b/apps/web/src/features/member/membership/components/MembershipV2Page.tsx
@@ -1,4 +1,5 @@
 import { auth } from '@/lib/auth';
+import { Link } from '@/i18n/routing';
 import {
   Button,
   Card,
@@ -11,7 +12,6 @@ import {
 import { AlertTriangle, CheckCircle, Shield } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 import { headers } from 'next/headers';
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { GracePeriodBanner } from '@/app/[locale]/(app)/member/membership/components/grace-period-banner';
@@ -31,13 +31,17 @@ type TranslationFn = (
   formats?: Record<string, unknown>
 ) => string;
 
-export async function MembershipV2Page() {
+interface MembershipV2PageProps {
+  locale: string;
+}
+
+export async function MembershipV2Page({ locale }: MembershipV2PageProps) {
   const session = await auth.api.getSession({
     headers: await headers(),
   });
 
   if (!session) {
-    redirect('/login');
+    redirect(`/${locale}/login`);
   }
 
   const t = (await getTranslations('membership')) as TranslationFn;

--- a/apps/web/src/features/member/policies/components/MemberPoliciesV2Page.tsx
+++ b/apps/web/src/features/member/policies/components/MemberPoliciesV2Page.tsx
@@ -18,13 +18,17 @@ import { auth } from '@/lib/auth';
 import { getPoliciesWithSignedUrlsCore } from '@/app/[locale]/(app)/member/policies/_core';
 import type { PolicyAnalysis } from '@/lib/ai/policy-analyzer';
 
-export async function MemberPoliciesV2Page() {
+interface MemberPoliciesV2PageProps {
+  locale: string;
+}
+
+export async function MemberPoliciesV2Page({ locale }: MemberPoliciesV2PageProps) {
   const session = await auth.api.getSession({
     headers: await headers(),
   });
 
   if (!session?.user) {
-    redirect('/login');
+    redirect(`/${locale}/login`);
   }
 
   const tenantId = ensureTenantId(session);


### PR DESCRIPTION
## Summary
- make member membership and policy surfaces use locale-aware redirects instead of hard-coded `/login`
- use the app routing `Link` in the membership follow-up path so inactive-member CTAs resolve to localized routes
- add focused tests covering localized pricing links and the membership page no-subscription state

## Why
The salvaged member follow-up slice still mattered on top of the latest `main`, but older branch changes conflicted with newer upstream work. This PR keeps the additive locale-aware navigation fixes without reintroducing superseded success-flow or dependency changes.

## Impact
- member follow-up navigation stays on canonical localized routes
- inactive-member recovery CTAs point to localized pricing pages
- coverage exists for the salvaged routing behavior

## Validation
- `pnpm --filter @interdomestik/web test:unit --run "src/app/[locale]/(app)/member/claims/new/page.test.tsx" "src/features/member/membership/components/MembershipV2Page.test.tsx"`
- `pnpm --filter @interdomestik/web exec tsc --noEmit`