### PR TITLE
fix: normalize paid-member fulfillment state

### DIFF
--- a/apps/web/src/app/track/[token]/page.tsx
+++ b/apps/web/src/app/track/[token]/page.tsx
@@ -1,7 +1,7 @@
 import { PublicTrackingCard } from '@/features/claims/tracking/components/PublicTrackingCard';
+import { loadMessagesForNamespaces } from '@/i18n/messages';
 import { getPublicClaimStatus } from '@/features/claims/tracking/server/getPublicClaimStatus';
 import { NextIntlClientProvider } from 'next-intl';
-import { getMessages } from 'next-intl/server';
 import { headers } from 'next/headers';
 import { getTrackingViewCore } from './_core';
 
@@ -48,7 +48,7 @@ export default async function PublicTrackingPage({ params, searchParams }: PageP
   }
 
   const data = result.data;
-  const messages = await getMessages({ locale });
+  const messages = await loadMessagesForNamespaces(locale, ['claims-tracking']);
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>

--- a/apps/web/src/i18n/messages.test.ts
+++ b/apps/web/src/i18n/messages.test.ts
@@ -1,6 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./routing', () => ({
+  routing: {
+    defaultLocale: 'en',
+  },
+}));
+
+import { loadMessagesForNamespaces } from './messages';
 
 function getArrayBlock(source: string, arrayName: string): string {
   const startToken = `export const ${arrayName} = [`;
@@ -51,5 +59,19 @@ describe('i18n shell namespace coverage', () => {
 
     expect(allNamespaces).toContain("'freeStart'");
     expect(home).toContain("'freeStart'");
+  });
+
+  it('can load only the namespaces a standalone route needs', async () => {
+    const messages = await loadMessagesForNamespaces('mk', ['claims-tracking']);
+
+    expect(messages).toHaveProperty('claims-tracking');
+    expect(messages['claims-tracking']).toMatchObject({
+      tracking: {
+        public: {
+          title: expect.any(String),
+        },
+      },
+    });
+    expect(messages).not.toHaveProperty('about');
   });
 });

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -153,60 +153,63 @@ type LoadAllMessagesOptions = {
   strict?: boolean;
 };
 
