### PR TITLE
feat: modernize qa verification surface

### DIFF
--- a/packages/qa/src/tool-router.ts
+++ b/packages/qa/src/tool-router.ts
@@ -10,7 +10,15 @@ import {
 } from './tools/audits.js';
 import { codeSearch, gitDiff, gitStatus, projectMap, readFiles } from './tools/repo.js';
 import { checkHealth } from './tools/health.js';
-import { runCoverage, runE2ETests, runTestsOrchestrator, runUnitTests } from './tools/tests.js';
+import {
+  runCoverage,
+  runE2EGate,
+  runE2ETests,
+  runPrVerify,
+  runSecurityGuard,
+  runTestsOrchestrator,
+  runUnitTests,
+} from './tools/tests.js';
 import { queryDb } from './tools/db.js';
 import { getPaddleResource } from './tools/paddle.js';
 
@@ -32,6 +40,9 @@ const handlers: Record<string, Handler> = {
   audit_auth: () => auditAuth(),
   audit_env: () => auditEnv(),
   check_health: () => checkHealth(),
+  pr_verify: () => runPrVerify(),
+  security_guard: () => runSecurityGuard(),
+  e2e_gate: () => runE2EGate(),
   run_unit_tests: () => runUnitTests(),
   run_coverage: () => runCoverage(),
   run_e2e_tests: () => runE2ETests(),

--- a/packages/qa/src/tool-router.ts
+++ b/packages/qa/src/tool-router.ts
@@ -11,10 +11,15 @@ import {
 import { codeSearch, gitDiff, gitStatus, projectMap, readFiles } from './tools/repo.js';
 import { checkHealth } from './tools/health.js';
 import {
+  runBuildCi,
   runCoverage,
   runE2EGate,
+  runE2EGatePrFast,
+  runE2EStateSetup,
   runE2ETests,
+  runCheckFast,
   runPrVerify,
+  runPrVerifyHosts,
   runSecurityGuard,
   runTestsOrchestrator,
   runUnitTests,
@@ -43,6 +48,11 @@ const handlers: Record<string, Handler> = {
   pr_verify: () => runPrVerify(),
   security_guard: () => runSecurityGuard(),
   e2e_gate: () => runE2EGate(),
+  build_ci: () => runBuildCi(),
+  check_fast: () => runCheckFast(),
+  e2e_state_setup: () => runE2EStateSetup(),
+  e2e_gate_pr_fast: () => runE2EGatePrFast(),
+  pr_verify_hosts: () => runPrVerifyHosts(),
   run_unit_tests: () => runUnitTests(),
   run_coverage: () => runCoverage(),
   run_e2e_tests: () => runE2ETests(),

--- a/packages/qa/src/tools/audits/dependencies.ts
+++ b/packages/qa/src/tools/audits/dependencies.ts
@@ -17,9 +17,11 @@ export async function auditDependencies() {
     };
   }
 
-  await execAsync('git branch --show-current', { cwd: REPO_ROOT }).catch(() => ({
-    stdout: 'unknown',
-  }));
+  await execAsync({ args: ['branch', '--show-current'], file: 'git' }, { cwd: REPO_ROOT }).catch(
+    () => ({
+      stdout: 'unknown',
+    })
+  );
   const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
   const checks: string[] = [];
   if (pkg.workspaces) checks.push('✅ Workspaces configured');

--- a/packages/qa/src/tools/health.ts
+++ b/packages/qa/src/tools/health.ts
@@ -1,50 +1,37 @@
-import { execAsync, type ExecResult } from '../utils/exec.js';
+import { coerceExecResult, execAsync, type ExecCommand } from '../utils/exec.js';
 import { REPO_ROOT } from '../utils/paths.js';
-import { buildCommandStructuredContent, buildHealthToolResult } from '../utils/tool-results.js';
+import {
+  buildCommandStructuredContent,
+  buildHealthToolResult,
+  type QACommandStructuredContent,
+} from '../utils/tool-results.js';
 
 type HealthCheckConfig = {
-  command: string;
+  command: ExecCommand;
   label: string;
   tool: string;
 };
 
 const HEALTH_CHECKS: HealthCheckConfig[] = [
   {
-    command: 'pnpm pr:verify',
+    command: { args: ['pr:verify'], display: 'pnpm pr:verify', file: 'pnpm' },
     label: 'PR Verify',
     tool: 'pr_verify',
   },
   {
-    command: 'pnpm security:guard',
+    command: { args: ['security:guard'], display: 'pnpm security:guard', file: 'pnpm' },
     label: 'Security Guard',
     tool: 'security_guard',
   },
   {
-    command: 'pnpm e2e:gate',
+    command: { args: ['e2e:gate'], display: 'pnpm e2e:gate', file: 'pnpm' },
     label: 'E2E Gate',
     tool: 'e2e_gate',
   },
 ];
 
-function coerceExecResult(error: any, fallbackCommand: string): ExecResult {
-  return {
-    command: error?.command ?? fallbackCommand,
-    cwd: error?.cwd ?? REPO_ROOT,
-    durationMs: error?.durationMs ?? 0,
-    exitCode: error?.exitCode ?? error?.code ?? null,
-    failedStage: error?.failedStage ?? null,
-    failureCategory: error?.failureCategory ?? null,
-    signal: error?.signal ?? null,
-    stderr: (error?.stderr || '').trim(),
-    stderrTruncated: error?.stderrTruncated ?? false,
-    stdout: (error?.stdout || '').trim(),
-    stdoutTruncated: error?.stdoutTruncated ?? false,
-    timedOut: error?.timedOut ?? false,
-  };
-}
-
 export async function checkHealth() {
-  const checks = [];
+  const checks: QACommandStructuredContent[] = [];
 
   for (const check of HEALTH_CHECKS) {
     try {
@@ -56,7 +43,7 @@ export async function checkHealth() {
           check.tool,
           check.label,
           'fail',
-          coerceExecResult(error, check.command)
+          coerceExecResult(error, check.command, REPO_ROOT)
         )
       );
     }

--- a/packages/qa/src/tools/health.ts
+++ b/packages/qa/src/tools/health.ts
@@ -3,14 +3,18 @@ import { REPO_ROOT } from '../utils/paths.js';
 
 export async function checkHealth() {
   try {
-    const typeCheck = await execAsync('pnpm type-check', { cwd: REPO_ROOT });
-    const lint = await execAsync('pnpm lint', { cwd: REPO_ROOT });
+    const prVerify = await execAsync('pnpm pr:verify', { cwd: REPO_ROOT });
+    const securityGuard = await execAsync('pnpm security:guard', { cwd: REPO_ROOT });
+    const e2eGate = await execAsync('pnpm e2e:gate', { cwd: REPO_ROOT });
 
     return {
       content: [
         {
           type: 'text',
-          text: `✅ HEALTH CHECK PASSED\n\nTYPE CHECK:\n${typeCheck.stdout}\n\nLINT:\n${lint.stdout}`,
+          text:
+            `✅ HEALTH CHECK PASSED\n\nPR VERIFY:\n${prVerify.stdout}\n` +
+            `\nSECURITY GUARD:\n${securityGuard.stdout}\n` +
+            `\nE2E GATE:\n${e2eGate.stdout}`,
         },
       ],
     };

--- a/packages/qa/src/tools/health.ts
+++ b/packages/qa/src/tools/health.ts
@@ -1,33 +1,66 @@
-import { execAsync } from '../utils/exec.js';
+import { execAsync, type ExecResult } from '../utils/exec.js';
 import { REPO_ROOT } from '../utils/paths.js';
+import { buildCommandStructuredContent, buildHealthToolResult } from '../utils/tool-results.js';
+
+type HealthCheckConfig = {
+  command: string;
+  label: string;
+  tool: string;
+};
+
+const HEALTH_CHECKS: HealthCheckConfig[] = [
+  {
+    command: 'pnpm pr:verify',
+    label: 'PR Verify',
+    tool: 'pr_verify',
+  },
+  {
+    command: 'pnpm security:guard',
+    label: 'Security Guard',
+    tool: 'security_guard',
+  },
+  {
+    command: 'pnpm e2e:gate',
+    label: 'E2E Gate',
+    tool: 'e2e_gate',
+  },
+];
+
+function coerceExecResult(error: any, fallbackCommand: string): ExecResult {
+  return {
+    command: error?.command ?? fallbackCommand,
+    cwd: error?.cwd ?? REPO_ROOT,
+    durationMs: error?.durationMs ?? 0,
+    exitCode: error?.exitCode ?? error?.code ?? null,
+    failedStage: error?.failedStage ?? null,
+    failureCategory: error?.failureCategory ?? null,
+    signal: error?.signal ?? null,
+    stderr: (error?.stderr || '').trim(),
+    stderrTruncated: error?.stderrTruncated ?? false,
+    stdout: (error?.stdout || '').trim(),
+    stdoutTruncated: error?.stdoutTruncated ?? false,
+    timedOut: error?.timedOut ?? false,
+  };
+}
 
 export async function checkHealth() {
-  try {
-    const prVerify = await execAsync('pnpm pr:verify', { cwd: REPO_ROOT });
-    const securityGuard = await execAsync('pnpm security:guard', { cwd: REPO_ROOT });
-    const e2eGate = await execAsync('pnpm e2e:gate', { cwd: REPO_ROOT });
+  const checks = [];
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text:
-            `✅ HEALTH CHECK PASSED\n\nPR VERIFY:\n${prVerify.stdout}\n` +
-            `\nSECURITY GUARD:\n${securityGuard.stdout}\n` +
-            `\nE2E GATE:\n${e2eGate.stdout}`,
-        },
-      ],
-    };
-  } catch (error: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `❌ HEALTH CHECK FAILED\n\nError: ${error.message}\n\nOutput: ${error.stdout || ''}\n${
-            error.stderr || ''
-          }`,
-        },
-      ],
-    };
+  for (const check of HEALTH_CHECKS) {
+    try {
+      const result = await execAsync(check.command, { cwd: REPO_ROOT });
+      checks.push(buildCommandStructuredContent(check.tool, check.label, 'pass', result));
+    } catch (error: any) {
+      checks.push(
+        buildCommandStructuredContent(
+          check.tool,
+          check.label,
+          'fail',
+          coerceExecResult(error, check.command)
+        )
+      );
+    }
   }
+
+  return buildHealthToolResult(checks);
 }

--- a/packages/qa/src/tools/list-tools.ts
+++ b/packages/qa/src/tools/list-tools.ts
@@ -46,11 +46,15 @@ export const tools = [
   },
   {
     name: 'tests_orchestrator',
-    description: 'Run project test suites (unit/e2e/smoke)',
+    description:
+      'Run project verification suites (unit/e2e/smoke/pr_verify/security_guard/e2e_gate/full)',
     inputSchema: {
       type: 'object',
       properties: {
-        suite: { type: 'string', description: 'unit | e2e | smoke | full' },
+        suite: {
+          type: 'string',
+          description: 'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | full',
+        },
         useHyperExecute: { type: 'boolean', description: 'Not supported; runs locally' },
       },
     },
@@ -61,7 +65,10 @@ export const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        suite: { type: 'string', description: 'unit | e2e | smoke | full' },
+        suite: {
+          type: 'string',
+          description: 'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | full',
+        },
         useHyperExecute: { type: 'boolean', description: 'Not supported; runs locally' },
       },
     },
