### PR TITLE
[codex] Stabilize repo QA MCP discovery

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -24,7 +24,7 @@ args = [
 ]
 
 [mcp_servers.interdomestik_qa]
-command = "bash"
+command = "/bin/bash"
 args = ["scripts/start-repo-qa.sh"]
 cwd = "."
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -24,8 +24,8 @@ args = [
 ]
 
 [mcp_servers.interdomestik_qa]
-command = "pnpm"
-args = ["exec", "tsx", "packages/qa/src/index.ts"]
+command = "bash"
+args = ["scripts/start-repo-qa.sh"]
 cwd = "."
 
 [roles.scribe]

--- a/scripts/ci/codex-contracts.test.mjs
+++ b/scripts/ci/codex-contracts.test.mjs
@@ -27,7 +27,7 @@ test('project-scoped Codex config registers the repo MCP servers Interdomestik d
   assert.match(configToml, /\/tmp\/pilot-evidence\/playwright-mcp-profile/);
   assert.match(configToml, /--output-dir/);
   assert.match(configToml, /\/tmp\/pilot-evidence\/playwright-mcp-output/);
-  assert.match(configToml, /command = "bash"/);
+  assert.match(configToml, /command = "\/bin\/bash"/);
   assert.match(configToml, /scripts\/start-repo-qa\.sh/);
   assert.doesNotMatch(configToml, /packages\/qa\/src\/index\.ts/);
   assert.doesNotMatch(configToml, /packages\/qa\/dist\/index\.js/);

--- a/scripts/ci/codex-contracts.test.mjs
+++ b/scripts/ci/codex-contracts.test.mjs
@@ -27,10 +27,9 @@ test('project-scoped Codex config registers the repo MCP servers Interdomestik d
   assert.match(configToml, /\/tmp\/pilot-evidence\/playwright-mcp-profile/);
   assert.match(configToml, /--output-dir/);
   assert.match(configToml, /\/tmp\/pilot-evidence\/playwright-mcp-output/);
-  assert.match(configToml, /command = "pnpm"/);
-  assert.match(configToml, /"exec"/);
-  assert.match(configToml, /"tsx"/);
-  assert.match(configToml, /packages\/qa\/src\/index\.ts/);
+  assert.match(configToml, /command = "bash"/);
+  assert.match(configToml, /scripts\/start-repo-qa\.sh/);
+  assert.doesNotMatch(configToml, /packages\/qa\/src\/index\.ts/);
   assert.doesNotMatch(configToml, /packages\/qa\/dist\/index\.js/);
 });
 
