### PR TITLE
docs: refresh QA README for Phase C tooling

### DIFF
--- a/packages/qa/README.md
+++ b/packages/qa/README.md
@@ -115,7 +115,7 @@ Supported `tests_orchestrator` suites:
 - `git_status` - Get git status
 - `git_diff` - Get git diff
 - `code_search` - Search the codebase
-- `query_db` - Execute read-only SQL against local Postgres
+- `query_db` - Execute SQL against local Postgres
 - `get_paddle_resource` - Fetch Paddle resources such as subscriptions, customers, products, or prices
 
 ## Structured Results
@@ -155,7 +155,7 @@ Relevant variables depend on the tool you call, but common local expectations in
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
-Some auth-related audits intentionally treat GitHub OAuth credentials as optional when that provider is not configured for the local environment.
+These audits do not require GitHub OAuth credentials.
 
 ## Development Notes
 

--- a/packages/qa/README.md
+++ b/packages/qa/README.md
@@ -1,241 +1,218 @@
 # Interdomestik QA Tools
 
-MCP-based quality assurance tools for the Interdomestik V2 project.
+MCP-based QA tools for the Interdomestik monorepo.
+
+The package exists to make the repo's real verification contract callable from Codex and other MCP clients without forcing every check through raw shell commands.
+
+## What This Package Does
+
+- Exposes repo-aware audit, verification, repo, database, and Paddle tools over MCP stdio
+- Mirrors the current Phase C verification contract instead of older generic health checks
+- Returns structured command results for verification tools, including command, duration, exit code, failure stage, and output tails
+
+## Current Verification Contract
+
+For Interdomestik Phase C work, the important contract is:
+
+```bash
+pnpm pr:verify
+pnpm security:guard
+pnpm e2e:gate
+```
+
+`check_health` now runs exactly that contract.
+
+The testing/orchestration surface also exposes smaller repo-real commands:
+
+- `build_ci`
+- `check_fast`
+- `e2e_state_setup`
+- `e2e_gate_pr_fast`
+- `pr_verify_hosts`
 
 ## Quick Start
 
-### Setup (First Time)
+### Build The Package
 
 ```bash
-# From project root
-pnpm mcp:setup
+pnpm --filter @interdomestik/qa build
 ```
 
-### Run All Audits
+### Run Local Package Helpers
 
 ```bash
-# From project root
-pnpm mcp:audit
-
-# Or from this directory
-pnpm run-all-audits
+pnpm --filter @interdomestik/qa check
+pnpm --filter @interdomestik/qa run-all-audits
 ```
 
-## Available Tools
+### Use Via MCP
+
+The server is a stdio MCP server whose default name is `interdomestik-qa`.
+
+If you are using the repo's Codex setup, the server is configured from the project-scoped MCP config. If you are wiring another MCP client manually, point it at:
+
+```bash
+node packages/qa/dist/index.js
+```
+
+Example prompts:
+
+- `Run check_health and summarize the first failing stage`
+- `Run tests_orchestrator with suite=pr_verify_hosts`
+- `Audit auth and env assumptions for this repo`
+- `Query the local database for a tenant-scoped record`
+
+## Tool Surface
 
 ### Audit Tools
 
-- `audit_auth` - Verify Better Auth configuration
-- `audit_env` - Check environment variables
-- `audit_navigation` - Validate routing and i18n
-- `audit_dependencies` - Check package configuration
-- `audit_supabase` - Verify Supabase setup
-- `audit_accessibility` - Check a11y configuration
-- `audit_csp` - Verify Content Security Policy
-- `audit_performance` - Check performance config
+- `audit_auth` - Verify Better Auth configuration, auth env assumptions, and related repo files
+- `audit_env` - Validate repo env expectations
+- `audit_navigation` - Verify routing/i18n layout structure
+- `audit_dependencies` - Check critical dependency/package configuration
+- `dependency_audit` - Alias for `audit_dependencies`
+- `audit_supabase` - Verify Supabase env/config presence
+- `audit_accessibility` - Check accessibility testing/config setup
+- `audit_csp` - Verify Content Security Policy setup
+- `audit_performance` - Check performance-related configuration
 
-### Testing Tools
+### Verification And Test Tools
 
-- `check_health` - Run type-check and lint
-- `run_unit_tests` - Execute Vitest tests
-- `run_coverage` - Run tests with coverage
-- `run_e2e_tests` - Execute Playwright tests
-- `tests_orchestrator` - Run unit/e2e/smoke suites (alias: `test_runner`)
+- `check_health` - Run `pnpm pr:verify`, `pnpm security:guard`, and `pnpm e2e:gate`
+- `pr_verify` - Run `pnpm pr:verify`
+- `security_guard` - Run `pnpm security:guard`
+- `e2e_gate` - Run `pnpm e2e:gate`
+- `build_ci` - Run the CI-grade web build used in repo verification
+- `check_fast` - Run `pnpm check:fast`
+- `e2e_state_setup` - Run deterministic Playwright auth-state setup only
+- `e2e_gate_pr_fast` - Run the fast PR gate path without the full PR verify contract
+- `pr_verify_hosts` - Run the host-routed PR verification variant
+- `run_unit_tests` - Run web unit tests
+- `run_coverage` - Run web unit tests with coverage
+- `run_e2e_tests` - Run web Playwright tests
+- `tests_orchestrator` - Run one named suite from the supported suite list
+- `test_runner` - Alias for `tests_orchestrator`
 