@@ -83,7 +90,22 @@ export const tools = [
   },
   {
     name: 'check_health',
-    description: 'Run type-check and lint across workspace',
+    description: 'Run the full Phase C verification contract (pr:verify, security:guard, e2e:gate)',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'pr_verify',
+    description: 'Run pnpm pr:verify for the repo verification contract',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'security_guard',
+    description: 'Run pnpm security:guard for the repo security contract',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'e2e_gate',
+    description: 'Run pnpm e2e:gate for the repo end-to-end gate contract',
     inputSchema: { type: 'object', properties: {} },
   },
   {

--- a/packages/qa/src/tools/list-tools.ts
+++ b/packages/qa/src/tools/list-tools.ts
@@ -47,13 +47,14 @@ export const tools = [
   {
     name: 'tests_orchestrator',
     description:
-      'Run project verification suites (unit/e2e/smoke/pr_verify/security_guard/e2e_gate/full)',
+      'Run project verification suites (unit/e2e/smoke/pr_verify/security_guard/e2e_gate/build_ci/check_fast/e2e_state_setup/e2e_gate_pr_fast/pr_verify_hosts/full)',
     inputSchema: {
       type: 'object',
       properties: {
         suite: {
           type: 'string',
-          description: 'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | full',
+          description:
+            'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | build_ci | check_fast | e2e_state_setup | e2e_gate_pr_fast | pr_verify_hosts | full',
         },
         useHyperExecute: { type: 'boolean', description: 'Not supported; runs locally' },
       },
@@ -67,7 +68,8 @@ export const tools = [
       properties: {
         suite: {
           type: 'string',
-          description: 'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | full',
+          description:
+            'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | build_ci | check_fast | e2e_state_setup | e2e_gate_pr_fast | pr_verify_hosts | full',
         },
         useHyperExecute: { type: 'boolean', description: 'Not supported; runs locally' },
       },
@@ -106,6 +108,31 @@ export const tools = [
   {
     name: 'e2e_gate',
     description: 'Run pnpm e2e:gate for the repo end-to-end gate contract',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'build_ci',
+    description: 'Run the CI-grade web build command used by the repo verification flow',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'check_fast',
+    description: 'Run pnpm check:fast for the repo build and fast-gate verification path',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'e2e_state_setup',
+    description: 'Run the deterministic E2E auth state setup flow only',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'e2e_gate_pr_fast',
+    description: 'Run the fast PR-oriented E2E gate without the full PR verify contract',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'pr_verify_hosts',
+    description: 'Run the host-routed PR verification variant for deterministic local verification',
     inputSchema: { type: 'object', properties: {} },
   },
   {

--- a/packages/qa/src/tools/list-tools.ts
+++ b/packages/qa/src/tools/list-tools.ts
@@ -1,140 +1,80 @@
+const EMPTY_INPUT_SCHEMA = { type: 'object', properties: {} };
+
+const TEST_SUITE_DESCRIPTION =
+  'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | build_ci | check_fast | ' +
+  'e2e_state_setup | e2e_gate_pr_fast | pr_verify_hosts | full';
+
+const TEST_ORCHESTRATOR_INPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    suite: {
+      type: 'string',
+      description: TEST_SUITE_DESCRIPTION,
+    },
+    useHyperExecute: { type: 'boolean', description: 'Not supported; runs locally' },
+  },
+};
+
+function createNoArgTool(name: string, description: string) {
+  return {
+    name,
+    description,
+    inputSchema: EMPTY_INPUT_SCHEMA,
+  };
+}
+
+const phaseCVerificationTools = [
+  createNoArgTool(
+    'check_health',
+    'Run the full Phase C verification contract (pr:verify, security:guard, e2e:gate)'
+  ),
+  createNoArgTool('pr_verify', 'Run pnpm pr:verify for the repo verification contract'),
+  createNoArgTool('security_guard', 'Run pnpm security:guard for the repo security contract'),
+  createNoArgTool('e2e_gate', 'Run pnpm e2e:gate for the repo end-to-end gate contract'),
+  createNoArgTool(
+    'build_ci',
+    'Run the CI-grade web build command used by the repo verification flow'
+  ),
+  createNoArgTool(
+    'check_fast',
+    'Run pnpm check:fast for the repo build and fast-gate verification path'
+  ),
+  createNoArgTool('e2e_state_setup', 'Run the deterministic E2E auth state setup flow only'),
+  createNoArgTool(
+    'e2e_gate_pr_fast',
+    'Run the fast PR-oriented E2E gate without the full PR verify contract'
+  ),
+  createNoArgTool(
+    'pr_verify_hosts',
+    'Run the host-routed PR verification variant for deterministic local verification'
+  ),
+];
+
 export const tools = [
-  {
-    name: 'audit_auth',
-    description: 'Verify Better Auth configuration (files, env, proxy)',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'audit_env',
-    description: 'Verify Environment Variables for Interdomestik',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'audit_navigation',
-    description: 'Verify Navigation & Layout Structure (i18n, layouts)',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'audit_dependencies',
-    description: 'Verify Critical Dependencies & Package Configuration',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'dependency_audit',
-    description: 'Alias for audit_dependencies',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'audit_supabase',
-    description: 'Verify Supabase Environment & Connectivity (env vars only)',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'run_unit_tests',
-    description: 'Run unit tests for the web application using Vitest',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'run_coverage',
-    description: 'Run unit tests with coverage for the web application',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'run_e2e_tests',
-    description: 'Run E2E tests for the web application using Playwright',
-    inputSchema: { type: 'object', properties: {} },
-  },
+  createNoArgTool('audit_auth', 'Verify Better Auth configuration (files, env, proxy)'),
+  createNoArgTool('audit_env', 'Verify Environment Variables for Interdomestik'),
+  createNoArgTool('audit_navigation', 'Verify Navigation & Layout Structure (i18n, layouts)'),
+  createNoArgTool('audit_dependencies', 'Verify Critical Dependencies & Package Configuration'),
+  createNoArgTool('dependency_audit', 'Alias for audit_dependencies'),
+  createNoArgTool('audit_supabase', 'Verify Supabase Environment & Connectivity (env vars only)'),
+  createNoArgTool('run_unit_tests', 'Run unit tests for the web application using Vitest'),
+  createNoArgTool('run_coverage', 'Run unit tests with coverage for the web application'),
+  createNoArgTool('run_e2e_tests', 'Run E2E tests for the web application using Playwright'),
   {
     name: 'tests_orchestrator',
     description:
       'Run project verification suites (unit/e2e/smoke/pr_verify/security_guard/e2e_gate/build_ci/check_fast/e2e_state_setup/e2e_gate_pr_fast/pr_verify_hosts/full)',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        suite: {
-          type: 'string',
-          description:
-            'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | build_ci | check_fast | e2e_state_setup | e2e_gate_pr_fast | pr_verify_hosts | full',
-        },
-        useHyperExecute: { type: 'boolean', description: 'Not supported; runs locally' },
-      },
-    },
+    inputSchema: TEST_ORCHESTRATOR_INPUT_SCHEMA,
   },
   {
     name: 'test_runner',
     description: 'Alias for tests_orchestrator',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        suite: {
-          type: 'string',
-          description:
-            'unit | e2e | smoke | pr_verify | security_guard | e2e_gate | build_ci | check_fast | e2e_state_setup | e2e_gate_pr_fast | pr_verify_hosts | full',
-        },
-        useHyperExecute: { type: 'boolean', description: 'Not supported; runs locally' },
-      },
-    },
+    inputSchema: TEST_ORCHESTRATOR_INPUT_SCHEMA,
   },
-  {
-    name: 'audit_accessibility',
-    description: 'Verify Accessibility Testing Setup',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'audit_csp',
-    description: 'Verify Content Security Policy',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'audit_performance',
-    description: 'Verify Performance Optimization Config',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'check_health',
-    description: 'Run the full Phase C verification contract (pr:verify, security:guard, e2e:gate)',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'pr_verify',
-    description: 'Run pnpm pr:verify for the repo verification contract',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'security_guard',
-    description: 'Run pnpm security:guard for the repo security contract',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'e2e_gate',
-    description: 'Run pnpm e2e:gate for the repo end-to-end gate contract',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'build_ci',
-    description: 'Run the CI-grade web build command used by the repo verification flow',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'check_fast',
-    description: 'Run pnpm check:fast for the repo build and fast-gate verification path',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'e2e_state_setup',
-    description: 'Run the deterministic E2E auth state setup flow only',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'e2e_gate_pr_fast',
-    description: 'Run the fast PR-oriented E2E gate without the full PR verify contract',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'pr_verify_hosts',
-    description: 'Run the host-routed PR verification variant for deterministic local verification',
-    inputSchema: { type: 'object', properties: {} },
-  },
+  createNoArgTool('audit_accessibility', 'Verify Accessibility Testing Setup'),
+  createNoArgTool('audit_csp', 'Verify Content Security Policy'),
+  createNoArgTool('audit_performance', 'Verify Performance Optimization Config'),
+  ...phaseCVerificationTools,
   {
     name: 'project_map',
     description: 'Generate a map of the project structure',

--- a/packages/qa/src/tools/repo.ts
+++ b/packages/qa/src/tools/repo.ts
@@ -5,9 +5,34 @@ import { REPO_ROOT } from '../utils/paths.js';
 
 export async function projectMap(args?: { maxDepth?: number }) {
   const maxDepth = args?.maxDepth || 3;
-  const command = `find . -maxdepth ${maxDepth} -not -path '*/.*' -not -path '*/node_modules*' -not -path '*/dist*' | sort`;
-  const { stdout } = await execAsync(command, { cwd: REPO_ROOT });
-  return { content: [{ type: 'text', text: `PROJECT MAP (Depth ${maxDepth}):\n\n${stdout}` }] };
+  const { stdout } = await execAsync(
+    {
+      args: [
+        '.',
+        '-maxdepth',
+        String(maxDepth),
+        '-not',
+        '-path',
+        '*/.*',
+        '-not',
+        '-path',
+        '*/node_modules*',
+        '-not',
+        '-path',
+        '*/dist*',
+      ],
+      file: 'find',
+    },
+    { cwd: REPO_ROOT }
+  );
+  const sortedOutput = stdout
+    .split('\n')
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right))
+    .join('\n');
+  return {
+    content: [{ type: 'text', text: `PROJECT MAP (Depth ${maxDepth}):\n\n${sortedOutput}` }],
+  };
 }
 
 export async function readFiles(args: { files: string[] }) {
@@ -29,19 +54,24 @@ export async function readFiles(args: { files: string[] }) {
 }
 
 export async function gitStatus() {
-  const { stdout } = await execAsync('git status', { cwd: REPO_ROOT });
+  const { stdout } = await execAsync({ args: ['status'], file: 'git' }, { cwd: REPO_ROOT });
   return { content: [{ type: 'text', text: stdout }] };
 }
 
 export async function gitDiff(args?: { cached?: boolean }) {
-  const command = args?.cached ? 'git diff --cached' : 'git diff';
+  const command = args?.cached
+    ? { args: ['diff', '--cached'], file: 'git' }
+    : { args: ['diff'], file: 'git' };
   const { stdout } = await execAsync(command, { cwd: REPO_ROOT });
   return { content: [{ type: 'text', text: stdout || '(No changes)' }] };
 }
 
 export async function codeSearch(args: { query: string; filePattern?: string }) {
   const { query, filePattern } = args;
-  const command = `git grep -n -I "${query}" -- ${filePattern || '.'}`;
+  const command = {
+    args: ['grep', '-n', '-I', query, '--', filePattern || '.'],
+    file: 'git',
+  };
   try {
     const { stdout } = await execAsync(command, { cwd: REPO_ROOT });
     if (!stdout) return { content: [{ type: 'text', text: 'No matches found.' }] };
@@ -51,7 +81,7 @@ export async function codeSearch(args: { query: string; filePattern?: string }) 
       ],
     };
   } catch (e: any) {
-    if (e.code === 1) return { content: [{ type: 'text', text: 'No matches found.' }] };
+    if (e.exitCode === 1) return { content: [{ type: 'text', text: 'No matches found.' }] };
     return { content: [{ type: 'text', text: `Error searching: ${e.message}` }] };
   }
 }

--- a/packages/qa/src/tools/tests.ts
+++ b/packages/qa/src/tools/tests.ts
@@ -23,6 +23,141 @@ type TestResult = {
   status: 'pass' | 'fail';
 };
 