@@ -42,7 +41,8 @@ test('mcp setup verifies Codex project config as well as local QA server prerequ
   assert.match(setupScript, /context7/);
   assert.match(setupScript, /playwright/);
   assert.match(setupScript, /interdomestik_qa/);
-  assert.match(setupScript, /dist\/tools\/list-tools\.js/);
+  assert.match(setupScript, /scripts\/start-repo-qa\.sh/);
+  assert.match(setupScript, /tools\/list/);
 });
 
 test('Codex PR review workflow uses the official action with a repo-owned review prompt', () => {

--- a/scripts/ci/qa-mcp-discovery-contracts.test.mjs
+++ b/scripts/ci/qa-mcp-discovery-contracts.test.mjs
@@ -8,7 +8,7 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '../..');
 
 async function listToolsViaMcp() {
-  const child = spawn('bash', ['scripts/start-repo-qa.sh'], {
+  const child = spawn('/bin/bash', ['scripts/start-repo-qa.sh'], {
     cwd: rootDir,
     detached: true,
     stdio: ['pipe', 'pipe', 'inherit'],

--- a/scripts/ci/qa-mcp-discovery-contracts.test.mjs
+++ b/scripts/ci/qa-mcp-discovery-contracts.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '../..');
+
+async function listToolsViaMcp() {
+  const child = spawn('bash', ['scripts/start-repo-qa.sh'], {
+    cwd: rootDir,
+    detached: true,
+    stdio: ['pipe', 'pipe', 'inherit'],
+    env: { ...process.env, MCP_REPO_ROOT: rootDir },
+  });
+
+  let stdout = '';
+
+  try {
+    const response = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Timed out waiting for tools/list response'));
+      }, 10000);
+
+      child.stdout.on('data', chunk => {
+        stdout += chunk.toString();
+
+        for (const line of stdout.split('\n')) {
+          if (!line.trim()) continue;
+
+          let message;
+          try {
+            message = JSON.parse(line);
+          } catch {
+            continue;
+          }
+
+          if (message.id === 2) {
+            clearTimeout(timeout);
+            resolve(message);
+            return;
+          }
+        }
+      });
+
+      child.on('exit', code => {
+        clearTimeout(timeout);
+        reject(new Error(`QA MCP server exited before tools/list completed (code=${code ?? 'null'})`));
+      });
+
+      child.stdin.write(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'qa-mcp-contract', version: '1.0.0' },
+          },
+        }) + '\n'
+      );
+      child.stdin.write(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'notifications/initialized',
+          params: {},
+        }) + '\n'
+      );
+      child.stdin.write(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/list',
+          params: {},
+        }) + '\n'
+      );
+    });
+
+    return response.result.tools.map(tool => tool.name);
+  } finally {
+    if (child.pid && child.exitCode === null && !child.killed) {
+      await new Promise(resolve => {
+        const forceKillTimer = setTimeout(() => {
+          try {
+            process.kill(-child.pid, 'SIGKILL');
+          } catch {
+            // Process group already exited.
+          }
+        }, 2000);
+
+        child.once('close', () => {
+          clearTimeout(forceKillTimer);
+          resolve();
+        });
+
+        try {
+          process.kill(-child.pid, 'SIGTERM');
+        } catch {
+          clearTimeout(forceKillTimer);
+          resolve();
+        }
+      });
+    }
+  }
+}
+
+test('repo QA MCP launcher exposes the expected live tool surface over stdio', async () => {
+  const toolNames = await listToolsViaMcp();
+
+  for (const toolName of [
+    'project_map',
+    'read_files',
+    'code_search',
+    'check_health',
+    'pr_verify',
+    'security_guard',
+    'e2e_gate',
+  ]) {
+    assert.ok(toolNames.includes(toolName), `expected live QA tool ${toolName}`);
+  }
+});

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -74,7 +74,7 @@ if (!projectRoot) {
   throw new Error('PROJECT_ROOT is required');
 }
 