-### Development Tools
+Supported `tests_orchestrator` suites:
 
-- `project_map` - Generate project structure
-- `read_files` - Read file contents
+- `unit`
+- `e2e`
+- `smoke`
+- `pr_verify`
+- `security_guard`
+- `e2e_gate`
+- `build_ci`
+- `check_fast`
+- `e2e_state_setup`
+- `e2e_gate_pr_fast`
+- `pr_verify_hosts`
+- `full`
+
+### Repo And Integration Tools
+
+- `project_map` - Generate a repo structure map
+- `read_files` - Read multiple files
 - `git_status` - Get git status
-- `git_diff` - View git changes
-- `code_search` - Search codebase
+- `git_diff` - Get git diff
+- `code_search` - Search the codebase
+- `query_db` - Execute read-only SQL against local Postgres
+- `get_paddle_resource` - Fetch Paddle resources such as subscriptions, customers, products, or prices
 
-### Integration Tools
+## Structured Results
 
-- `query_db` - Query local PostgreSQL database
-- `get_paddle_resource` - Fetch Paddle resources
+The verification tools return structured MCP content in addition to text output. The structured payload includes:
 
-## Usage
+- `tool`
+- `label`
+- `status`
+- `command`
+- `cwd`
+- `durationMs`
+- `exitCode`
+- `failedStage`
+- `failureCategory`
+- `stdoutTail`
+- `stderrTail`
+- truncation and timeout metadata
 
-### Via MCP (Recommended)
+This is intended to make Codex- and agent-driven fix loops more precise than raw shell transcript parsing.
 
-When using Gemini CLI, all tools are available automatically:
+## Environment Resolution
 
-```
-"Run all QA audits"
-"Check the health of the project"
-"Run unit tests with coverage"
-```
+The QA server loads the first repo-root env file that exists in this order:
 
-### Via Command Line
+1. `.env.local`
+2. `.env.development.local`
+3. `.env`
 
-```bash
-# Build the package
-pnpm build
+That matches the current repo assumptions better than the older `.env`-only behavior.
 
-# Run all audits
-pnpm run-all-audits
+Relevant variables depend on the tool you call, but common local expectations include:
 
-# Test tools
-pnpm check
-```
+- `DATABASE_URL`
+- `BETTER_AUTH_SECRET`
+- `NEXT_PUBLIC_APP_URL`
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
-## Development
+Some auth-related audits intentionally treat GitHub OAuth credentials as optional when that provider is not configured for the local environment.
+
+## Development Notes
 
 ### Project Structure
 
-```
+```text
 packages/qa/
 ├── src/
-│   ├── index.ts          # MCP server entry point
-│   ├── server.ts         # Server implementation
-│   ├── tool-router.ts    # Tool routing logic
-│   ├── tools/            # Tool implementations
-│   │   ├── audits.ts     # Audit tools
-│   │   ├── health.ts     # Health check tools
-│   │   ├── tests.ts      # Testing tools
-│   │   ├── repo.ts       # Repository tools
-│   │   ├── db.ts         # Database tools
-│   │   └── paddle.ts     # Paddle tools
-│   └── utils/            # Utilities
-│       ├── paths.ts      # Path resolution
-│       └── exec.ts       # Command execution
-├── dist/                 # Compiled output
-├── run-all-audits.ts     # Audit runner script
-└── test-tools.ts         # Tool testing script
+│   ├── index.ts
+│   ├── server.ts
+│   ├── tool-router.ts
+│   ├── tools/
+│   │   ├── audits.ts
+│   │   ├── health.ts
+│   │   ├── tests.ts
+│   │   ├── repo.ts
+│   │   ├── db.ts
+│   │   └── paddle.ts
+│   └── utils/
+│       ├── exec.ts
+│       ├── paths.ts
+│       └── tool-results.ts
+├── dist/
+├── run-all-audits.ts
+└── test-tools.ts
 ```
 
-### Adding New Tools
+### Adding Or Updating A Tool
 
-1. **Create tool implementation**:
+1. Add or update the implementation under `src/tools/` or `src/utils/`
+2. Register the tool in `src/tool-router.ts`
+3. Add the tool definition in `src/tools/list-tools.ts`
+4. Rebuild with `pnpm --filter @interdomestik/qa build`
+5. Update or add the relevant contract tests under `scripts/ci/`
 
-```typescript
-// src/tools/my-tool.ts
-export async function myNewTool(args: { param: string }) {
-  // Implementation
-  return {
-    content: [
-      {
-        type: 'text',
-        text: 'Result of my tool',
-      },
-    ],
-  };
-}
-```
-
-2. **Add tool definition**:
-
-```typescript
-// src/tools/list-tools.ts
-{
-  name: 'my_new_tool',
-  description: 'Description of what it does',
-  inputSchema: {
-    type: 'object',
-    properties: {
-      param: { type: 'string' }
-    },
-    required: ['param']
-  }
-}
-```
-
-3. **Add handler**:
-
-```typescript
-// src/tool-router.ts
-import { myNewTool } from './tools/my-tool.js';
-
-const handlers: Record<string, Handler> = {
-  // ... existing handlers
-  my_new_tool: args => myNewTool(args),
-};
-```
-
-4. **Rebuild**:
-
-```bash
-pnpm build
-```
-
-## Configuration
-
-### Environment Variables
-
-The QA tools use the project's `.env` file. Required variables:
-
-- `DATABASE_URL` - PostgreSQL connection string
-- `BETTER_AUTH_SECRET` - Auth secret key
-- `NEXT_PUBLIC_APP_URL` - Application URL
-- `NEXT_PUBLIC_SUPABASE_URL` - Supabase project URL
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY` - Supabase anon key
-
-### Path Resolution
-
-The tools automatically resolve the project root by going up 4 levels from `packages/qa/src/utils/paths.ts`:
-
-```
-utils -> src -> qa -> packages -> ROOT
-```
-
-Override with environment variable:
-
-```bash
-MCP_REPO_ROOT=/path/to/project pnpm check
-```
+For tool-surface changes, keep `tool-router.ts`, `list-tools.ts`, and the QA contract tests in sync.
 
 ## Troubleshooting
 