+function createPnpmCommand(display: string, ...args: string[]): ExecCommand {
+  return { args, display, file: 'pnpm' };
+}
+
+function createNodeCommand(display: string, ...args: string[]): ExecCommand {
+  return { args, display, file: 'node' };
+}
+
+function createToolConfig(
+  tool: string,
+  label: string,
+  cwd: string,
+  command: ExecCommand
+): ToolCommandConfig {
+  return { command, cwd, label, tool };
+}
+
+const TOOL_CONFIGS = {
+  build_ci: createToolConfig(
+    'build_ci',
+    'Build CI',
+    REPO_ROOT,
+    createNodeCommand(
+      'node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/web run build:ci',
+      'scripts/run-with-default-db-url.mjs',
+      'pnpm',
+      '--filter',
+      '@interdomestik/web',
+      'run',
+      'build:ci'
+    )
+  ),
+  check_fast: createToolConfig(
+    'check_fast',
+    'Check Fast',
+    REPO_ROOT,
+    createPnpmCommand('pnpm check:fast', 'check:fast')
+  ),
+  e2e_gate: createToolConfig(
+    'e2e_gate',
+    'E2E Gate',
+    REPO_ROOT,
+    createPnpmCommand('pnpm e2e:gate', 'e2e:gate')
+  ),
+  e2e_gate_pr_fast: createToolConfig(
+    'e2e_gate_pr_fast',
+    'E2E Gate PR Fast',
+    REPO_ROOT,
+    createNodeCommand(
+      'node scripts/run-with-default-db-url.mjs pnpm e2e:gate:pr:fast',
+      'scripts/run-with-default-db-url.mjs',
+      'pnpm',
+      'e2e:gate:pr:fast'
+    )
+  ),
+  e2e_state_setup: createToolConfig(
+    'e2e_state_setup',
+    'E2E State Setup',
+    REPO_ROOT,
+    createNodeCommand(
+      'node scripts/run-with-default-db-url.mjs pnpm e2e:state:setup',
+      'scripts/run-with-default-db-url.mjs',
+      'pnpm',
+      'e2e:state:setup'
+    )
+  ),
+  pr_verify: createToolConfig(
+    'pr_verify',
+    'PR Verify',
+    REPO_ROOT,
+    createPnpmCommand('pnpm pr:verify', 'pr:verify')
+  ),
+  pr_verify_hosts: createToolConfig(
+    'pr_verify_hosts',
+    'PR Verify Hosts',
+    REPO_ROOT,
+    createPnpmCommand('pnpm pr:verify:hosts', 'pr:verify:hosts')
+  ),
+  run_coverage: createToolConfig(
+    'run_coverage',
+    'Coverage',
+    WEB_APP,
+    createPnpmCommand('pnpm test:unit -- --coverage', 'test:unit', '--', '--coverage')
+  ),
+  run_e2e_tests: createToolConfig(
+    'run_e2e_tests',
+    'E2E Tests',
+    WEB_APP,
+    createPnpmCommand('pnpm test:e2e', 'test:e2e')
+  ),
+  run_unit_tests: createToolConfig(
+    'run_unit_tests',
+    'Unit Tests',
+    WEB_APP,
+    createPnpmCommand('pnpm test:unit', 'test:unit')
+  ),
+  security_guard: createToolConfig(
+    'security_guard',
+    'Security Guard',
+    REPO_ROOT,
+    createPnpmCommand('pnpm security:guard', 'security:guard')
+  ),
+  smoke: createToolConfig(
+    'smoke',
+    'E2E Smoke Tests',
+    REPO_ROOT,
+    createPnpmCommand(
+      'pnpm --filter @interdomestik/web test:e2e -- --grep smoke',
+      '--filter',
+      '@interdomestik/web',
+      'test:e2e',
+      '--',
+      '--grep',
+      'smoke'
+    )
+  ),
+} satisfies Record<string, ToolCommandConfig>;
+
+type ToolConfigName = keyof typeof TOOL_CONFIGS;
+
+const SUITE_TO_TOOL_CONFIGS: Record<string, ToolConfigName[]> = {
+  build_ci: ['build_ci'],
+  check_fast: ['check_fast'],
+  e2e: ['run_e2e_tests'],
+  e2e_gate: ['e2e_gate'],
+  e2e_gate_pr_fast: ['e2e_gate_pr_fast'],
+  e2e_state_setup: ['e2e_state_setup'],
+  full: ['pr_verify', 'security_guard', 'e2e_gate'],
+  pr_verify: ['pr_verify'],
+  pr_verify_hosts: ['pr_verify_hosts'],
+  security_guard: ['security_guard'],
+  smoke: ['smoke'],
+  unit: ['run_unit_tests'],
+};
+
 function formatSummary(results: TestResult[]) {
   const passed = results.filter(result => result.status === 'pass').length;
   const failed = results.filter(result => result.status === 'fail').length;
@@ -79,100 +214,7 @@ async function runCommand(config: ToolCommandConfig): Promise<TestResult> {
 }
 
 function getToolConfig(tool: string): ToolCommandConfig {
-  const configs: Record<string, ToolCommandConfig> = {
-    build_ci: {
-      command: {
-        args: [
-          'scripts/run-with-default-db-url.mjs',
-          'pnpm',
-          '--filter',
-          '@interdomestik/web',
-          'run',
-          'build:ci',
-        ],
-        display:
-          'node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/web run build:ci',
-        file: 'node',
-      },
-      cwd: REPO_ROOT,
-      label: 'Build CI',
-      tool: 'build_ci',
-    },
-    check_fast: {
-      command: { args: ['check:fast'], display: 'pnpm check:fast', file: 'pnpm' },
-      cwd: REPO_ROOT,
-      label: 'Check Fast',
-      tool: 'check_fast',
-    },
-    e2e_gate: {
-      command: { args: ['e2e:gate'], display: 'pnpm e2e:gate', file: 'pnpm' },
-      cwd: REPO_ROOT,
-      label: 'E2E Gate',
-      tool: 'e2e_gate',
-    },
-    e2e_gate_pr_fast: {
-      command: {
-        args: ['scripts/run-with-default-db-url.mjs', 'pnpm', 'e2e:gate:pr:fast'],
-        display: 'node scripts/run-with-default-db-url.mjs pnpm e2e:gate:pr:fast',
-        file: 'node',
-      },
-      cwd: REPO_ROOT,
-      label: 'E2E Gate PR Fast',
-      tool: 'e2e_gate_pr_fast',
-    },
-    e2e_state_setup: {
-      command: {
-        args: ['scripts/run-with-default-db-url.mjs', 'pnpm', 'e2e:state:setup'],
-        display: 'node scripts/run-with-default-db-url.mjs pnpm e2e:state:setup',
-        file: 'node',
-      },
-      cwd: REPO_ROOT,
-      label: 'E2E State Setup',
-      tool: 'e2e_state_setup',
-    },
-    pr_verify: {
-      command: { args: ['pr:verify'], display: 'pnpm pr:verify', file: 'pnpm' },
-      cwd: REPO_ROOT,
-      label: 'PR Verify',
-      tool: 'pr_verify',
-    },
-    pr_verify_hosts: {
-      command: { args: ['pr:verify:hosts'], display: 'pnpm pr:verify:hosts', file: 'pnpm' },
-      cwd: REPO_ROOT,
-      label: 'PR Verify Hosts',
-      tool: 'pr_verify_hosts',
-    },
-    run_coverage: {
-      command: {
-        args: ['test:unit', '--', '--coverage'],
-        display: 'pnpm test:unit -- --coverage',
-        file: 'pnpm',
-      },
-      cwd: WEB_APP,
-      label: 'Coverage',
-      tool: 'run_coverage',
-    },
-    run_e2e_tests: {
-      command: { args: ['test:e2e'], display: 'pnpm test:e2e', file: 'pnpm' },
-      cwd: WEB_APP,
-      label: 'E2E Tests',
-      tool: 'run_e2e_tests',
-    },
-    run_unit_tests: {
-      command: { args: ['test:unit'], display: 'pnpm test:unit', file: 'pnpm' },
-      cwd: WEB_APP,
-      label: 'Unit Tests',
-      tool: 'run_unit_tests',
-    },
-    security_guard: {
-      command: { args: ['security:guard'], display: 'pnpm security:guard', file: 'pnpm' },
-      cwd: REPO_ROOT,
-      label: 'Security Guard',
-      tool: 'security_guard',
-    },
-  };
-
-  const config = configs[tool];
+  const config = TOOL_CONFIGS[tool as ToolConfigName];
 
   if (!config) {
     throw new Error(`Unknown tool config: ${tool}`);
@@ -182,55 +224,8 @@ function getToolConfig(tool: string): ToolCommandConfig {
 }
 
 function getOrchestratorConfigs(suite: string): ToolCommandConfig[] | null {
-  if (suite === 'unit') {
-    return [getToolConfig('run_unit_tests')];
-  }
-  if (suite === 'e2e') {
-    return [getToolConfig('run_e2e_tests')];
-  }
-  if (suite === 'smoke') {
-    return [
-      {
-        command: {
-          args: ['--filter', '@interdomestik/web', 'test:e2e', '--', '--grep', 'smoke'],
-          display: 'pnpm --filter @interdomestik/web test:e2e -- --grep smoke',
-          file: 'pnpm',
-        },
-        cwd: REPO_ROOT,
-        label: 'E2E Smoke Tests',
-        tool: 'smoke',
-      },
-    ];
-  }
-  if (suite === 'pr_verify') {
-    return [getToolConfig('pr_verify')];
-  }
-  if (suite === 'security_guard') {
-    return [getToolConfig('security_guard')];
-  }
-  if (suite === 'e2e_gate') {
-    return [getToolConfig('e2e_gate')];
-  }
-  if (suite === 'build_ci') {
-    return [getToolConfig('build_ci')];
-  }
-  if (suite === 'check_fast') {
-    return [getToolConfig('check_fast')];
-  }
-  if (suite === 'e2e_state_setup') {
-    return [getToolConfig('e2e_state_setup')];
-  }
-  if (suite === 'e2e_gate_pr_fast') {
-    return [getToolConfig('e2e_gate_pr_fast')];
-  }
-  if (suite === 'pr_verify_hosts') {
-    return [getToolConfig('pr_verify_hosts')];
-  }
-  if (suite === 'full') {
-    return [getToolConfig('pr_verify'), getToolConfig('security_guard'), getToolConfig('e2e_gate')];
-  }
-
-  return null;
+  const toolNames = SUITE_TO_TOOL_CONFIGS[suite];
+  return toolNames ? toolNames.map(tool => getToolConfig(tool)) : null;
 }
 
 export async function runUnitTests() {

--- a/packages/qa/src/tools/tests.ts
+++ b/packages/qa/src/tools/tests.ts
@@ -1,7 +1,7 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { execAsync, type ExecResult } from '../utils/exec.js';
+import { coerceExecResult, execAsync, type ExecCommand, type ExecResult } from '../utils/exec.js';
 import { REPO_ROOT, WEB_APP } from '../utils/paths.js';
-import { buildCommandStructuredContent, buildCommandToolResult } from '../utils/tool-results.js';
+import { buildCommandToolResult } from '../utils/tool-results.js';
 
 type OrchestratorArgs = {
   suite?: string;
@@ -9,7 +9,7 @@ type OrchestratorArgs = {
 };
 
 type ToolCommandConfig = {
-  command: string;
+  command: ExecCommand;
   cwd: string;
   label: string;
   tool: string;
@@ -22,23 +22,6 @@ type TestResult = {
   output: string;
   status: 'pass' | 'fail';
 };
-
-function coerceExecResult(error: any, fallbackCommand: string, fallbackCwd: string): ExecResult {
-  return {
-    command: error?.command ?? fallbackCommand,
-    cwd: error?.cwd ?? fallbackCwd,
-    durationMs: error?.durationMs ?? 0,
-    exitCode: error?.exitCode ?? error?.code ?? null,
-    failedStage: error?.failedStage ?? null,
-    failureCategory: error?.failureCategory ?? null,
-    signal: error?.signal ?? null,
-    stderr: (error?.stderr || '').trim(),
-    stderrTruncated: error?.stderrTruncated ?? false,
-    stdout: (error?.stdout || '').trim(),
-    stdoutTruncated: error?.stdoutTruncated ?? false,
-    timedOut: error?.timedOut ?? false,
-  };
-}
 
 function formatSummary(results: TestResult[]) {
   const passed = results.filter(result => result.status === 'pass').length;
@@ -98,75 +81,104 @@ async function runCommand(config: ToolCommandConfig): Promise<TestResult> {
 function getToolConfig(tool: string): ToolCommandConfig {
   const configs: Record<string, ToolCommandConfig> = {
     build_ci: {
-      command:
-        'node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/web run build:ci',
+      command: {
+        args: [
+          'scripts/run-with-default-db-url.mjs',
+          'pnpm',
+          '--filter',
+          '@interdomestik/web',
+          'run',
+          'build:ci',
+        ],
+        display:
+          'node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/web run build:ci',
+        file: 'node',
+      },
       cwd: REPO_ROOT,
       label: 'Build CI',
       tool: 'build_ci',
     },
     check_fast: {
-      command: 'pnpm check:fast',
+      command: { args: ['check:fast'], display: 'pnpm check:fast', file: 'pnpm' },
       cwd: REPO_ROOT,
       label: 'Check Fast',
       tool: 'check_fast',
     },
     e2e_gate: {
-      command: 'pnpm e2e:gate',
+      command: { args: ['e2e:gate'], display: 'pnpm e2e:gate', file: 'pnpm' },
       cwd: REPO_ROOT,
       label: 'E2E Gate',
       tool: 'e2e_gate',
     },
     e2e_gate_pr_fast: {
-      command: 'node scripts/run-with-default-db-url.mjs pnpm e2e:gate:pr:fast',
+      command: {
+        args: ['scripts/run-with-default-db-url.mjs', 'pnpm', 'e2e:gate:pr:fast'],
+        display: 'node scripts/run-with-default-db-url.mjs pnpm e2e:gate:pr:fast',
+        file: 'node',
+      },
       cwd: REPO_ROOT,
       label: 'E2E Gate PR Fast',
       tool: 'e2e_gate_pr_fast',
     },
     e2e_state_setup: {
-      command: 'node scripts/run-with-default-db-url.mjs pnpm e2e:state:setup',
+      command: {
+        args: ['scripts/run-with-default-db-url.mjs', 'pnpm', 'e2e:state:setup'],
+        display: 'node scripts/run-with-default-db-url.mjs pnpm e2e:state:setup',
+        file: 'node',
+      },
       cwd: REPO_ROOT,
       label: 'E2E State Setup',
       tool: 'e2e_state_setup',
     },
     pr_verify: {
-      command: 'pnpm pr:verify',
+      command: { args: ['pr:verify'], display: 'pnpm pr:verify', file: 'pnpm' },
       cwd: REPO_ROOT,
       label: 'PR Verify',
       tool: 'pr_verify',
     },
     pr_verify_hosts: {
-      command: 'pnpm pr:verify:hosts',
+      command: { args: ['pr:verify:hosts'], display: 'pnpm pr:verify:hosts', file: 'pnpm' },
       cwd: REPO_ROOT,
       label: 'PR Verify Hosts',
       tool: 'pr_verify_hosts',
     },
     run_coverage: {
-      command: 'pnpm test:unit -- --coverage',
+      command: {
+        args: ['test:unit', '--', '--coverage'],
+        display: 'pnpm test:unit -- --coverage',
+        file: 'pnpm',
+      },
       cwd: WEB_APP,
       label: 'Coverage',
       tool: 'run_coverage',
     },
     run_e2e_tests: {
-      command: 'pnpm test:e2e',
+      command: { args: ['test:e2e'], display: 'pnpm test:e2e', file: 'pnpm' },
       cwd: WEB_APP,
       label: 'E2E Tests',
       tool: 'run_e2e_tests',
     },
     run_unit_tests: {
-      command: 'pnpm test:unit',
+      command: { args: ['test:unit'], display: 'pnpm test:unit', file: 'pnpm' },
       cwd: WEB_APP,
       label: 'Unit Tests',
       tool: 'run_unit_tests',
     },
     security_guard: {
-      command: 'pnpm security:guard',
+      command: { args: ['security:guard'], display: 'pnpm security:guard', file: 'pnpm' },
       cwd: REPO_ROOT,
       label: 'Security Guard',
       tool: 'security_guard',
     },
   };
 
-  return configs[tool];
+  const config = configs[tool];
+
+  if (!config) {
+    throw new Error(`Unknown tool config: ${tool}`);
+  }
+
+  return config;
 }
 
 function getOrchestratorConfigs(suite: string): ToolCommandConfig[] | null {
@@ -179,7 +191,11 @@ function getOrchestratorConfigs(suite: string): ToolCommandConfig[] | null {
   if (suite === 'smoke') {
     return [
       {
-        command: 'pnpm --filter @interdomestik/web test:e2e -- --grep smoke',
+        command: {
+          args: ['--filter', '@interdomestik/web', 'test:e2e', '--', '--grep', 'smoke'],
+          display: 'pnpm --filter @interdomestik/web test:e2e -- --grep smoke',
+          file: 'pnpm',
+        },
         cwd: REPO_ROOT,
         label: 'E2E Smoke Tests',
         tool: 'smoke',

--- a/packages/qa/src/tools/tests.ts
+++ b/packages/qa/src/tools/tests.ts
@@ -1,31 +1,53 @@
-import { execAsync } from '../utils/exec.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { execAsync, type ExecResult } from '../utils/exec.js';
 import { REPO_ROOT, WEB_APP } from '../utils/paths.js';
+import { buildCommandStructuredContent, buildCommandToolResult } from '../utils/tool-results.js';
 
 type OrchestratorArgs = {
   suite?: string;
   useHyperExecute?: boolean;
 };
 
-type TestResult = {
-  name: string;
-  status: 'pass' | 'fail';
-  output: string;
+type ToolCommandConfig = {
+  command: string;
+  cwd: string;
+  label: string;
+  tool: string;
 };
 
-type ToolResponse = {
-  content: Array<{
-    type: 'text';
-    text: string;
-  }>;
+type TestResult = {
+  durationMs: number;
+  failedStage: string | null;
+  name: string;
+  output: string;
+  status: 'pass' | 'fail';
 };
+
+function coerceExecResult(error: any, fallbackCommand: string, fallbackCwd: string): ExecResult {
+  return {
+    command: error?.command ?? fallbackCommand,
+    cwd: error?.cwd ?? fallbackCwd,
+    durationMs: error?.durationMs ?? 0,
+    exitCode: error?.exitCode ?? error?.code ?? null,
+    failedStage: error?.failedStage ?? null,
+    failureCategory: error?.failureCategory ?? null,
+    signal: error?.signal ?? null,
+    stderr: (error?.stderr || '').trim(),
+    stderrTruncated: error?.stderrTruncated ?? false,
+    stdout: (error?.stdout || '').trim(),
+    stdoutTruncated: error?.stdoutTruncated ?? false,
+    timedOut: error?.timedOut ?? false,
+  };
+}
 
 function formatSummary(results: TestResult[]) {
-  const passed = results.filter(r => r.status === 'pass').length;
-  const failed = results.filter(r => r.status === 'fail').length;
+  const passed = results.filter(result => result.status === 'pass').length;
+  const failed = results.filter(result => result.status === 'fail').length;
 
   const lines = results.map(result => {
     const icon = result.status === 'pass' ? '✅' : '❌';
-    return `${icon} ${result.name}`;
+    const stageSuffix = result.failedStage ? ` [${result.failedStage}]` : '';
+    return `${icon} ${result.name}${stageSuffix} (${result.durationMs}ms)`;
   });
 
   return [
@@ -38,101 +60,205 @@ function formatSummary(results: TestResult[]) {
   ].join('\n');
 }
 
-async function runCommand(name: string, command: string, cwd: string): Promise<TestResult> {
-  try {
-    const { stdout, stderr } = await execAsync(command, { cwd });
-    const errOutput = stderr ? `\n${stderr}` : '';
-    return {
-      name,
-      status: 'pass',
-      output: `${stdout}${errOutput}`.trim(),
-    };
-  } catch (error: any) {
-    const errOutput = error.stderr ? `\n${error.stderr}` : '';
-    return {
-      name,
-      status: 'fail',
-      output: `${error.stdout || ''}${errOutput}`.trim(),
-    };
-  }
-}
+function toTestResult(name: string, result: ExecResult, status: 'pass' | 'fail'): TestResult {
+  const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
 
-function formatToolResponse(prefix: string, stdout: string, stderr: string): ToolResponse {
-  const sections = [prefix, '', stdout, stderr].filter(Boolean);
   return {
-    content: [
-      {
-        type: 'text',
-        text: sections.join('\n'),
-      },
-    ],
+    durationMs: result.durationMs,
+    failedStage: result.failedStage,
+    name,
+    output: output || '(no output)',
+    status,
   };
 }
 
-function formatToolError(prefix: string, error: any): ToolResponse {
-  const output = error.stdout || '';
-  const errOutput = error.stderr || '';
-
-  return {
-    content: [
-      {
-        type: 'text',
-        text: `${prefix}\n\nError: ${error.message}\n\nOutput: ${output}\n${errOutput}`,
-      },
-    ],
-  };
+async function executeToolCommand(config: ToolCommandConfig): Promise<CallToolResult> {
+  try {
+    const result = await execAsync(config.command, { cwd: config.cwd });
+    return buildCommandToolResult(config.tool, config.label, 'pass', result);
+  } catch (error: any) {
+    return buildCommandToolResult(
+      config.tool,
+      config.label,
+      'fail',
+      coerceExecResult(error, config.command, config.cwd)
+    );
+  }
 }
 
-async function runVerificationTool(command: string, successPrefix: string, failurePrefix: string) {
+async function runCommand(config: ToolCommandConfig): Promise<TestResult> {
   try {
-    const { stdout, stderr } = await execAsync(command, { cwd: REPO_ROOT });
-    return formatToolResponse(successPrefix, stdout, stderr);
+    const result = await execAsync(config.command, { cwd: config.cwd });
+    return toTestResult(config.label, result, 'pass');
   } catch (error: any) {
-    return formatToolError(failurePrefix, error);
+    return toTestResult(config.label, coerceExecResult(error, config.command, config.cwd), 'fail');
   }
+}
+
+function getToolConfig(tool: string): ToolCommandConfig {
+  const configs: Record<string, ToolCommandConfig> = {
+    build_ci: {
+      command:
+        'node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/web run build:ci',
+      cwd: REPO_ROOT,
+      label: 'Build CI',
+      tool: 'build_ci',
+    },
+    check_fast: {
+      command: 'pnpm check:fast',
+      cwd: REPO_ROOT,
+      label: 'Check Fast',
+      tool: 'check_fast',
+    },
+    e2e_gate: {
+      command: 'pnpm e2e:gate',
+      cwd: REPO_ROOT,
+      label: 'E2E Gate',
+      tool: 'e2e_gate',
+    },
+    e2e_gate_pr_fast: {
+      command: 'node scripts/run-with-default-db-url.mjs pnpm e2e:gate:pr:fast',
+      cwd: REPO_ROOT,
+      label: 'E2E Gate PR Fast',
+      tool: 'e2e_gate_pr_fast',
+    },
+    e2e_state_setup: {
+      command: 'node scripts/run-with-default-db-url.mjs pnpm e2e:state:setup',
+      cwd: REPO_ROOT,
+      label: 'E2E State Setup',
+      tool: 'e2e_state_setup',
+    },
+    pr_verify: {
+      command: 'pnpm pr:verify',
+      cwd: REPO_ROOT,
+      label: 'PR Verify',
+      tool: 'pr_verify',
+    },
+    pr_verify_hosts: {
+      command: 'pnpm pr:verify:hosts',
+      cwd: REPO_ROOT,
+      label: 'PR Verify Hosts',
+      tool: 'pr_verify_hosts',
+    },
+    run_coverage: {
+      command: 'pnpm test:unit -- --coverage',
+      cwd: WEB_APP,
+      label: 'Coverage',
+      tool: 'run_coverage',
+    },
+    run_e2e_tests: {
+      command: 'pnpm test:e2e',
+      cwd: WEB_APP,
+      label: 'E2E Tests',
+      tool: 'run_e2e_tests',
+    },
+    run_unit_tests: {
+      command: 'pnpm test:unit',
+      cwd: WEB_APP,
+      label: 'Unit Tests',
+      tool: 'run_unit_tests',
+    },
+    security_guard: {
+      command: 'pnpm security:guard',
+      cwd: REPO_ROOT,
+      label: 'Security Guard',
+      tool: 'security_guard',
+    },
+  };
+
+  return configs[tool];
+}
+
+function getOrchestratorConfigs(suite: string): ToolCommandConfig[] | null {
+  if (suite === 'unit') {
+    return [getToolConfig('run_unit_tests')];
+  }
+  if (suite === 'e2e') {
+    return [getToolConfig('run_e2e_tests')];
+  }
+  if (suite === 'smoke') {
+    return [
+      {
+        command: 'pnpm --filter @interdomestik/web test:e2e -- --grep smoke',
+        cwd: REPO_ROOT,
+        label: 'E2E Smoke Tests',
+        tool: 'smoke',
+      },
+    ];
+  }
+  if (suite === 'pr_verify') {
+    return [getToolConfig('pr_verify')];
+  }
+  if (suite === 'security_guard') {
+    return [getToolConfig('security_guard')];
+  }
+  if (suite === 'e2e_gate') {
+    return [getToolConfig('e2e_gate')];
+  }
+  if (suite === 'build_ci') {
+    return [getToolConfig('build_ci')];
+  }
+  if (suite === 'check_fast') {
+    return [getToolConfig('check_fast')];
+  }
+  if (suite === 'e2e_state_setup') {
+    return [getToolConfig('e2e_state_setup')];
+  }
+  if (suite === 'e2e_gate_pr_fast') {
+    return [getToolConfig('e2e_gate_pr_fast')];
+  }
+  if (suite === 'pr_verify_hosts') {
+    return [getToolConfig('pr_verify_hosts')];
+  }
+  if (suite === 'full') {
+    return [getToolConfig('pr_verify'), getToolConfig('security_guard'), getToolConfig('e2e_gate')];
+  }
+
+  return null;
 }
 
 export async function runUnitTests() {
-  try {
-    const { stdout, stderr } = await execAsync('pnpm test:unit', { cwd: WEB_APP });
-    return formatToolResponse('✅ UNIT TESTS PASSED', stdout, stderr);
-  } catch (error: any) {
-    return formatToolError('❌ UNIT TESTS FAILED', error);
-  }
+  return executeToolCommand(getToolConfig('run_unit_tests'));
 }
 
 export async function runE2ETests() {
-  try {
-    const { stdout, stderr } = await execAsync('pnpm test:e2e', { cwd: WEB_APP });
-    return formatToolResponse('✅ E2E TESTS PASSED', stdout, stderr);
-  } catch (error: any) {
-    return formatToolError('❌ E2E TESTS FAILED', error);
-  }
+  return executeToolCommand(getToolConfig('run_e2e_tests'));
 }
 
 export async function runCoverage() {
-  try {
-    const { stdout, stderr } = await execAsync('pnpm test:unit -- --coverage', { cwd: WEB_APP });
-    return formatToolResponse('✅ COVERAGE RUN PASSED', stdout, stderr);
-  } catch (error: any) {
-    return formatToolError('❌ COVERAGE RUN FAILED', error);
-  }
+  return executeToolCommand(getToolConfig('run_coverage'));
 }
 
 export async function runPrVerify() {
-  return runVerificationTool('pnpm pr:verify', '✅ PR VERIFY PASSED', '❌ PR VERIFY FAILED');
+  return executeToolCommand(getToolConfig('pr_verify'));
 }
 
 export async function runSecurityGuard() {
-  return runVerificationTool(
-    'pnpm security:guard',
-    '✅ SECURITY GUARD PASSED',
-    '❌ SECURITY GUARD FAILED'
-  );
+  return executeToolCommand(getToolConfig('security_guard'));
 }
 
 export async function runE2EGate() {
-  return runVerificationTool('pnpm e2e:gate', '✅ E2E GATE PASSED', '❌ E2E GATE FAILED');
+  return executeToolCommand(getToolConfig('e2e_gate'));
+}
+
+export async function runBuildCi() {
+  return executeToolCommand(getToolConfig('build_ci'));
+}
+
+export async function runCheckFast() {
+  return executeToolCommand(getToolConfig('check_fast'));
+}
+
+export async function runE2EStateSetup() {
+  return executeToolCommand(getToolConfig('e2e_state_setup'));
+}
+
+export async function runE2EGatePrFast() {
+  return executeToolCommand(getToolConfig('e2e_gate_pr_fast'));
+}
+
+export async function runPrVerifyHosts() {
+  return executeToolCommand(getToolConfig('pr_verify_hosts'));
 }
 
 export async function runTestsOrchestrator(args: OrchestratorArgs = {}) {
@@ -141,57 +267,44 @@ export async function runTestsOrchestrator(args: OrchestratorArgs = {}) {
 
   if (args.useHyperExecute) {
     results.push({
+      durationMs: 0,
+      failedStage: null,
       name: 'HyperExecute',
-      status: 'fail',
       output: 'HyperExecute is not configured for this repo. Running local tests instead.',
+      status: 'fail',
     });
   }
 
-  const commands: Array<{ name: string; command: string; cwd: string }> = [];
+  const commands = getOrchestratorConfigs(suite);
 
-  if (suite === 'unit') {
-    commands.push({ name: 'Unit Tests', command: 'pnpm test', cwd: REPO_ROOT });
-  } else if (suite === 'e2e') {
-    commands.push({ name: 'E2E Tests', command: 'pnpm test:e2e', cwd: REPO_ROOT });
-  } else if (suite === 'smoke') {
-    commands.push({
-      name: 'E2E Smoke Tests',
-      command: 'pnpm --filter @interdomestik/web test:e2e -- --grep smoke',
-      cwd: REPO_ROOT,
-    });
-  } else if (suite === 'pr_verify') {
-    commands.push({ name: 'PR Verify', command: 'pnpm pr:verify', cwd: REPO_ROOT });
-  } else if (suite === 'security_guard') {
-    commands.push({ name: 'Security Guard', command: 'pnpm security:guard', cwd: REPO_ROOT });
-  } else if (suite === 'e2e_gate') {
-    commands.push({ name: 'E2E Gate', command: 'pnpm e2e:gate', cwd: REPO_ROOT });
-  } else if (suite === 'full') {
-    commands.push(
-      { name: 'PR Verify', command: 'pnpm pr:verify', cwd: REPO_ROOT },
-      { name: 'Security Guard', command: 'pnpm security:guard', cwd: REPO_ROOT },
-      { name: 'E2E Gate', command: 'pnpm e2e:gate', cwd: REPO_ROOT }
-    );
-  } else {
+  if (!commands) {
     return {
       content: [
         {
           type: 'text',
-          text: `❌ Unknown suite "${suite}". Use: unit | e2e | smoke | pr_verify | security_guard | e2e_gate | full.`,
+          text:
+            `❌ Unknown suite "${suite}". Use: unit | e2e | smoke | pr_verify | security_guard | ` +
+            'e2e_gate | build_ci | check_fast | e2e_state_setup | e2e_gate_pr_fast | ' +
+            'pr_verify_hosts | full.',
         },
       ],
-    };
+      isError: true,
+      structuredContent: {
+        failedStage: null,
+        status: 'fail',
+        suite,
+        tool: 'tests_orchestrator',
+      },
+    } satisfies CallToolResult;
   }
 
   for (const command of commands) {
-    results.push(await runCommand(command.name, command.command, command.cwd));
+    results.push(await runCommand(command));
   }
 
   const summary = formatSummary(results);
   const details = results
-    .map(
-      result =>
-        `\n\n${result.name} (${result.status.toUpperCase()}):\n${result.output || '(no output)'}`
-    )
+    .map(result => `\n\n${result.name} (${result.status.toUpperCase()}):\n${result.output}`)
     .join('');
 
   return {
@@ -201,5 +314,20 @@ export async function runTestsOrchestrator(args: OrchestratorArgs = {}) {
         text: `${summary}${details}`,
       },
     ],
-  };
+    isError: results.some(result => result.status === 'fail'),
+    structuredContent: {
+      failedStages: results
+        .filter(result => result.status === 'fail' && result.failedStage)
+        .map(result => result.failedStage),
+      results: results.map(result => ({
+        durationMs: result.durationMs,
+        failedStage: result.failedStage,
+        name: result.name,
+        status: result.status,
+      })),
+      status: results.some(result => result.status === 'fail') ? 'fail' : 'pass',
+      suite,
+      tool: 'tests_orchestrator',
+    },
+  } satisfies CallToolResult;
 }

--- a/packages/qa/src/tools/tests.ts
+++ b/packages/qa/src/tools/tests.ts
@@ -12,6 +12,13 @@ type TestResult = {
   output: string;
 };
 
+type ToolResponse = {
+  content: Array<{
+    type: 'text';
+    text: string;
+  }>;
+};
+
 function formatSummary(results: TestResult[]) {
   const passed = results.filter(r => r.status === 'pass').length;
   const failed = results.filter(r => r.status === 'fail').length;
@@ -50,58 +57,82 @@ async function runCommand(name: string, command: string, cwd: string): Promise<T
   }
 }
 
+function formatToolResponse(prefix: string, stdout: string, stderr: string): ToolResponse {
+  const sections = [prefix, '', stdout, stderr].filter(Boolean);
+  return {
+    content: [
+      {
+        type: 'text',
+        text: sections.join('\n'),
+      },
+    ],
+  };
+}
+
+function formatToolError(prefix: string, error: any): ToolResponse {
+  const output = error.stdout || '';
+  const errOutput = error.stderr || '';
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `${prefix}\n\nError: ${error.message}\n\nOutput: ${output}\n${errOutput}`,
+      },
+    ],
+  };
+}
+
+async function runVerificationTool(command: string, successPrefix: string, failurePrefix: string) {
+  try {
+    const { stdout, stderr } = await execAsync(command, { cwd: REPO_ROOT });
+    return formatToolResponse(successPrefix, stdout, stderr);
+  } catch (error: any) {
+    return formatToolError(failurePrefix, error);
+  }
+}
+
 export async function runUnitTests() {
   try {
     const { stdout, stderr } = await execAsync('pnpm test:unit', { cwd: WEB_APP });
-    return { content: [{ type: 'text', text: `✅ UNIT TESTS PASSED\n\n${stdout}\n${stderr}` }] };
+    return formatToolResponse('✅ UNIT TESTS PASSED', stdout, stderr);
   } catch (error: any) {
-    const output = error.stdout || '';
-    const errOutput = error.stderr || '';
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `❌ UNIT TESTS FAILED\n\nError: ${error.message}\n\nOutput: ${output}\n${errOutput}`,
-        },
-      ],
-    };
+    return formatToolError('❌ UNIT TESTS FAILED', error);
   }
 }
 
 export async function runE2ETests() {
   try {
     const { stdout, stderr } = await execAsync('pnpm test:e2e', { cwd: WEB_APP });
-    return { content: [{ type: 'text', text: `✅ E2E TESTS PASSED\n\n${stdout}\n${stderr}` }] };
+    return formatToolResponse('✅ E2E TESTS PASSED', stdout, stderr);
   } catch (error: any) {
-    const output = error.stdout || '';
-    const errOutput = error.stderr || '';
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `❌ E2E TESTS FAILED\n\nError: ${error.message}\n\nOutput: ${output}\n${errOutput}`,
-        },
-      ],
-    };
+    return formatToolError('❌ E2E TESTS FAILED', error);
   }
 }
 
 export async function runCoverage() {
   try {
     const { stdout, stderr } = await execAsync('pnpm test:unit -- --coverage', { cwd: WEB_APP });
-    return { content: [{ type: 'text', text: `✅ COVERAGE RUN PASSED\n\n${stdout}\n${stderr}` }] };
+    return formatToolResponse('✅ COVERAGE RUN PASSED', stdout, stderr);
   } catch (error: any) {
-    const output = error.stdout || '';
-    const errOutput = error.stderr || '';
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `❌ COVERAGE RUN FAILED\n\nError: ${error.message}\n\nOutput: ${output}\n${errOutput}`,
-        },
-      ],
-    };
+    return formatToolError('❌ COVERAGE RUN FAILED', error);
   }
+}
+
+export async function runPrVerify() {
+  return runVerificationTool('pnpm pr:verify', '✅ PR VERIFY PASSED', '❌ PR VERIFY FAILED');
+}
+
+export async function runSecurityGuard() {
+  return runVerificationTool(
+    'pnpm security:guard',
+    '✅ SECURITY GUARD PASSED',
+    '❌ SECURITY GUARD FAILED'
+  );
+}
+
+export async function runE2EGate() {
+  return runVerificationTool('pnpm e2e:gate', '✅ E2E GATE PASSED', '❌ E2E GATE FAILED');
 }
 
 export async function runTestsOrchestrator(args: OrchestratorArgs = {}) {
@@ -128,17 +159,24 @@ export async function runTestsOrchestrator(args: OrchestratorArgs = {}) {
       command: 'pnpm --filter @interdomestik/web test:e2e -- --grep smoke',
       cwd: REPO_ROOT,
     });
+  } else if (suite === 'pr_verify') {
+    commands.push({ name: 'PR Verify', command: 'pnpm pr:verify', cwd: REPO_ROOT });
+  } else if (suite === 'security_guard') {
+    commands.push({ name: 'Security Guard', command: 'pnpm security:guard', cwd: REPO_ROOT });
+  } else if (suite === 'e2e_gate') {
+    commands.push({ name: 'E2E Gate', command: 'pnpm e2e:gate', cwd: REPO_ROOT });
   } else if (suite === 'full') {
     commands.push(
-      { name: 'Unit Tests', command: 'pnpm test', cwd: REPO_ROOT },
-      { name: 'E2E Tests', command: 'pnpm test:e2e', cwd: REPO_ROOT }
+      { name: 'PR Verify', command: 'pnpm pr:verify', cwd: REPO_ROOT },
+      { name: 'Security Guard', command: 'pnpm security:guard', cwd: REPO_ROOT },
+      { name: 'E2E Gate', command: 'pnpm e2e:gate', cwd: REPO_ROOT }
     );
   } else {
     return {
       content: [
         {
           type: 'text',
-          text: `❌ Unknown suite "${suite}". Use: unit | e2e | smoke | full.`,
+          text: `❌ Unknown suite "${suite}". Use: unit | e2e | smoke | pr_verify | security_guard | e2e_gate | full.`,
         },
       ],
     };

--- a/packages/qa/src/utils/exec.ts
+++ b/packages/qa/src/utils/exec.ts
@@ -1,4 +1,295 @@
-import { exec } from 'child_process';
-import { promisify } from 'node:util';
+import { spawn } from 'node:child_process';
 
-export const execAsync = promisify(exec);
+export type FailureCategory =
+  | 'build'
+  | 'coverage'
+  | 'db'
+  | 'e2e'
+  | 'i18n'
+  | 'precheck'
+  | 'release_gate'
+  | 'security'
+  | 'seed'
+  | 'smoke'
+  | 'unknown';
+
+export type ExecOptions = {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  maxOutputBytes?: number;
+  timeoutMs?: number;
+};
+
+export type ExecResult = {
+  command: string;
+  cwd: string;
+  durationMs: number;
+  exitCode: number | null;
+  failedStage: string | null;
+  failureCategory: FailureCategory | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+  stderrTruncated: boolean;
+  stdout: string;
+  stdoutTruncated: boolean;
+  timedOut: boolean;
+};
+
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
+const DEFAULT_TIMEOUT_MS = 0;
+
+type OutputBufferState = {
+  text: string;
+  truncated: boolean;
+};
+
+type StageDefinition = {
+  marker: string;
+  stage: string;
+};
+
+type FailurePattern = {
+  commandPattern: RegExp;
+  fallbackStage: string;
+  stages: StageDefinition[];
+};
+
+const FAILURE_PATTERNS: FailurePattern[] = [
+  {
+    commandPattern: /\bpnpm pr:verify:hosts\b/,
+    fallbackStage: 'pr_verify_hosts',
+    stages: [{ marker: 'pr-verify-hosts.sh', stage: 'pr_verify_hosts' }],
+  },
+  {
+    commandPattern: /\bpnpm pr:verify\b/,
+    fallbackStage: 'pr_verify',
+    stages: [
+      { marker: 'memory:precheck', stage: 'memory_precheck' },
+      { marker: 'test:release-gate', stage: 'release_gate' },
+      { marker: 'db:migrations:check-journal', stage: 'db_migrations_check_journal' },
+      { marker: 'db:rls:test:required', stage: 'db_rls_test_required' },
+      { marker: 'i18n:check', stage: 'i18n_check' },
+      { marker: 'i18n:purity:check', stage: 'i18n_purity_check' },
+      { marker: 'coverage:gate', stage: 'coverage_gate' },
+      { marker: 'check:fast', stage: 'check_fast' },
+      { marker: 'e2e:smoke', stage: 'e2e_smoke' },
+    ],
+  },
+  {
+    commandPattern: /\bpnpm check:fast\b/,
+    fallbackStage: 'check_fast',
+    stages: [
+      { marker: 'build:ci', stage: 'build_ci' },
+      { marker: 'e2e:state:setup', stage: 'e2e_state_setup' },
+      { marker: 'e2e:gate:pr:fast', stage: 'e2e_gate_pr_fast' },
+    ],
+  },
+  {
+    commandPattern: /\bpnpm security:guard\b/,
+    fallbackStage: 'security_guard',
+    stages: [{ marker: 'security-guard.mjs', stage: 'security_guard' }],
+  },
+  {
+    commandPattern: /\bpnpm e2e:gate\b/,
+    fallbackStage: 'e2e_gate',
+    stages: [
+      { marker: '[Gatekeeper] Applying Schema', stage: 'db_migrate' },
+      { marker: 'seed:e2e', stage: 'seed_e2e' },
+      { marker: 'Building production-like standalone web artifact', stage: 'build_ci' },
+      { marker: 'Running 61 tests using 1 worker', stage: 'e2e_gate' },
+    ],
+  },
+  {
+    commandPattern: /\bpnpm e2e:gate:pr:fast\b/,
+    fallbackStage: 'e2e_gate_pr_fast',
+    stages: [
+      { marker: '[Gatekeeper] Applying Schema', stage: 'db_migrate' },
+      { marker: 'seed:e2e', stage: 'seed_e2e' },
+      { marker: 'Building production-like standalone web artifact', stage: 'build_ci' },
+      { marker: 'Running 61 tests using 1 worker', stage: 'e2e_gate_pr_fast' },
+    ],
+  },
+  {
+    commandPattern: /\be2e:state:setup\b/,
+    fallbackStage: 'e2e_state_setup',
+    stages: [
+      { marker: 'e2e/setup.state.spec.ts', stage: 'e2e_state_setup' },
+      { marker: '[Setup] Generating state', stage: 'e2e_state_setup' },
+    ],
+  },
+  {
+    commandPattern: /\bbuild:ci\b/,
+    fallbackStage: 'build_ci',
+    stages: [
+      { marker: 'Creating an optimized production build', stage: 'build_ci' },
+      { marker: 'Running TypeScript', stage: 'build_ci' },
+    ],
+  },
+];
+
+const STAGE_CATEGORY_MAP: Record<string, FailureCategory> = {
+  build_ci: 'build',
+  check_fast: 'build',
+  coverage_gate: 'coverage',
+  db_migrate: 'db',
+  db_migrations_check_journal: 'db',
+  db_rls_test_required: 'db',
+  e2e_gate: 'e2e',
+  e2e_gate_pr_fast: 'e2e',
+  e2e_state_setup: 'e2e',
+  e2e_smoke: 'smoke',
+  i18n_check: 'i18n',
+  i18n_purity_check: 'i18n',
+  memory_precheck: 'precheck',
+  pr_verify: 'unknown',
+  pr_verify_hosts: 'e2e',
+  release_gate: 'release_gate',
+  security_guard: 'security',
+  seed_e2e: 'seed',
+};
+
+function trimToLastBytes(text: string, maxOutputBytes: number) {
+  const textBuffer = Buffer.from(text);
+
+  if (textBuffer.length <= maxOutputBytes) {
+    return text;
+  }
+
+  return textBuffer.subarray(textBuffer.length - maxOutputBytes).toString('utf8');
+}
+
+function appendOutput(
+  current: OutputBufferState,
+  chunk: string,
+  maxOutputBytes: number
+): OutputBufferState {
+  const combined = current.text + chunk;
+  const truncated = current.truncated || Buffer.byteLength(combined) > maxOutputBytes;
+
+  return {
+    text: truncated ? trimToLastBytes(combined, maxOutputBytes) : combined,
+    truncated,
+  };
+}
+
+function normalizeFailureCategory(stage: string | null): FailureCategory | null {
+  if (!stage) {
+    return null;
+  }
+
+  return STAGE_CATEGORY_MAP[stage] ?? 'unknown';
+}
+
+export function classifyVerificationFailure(command: string, output: string) {
+  const pattern = FAILURE_PATTERNS.find(candidate => candidate.commandPattern.test(command));
+
+  if (!pattern) {
+    return {
+      failedStage: null,
+      failureCategory: null,
+    };
+  }
+
+  let failedStage = pattern.fallbackStage;
+  let lastSeenIndex = -1;
+
+  for (const stage of pattern.stages) {
+    const stageIndex = output.lastIndexOf(stage.marker);
+    if (stageIndex > lastSeenIndex) {
+      lastSeenIndex = stageIndex;
+      failedStage = stage.stage;
+    }
+  }
+
+  return {
+    failedStage,
+    failureCategory: normalizeFailureCategory(failedStage),
+  };
+}
+
+export async function execAsync(command: string, options: ExecOptions): Promise<ExecResult> {
+  const {
+    cwd,
+    env,
+    maxOutputBytes = DEFAULT_MAX_OUTPUT_BYTES,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = options;
+  const startedAt = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, {
+      cwd,
+      env: {
+        ...process.env,
+        ...env,
+      },
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutState: OutputBufferState = { text: '', truncated: false };
+    let stderrState: OutputBufferState = { text: '', truncated: false };
+    let timedOut = false;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let killHandle: NodeJS.Timeout | undefined;
+
+    child.stdout.on('data', chunk => {
+      stdoutState = appendOutput(stdoutState, chunk.toString(), maxOutputBytes);
+    });
+
+    child.stderr.on('data', chunk => {
+      stderrState = appendOutput(stderrState, chunk.toString(), maxOutputBytes);
+    });
+
+    child.on('error', error => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (killHandle) clearTimeout(killHandle);
+      reject(error);
+    });
+
+    if (timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+        killHandle = setTimeout(() => child.kill('SIGKILL'), 5000);
+      }, timeoutMs);
+    }
+
+    child.on('close', (exitCode, signal) => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (killHandle) clearTimeout(killHandle);
+
+      const result: ExecResult = {
+        command,
+        cwd,
+        durationMs: Date.now() - startedAt,
+        exitCode,
+        failedStage: null,
+        failureCategory: null,
+        signal,
+        stderr: stderrState.text.trim(),
+        stderrTruncated: stderrState.truncated,
+        stdout: stdoutState.text.trim(),
+        stdoutTruncated: stdoutState.truncated,
+        timedOut,
+      };
+
+      if (exitCode === 0 && !timedOut) {
+        resolve(result);
+        return;
+      }
+
+      const combinedOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
+      const classification = classifyVerificationFailure(command, combinedOutput);
+      const failure = Object.assign(
+        new Error(
+          `Command failed with exit code ${exitCode ?? 'null'}${timedOut ? ' (timeout)' : ''}`
+        ),
+        result,
+        classification
+      );
+
+      reject(failure);
+    });
+  });
+}

--- a/packages/qa/src/utils/exec.ts
+++ b/packages/qa/src/utils/exec.ts
@@ -20,6 +20,12 @@ export type ExecOptions = {
   timeoutMs?: number;
 };
 
+export type ExecCommand = {
+  args?: string[];
+  display?: string;
+  file: string;
+};
+
 export type ExecResult = {
   command: string;
   cwd: string;
@@ -52,6 +58,11 @@ type FailurePattern = {
   commandPattern: RegExp;
   fallbackStage: string;
   stages: StageDefinition[];
+};
+
+type ExecErrorLike = Partial<ExecResult> & {
+  code?: unknown;
+  command?: string;
 };
 
 const FAILURE_PATTERNS: FailurePattern[] = [
@@ -180,6 +191,60 @@ function normalizeFailureCategory(stage: string | null): FailureCategory | null 
   return STAGE_CATEGORY_MAP[stage] ?? 'unknown';
 }
 
+function formatCommandPart(part: string) {
+  return /\s|["'`$\\]/.test(part) ? JSON.stringify(part) : part;
+}
+
+export function formatExecCommand(command: ExecCommand) {
+  if (command.display) {
+    return command.display;
+  }
+
+  return [command.file, ...(command.args ?? [])].map(formatCommandPart).join(' ');
+}
+
+export function coerceExitCode(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue) {
+      return null;
+    }
+
+    const parsedValue = Number(trimmedValue);
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+  }
+
+  return null;
+}
+
+export function coerceExecResult(
+  error: unknown,
+  fallbackCommand: ExecCommand,
+  fallbackCwd: string
+): ExecResult {
+  const execError = (error ?? {}) as ExecErrorLike;
+
+  return {
+    command: execError.command ?? formatExecCommand(fallbackCommand),
+    cwd: execError.cwd ?? fallbackCwd,
+    durationMs: execError.durationMs ?? 0,
+    exitCode: coerceExitCode(execError.exitCode ?? execError.code),
+    failedStage: execError.failedStage ?? null,
+    failureCategory: execError.failureCategory ?? null,
+    signal: execError.signal ?? null,
+    stderr: (execError.stderr || '').trim(),
+    stderrTruncated: execError.stderrTruncated ?? false,
+    stdout: (execError.stdout || '').trim(),
+    stdoutTruncated: execError.stdoutTruncated ?? false,
+    timedOut: execError.timedOut ?? false,
+  };
+}
+
 export function classifyVerificationFailure(command: string, output: string) {
   const pattern = FAILURE_PATTERNS.find(candidate => candidate.commandPattern.test(command));
 
@@ -207,7 +272,7 @@ export function classifyVerificationFailure(command: string, output: string) {
   };
 }
 
-export async function execAsync(command: string, options: ExecOptions): Promise<ExecResult> {
+export async function execAsync(command: ExecCommand, options: ExecOptions): Promise<ExecResult> {
   const {
     cwd,
     env,
@@ -215,15 +280,15 @@ export async function execAsync(command: string, options: ExecOptions): Promise<
     timeoutMs = DEFAULT_TIMEOUT_MS,
   } = options;
   const startedAt = Date.now();
+  const commandDisplay = formatExecCommand(command);
 
   return new Promise((resolve, reject) => {
-    const child = spawn(command, {
+    const child = spawn(command.file, command.args ?? [], {
       cwd,
       env: {
         ...process.env,
         ...env,
       },
-      shell: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -232,6 +297,44 @@ export async function execAsync(command: string, options: ExecOptions): Promise<
     let timedOut = false;
     let timeoutHandle: NodeJS.Timeout | undefined;
     let killHandle: NodeJS.Timeout | undefined;
+    let settled = false;
+
+    const clearHandles = () => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (killHandle) clearTimeout(killHandle);
+    };
+
+    const buildResult = (exitCode: number | null, signal: NodeJS.Signals | null): ExecResult => ({
+      command: commandDisplay,
+      cwd,
+      durationMs: Date.now() - startedAt,
+      exitCode,
+      failedStage: null,
+      failureCategory: null,
+      signal,
+      stderr: stderrState.text.trim(),
+      stderrTruncated: stderrState.truncated,
+      stdout: stdoutState.text.trim(),
+      stdoutTruncated: stdoutState.truncated,
+      timedOut,
+    });
+
+    const rejectWithResult = (result: ExecResult, error?: Error) => {
+      const combinedOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
+      const classification = classifyVerificationFailure(commandDisplay, combinedOutput);
+      const baseError =
+        error ??
+        new Error(
+          `Command failed with exit code ${result.exitCode ?? 'null'}${timedOut ? ' (timeout)' : ''}`
+        );
+
+      reject(
+        Object.assign(baseError, {
+          ...result,
+          ...classification,
+        })
+      );
+    };
 
     child.stdout.on('data', chunk => {
       stdoutState = appendOutput(stdoutState, chunk.toString(), maxOutputBytes);
@@ -242,9 +345,13 @@ export async function execAsync(command: string, options: ExecOptions): Promise<
     });
 
     child.on('error', error => {
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-      if (killHandle) clearTimeout(killHandle);
-      reject(error);
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearHandles();
+      rejectWithResult(buildResult(null, null), error);
     });
 
     if (timeoutMs > 0) {
@@ -256,40 +363,19 @@ export async function execAsync(command: string, options: ExecOptions): Promise<
     }
 
     child.on('close', (exitCode, signal) => {
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-      if (killHandle) clearTimeout(killHandle);
+      if (settled) {
+        return;
+      }
 
-      const result: ExecResult = {
-        command,
-        cwd,
-        durationMs: Date.now() - startedAt,
-        exitCode,
-        failedStage: null,
-        failureCategory: null,
-        signal,
-        stderr: stderrState.text.trim(),
-        stderrTruncated: stderrState.truncated,
-        stdout: stdoutState.text.trim(),
-        stdoutTruncated: stdoutState.truncated,
-        timedOut,
-      };
-
+      settled = true;
+      clearHandles();
+      const result = buildResult(exitCode, signal);
       if (exitCode === 0 && !timedOut) {
         resolve(result);
         return;
       }
 
-      const combinedOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
-      const classification = classifyVerificationFailure(command, combinedOutput);
-      const failure = Object.assign(
-        new Error(
-          `Command failed with exit code ${exitCode ?? 'null'}${timedOut ? ' (timeout)' : ''}`
-        ),
-        result,
-        classification
-      );
-
-      reject(failure);
+      rejectWithResult(result);
     });
   });
 }

--- a/packages/qa/src/utils/tool-results.ts
+++ b/packages/qa/src/utils/tool-results.ts
@@ -1,0 +1,159 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ExecResult, FailureCategory } from './exec.js';
+
+type CommandStatus = 'pass' | 'fail';
+
+export type QACommandStructuredContent = {
+  command: string;
+  cwd: string;
+  durationMs: number;
+  exitCode: number | null;
+  failedStage: string | null;
+  failureCategory: FailureCategory | null;
+  label: string;
+  signal: NodeJS.Signals | null;
+  status: CommandStatus;
+  stderrTail: string;
+  stderrTruncated: boolean;
+  stdoutTail: string;
+  stdoutTruncated: boolean;
+  timedOut: boolean;
+  tool: string;
+};
+
+export type QAHealthStructuredContent = {
+  checks: QACommandStructuredContent[];
+  durationMs: number;
+  failedChecks: string[];
+  status: CommandStatus;
+  tool: 'check_health';
+};
+
+function clipText(text: string, maxChars = 4000) {
+  if (text.length <= maxChars) {
+    return text;
+  }
+
+  return text.slice(text.length - maxChars);
+}
+
+function formatDuration(durationMs: number) {
+  if (durationMs < 1000) {
+    return `${durationMs}ms`;
+  }
+
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function buildTextBlock(title: string, value: string) {
+  if (!value) {
+    return null;
+  }
+
+  return `${title}:\n${clipText(value)}`;
+}
+
+export function buildCommandStructuredContent(
+  tool: string,
+  label: string,
+  status: CommandStatus,
+  result: ExecResult
+): QACommandStructuredContent {
+  return {
+    command: result.command,
+    cwd: result.cwd,
+    durationMs: result.durationMs,
+    exitCode: result.exitCode,
+    failedStage: result.failedStage,
+    failureCategory: result.failureCategory,
+    label,
+    signal: result.signal,
+    status,
+    stderrTail: result.stderr,
+    stderrTruncated: result.stderrTruncated,
+    stdoutTail: result.stdout,
+    stdoutTruncated: result.stdoutTruncated,
+    timedOut: result.timedOut,
+    tool,
+  };
+}
+
+export function buildCommandToolResult(
+  tool: string,
+  label: string,
+  status: CommandStatus,
+  result: ExecResult
+): CallToolResult {
+  const structuredContent = buildCommandStructuredContent(tool, label, status, result);
+  const headline =
+    status === 'pass' ? `✅ ${label.toUpperCase()} PASSED` : `❌ ${label.toUpperCase()} FAILED`;
+  const details = [
+    `Command: ${structuredContent.command}`,
+    `Duration: ${formatDuration(structuredContent.durationMs)}`,
+    `Cwd: ${structuredContent.cwd}`,
+    `Exit code: ${structuredContent.exitCode ?? 'null'}`,
+    structuredContent.failedStage ? `Failed stage: ${structuredContent.failedStage}` : null,
+    structuredContent.failureCategory
+      ? `Failure category: ${structuredContent.failureCategory}`
+      : null,
+    structuredContent.timedOut ? 'Timed out: yes' : null,
+    structuredContent.stdoutTruncated ? 'Stdout truncated: yes' : null,
+    structuredContent.stderrTruncated ? 'Stderr truncated: yes' : null,
+  ].filter(Boolean);
+
+  const blocks = [
+    headline,
+    '',
+    ...details,
+    buildTextBlock('STDOUT (tail)', structuredContent.stdoutTail),
+    buildTextBlock('STDERR (tail)', structuredContent.stderrTail),
+  ].filter(Boolean);
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: blocks.join('\n\n'),
+      },
+    ],
+    isError: status === 'fail',
+    structuredContent,
+  };
+}
+
+export function buildHealthToolResult(checks: QACommandStructuredContent[]): CallToolResult {
+  const durationMs = checks.reduce((sum, check) => sum + check.durationMs, 0);
+  const failedChecks = checks.filter(check => check.status === 'fail').map(check => check.tool);
+  const status: CommandStatus = failedChecks.length === 0 ? 'pass' : 'fail';
+
+  const structuredContent: QAHealthStructuredContent = {
+    checks,
+    durationMs,
+    failedChecks,
+    status,
+    tool: 'check_health',
+  };
+
+  const summaryLines = checks.map(check => {
+    const icon = check.status === 'pass' ? '✅' : '❌';
+    const suffix = check.failedStage ? ` (${check.failedStage})` : '';
+    return `${icon} ${check.label} [${formatDuration(check.durationMs)}]${suffix}`;
+  });
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: [
+          status === 'pass' ? '✅ HEALTH CHECK PASSED' : '❌ HEALTH CHECK FAILED',
+          '',
+          ...summaryLines,
+          '',
+          `Failed checks: ${failedChecks.length}`,
+        ].join('\n'),
+      },
+    ],
+    isError: status === 'fail',
+    structuredContent,
+  };
+}