-export async function loadAllMessages(locale: string, options: LoadAllMessagesOptions = {}) {
+async function loadNamespaceMessages(
+  locale: string,
+  namespace: MessageNamespace,
+  options: LoadAllMessagesOptions = {}
+) {
   const strict = options.strict === true;
-  const modules = await Promise.all(
-    MESSAGE_NAMESPACES.map(async namespace => {
+  try {
+    const mod = await import(`../messages/${locale}/${namespace}.json`);
+    let messages = mod.default;
+
+    if (locale !== routing.defaultLocale) {
       try {
-        const mod = await import(`../messages/${locale}/${namespace}.json`);
-        let messages = mod.default;
-
-        if (locale !== routing.defaultLocale) {
-          try {
-            const fallback = await import(`../messages/${routing.defaultLocale}/${namespace}.json`);
-            messages = mergeMessages(fallback.default, messages);
-          } catch {
-            if (strict) {
-              throw new Error(
-                `[i18n] Missing fallback messages file for locale=${routing.defaultLocale} namespace=${namespace}`
-              );
-            }
-
-            // Fallback might fail if the file doesn't exist, just use what we have.
-          }
-        }
-
-        // Special handling for split admin files to merge them under 'admin' key
-        if (namespace.startsWith('admin-')) {
-          // If the file content isn't wrapped in 'admin', wrap it?
-          // Actually, the easiest way is to NOT wrap them in the file, but wrap them here.
-          // BUT, to maintain backward compatibility with current structure which wraps in "admin":
-          // The current plan implies the new files will contain { "admin": { "sidebar": ... } }
-          // If so, simple merge works.
-          // Let's assume the new files will mirror the structure: { "admin": { "sub-section": ... } }
-          return messages;
-        }
-
-        return messages;
+        const fallback = await import(`../messages/${routing.defaultLocale}/${namespace}.json`);
+        messages = mergeMessages(fallback.default, messages);
       } catch {
         if (strict) {
           throw new Error(
-            `[i18n] Missing messages file for locale=${locale} namespace=${namespace}`
+            `[i18n] Missing fallback messages file for locale=${routing.defaultLocale} namespace=${namespace}`
           );
         }
 
-        try {
-          // Try loading fallback locale if main failed entirely
-          const fallback = await import(`../messages/${routing.defaultLocale}/${namespace}.json`);
-          return fallback.default;
-        } catch {
-          return {};
-        }
+        // Fallback might fail if the file doesn't exist, just use what we have.
       }
-    })
+    }
+
+    return messages;
+  } catch {
+    if (strict) {
+      throw new Error(`[i18n] Missing messages file for locale=${locale} namespace=${namespace}`);
+    }
+
+    try {
+      const fallback = await import(`../messages/${routing.defaultLocale}/${namespace}.json`);
+      return fallback.default;
+    } catch {
+      return {};
+    }
+  }
+}
+
+export async function loadMessagesForNamespaces(
+  locale: string,
+  namespaces: readonly MessageNamespace[],
+  options: LoadAllMessagesOptions = {}
+) {
+  const modules = await Promise.all(
+    namespaces.map(namespace => loadNamespaceMessages(locale, namespace, options))
   );
 
-  // Use deep merge for the final object accumulation to ensure 'admin' keys from different files merge correctly
+  return modules.reduce((acc, curr) => mergeMessages(acc, curr), {});
+}
+
+export async function loadAllMessages(locale: string, options: LoadAllMessagesOptions = {}) {
+  const modules = await Promise.all(
+    MESSAGE_NAMESPACES.map(namespace => loadNamespaceMessages(locale, namespace, options))
+  );
+
   return modules.reduce((acc, curr) => mergeMessages(acc, curr), {});
 }
 // Force reload

--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -1,9 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const tableRefs = vi.hoisted(() => ({
+  memberLeads: { table: 'memberLeads', id: 'memberLeads.id' },
+  membershipCards: { table: 'membershipCards' },
+  subscriptions: { table: 'subscriptions' },
+  user: { table: 'user' },
+  agentClients: { table: 'agentClients' },
+}));
+
 const mocks = vi.hoisted(() => ({
-  findFirst: vi.fn(),
-  transaction: vi.fn(),
   eq: vi.fn((left, right) => ({ left, right, op: 'eq' })),
+  and: vi.fn((...clauses) => ({ clauses, op: 'and' })),
   db: {
     query: {
       memberLeads: {
@@ -17,6 +24,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  and: mocks.and,
   db: mocks.db,
   eq: mocks.eq,
 }));
@@ -25,25 +33,60 @@ vi.mock('@interdomestik/database/member-number', () => ({
   generateMemberNumber: mocks.generateMemberNumber,
 }));
 
+vi.mock('@interdomestik/database/schema', () => tableRefs);
+
 vi.mock('nanoid', () => ({
   nanoid: mocks.nanoid,
 }));
 
 import { convertLeadToMember } from './convert';
 
+type InsertRecord = {
+  table: unknown;
+  values: Record<string, unknown>;
+};
+
+function createTransactionHarness() {
+  const insertRecords: InsertRecord[] = [];
+  const updateCalls: Array<{ table: unknown; values?: Record<string, unknown>; where?: unknown }> =
+    [];
+
+  const tx = {
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn(async (values: Record<string, unknown>) => {
+        insertRecords.push({ table, values });
+      }),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        updateCalls.push({ table, values });
+        return {
+          where: vi.fn(async (where: unknown) => {
+            const lastCall = updateCalls[updateCalls.length - 1];
+            if (lastCall) {
+              lastCall.where = where;
+            }
+          }),
+        };
+      }),
+    })),
+  };
+
+  return { insertRecords, tx, updateCalls };
+}
+
 describe('convertLeadToMember', () => {
   beforeEach(() => {
-    mocks.db.query.memberLeads.findFirst = mocks.findFirst;
-    mocks.db.transaction = mocks.transaction;
-
-    mocks.findFirst.mockReset();
-    mocks.transaction.mockReset();
+    mocks.db.query.memberLeads.findFirst.mockReset();
+    mocks.db.transaction.mockReset();
     mocks.generateMemberNumber.mockReset();
     mocks.nanoid.mockReset();
+    mocks.eq.mockClear();
+    mocks.and.mockClear();
   });
 
   it('returns null and does not convert when convertedUserId already exists', async () => {
-    mocks.findFirst.mockResolvedValue({
+    mocks.db.query.memberLeads.findFirst.mockResolvedValue({
       id: 'lead-1',
       tenantId: 'tenant-1',
       branchId: 'branch-1',
@@ -55,16 +98,135 @@ describe('convertLeadToMember', () => {
       convertedUserId: 'usr_existing',
     });
 
-    mocks.transaction.mockImplementation(async () => {
+    mocks.db.transaction.mockImplementation(async () => {
       throw new Error('transaction should not run');
     });
 
-    const result = await convertLeadToMember(
-      { tenantId: 'tenant-1' },
-      { leadId: 'lead-1', planId: 'monthly_std' }
-    );
+    const result = await convertLeadToMember({ tenantId: 'tenant-1' }, { leadId: 'lead-1' });
 
     expect(result).toBeNull();
-    expect(mocks.transaction).not.toHaveBeenCalled();
+    expect(mocks.db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('defaults lead conversion to the standard annual plan and creates agent binding', async () => {
+    const now = new Date('2026-04-16T09:00:00.000Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mocks.db.query.memberLeads.findFirst.mockResolvedValue({
+      id: 'lead-1',
+      tenantId: 'tenant-1',
+      branchId: 'branch-1',
+      agentId: 'agent-1',
+      firstName: 'Arben',
+      lastName: 'Krasniqi',
+      email: 'arben@example.com',
+      status: 'new',
+      convertedUserId: null,
+    });
+    mocks.generateMemberNumber.mockResolvedValue({ memberNumber: 'M-1001' });
+    mocks.nanoid
+      .mockReturnValueOnce('user-seed')
+      .mockReturnValueOnce('subscription-seed')
+      .mockReturnValueOnce('agent-client-seed')
+      .mockReturnValueOnce('card-seed')
+      .mockReturnValueOnce('card-num')
+      .mockReturnValueOnce('card-qr');
+
+    const { insertRecords, tx, updateCalls } = createTransactionHarness();
+    mocks.db.transaction.mockImplementation(async callback => callback(tx));
+
+    const result = await convertLeadToMember({ tenantId: 'tenant-1' }, { leadId: 'lead-1' });
+
+    expect(result).toEqual({
+      userId: 'usr_user-seed',
+      memberNumber: 'M-1001',
+      subscriptionId: 'sub_subscription-seed',
+    });
+
+    const subscriptionInsert = insertRecords.find(
+      record => record.table === tableRefs.subscriptions
+    )?.values;
+    expect(subscriptionInsert).toMatchObject({
+      id: 'sub_subscription-seed',
+      tenantId: 'tenant-1',
+      userId: 'usr_user-seed',
+      status: 'active',
+      planId: 'standard',
+      agentId: 'agent-1',
+      branchId: 'branch-1',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const agentClientInsert = insertRecords.find(
+      record => record.table === tableRefs.agentClients
+    )?.values;
+    expect(agentClientInsert).toMatchObject({
+      id: 'agent-client-seed',
+      tenantId: 'tenant-1',
+      agentId: 'agent-1',
+      memberId: 'usr_user-seed',
+      status: 'active',
+      joinedAt: now,
+      createdAt: now,
+    });
+
+    expect(updateCalls).toEqual([
+      expect.objectContaining({
+        table: tableRefs.memberLeads,
+        values: {
+          status: 'converted',
+          convertedUserId: 'usr_user-seed',
+          updatedAt: now,
+        },
+      }),
+    ]);
+
+    vi.useRealTimers();
+  });
+
+  it('does not create an agent binding when the lead has no agent', async () => {
+    const now = new Date('2026-04-16T10:00:00.000Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mocks.db.query.memberLeads.findFirst.mockResolvedValue({
+      id: 'lead-1',
+      tenantId: 'tenant-1',
+      branchId: 'branch-1',
+      agentId: null,
+      firstName: 'Arben',
+      lastName: 'Krasniqi',
+      email: 'arben@example.com',
+      status: 'new',
+      convertedUserId: null,
+    });
+    mocks.generateMemberNumber.mockResolvedValue({ memberNumber: 'M-1002' });
+    mocks.nanoid
+      .mockReturnValueOnce('user-seed')
+      .mockReturnValueOnce('subscription-seed')
+      .mockReturnValueOnce('card-seed')
+      .mockReturnValueOnce('card-num')
+      .mockReturnValueOnce('card-qr');
+
+    const { insertRecords, tx } = createTransactionHarness();
+    mocks.db.transaction.mockImplementation(async callback => callback(tx));
+
+    await convertLeadToMember({ tenantId: 'tenant-1' }, { leadId: 'lead-1', planId: 'family' });
+
+    const agentClientInsert = insertRecords.find(record => record.table === tableRefs.agentClients);
+    expect(agentClientInsert).toBeUndefined();
+
+    const subscriptionInsert = insertRecords.find(
+      record => record.table === tableRefs.subscriptions
+    )?.values;
+    expect(subscriptionInsert).toMatchObject({
+      planId: 'family',
+      branchId: 'branch-1',
+      updatedAt: now,
+    });
+
+    vi.useRealTimers();
   });
 });

--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -45,16 +45,27 @@ type InsertRecord = {
   table: unknown;
   values: Record<string, unknown>;
 };
+type ConflictRecord = {
+  payload: Record<string, unknown>;
+  table: unknown;
+  values: Record<string, unknown>;
+};
 
 function createTransactionHarness() {
   const insertRecords: InsertRecord[] = [];
+  const conflictRecords: ConflictRecord[] = [];
   const updateCalls: Array<{ table: unknown; values?: Record<string, unknown>; where?: unknown }> =
     [];
 
   const tx = {
     insert: vi.fn((table: unknown) => ({
-      values: vi.fn(async (values: Record<string, unknown>) => {
+      values: vi.fn((values: Record<string, unknown>) => {
         insertRecords.push({ table, values });
+        return {
+          onConflictDoUpdate: vi.fn(async (payload: Record<string, unknown>) => {
+            conflictRecords.push({ table, values, payload });
+          }),
+        };
       }),
     })),
     update: vi.fn((table: unknown) => ({
@@ -72,7 +83,7 @@ function createTransactionHarness() {
     })),
   };
 
-  return { insertRecords, tx, updateCalls };
+  return { conflictRecords, insertRecords, tx, updateCalls };
 }
 
 describe('convertLeadToMember', () => {
@@ -133,7 +144,7 @@ describe('convertLeadToMember', () => {
       .mockReturnValueOnce('card-num')
       .mockReturnValueOnce('card-qr');
 
-    const { insertRecords, tx, updateCalls } = createTransactionHarness();
+    const { conflictRecords, insertRecords, tx, updateCalls } = createTransactionHarness();
     mocks.db.transaction.mockImplementation(async callback => callback(tx));
 
     const result = await convertLeadToMember({ tenantId: 'tenant-1' }, { leadId: 'lead-1' });
@@ -171,8 +182,26 @@ describe('convertLeadToMember', () => {
       joinedAt: now,
       createdAt: now,
     });
+    expect(conflictRecords).toEqual([
+      expect.objectContaining({
+        table: tableRefs.agentClients,
+        payload: expect.objectContaining({
+          set: expect.objectContaining({
+            status: 'active',
+            joinedAt: now,
+          }),
+          target: expect.any(Array),
+        }),
+      }),
+    ]);
 
     expect(updateCalls).toEqual([
+      expect.objectContaining({
+        table: tableRefs.agentClients,
+        values: {
+          status: 'inactive',
+        },
+      }),
       expect.objectContaining({
         table: tableRefs.memberLeads,
         values: {

--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const tableRefs = vi.hoisted(() => ({
   memberLeads: { table: 'memberLeads', id: 'memberLeads.id' },
@@ -87,6 +87,10 @@ function createTransactionHarness() {
 }
 
 describe('convertLeadToMember', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     mocks.db.query.memberLeads.findFirst.mockReset();
     mocks.db.transaction.mockReset();
@@ -211,8 +215,6 @@ describe('convertLeadToMember', () => {
         },
       }),
     ]);
-
-    vi.useRealTimers();
   });
 
   it('does not create an agent binding when the lead has no agent', async () => {
@@ -255,7 +257,5 @@ describe('convertLeadToMember', () => {
       branchId: 'branch-1',
       updatedAt: now,
     });
-
-    vi.useRealTimers();
   });
 });

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -1,6 +1,7 @@
 import { db, eq } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
 import {
+  agentClients,
   memberLeads,
   membershipCards,
   subscriptions,
@@ -20,11 +21,21 @@ function isLeadAlreadyConverted(lead: LeadConversionState): boolean {
   return lead.convertedUserId != null || lead.status === 'converted';
 }
 
+function resolveLeadConversionPlanId(planId?: string): string {
+  const normalizedPlanId = planId?.trim();
+  if (!normalizedPlanId || normalizedPlanId === 'monthly_std') {
+    return 'standard';
+  }
+
+  return normalizedPlanId;
+}
+
 export async function convertLeadToMember(
   ctx: { tenantId: string },
   args: { leadId: string; planId?: string }
 ): Promise<ConvertLeadResult | null> {
-  const { leadId, planId = 'monthly_std' } = args;
+  const { leadId } = args;
+  const planId = resolveLeadConversionPlanId(args.planId);
 
   const lead = await db.query.memberLeads.findFirst({
     where: (l, { eq, and }) => and(eq(l.id, leadId), eq(l.tenantId, ctx.tenantId)),
@@ -61,21 +72,34 @@ export async function convertLeadToMember(
     await tx.insert(subscriptions).values({
       id: subscriptionId,
       tenantId: ctx.tenantId,
-      userId: userId,
+      userId,
       status: 'active',
-      planId: planId,
+      planId,
       agentId: lead.agentId,
       branchId: lead.branchId,
       createdAt: now,
+      updatedAt: now,
     });
+
+    if (lead.agentId) {
+      await tx.insert(agentClients).values({
+        id: nanoid(),
+        tenantId: ctx.tenantId,
+        agentId: lead.agentId,
+        memberId: userId,
+        status: 'active',
+        joinedAt: now,
+        createdAt: now,
+      });
+    }
 
     // D. Issue Membership Card
     const cardNumber = `MEM-${nanoid(8).toUpperCase()}`;
     await tx.insert(membershipCards).values({
       id: `card_${nanoid()}`,
       tenantId: ctx.tenantId,
-      userId: userId,
-      subscriptionId: subscriptionId,
+      userId,
+      subscriptionId,
       status: 'active',
       cardNumber,
       qrCodeToken: nanoid(32),

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -1,4 +1,4 @@
-import { db, eq } from '@interdomestik/database';
+import { and, db, eq } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
 import {
   agentClients,
@@ -82,15 +82,29 @@ export async function convertLeadToMember(
     });
 
     if (lead.agentId) {
-      await tx.insert(agentClients).values({
-        id: nanoid(),
-        tenantId: ctx.tenantId,
-        agentId: lead.agentId,
-        memberId: userId,
-        status: 'active',
-        joinedAt: now,
-        createdAt: now,
-      });
+      await tx
+        .update(agentClients)
+        .set({ status: 'inactive' })
+        .where(and(eq(agentClients.tenantId, ctx.tenantId), eq(agentClients.memberId, userId)));
+
+      await tx
+        .insert(agentClients)
+        .values({
+          id: nanoid(),
+          tenantId: ctx.tenantId,
+          agentId: lead.agentId,
+          memberId: userId,
+          status: 'active',
+          joinedAt: now,
+          createdAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [agentClients.tenantId, agentClients.agentId, agentClients.memberId],
+          set: {
+            status: 'active',
+            joinedAt: now,
+          },
+        });
     }
 
     // D. Issue Membership Card

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -62,7 +62,9 @@ describe('Paddle Webhook Handlers', () => {
     hoisted.tx.insert.mockImplementation(() => ({
       values: hoisted.insertedUserValues,
     }));
-    hoisted.insertedUserValues.mockResolvedValue(undefined);
+    hoisted.insertedUserValues.mockReturnValue({
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    });
     hoisted.tx.update.mockImplementation(() => ({
       set: hoisted.updatedUserValues,
     }));
@@ -182,7 +184,7 @@ describe('Paddle Webhook Handlers', () => {
         email: 'buyer@example.com',
         tenantId: 'tenant_mk',
       });
-      expect(hoisted.db.transaction).toHaveBeenCalledTimes(1);
+      expect(hoisted.db.transaction).toHaveBeenCalledTimes(2);
       expect(hoisted.db.insert).toHaveBeenCalled();
     });
 

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -9,6 +9,7 @@ const hoisted = vi.hoisted(() => ({
     query: {
       user: { findFirst: vi.fn() },
       account: { findFirst: vi.fn() },
+      agentClients: { findFirst: vi.fn() },
       subscriptions: { findFirst: vi.fn() },
       tenantSettings: { findFirst: vi.fn() },
       webhookEvents: { findFirst: vi.fn() },
@@ -52,6 +53,7 @@ describe('Paddle Webhook Handlers', () => {
     hoisted.db.insert.mockImplementation(() => ({
       values: vi.fn().mockResolvedValue(undefined),
     }));
+    hoisted.db.query.agentClients.findFirst.mockResolvedValue(null);
     hoisted.db.update.mockImplementation(() => ({
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue(undefined),

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
@@ -12,14 +12,9 @@ import {
 // Mock dependencies
 vi.mock('@interdomestik/database', () => ({
   db: {
-    insert: vi.fn(() => ({
-      values: vi.fn(),
-    })),
+    transaction: vi.fn(),
     query: {
       agentSettings: {
-        findFirst: vi.fn(),
-      },
-      agentClients: {
         findFirst: vi.fn(),
       },
       referrals: {
@@ -85,15 +80,32 @@ describe('extras', () => {
       name: 'Test Member',
       memberNumber: 'M-123',
     };
+    const tx = {
+      insert: vi.fn(),
+      update: vi.fn(),
+    };
+    const insertValues = vi.fn();
+    const onConflictDoUpdate = vi.fn();
+    const updateWhere = vi.fn();
 
     beforeEach(() => {
       vi.clearAllMocks();
       // Default success mocks
       (db.query.agentSettings.findFirst as any).mockResolvedValue(null);
-      (db.query.agentClients.findFirst as any).mockResolvedValue(null);
-      (db.insert as any).mockReturnValue({
-        values: vi.fn().mockResolvedValue(undefined),
+      (db.transaction as any).mockImplementation(async callback => callback(tx));
+      tx.insert.mockImplementation(() => ({
+        values: insertValues,
+      }));
+      insertValues.mockReturnValue({
+        onConflictDoUpdate,
       });
+      onConflictDoUpdate.mockResolvedValue(undefined);
+      tx.update.mockImplementation(() => ({
+        set: vi.fn().mockReturnValue({
+          where: updateWhere,
+        }),
+      }));
+      updateWhere.mockResolvedValue(undefined);
       (createCommissionCore as any).mockResolvedValue({ success: true, data: { id: 'comm_1' } });
       (db.query.referrals.findFirst as any).mockResolvedValue(null);
       (createMemberReferralRewardCore as any).mockResolvedValue({
@@ -128,8 +140,9 @@ describe('extras', () => {
           action: 'commission.created',
         })
       );
-      expect(db.query.agentClients.findFirst).toHaveBeenCalled();
-      expect(db.insert).toHaveBeenCalled();
+      expect(db.transaction).toHaveBeenCalled();
+      expect(tx.update).toHaveBeenCalled();
+      expect(tx.insert).toHaveBeenCalled();
     });
 
     it('should use custom commission rates if found', async () => {
@@ -167,13 +180,10 @@ describe('extras', () => {
       });
 
       expect(createCommissionCore).not.toHaveBeenCalled();
-      expect(db.query.agentClients.findFirst).not.toHaveBeenCalled();
-      expect(db.insert).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
     });
 
-    it('does not create a duplicate agent-client binding when one already exists', async () => {
-      (db.query.agentClients.findFirst as any).mockResolvedValue({ id: 'existing-binding' });
-
+    it('deactivates prior agent bindings before reactivating the requested agent-client link', async () => {
       await handleNewSubscriptionExtras({
         sub: mockSub,
         userId: 'user_1',
@@ -184,8 +194,19 @@ describe('extras', () => {
         deps: mockDeps,
       });
 
-      expect(db.query.agentClients.findFirst).toHaveBeenCalled();
-      expect(db.insert).not.toHaveBeenCalled();
+      expect(db.transaction).toHaveBeenCalled();
+      expect(tx.update).toHaveBeenCalled();
+      expect(updateWhere).toHaveBeenCalled();
+      expect(tx.insert).toHaveBeenCalled();
+      expect(onConflictDoUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.any(Array),
+          set: expect.objectContaining({
+            status: 'active',
+            joinedAt: expect.any(Date),
+          }),
+        })
+      );
     });
 
     it('creates a member referral reward for a first paid subscription without an agent commission', async () => {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
@@ -12,8 +12,14 @@ import {
 // Mock dependencies
 vi.mock('@interdomestik/database', () => ({
   db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(),
+    })),
     query: {
       agentSettings: {
+        findFirst: vi.fn(),
+      },
+      agentClients: {
         findFirst: vi.fn(),
       },
       referrals: {
@@ -21,6 +27,10 @@ vi.mock('@interdomestik/database', () => ({
       },
     },
   },
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'agent-client-id'),
 }));
 
 vi.mock('../../../../../domain-referrals/src', () => ({
@@ -80,6 +90,10 @@ describe('extras', () => {
       vi.clearAllMocks();
       // Default success mocks
       (db.query.agentSettings.findFirst as any).mockResolvedValue(null);
+      (db.query.agentClients.findFirst as any).mockResolvedValue(null);
+      (db.insert as any).mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      });
       (createCommissionCore as any).mockResolvedValue({ success: true, data: { id: 'comm_1' } });
       (db.query.referrals.findFirst as any).mockResolvedValue(null);
       (createMemberReferralRewardCore as any).mockResolvedValue({
@@ -114,6 +128,8 @@ describe('extras', () => {
           action: 'commission.created',
         })
       );
+      expect(db.query.agentClients.findFirst).toHaveBeenCalled();
+      expect(db.insert).toHaveBeenCalled();
     });
 
     it('should use custom commission rates if found', async () => {
@@ -151,6 +167,25 @@ describe('extras', () => {
       });
 
       expect(createCommissionCore).not.toHaveBeenCalled();
+      expect(db.query.agentClients.findFirst).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('does not create a duplicate agent-client binding when one already exists', async () => {
+      (db.query.agentClients.findFirst as any).mockResolvedValue({ id: 'existing-binding' });
+
+      await handleNewSubscriptionExtras({
+        sub: mockSub,
+        userId: 'user_1',
+        tenantId: 'tenant_1',
+        customData: { agentId: 'agent_1' },
+        priceId: 'price_1',
+        userRecord: mockUserRecord,
+        deps: mockDeps,
+      });
+
+      expect(db.query.agentClients.findFirst).toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
     });
 
     it('creates a member referral reward for a first paid subscription without an agent commission', async () => {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
@@ -92,7 +92,9 @@ describe('extras', () => {
       vi.clearAllMocks();
       // Default success mocks
       (db.query.agentSettings.findFirst as any).mockResolvedValue(null);
-      (db.transaction as any).mockImplementation(async callback => callback(tx));
+      (db.transaction as any).mockImplementation(
+        async (callback: (trx: typeof tx) => Promise<unknown> | unknown) => callback(tx)
+      );
       tx.insert.mockImplementation(() => ({
         values: insertValues,
       }));

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
@@ -136,27 +136,31 @@ async function ensureAgentClientBinding(args: {
   const agentId = args.customData?.agentId?.trim();
   if (!agentId) return;
 
-  const existingBinding = await db.query.agentClients.findFirst({
-    where: (bindings, { and, eq }) =>
-      and(
-        eq(bindings.tenantId, args.tenantId),
-        eq(bindings.agentId, agentId),
-        eq(bindings.memberId, args.userId)
-      ),
-    columns: { id: true },
-  });
-
-  if (existingBinding) return;
-
   const now = new Date();
-  await db.insert(agentClients).values({
-    id: nanoid(),
-    tenantId: args.tenantId,
-    agentId,
-    memberId: args.userId,
-    status: 'active',
-    joinedAt: now,
-    createdAt: now,
+  await db.transaction(async tx => {
+    await tx
+      .update(agentClients)
+      .set({ status: 'inactive' })
+      .where(and(eq(agentClients.tenantId, args.tenantId), eq(agentClients.memberId, args.userId)));
+
+    await tx
+      .insert(agentClients)
+      .values({
+        id: nanoid(),
+        tenantId: args.tenantId,
+        agentId,
+        memberId: args.userId,
+        status: 'active',
+        joinedAt: now,
+        createdAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [agentClients.tenantId, agentClients.agentId, agentClients.memberId],
+        set: {
+          status: 'active',
+          joinedAt: now,
+        },
+      });
   });
 }
 

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
@@ -1,6 +1,7 @@
 import { db } from '@interdomestik/database';
-import { referrals } from '@interdomestik/database/schema';
+import { agentClients, referrals } from '@interdomestik/database/schema';
 import { and, eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
 import { createMemberReferralRewardCore } from '../../../../../domain-referrals/src';
 import { createCommissionCore } from '../../../commissions/create';
 import { createRenewalCommissionCore } from '../../../commissions/create-renewal';
@@ -127,6 +128,38 @@ async function processMemberReferralRewards(args: {
   }
 }
 
+async function ensureAgentClientBinding(args: {
+  tenantId: string;
+  userId: string;
+  customData: { agentId?: string } | undefined;
+}) {
+  const agentId = args.customData?.agentId?.trim();
+  if (!agentId) return;
+
+  const existingBinding = await db.query.agentClients.findFirst({
+    where: (bindings, { and, eq }) =>
+      and(
+        eq(bindings.tenantId, args.tenantId),
+        eq(bindings.agentId, agentId),
+        eq(bindings.memberId, args.userId)
+      ),
+    columns: { id: true },
+  });
+
+  if (existingBinding) return;
+
+  const now = new Date();
+  await db.insert(agentClients).values({
+    id: nanoid(),
+    tenantId: args.tenantId,
+    agentId,
+    memberId: args.userId,
+    status: 'active',
+    joinedAt: now,
+    createdAt: now,
+  });
+}
+
 async function processRenewalCommissions(args: {
   internalSubscriptionId?: string;
   sub: any;
@@ -246,6 +279,7 @@ export async function handleNewSubscriptionExtras(args: {
   deps: Pick<PaddleWebhookDeps, 'sendThankYouLetter'> & PaddleWebhookAuditDeps;
 }) {
   await processCommissions(args);
+  await ensureAgentClientBinding(args);
   await processMemberReferralRewards(args);
   await processThankYouLetter(args);
 }


### PR DESCRIPTION
## Summary
- normalize lead conversion onto canonical paid-member fulfillment state
- add idempotent agent-client binding for checkout attribution
- narrow public tracking i18n loading so standalone host-routed gates stay green

## Verification
- pnpm --filter @interdomestik/domain-leads test:unit --run src/convert.test.ts
- pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/paddle-webhooks/handlers/utils/extras.test.ts
- pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/paddle-webhooks/handlers.test.ts
- pnpm --filter @interdomestik/web test:unit --run src/i18n/messages.test.ts
- pnpm --filter @interdomestik/web run build:ci
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate