### PR TITLE
fix(ci): clean stale supabase containers before retry

### DIFF
--- a/scripts/ci/m4-gatekeeper-contracts.test.mjs
+++ b/scripts/ci/m4-gatekeeper-contracts.test.mjs
@@ -17,7 +17,7 @@ test('m4 gatekeeper force-cleans stale Supabase containers before retrying supab
   assert.match(gatekeeperScript, /cleanup_stale_supabase_containers\(\)/);
   assert.match(gatekeeperScript, /docker ps -a --format '\{\{\.Names\}\}'/);
   assert.match(gatekeeperScript, /grep '\^supabase_\.\*_interdomestik\$'/);
-  assert.match(gatekeeperScript, /xargs -r docker rm -f/);
+  assert.match(gatekeeperScript, /xargs docker rm -f/);
   assert.match(
     gatekeeperScript,
     /supabase stop --project-id interdomestik[\s\S]*supabase stop[\s\S]*cleanup_stale_supabase_containers[\s\S]*supabase start/

--- a/scripts/ci/m4-gatekeeper-contracts.test.mjs
+++ b/scripts/ci/m4-gatekeeper-contracts.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '../..');
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+test('m4 gatekeeper force-cleans stale Supabase containers before retrying supabase start', () => {
+  const gatekeeperScript = readRepoFile('scripts/m4-gatekeeper.sh');
+
+  assert.match(gatekeeperScript, /cleanup_stale_supabase_containers\(\)/);
+  assert.match(gatekeeperScript, /docker ps -a --format '\{\{\.Names\}\}'/);
+  assert.match(gatekeeperScript, /grep '\^supabase_\.\*_interdomestik\$'/);
+  assert.match(gatekeeperScript, /xargs -r docker rm -f/);
+  assert.match(
+    gatekeeperScript,
+    /supabase stop --project-id interdomestik[\s\S]*supabase stop[\s\S]*cleanup_stale_supabase_containers[\s\S]*supabase start/
+  );
+});

--- a/scripts/m4-gatekeeper.sh
+++ b/scripts/m4-gatekeeper.sh
@@ -133,7 +133,7 @@ cleanup_stale_supabase_containers() {
   fi
 
   echo "🧹 [Gatekeeper] Removing stale Supabase containers that may still hold host ports..."
-  echo "${stale_supabase_containers}" | xargs -r docker rm -f >/dev/null 2>&1 || true
+  echo "${stale_supabase_containers}" | xargs docker rm -f >/dev/null 2>&1 || true
 }
 
 # 0. Kill stale processes

--- a/scripts/m4-gatekeeper.sh
+++ b/scripts/m4-gatekeeper.sh
@@ -122,6 +122,20 @@ cleanup_stale_playwright_processes() {
   done
 }
 
+cleanup_stale_supabase_containers() {
+  local stale_supabase_containers
+  stale_supabase_containers="$(
+    docker ps -a --format '{{.Names}}' | grep '^supabase_.*_interdomestik$' || true
+  )"
+
+  if [[ -z "${stale_supabase_containers}" ]]; then
+    return 0
+  fi
+
+  echo "🧹 [Gatekeeper] Removing stale Supabase containers that may still hold host ports..."
+  echo "${stale_supabase_containers}" | xargs -r docker rm -f >/dev/null 2>&1 || true
+}
+
 # 0. Kill stale processes
 cleanup_stale_playwright_processes
 
@@ -171,6 +185,7 @@ NODE
     echo "   Attempting to stop Supabase project 'interdomestik' and retry..."
     pnpm --filter @interdomestik/database exec supabase stop --project-id interdomestik >/dev/null 2>&1 || true
     pnpm --filter @interdomestik/database exec supabase stop >/dev/null 2>&1 || true
+    cleanup_stale_supabase_containers
     pnpm --filter @interdomestik/database exec supabase start
   fi
 }


### PR DESCRIPTION
## Summary
- harden `scripts/m4-gatekeeper.sh` to force-remove stale `supabase_*_interdomestik` containers before retrying `supabase start`
- add a CI contract test that locks this retry-cleanup behavior in place

## Root Cause
The failing `e2e-gate` CI job in run `24438773764` was not an app regression. `supabase start` failed because Docker could not re-bind host port `54324` for `supabase_inbucket_interdomestik`, even after the existing retry path called `supabase stop`. That left the retry susceptible to stale container state that still held the port.

## Verification
- `node --test scripts/ci/m4-gatekeeper-contracts.test.mjs`
- `bash -n scripts/m4-gatekeeper.sh`
- `pnpm test:ci:contracts`