-const child = spawn('bash', ['scripts/start-repo-qa.sh'], {
+const child = spawn('/bin/bash', ['scripts/start-repo-qa.sh'], {
   cwd: projectRoot,
   detached: true,
   stdio: ['pipe', 'pipe', 'inherit'],

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -2,7 +2,7 @@
 # MCP Tools Setup for Interdomestik
 # This script ensures all MCP servers are properly configured and built
 
-set -e
+set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 echo "🔧 Setting up MCP tools for Interdomestik"
@@ -63,13 +63,124 @@ if [ "$ALL_CONFIGURED" = false ]; then
     exit 1
 fi
 
-# 3. Test QA tools
-echo -e "\n${YELLOW}🧪 Testing QA tools...${NC}"
-cd "$PROJECT_ROOT/packages/qa"
-if node --input-type=module -e "import { tools } from './dist/tools/list-tools.js'; console.log(\`Loaded QA tools: \${tools.length}\`);"; then
-    echo -e "${GREEN}✅ QA tools are working${NC}"
+# 3. Test QA MCP discovery
+echo -e "\n${YELLOW}🧪 Testing QA MCP discovery...${NC}"
+cd "$PROJECT_ROOT"
+if PROJECT_ROOT="$PROJECT_ROOT" node --input-type=module - <<'EOF'
+import { spawn } from 'node:child_process';
+
+const projectRoot = process.env.PROJECT_ROOT;
+if (!projectRoot) {
+  throw new Error('PROJECT_ROOT is required');
+}
+
+const child = spawn('bash', ['scripts/start-repo-qa.sh'], {
+  cwd: projectRoot,
+  detached: true,
+  stdio: ['pipe', 'pipe', 'inherit'],
+  env: { ...process.env, MCP_REPO_ROOT: projectRoot },
+});
+
+let stdout = '';
+let settled = false;
+
+const response = await new Promise((resolve, reject) => {
+  const timeout = setTimeout(() => {
+    reject(new Error('Timed out waiting for tools/list response'));
+  }, 10000);
+
+  child.stdout.on('data', chunk => {
+    stdout += chunk.toString();
+    for (const line of stdout.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const message = JSON.parse(line);
+        if (message.id === 2) {
+          clearTimeout(timeout);
+          resolve(message);
+          return;
+        }
+      } catch {
+        // Ignore partial JSON until the full line arrives.
+      }
+    }
+  });
+
+  child.on('exit', code => {
+    if (!settled) {
+      clearTimeout(timeout);
+      reject(new Error(`QA MCP server exited before responding (code=${code ?? 'null'})`));
+    }
+  });
+
+  child.stdin.write(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'setup-mcp', version: '1.0.0' },
+      },
+    }) + '\n'
+  );
+  child.stdin.write(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {},
+    }) + '\n'
+  );
+  child.stdin.write(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {},
+    }) + '\n'
+  );
+});
+
+settled = true;
+
+if (child.pid && child.exitCode === null && !child.killed) {
+  await new Promise(resolve => {
+    const forceKillTimer = setTimeout(() => {
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        // Process group already exited.
+      }
+    }, 2000);
+
+    child.once('close', () => {
+      clearTimeout(forceKillTimer);
+      resolve();
+    });
+
+    try {
+      process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      clearTimeout(forceKillTimer);
+      resolve();
+    }
+  });
+}
+
+const toolNames = response.result?.tools?.map(tool => tool.name) ?? [];
+for (const requiredTool of ['project_map', 'read_files', 'pr_verify', 'security_guard', 'e2e_gate']) {
+  if (!toolNames.includes(requiredTool)) {
+    throw new Error(`Missing QA MCP tool: ${requiredTool}`);
+  }
+}
+
+console.log(`Live QA MCP tools: ${toolNames.length}`);
+EOF
+then
+    echo -e "${GREEN}✅ QA MCP discovery is working${NC}"
 else
-    echo -e "${RED}❌ QA tools test failed${NC}"
+    echo -e "${RED}❌ QA MCP discovery test failed${NC}"
     exit 1
 fi
 

--- a/scripts/start-repo-qa.sh
+++ b/scripts/start-repo-qa.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Wrapper to start repo-qa-server with correct MCP_REPO_ROOT
-set -e
+# Wrapper to start the repo-local Interdomestik QA MCP server with a stable repo root.
+set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export MCP_REPO_ROOT="$REPO_ROOT"
+cd "$REPO_ROOT"
 
-# Execute the server
-exec node /Users/arbenlila/development/mcp-toolkit/servers/repo-qa-server/src/index.mjs
+exec pnpm exec tsx packages/qa/src/index.ts


### PR DESCRIPTION
## Summary
- switch `interdomestik_qa` to a repo-owned launcher instead of a machine-specific external path
- make `pnpm mcp:setup` verify live MCP `tools/list` discovery rather than only importing built tool metadata
- add a CI contract test that boots the QA MCP server and asserts the expected live tool surface

## Why
The QA MCP server was healthy locally, but the repo only checked static config and exported tool lists. That left the real discovery path under-tested and allowed environment-specific launcher assumptions to slip through.

## Validation
- `node --test scripts/ci/codex-contracts.test.mjs scripts/ci/qa-mcp-discovery-contracts.test.mjs`
- `pnpm mcp:setup`
- direct MCP `tools/call` against `project_map` via `scripts/start-repo-qa.sh`
