### PR TITLE
test: salvage member-number e2e after pricing-first entry

### DIFF
--- a/apps/web/e2e/fixtures/auth.fixture.ts
+++ b/apps/web/e2e/fixtures/auth.fixture.ts
@@ -308,17 +308,12 @@ async function ensureAuthenticated(
   // Navigate using gotoApp (handles locale)
   await gotoApp(page, targetPath, testInfo, { marker: 'body' });
 
-  // Check if we bounced to login (auth-ready or registration-page-ready visible OR url contains /login)
+  // Check if we bounced to login (auth-ready visible or url contains /login)
   // We purposefully include a URL check for speed/robustness on slow renderers.
   const isLoginPage =
     (await Promise.race([
       page
         .getByTestId('auth-ready')
-        .waitFor({ timeout: 3000 })
-        .then(() => true)
-        .catch(() => false),
-      page
-        .getByTestId('registration-page-ready')
         .waitFor({ timeout: 3000 })
         .then(() => true)
         .catch(() => false),

--- a/apps/web/e2e/member-number.spec.ts
+++ b/apps/web/e2e/member-number.spec.ts
@@ -2,23 +2,23 @@ import { db } from '@interdomestik/database/db';
 import { user } from '@interdomestik/database/schema';
 import { eq } from 'drizzle-orm';
 import { expect, test } from './fixtures/auth.fixture';
-import { getProjectUrlInfo } from './fixtures/auth.project';
+import { getProjectUrlInfo, getTenantFromTestInfo, type Tenant } from './fixtures/auth.project';
 import { routes } from './routes';
+import { withAnonymousPage } from './utils/anonymous-context';
 import { gotoApp } from './utils/navigation';
 
 // Enable full trace for this test suite
 test.use({ trace: 'on' });
 
-function resolveTenantId(projectName: string) {
-  if (projectName.includes('pilot')) {
-    return 'pilot-mk';
+function resolveTenantId(tenant: Tenant) {
+  switch (tenant) {
+    case 'pilot':
+      return 'pilot-mk';
+    case 'mk':
+      return 'tenant_mk';
+    default:
+      return 'tenant_ks';
   }
-
-  if (projectName.includes('mk')) {
-    return 'tenant_mk';
-  }
-
-  return 'tenant_ks';
 }
 
 async function registerMemberViaAuthApi(args: {
@@ -136,9 +136,10 @@ test.describe('Member Number Hardening @quarantine', () => {
   });
 
   test('should assign member number immediately upon registration (Production Grade)', async ({
+    browser,
     page,
   }, testInfo) => {
-    const tenantId = resolveTenantId(testInfo.project.name);
+    const tenantId = resolveTenantId(getTenantFromTestInfo(testInfo));
     const info = getProjectUrlInfo(testInfo, null);
     const projectHeaders = (testInfo.project.use.extraHTTPHeaders || {}) as Record<string, string>;
 
@@ -147,16 +148,18 @@ test.describe('Member Number Hardening @quarantine', () => {
     const memberName = 'Test ProdMember';
 
     console.log('Creating member through public auth sign-up API...');
-    const response = await registerMemberViaAuthApi({
-      page,
-      baseURL: info.origin,
-      tenantId,
-      email,
-      password,
-      name: memberName,
-      locale: info.locale,
-      projectHeaders,
-    });
+    const response = await withAnonymousPage(browser, testInfo, anonymousPage =>
+      registerMemberViaAuthApi({
+        page: anonymousPage,
+        baseURL: info.origin,
+        tenantId,
+        email,
+        password,
+        name: memberName,
+        locale: info.locale,
+        projectHeaders,
+      })
+    );
     console.log(`Registration API Success: ${response.status()} ${response.url()}`);
 
     // 3. Verify DB State (The Real Truth)
@@ -208,9 +211,10 @@ test.describe('Member Number Hardening @quarantine', () => {
   });
 
   test('should self-heal missing member number on login with correct year', async ({
+    browser,
     page,
   }, testInfo) => {
-    const tenantId = resolveTenantId(testInfo.project.name);
+    const tenantId = resolveTenantId(getTenantFromTestInfo(testInfo));
     const info = getProjectUrlInfo(testInfo, null);
     const projectHeaders = (testInfo.project.use.extraHTTPHeaders || {}) as Record<string, string>;
 
@@ -218,16 +222,18 @@ test.describe('Member Number Hardening @quarantine', () => {
     const pastDate = new Date(`${lastYear}-06-15T12:00:00Z`); // Specific date in past year
     const email = `heal-${Date.now()}@example.com`;
     const password = 'Password123!';
-    await registerMemberViaAuthApi({
-      page,
-      baseURL: info.origin,
-      tenantId,
-      email,
-      password,
-      name: 'Heal Member',
-      locale: info.locale,
-      projectHeaders,
-    });
+    await withAnonymousPage(browser, testInfo, anonymousPage =>
+      registerMemberViaAuthApi({
+        page: anonymousPage,
+        baseURL: info.origin,
+        tenantId,
+        email,
+        password,
+        name: 'Heal Member',
+        locale: info.locale,
+        projectHeaders,
+      })
+    );
 
     // Simulating "broken state": remove memberNumber and backdate createdAt
     await db

--- a/apps/web/e2e/member-number.spec.ts
+++ b/apps/web/e2e/member-number.spec.ts
@@ -1,12 +1,115 @@
 import { db } from '@interdomestik/database/db';
-import { tenants, user } from '@interdomestik/database/schema';
-import { expect, test } from '@playwright/test';
+import { user } from '@interdomestik/database/schema';
 import { eq } from 'drizzle-orm';
+import { expect, test } from './fixtures/auth.fixture';
+import { getProjectUrlInfo } from './fixtures/auth.project';
 import { routes } from './routes';
 import { gotoApp } from './utils/navigation';
 
 // Enable full trace for this test suite
 test.use({ trace: 'on' });
+
+function resolveTenantId(projectName: string) {
+  if (projectName.includes('pilot')) {
+    return 'pilot-mk';
+  }
+
+  if (projectName.includes('mk')) {
+    return 'tenant_mk';
+  }
+
+  return 'tenant_ks';
+}
+
+async function registerMemberViaAuthApi(args: {
+  page: {
+    request: {
+      post: (
+        url: string,
+        options: { data: unknown; headers: Record<string, string> }
+      ) => Promise<{
+        ok(): boolean;
+        status(): number;
+        text(): Promise<string>;
+        url(): string;
+      }>;
+    };
+  };
+  baseURL: string;
+  tenantId: string;
+  email: string;
+  password: string;
+  name: string;
+  locale: string;
+  projectHeaders: Record<string, string>;
+}) {
+  const response = await args.page.request.post(
+    new URL('/api/auth/sign-up/email', args.baseURL).toString(),
+    {
+      data: {
+        email: args.email,
+        name: args.name,
+        password: args.password,
+        callbackURL: '/login',
+        tenantId: args.tenantId,
+        tenantClassificationPending: true,
+      },
+      headers: {
+        Origin: args.baseURL,
+        Referer: `${args.baseURL}/${args.locale}/register?tenantId=${args.tenantId}`,
+        ...args.projectHeaders,
+      },
+    }
+  );
+
+  if (!response.ok()) {
+    throw new Error(`Registration auth API failed: ${response.status()} ${await response.text()}`);
+  }
+
+  return response;
+}
+
+async function loginMemberViaApi(args: {
+  page: {
+    request: {
+      post: (
+        url: string,
+        options: { data: unknown; headers: Record<string, string> }
+      ) => Promise<{
+        ok(): boolean;
+        status(): number;
+        text(): Promise<string>;
+        url(): string;
+      }>;
+    };
+  };
+  origin: string;
+  locale: string;
+  projectHeaders: Record<string, string>;
+  email: string;
+  password: string;
+}) {
+  const response = await args.page.request.post(
+    new URL('/api/auth/sign-in/email', args.origin).toString(),
+    {
+      data: {
+        email: args.email,
+        password: args.password,
+      },
+      headers: {
+        Origin: args.origin,
+        Referer: `${args.origin}/${args.locale}/login`,
+        ...args.projectHeaders,
+      },
+    }
+  );
+
+  if (!response.ok()) {
+    throw new Error(`Member login API failed: ${response.status()} ${await response.text()}`);
+  }
+
+  return response;
+}
 
 test.describe('Member Number Hardening @quarantine', () => {
   test.beforeEach(({ page }) => {
@@ -34,54 +137,27 @@ test.describe('Member Number Hardening @quarantine', () => {
 
   test('should assign member number immediately upon registration (Production Grade)', async ({
     page,
-  }) => {
-    // 0. Get a valid tenant
-    const tenant = await db.query.tenants.findFirst({
-      where: eq(tenants.isActive, true),
-    });
-    if (!tenant) throw new Error('No active tenant found for test');
+  }, testInfo) => {
+    const tenantId = resolveTenantId(testInfo.project.name);
+    const info = getProjectUrlInfo(testInfo, null);
+    const projectHeaders = (testInfo.project.use.extraHTTPHeaders || {}) as Record<string, string>;
 
-    // 1. Register a new member
     const email = `mem-prod-${Date.now()}@example.com`;
     const password = 'Password123!';
+    const memberName = 'Test ProdMember';
 
-    await gotoApp(page, `${routes.register(test.info())}?tenantId=${tenant.id}`, test.info(), {
-      marker: 'auth-ready',
+    console.log('Creating member through public auth sign-up API...');
+    const response = await registerMemberViaAuthApi({
+      page,
+      baseURL: info.origin,
+      tenantId,
+      email,
+      password,
+      name: memberName,
+      locale: info.locale,
+      projectHeaders,
     });
-
-    await page.fill('input[name="fullName"]', 'Test ProdMember');
-    await page.fill('input[name="email"]', email);
-    await page.fill('input[name="password"]', password);
-    await page.fill('input[name="confirmPassword"]', password);
-
-    // Robust terms handling
-    const termsButton = page.locator('button[role="checkbox"]');
-    if ((await termsButton.getAttribute('aria-checked')) !== 'true') {
-      await termsButton.click();
-    }
-
-    // 2. Submit & Wait for Server Response (Primary Signal)
-    console.log('Clicking submit & waiting for API response...');
-    const responsePromise = page.waitForResponse(
-      resp => resp.url().includes('sign-up') && resp.status() === 200
-    );
-
-    // We also watch for potential redirects, but don't strictly require them to happen *instantly* vs the DB check
-    const redirectPromise = page.waitForURL(/\/member/, { timeout: 15000 }).catch(() => 'timeout');
-
-    await page.click('button[type="submit"]');
-
-    const response = await responsePromise;
     console.log(`Registration API Success: ${response.status()} ${response.url()}`);
-
-    // Wait for redirect or timeout (just for UI state, doesn't fail test hard yet)
-    await redirectPromise;
-
-    // Capture state if visual redirect failed (but API worked)
-    if (page.url().includes('/register')) {
-      console.log('WARN: Page is still on /register, taking screenshot...');
-      await page.screenshot({ path: 'registration-ui-state.png' });
-    }
 
     // 3. Verify DB State (The Real Truth)
     const member = await db.query.user.findFirst({
@@ -111,13 +187,17 @@ test.describe('Member Number Hardening @quarantine', () => {
     expect(actualYear).toBe(expectedYear);
 
     // 4. Immutability Check (Relogin)
-    console.log('Immutability Check: Re-logging in...');
+    console.log('Immutability Check: Re-logging in via auth API...');
     await page.context().clearCookies();
-    await gotoApp(page, routes.login(test.info()), test.info(), { marker: 'auth-ready' });
-    await page.fill('input[name="email"]', email);
-    await page.fill('input[name="password"]', password);
-    await page.click('button[type="submit"]');
-    await page.waitForURL(/\/member/);
+    await loginMemberViaApi({
+      page,
+      origin: info.origin,
+      locale: info.locale,
+      projectHeaders,
+      email,
+      password,
+    });
+    await gotoApp(page, routes.member(testInfo), testInfo, { marker: 'member-dashboard-ready' });
 
     const memberAfterLogin = await db.query.user.findFirst({
       where: eq(user.email, email),
@@ -127,48 +207,27 @@ test.describe('Member Number Hardening @quarantine', () => {
     console.log('Immutability Verified: Member number unchanged after login.');
   });
 
-  test('should self-heal missing member number on login with correct year', async ({ page }) => {
-    // 0. Get a valid tenant
-    const tenant = await db.query.tenants.findFirst({
-      where: eq(tenants.isActive, true),
-    });
-    if (!tenant) throw new Error('No active tenant found for test');
+  test('should self-heal missing member number on login with correct year', async ({
+    page,
+  }, testInfo) => {
+    const tenantId = resolveTenantId(testInfo.project.name);
+    const info = getProjectUrlInfo(testInfo, null);
+    const projectHeaders = (testInfo.project.use.extraHTTPHeaders || {}) as Record<string, string>;
 
-    // 1. Seed a user created in previous year without member number
     const lastYear = new Date().getFullYear() - 1;
     const pastDate = new Date(`${lastYear}-06-15T12:00:00Z`); // Specific date in past year
     const email = `heal-${Date.now()}@example.com`;
     const password = 'Password123!';
-
-    // Register normally first
-    await gotoApp(page, `${routes.register(test.info())}?tenantId=${tenant.id}`, test.info(), {
-      marker: 'auth-ready',
+    await registerMemberViaAuthApi({
+      page,
+      baseURL: info.origin,
+      tenantId,
+      email,
+      password,
+      name: 'Heal Member',
+      locale: info.locale,
+      projectHeaders,
     });
-    await page.fill('input[name="fullName"]', 'Heal Member');
-    await page.fill('input[name="email"]', email);
-    await page.fill('input[name="password"]', password);
-    await page.fill('input[name="confirmPassword"]', password);
-
-    // Robustly handle terms checkbox
-    const termsButton = page.locator('button[role="checkbox"]');
-    const isChecked2 = (await termsButton.getAttribute('aria-checked')) === 'true';
-    if (!isChecked2) {
-      await termsButton.click();
-    }
-
-    console.log('Clicking submit...');
-    await page.click('button[type="submit"]');
-
-    try {
-      await page.waitForURL(/\/member|\/dashboard/, { timeout: 60000 });
-    } catch (e) {
-      const errorText = await page
-        .locator('.text-red-500')
-        .textContent()
-        .catch(() => null);
-      if (errorText) throw new Error(`Registration (Setup) failed: ${errorText}`);
-      throw e;
-    }
 
     // Simulating "broken state": remove memberNumber and backdate createdAt
     await db
@@ -182,13 +241,17 @@ test.describe('Member Number Hardening @quarantine', () => {
 
     // Logout
     await page.context().clearCookies();
-    await gotoApp(page, routes.login(test.info()), test.info(), { marker: 'auth-ready' });
 
     // 2. Login again to trigger self-heal
-    await page.fill('input[name="email"]', email);
-    await page.fill('input[name="password"]', password);
-    await page.click('button[type="submit"]');
-    await page.waitForURL(/\/member|\/dashboard/);
+    await loginMemberViaApi({
+      page,
+      origin: info.origin,
+      locale: info.locale,
+      projectHeaders,
+      email,
+      password,
+    });
+    await gotoApp(page, routes.member(testInfo), testInfo, { marker: 'member-dashboard-ready' });
 
     // 3. Verify self-heal worked and respected the creation year
     const healedMember = await db.query.user.findFirst({

--- a/apps/web/e2e/utils/deterministic-waits.ts
+++ b/apps/web/e2e/utils/deterministic-waits.ts
@@ -8,7 +8,7 @@ const DEFAULT_READY_TEST_IDS = [
   'staff-page-ready',
   'admin-page-ready',
   'auth-ready',
-  'registration-page-ready',
+  'pricing-page-ready',
 ];
 
 type WaitOptions = {


### PR DESCRIPTION
## Summary
- salvage the valid E2E slice from the parked root checkout
- stop auth helpers from treating the old public register surface as a live readiness marker
- move member-number hardening onto the real auth signup/login paths that still work after pricing-first entry

## Verification
- pnpm --filter @interdomestik/web test:e2e -- apps/web/e2e/member-number.spec.ts --project=smoke
- pnpm pr:verify
- pnpm security:guard