### PR TITLE
fix: allow admin claim detail on generic host

### DIFF
--- a/apps/web/src/features/admin/claims/server/getOpsClaimDetail.test.ts
+++ b/apps/web/src/features/admin/claims/server/getOpsClaimDetail.test.ts
@@ -226,6 +226,22 @@ describe('getOpsClaimDetail', () => {
     );
   });
 
+  it('falls back to session tenant when the deployment host is generic', async () => {
+    hoisted.headersFn.mockResolvedValueOnce(
+      new Headers([['host', 'interdomestik-web.vercel.app']])
+    );
+    mockSelectChains();
+
+    const result = await getOpsClaimDetail('claim-1');
+
+    expect(result.kind).toBe('ok');
+    expect(hoisted.withTenantContext).toHaveBeenCalledTimes(1);
+    expect(hoisted.withTenantContext.mock.calls[0]?.[0]).toMatchObject({
+      tenantId: 'tenant_ks',
+      role: 'admin',
+    });
+  });
+
   it('returns not_found when host tenant and session tenant mismatch', async () => {
     hoisted.headersFn.mockResolvedValueOnce(new Headers([['host', 'mk.localhost:3000']]));
 

--- a/apps/web/src/features/admin/claims/server/getOpsClaimDetail.test.ts
+++ b/apps/web/src/features/admin/claims/server/getOpsClaimDetail.test.ts
@@ -242,6 +242,16 @@ describe('getOpsClaimDetail', () => {
     });
   });
 
+  it('returns not_found when host is unknown and not allowlisted', async () => {
+    hoisted.headersFn.mockResolvedValueOnce(new Headers([['host', 'example.test']]));
+
+    const result = await getOpsClaimDetail('claim-1');
+
+    expect(result).toEqual({ kind: 'not_found' });
+    expect(hoisted.claimsFindFirst).not.toHaveBeenCalled();
+    expect(hoisted.withTenantContext).not.toHaveBeenCalled();
+  });
+
   it('returns not_found when host tenant and session tenant mismatch', async () => {
     hoisted.headersFn.mockResolvedValueOnce(new Headers([['host', 'mk.localhost:3000']]));
 

--- a/apps/web/src/features/admin/claims/server/getOpsClaimDetail.ts
+++ b/apps/web/src/features/admin/claims/server/getOpsClaimDetail.ts
@@ -40,8 +40,8 @@ export async function getOpsClaimDetail(claimId: string): Promise<OpsClaimDetail
   }
   const requestHost = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host') ?? '';
   const hostTenantId = resolveTenantFromHost(requestHost);
-  if (!hostTenantId || hostTenantId !== sessionTenantId) return { kind: 'not_found' };
-  const tenantId = hostTenantId;
+  if (hostTenantId && hostTenantId !== sessionTenantId) return { kind: 'not_found' };
+  const tenantId = hostTenantId ?? sessionTenantId;
 
   // 1-2. Read claim detail under tenant DB context (RLS where configured) + explicit tenant predicates.
   const { claim, userData, agentData, rawDocs, diasporaOrigin } = await withTenantContext(

--- a/apps/web/src/features/admin/claims/server/getOpsClaimDetail.ts
+++ b/apps/web/src/features/admin/claims/server/getOpsClaimDetail.ts
@@ -27,6 +27,36 @@ type ClaimWithRelations = typeof claims.$inferSelect & {
   // agent: manually fetched
 };
 
+const NEUTRAL_DEPLOYMENT_HOSTS = new Set(['interdomestik-web.vercel.app']);
+
+function normalizeRequestHost(host: string): string {
+  const raw = host.split(',')[0]?.trim() ?? '';
+  return raw.replace(/:\d+$/, '').toLowerCase().replace(/\.$/, '');
+}
+
+function configuredNeutralHosts(): Set<string> {
+  const hosts = new Set(NEUTRAL_DEPLOYMENT_HOSTS);
+
+  for (const candidate of [process.env.NEXT_PUBLIC_APP_URL, process.env.BETTER_AUTH_URL]) {
+    if (!candidate) continue;
+    try {
+      hosts.add(new URL(candidate).host.toLowerCase().replace(/\.$/, ''));
+    } catch {
+      // Ignore malformed env and keep the fallback allowlist deterministic.
+    }
+  }
+
+  if (process.env.VERCEL_URL) {
+    hosts.add(process.env.VERCEL_URL.toLowerCase().replace(/\.$/, ''));
+  }
+
+  return hosts;
+}
+
+function isNeutralDeploymentHost(host: string): boolean {
+  return configuredNeutralHosts().has(normalizeRequestHost(host));
+}
+
 export async function getOpsClaimDetail(claimId: string): Promise<OpsClaimDetailResult> {
   // 0. Resolve tenant context from trusted host + session and fail closed.
   const requestHeaders = await headers();
@@ -41,6 +71,7 @@ export async function getOpsClaimDetail(claimId: string): Promise<OpsClaimDetail
   const requestHost = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host') ?? '';
   const hostTenantId = resolveTenantFromHost(requestHost);
   if (hostTenantId && hostTenantId !== sessionTenantId) return { kind: 'not_found' };
+  if (!hostTenantId && !isNeutralDeploymentHost(requestHost)) return { kind: 'not_found' };
   const tenantId = hostTenantId ?? sessionTenantId;
 
   // 1-2. Read claim detail under tenant DB context (RLS where configured) + explicit tenant predicates.


### PR DESCRIPTION
## Summary
- allow admin claim detail reads on the generic deployment host when the session tenant is valid
- keep explicit host/session tenant mismatches fail-closed
- add a regression test for the generic host fallback

## Verification
- pnpm --filter @interdomestik/web exec vitest run src/features/admin/claims/server/getOpsClaimDetail.test.ts
- pnpm security:guard
- pnpm -s plan:audit
- pnpm -s track:audit
- pnpm pr:verify
- pnpm e2e:gate