--- a/scripts/ci/qa-exec-runtime-contracts.test.mjs
+++ b/scripts/ci/qa-exec-runtime-contracts.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import test from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+const repoRoot = process.cwd();
+
+function runModuleExpression(modulePath, expression) {
+  const moduleUrl = pathToFileURL(path.join(repoRoot, modulePath)).href;
+  const script = `
+    const mod = await import(${JSON.stringify(moduleUrl)});
+    const result = await (${expression});
+    console.log(JSON.stringify(result));
+  `;
+
+  const stdout = execFileSync(process.execPath, ['--import', 'tsx', '--eval', script], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+
+  return JSON.parse(stdout);
+}
+
+test('runSecurityGuard returns structured content with command metadata', () => {
+  const result = runModuleExpression(
+    'packages/qa/src/tools/tests.ts',
+    'mod.runSecurityGuard()'
+  );
+
+  assert.equal(result.isError, false);
+  assert.equal(result.structuredContent.tool, 'security_guard');
+  assert.equal(result.structuredContent.status, 'pass');
+  assert.equal(result.structuredContent.command, 'pnpm security:guard');
+  assert.equal(result.structuredContent.failedStage, null);
+  assert.equal(typeof result.structuredContent.durationMs, 'number');
+  assert.match(result.content[0].text, /SECURITY GUARD PASSED/);
+});
+
+test('execAsync classifies failed check:fast output by the active stage marker', () => {
+  const result = runModuleExpression(
+    'packages/qa/src/utils/exec.ts',
+    `mod.classifyVerificationFailure('pnpm check:fast', ['> interdomestik@0.1.0 e2e:state:setup /repo', 'boom'].join('\\n'))`
+  );
+
+  assert.equal(result.failedStage, 'e2e_state_setup');
+  assert.equal(result.failureCategory, 'e2e');
+});
+
+test('execAsync truncates oversized stdout without failing the command', () => {
+  const nodeCommand = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(
+    "process.stdout.write('x'.repeat(20000))"
+  )}`;
+
+  const result = runModuleExpression(
+    'packages/qa/src/utils/exec.ts',
+    `mod.execAsync(${JSON.stringify(nodeCommand)}, { cwd: ${JSON.stringify(
+      repoRoot
+    )}, maxOutputBytes: 1024 })`
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdoutTruncated, true);
+  assert.ok(result.stdout.length <= 1024);
+  assert.equal(result.stderrTruncated, false);
+});

--- a/scripts/ci/qa-exec-runtime-contracts.test.mjs
+++ b/scripts/ci/qa-exec-runtime-contracts.test.mjs
@@ -23,10 +23,7 @@ function runModuleExpression(modulePath, expression) {
 }
 
 test('runSecurityGuard returns structured content with command metadata', () => {
-  const result = runModuleExpression(
-    'packages/qa/src/tools/tests.ts',
-    'mod.runSecurityGuard()'
-  );
+  const result = runModuleExpression('packages/qa/src/tools/tests.ts', 'mod.runSecurityGuard()');
 
   assert.equal(result.isError, false);
   assert.equal(result.structuredContent.tool, 'security_guard');
@@ -40,7 +37,7 @@ test('runSecurityGuard returns structured content with command metadata', () => 
 test('execAsync classifies failed check:fast output by the active stage marker', () => {
   const result = runModuleExpression(
     'packages/qa/src/utils/exec.ts',
-    `mod.classifyVerificationFailure('pnpm check:fast', ['> interdomestik@0.1.0 e2e:state:setup /repo', 'boom'].join('\\n'))`
+    String.raw`mod.classifyVerificationFailure('pnpm check:fast', ['> interdomestik@0.1.0 e2e:state:setup /repo', 'boom'].join('\n'))`
   );
 
   assert.equal(result.failedStage, 'e2e_state_setup');
@@ -48,15 +45,11 @@ test('execAsync classifies failed check:fast output by the active stage marker',
 });
 
 test('execAsync truncates oversized stdout without failing the command', () => {
-  const nodeCommand = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(
-    "process.stdout.write('x'.repeat(20000))"
-  )}`;
-
   const result = runModuleExpression(
     'packages/qa/src/utils/exec.ts',
-    `mod.execAsync(${JSON.stringify(nodeCommand)}, { cwd: ${JSON.stringify(
-      repoRoot
-    )}, maxOutputBytes: 1024 })`
+    `mod.execAsync({ file: ${JSON.stringify(process.execPath)}, args: ['-e', ${JSON.stringify(
+      "process.stdout.write('x'.repeat(20000))"
+    )}] }, { cwd: ${JSON.stringify(repoRoot)}, maxOutputBytes: 1024 })`
   );
 
   assert.equal(result.exitCode, 0);

--- a/scripts/ci/qa-tools-surface-contracts.test.mjs
+++ b/scripts/ci/qa-tools-surface-contracts.test.mjs
@@ -11,6 +11,20 @@ function readText(relativePath) {
   return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
 }
 
+function listToolsDeclaresTool(source, toolName) {
+  return (
+    source.includes(`name: '${toolName}'`) ||
+    source.includes(`createNoArgTool('${toolName}'`) ||
+    source.includes(`'${toolName}',`)
+  );
+}
+
+function testsSourceDeclaresSuite(source, suiteName, toolName = suiteName) {
+  return (
+    source.includes(`${suiteName}: ['${toolName}']`) || source.includes(`suite === '${suiteName}'`)
+  );
+}
+
 test('qa tool surface exposes the Phase C verification contract', () => {
   const listToolsSource = readText('packages/qa/src/tools/list-tools.ts');
   const routerSource = readText('packages/qa/src/tool-router.ts');
@@ -27,7 +41,7 @@ test('qa tool surface exposes the Phase C verification contract', () => {
     'e2e_gate_pr_fast',
     'pr_verify_hosts',
   ]) {
-    assert.ok(listToolsSource.includes(`name: '${toolName}'`));
+    assert.ok(listToolsDeclaresTool(listToolsSource, toolName));
     assert.ok(routerSource.includes(`${toolName}: () =>`));
   }
 
@@ -40,14 +54,14 @@ test('qa tool surface exposes the Phase C verification contract', () => {
   assert.match(healthSource, /pnpm security:guard/);
   assert.match(healthSource, /pnpm e2e:gate/);
 
-  assert.match(testsSource, /suite === 'pr_verify'/);
-  assert.match(testsSource, /suite === 'security_guard'/);
-  assert.match(testsSource, /suite === 'e2e_gate'/);
-  assert.match(testsSource, /suite === 'build_ci'/);
-  assert.match(testsSource, /suite === 'check_fast'/);
-  assert.match(testsSource, /suite === 'e2e_state_setup'/);
-  assert.match(testsSource, /suite === 'e2e_gate_pr_fast'/);
-  assert.match(testsSource, /suite === 'pr_verify_hosts'/);
+  assert.ok(testsSourceDeclaresSuite(testsSource, 'pr_verify'));
+  assert.ok(testsSourceDeclaresSuite(testsSource, 'security_guard'));
+  assert.ok(testsSourceDeclaresSuite(testsSource, 'e2e_gate'));
+  assert.ok(testsSourceDeclaresSuite(testsSource, 'build_ci'));
+  assert.ok(testsSourceDeclaresSuite(testsSource, 'check_fast'));
+  assert.ok(testsSourceDeclaresSuite(testsSource, 'e2e_state_setup'));
+  assert.ok(testsSourceDeclaresSuite(testsSource, 'e2e_gate_pr_fast'));
+  assert.ok(testsSourceDeclaresSuite(testsSource, 'pr_verify_hosts'));
 });
 
 test('qa tool router and list expose the same contract-oriented orchestration tools', () => {
@@ -66,7 +80,7 @@ test('qa tool router and list expose the same contract-oriented orchestration to
     'e2e_gate_pr_fast',
     'pr_verify_hosts',
   ]) {
-    assert.ok(listToolsSource.includes(`name: '${toolName}'`));
+    assert.ok(listToolsDeclaresTool(listToolsSource, toolName));
     assert.ok(routerSource.includes(`${toolName}:`));
   }
 });

--- a/scripts/ci/qa-tools-surface-contracts.test.mjs
+++ b/scripts/ci/qa-tools-surface-contracts.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '../..');
+
+function readText(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+test('qa tool surface exposes the Phase C verification contract', () => {
+  const listToolsSource = readText('packages/qa/src/tools/list-tools.ts');
+  const routerSource = readText('packages/qa/src/tool-router.ts');
+  const healthSource = readText('packages/qa/src/tools/health.ts');
+  const testsSource = readText('packages/qa/src/tools/tests.ts');
+
+  for (const toolName of ['pr_verify', 'security_guard', 'e2e_gate']) {
+    assert.match(listToolsSource, new RegExp(`name: '${toolName}'`));
+    assert.match(routerSource, new RegExp(`${toolName}: \\(\\) =>`));
+  }
+
+  assert.match(
+    listToolsSource,
+    /Run the full Phase C verification contract \(pr:verify, security:guard, e2e:gate\)/
+  );
+  assert.match(healthSource, /pnpm pr:verify/);
+  assert.match(healthSource, /pnpm security:guard/);
+  assert.match(healthSource, /pnpm e2e:gate/);
+
+  assert.match(testsSource, /suite === 'pr_verify'/);
+  assert.match(testsSource, /suite === 'security_guard'/);
+  assert.match(testsSource, /suite === 'e2e_gate'/);
+});
+
+test('qa tool router and list expose the same contract-oriented orchestration tools', () => {
+  const listToolsSource = readText('packages/qa/src/tools/list-tools.ts');
+  const routerSource = readText('packages/qa/src/tool-router.ts');
+
+  for (const toolName of ['check_health', 'tests_orchestrator', 'pr_verify', 'security_guard', 'e2e_gate']) {
+    assert.match(listToolsSource, new RegExp(`name: '${toolName}'`));
+    assert.match(routerSource, new RegExp(`${toolName}:`));
+  }
+});

--- a/scripts/ci/qa-tools-surface-contracts.test.mjs
+++ b/scripts/ci/qa-tools-surface-contracts.test.mjs
@@ -17,7 +17,16 @@ test('qa tool surface exposes the Phase C verification contract', () => {
   const healthSource = readText('packages/qa/src/tools/health.ts');
   const testsSource = readText('packages/qa/src/tools/tests.ts');
 
-  for (const toolName of ['pr_verify', 'security_guard', 'e2e_gate']) {
+  for (const toolName of [
+    'pr_verify',
+    'security_guard',
+    'e2e_gate',
+    'build_ci',
+    'check_fast',
+    'e2e_state_setup',
+    'e2e_gate_pr_fast',
+    'pr_verify_hosts',
+  ]) {
     assert.match(listToolsSource, new RegExp(`name: '${toolName}'`));
     assert.match(routerSource, new RegExp(`${toolName}: \\(\\) =>`));
   }
@@ -33,13 +42,29 @@ test('qa tool surface exposes the Phase C verification contract', () => {
   assert.match(testsSource, /suite === 'pr_verify'/);
   assert.match(testsSource, /suite === 'security_guard'/);
   assert.match(testsSource, /suite === 'e2e_gate'/);
+  assert.match(testsSource, /suite === 'build_ci'/);
+  assert.match(testsSource, /suite === 'check_fast'/);
+  assert.match(testsSource, /suite === 'e2e_state_setup'/);
+  assert.match(testsSource, /suite === 'e2e_gate_pr_fast'/);
+  assert.match(testsSource, /suite === 'pr_verify_hosts'/);
 });
 
 test('qa tool router and list expose the same contract-oriented orchestration tools', () => {
   const listToolsSource = readText('packages/qa/src/tools/list-tools.ts');
   const routerSource = readText('packages/qa/src/tool-router.ts');
 
-  for (const toolName of ['check_health', 'tests_orchestrator', 'pr_verify', 'security_guard', 'e2e_gate']) {
+  for (const toolName of [
+    'check_health',
+    'tests_orchestrator',
+    'pr_verify',
+    'security_guard',
+    'e2e_gate',
+    'build_ci',
+    'check_fast',
+    'e2e_state_setup',
+    'e2e_gate_pr_fast',
+    'pr_verify_hosts',
+  ]) {
     assert.match(listToolsSource, new RegExp(`name: '${toolName}'`));
     assert.match(routerSource, new RegExp(`${toolName}:`));
   }

--- a/scripts/ci/qa-tools-surface-contracts.test.mjs
+++ b/scripts/ci/qa-tools-surface-contracts.test.mjs
@@ -27,14 +27,13 @@ test('qa tool surface exposes the Phase C verification contract', () => {
     'e2e_gate_pr_fast',
     'pr_verify_hosts',
   ]) {
-    assert.match(listToolsSource, new RegExp(`name: '${toolName}'`));
-    assert.match(routerSource, new RegExp(`${toolName}: \\(\\) =>`));
+    assert.ok(listToolsSource.includes(`name: '${toolName}'`));
+    assert.ok(routerSource.includes(`${toolName}: () =>`));
   }
 
-  assert.match(
-    listToolsSource,
-    new RegExp(
-      String.raw`Run the full Phase C verification contract \(pr:verify, security:guard, e2e:gate\)`
+  assert.ok(
+    listToolsSource.includes(
+      'Run the full Phase C verification contract (pr:verify, security:guard, e2e:gate)'
     )
   );
   assert.match(healthSource, /pnpm pr:verify/);
@@ -67,7 +66,7 @@ test('qa tool router and list expose the same contract-oriented orchestration to
     'e2e_gate_pr_fast',
     'pr_verify_hosts',
   ]) {
-    assert.match(listToolsSource, new RegExp(`name: '${toolName}'`));
-    assert.match(routerSource, new RegExp(`${toolName}:`));
+    assert.ok(listToolsSource.includes(`name: '${toolName}'`));
+    assert.ok(routerSource.includes(`${toolName}:`));
   }
 });

--- a/scripts/ci/qa-tools-surface-contracts.test.mjs
+++ b/scripts/ci/qa-tools-surface-contracts.test.mjs
@@ -33,7 +33,9 @@ test('qa tool surface exposes the Phase C verification contract', () => {
 
   assert.match(
     listToolsSource,
-    /Run the full Phase C verification contract \(pr:verify, security:guard, e2e:gate\)/
+    new RegExp(
+      String.raw`Run the full Phase C verification contract \(pr:verify, security:guard, e2e:gate\)`
+    )
   );
   assert.match(healthSource, /pnpm pr:verify/);
   assert.match(healthSource, /pnpm security:guard/);


### PR DESCRIPTION
## Summary
- align the QA MCP surface with Phase C verification commands and targeted repo checks
- replace fragile buffered command execution with structured spawn-based execution and failure classification
- add contract and runtime tests for the QA tool surface and execution layer

## Verification
- pnpm exec node --test scripts/ci/qa-tools-surface-contracts.test.mjs scripts/ci/qa-exec-runtime-contracts.test.mjs scripts/ci/qa-audits-contracts.test.mjs scripts/ci/qa-server-contracts.test.mjs
- pnpm --filter @interdomestik/qa build
- node --import tsx --eval "const mod = await import('./packages/qa/src/tools/tests.ts'); const result = await mod.runSecurityGuard(); console.log(JSON.stringify(result.structuredContent, null, 2));"
- node --import tsx --eval "const mod = await import('./packages/qa/src/tools/tests.ts'); const result = await mod.runCheckFast(); console.log(JSON.stringify(result.structuredContent, null, 2));"
- pnpm pr:verify
- pnpm security:guard