-### Tools Not Working
+### MCP Server Does Not Start
 
-1. Rebuild the package: `pnpm build`
-2. Check path resolution in `src/utils/paths.ts`
-3. Verify `.env` file exists in project root
+1. Rebuild the package: `pnpm --filter @interdomestik/qa build`
+2. Verify the client is pointing at `packages/qa/dist/index.js`
+3. Check that the repo root resolves correctly from `src/utils/paths.ts`
 
-### MCP Server Not Responding
+### Audits Fail On Env Detection
 
-1. Check MCP configuration: `cat ~/.config/google/gemini/mcp.json`
-2. Restart Gemini CLI
-3. Verify server path points to `packages/qa/dist/index.js`
+1. Verify one of `.env.local`, `.env.development.local`, or `.env` exists at repo root
+2. Prefer `.env.local` for normal local development
+3. Confirm the required local services are actually running before assuming the QA tool is wrong
 
-### Database Tools Failing
+### Verification Tools Fail
 
-1. Ensure PostgreSQL is running
-2. Check `DATABASE_URL` in `.env`
-3. Verify database exists and is accessible
-
-## Testing
-
-### Run Tool Tests
-
-```bash
-pnpm check
-```
-
-### Test Specific Tool
-
-```bash
-tsx -e "import { auditAuth } from './src/tools/audits.js'; auditAuth().then(console.log)"
-```
-
-## CI/CD Integration
-
-```yaml
-# Example GitHub Actions
-- name: Setup MCP Tools
-  run: |
-    cd packages/qa
-    pnpm install
-    pnpm build
-
-- name: Run QA Audits
-  run: pnpm mcp:audit
-
-- name: Run Tests
-  run: pnpm test
-```
+1. Re-run the exact failing repo command directly
+2. Inspect `failedStage`, `failureCategory`, and the stdout/stderr tails in the structured result
+3. If the failure is environment-specific, fix that first before changing the QA package
 
 ## License
 
-Private - Interdomestik V2 Project
+Private - Interdomestik


### PR DESCRIPTION
## Summary\n- refresh  to match the current Phase C QA surface\n- document the actual verification/orchestration commands and structured tool results\n- clarify current MCP usage and env precedence\n\n## Verification\n- \n- TAP version 13
# Subtest: auditEnv accepts .env.local as the repo root env file
ok 1 - auditEnv accepts .env.local as the repo root env file
  ---
  duration_ms: 130.102542
  ...
# Subtest: auditAuth accepts .env.local and does not require GitHub OAuth credentials
ok 2 - auditAuth accepts .env.local and does not require GitHub OAuth credentials
  ---
  duration_ms: 101.125125
  ...
# Subtest: qa server loads the same root env file precedence as the repo runtime
ok 3 - qa server loads the same root env file precedence as the repo runtime
  ---
  duration_ms: 1.587833
  ...
# Subtest: qa tool surface exposes the Phase C verification contract
ok 4 - qa tool surface exposes the Phase C verification contract
  ---
  duration_ms: 2.528542
  ...
# Subtest: qa tool router and list expose the same contract-oriented orchestration tools
ok 5 - qa tool router and list expose the same contract-oriented orchestration tools
  ---
  duration_ms: 1.536958
  ...
1..5
# tests 5
# suites 0
# pass 5
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 275.06\n\n## Notes\n- leaves the mixed local  branch untouched\n