### PR TITLE
[codex] harden claim upload and agent tracking scope

### DIFF
--- a/apps/web/src/app/api/claims/evidence-upload/route.test.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.test.ts
@@ -5,7 +5,7 @@ const hoisted = vi.hoisted(() => ({
   ensureTenantId: vi.fn(),
   resolveEvidenceBucketName: vi.fn(),
   resolveTenantFromHost: vi.fn(),
-  findClaimFirst: vi.fn(),
+  findAccessibleAdminUploadClaim: vi.fn(),
   upload: vi.fn(),
   createAdminClient: vi.fn(),
   confirmAdminUpload: vi.fn(),
@@ -28,18 +28,6 @@ vi.mock('@/lib/tenant/tenant-hosts', () => ({
   resolveTenantFromHost: hoisted.resolveTenantFromHost,
 }));
 vi.mock('@interdomestik/database', () => ({
-  db: {
-    query: {
-      claims: {
-        findFirst: hoisted.findClaimFirst,
-      },
-    },
-  },
-  claims: {
-    id: 'claims.id',
-    tenantId: 'claims.tenantId',
-    userId: 'claims.userId',
-  },
   createAdminClient: hoisted.createAdminClient,
 }));
 vi.mock('drizzle-orm', () => ({
@@ -52,11 +40,30 @@ vi.mock('@/features/admin/claims/actions', () => ({
 vi.mock('@/features/member/claims/actions', () => ({
   confirmUpload: hoisted.confirmUpload,
 }));
+vi.mock('@/features/claims/upload/server/access', () => ({
+  findAccessibleAdminUploadClaim: hoisted.findAccessibleAdminUploadClaim,
+}));
 vi.mock('@sentry/nextjs', () => ({
   captureMessage: hoisted.captureMessage,
 }));
 
 import { POST } from './route';
+
+function createEvidenceUploadRequest(): Request {
+  const form = new FormData();
+  form.set('claimId', 'claim-1');
+  form.set('category', 'evidence');
+  form.set('locale', 'mk');
+  form.set('file', new File(['test'], 'evidence.pdf', { type: 'application/pdf' }));
+
+  return {
+    headers: new Headers({
+      host: 'tenant.example.test',
+      'x-forwarded-host': 'tenant.example.test',
+    }),
+    formData: vi.fn().mockResolvedValue(form),
+  } as unknown as Request;
+}
 
 describe('POST /api/claims/evidence-upload', () => {
   beforeEach(() => {
@@ -67,11 +74,9 @@ describe('POST /api/claims/evidence-upload', () => {
     hoisted.ensureTenantId.mockReturnValue('tenant-1');
     hoisted.resolveEvidenceBucketName.mockReturnValue('claim-evidence');
     hoisted.resolveTenantFromHost.mockReturnValue('tenant-1');
-    hoisted.findClaimFirst.mockResolvedValue({
-      id: 'claim-1',
+    hoisted.findAccessibleAdminUploadClaim.mockResolvedValue({
       branchId: 'branch-1',
       staffId: 'staff-1',
-      userId: 'member-1',
     });
     hoisted.upload.mockResolvedValue({ error: null });
     hoisted.createAdminClient.mockReturnValue({
@@ -86,27 +91,9 @@ describe('POST /api/claims/evidence-upload', () => {
   });
 
   it('denies staff uploads outside branch or assignment scope before storage upload', async () => {
-    hoisted.findClaimFirst.mockResolvedValueOnce({
-      id: 'claim-1',
-      branchId: 'branch-2',
-      staffId: 'staff-9',
-      userId: 'member-1',
-    });
+    hoisted.findAccessibleAdminUploadClaim.mockResolvedValueOnce(null);
 
-    const form = new FormData();
-    form.set('claimId', 'claim-1');
-    form.set('category', 'evidence');
-    form.set('locale', 'mk');
-    form.set('file', new File(['test'], 'evidence.pdf', { type: 'application/pdf' }));
-    const request = {
-      headers: new Headers({
-        host: 'tenant.example.test',
-        'x-forwarded-host': 'tenant.example.test',
-      }),
-      formData: vi.fn().mockResolvedValue(form),
-    } as unknown as Request;
-
-    const response = await POST(request);
+    const response = await POST(createEvidenceUploadRequest());
     const data = await response.json();
 
     expect(response.status).toBe(404);
@@ -122,20 +109,7 @@ describe('POST /api/claims/evidence-upload', () => {
       status: 500,
     });
 
-    const form = new FormData();
-    form.set('claimId', 'claim-1');
-    form.set('category', 'evidence');
-    form.set('locale', 'mk');
-    form.set('file', new File(['test'], 'evidence.pdf', { type: 'application/pdf' }));
-    const request = {
-      headers: new Headers({
-        host: 'tenant.example.test',
-        'x-forwarded-host': 'tenant.example.test',
-      }),
-      formData: vi.fn().mockResolvedValue(form),
-    } as unknown as Request;
-
-    const response = await POST(request);
+    const response = await POST(createEvidenceUploadRequest());
     const data = await response.json();
 
     expect(response.status).toBe(500);

--- a/apps/web/src/app/api/claims/evidence-upload/route.test.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  ensureTenantId: vi.fn(),
+  resolveEvidenceBucketName: vi.fn(),
+  resolveTenantFromHost: vi.fn(),
+  findClaimFirst: vi.fn(),
+  upload: vi.fn(),
+  createAdminClient: vi.fn(),
+  confirmAdminUpload: vi.fn(),
+  confirmUpload: vi.fn(),
+  captureMessage: vi.fn(),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: { api: { getSession: hoisted.getSession } },
+}));
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: hoisted.ensureTenantId,
+}));
+vi.mock('@/lib/storage/evidence-bucket', () => ({
+  resolveEvidenceBucketName: hoisted.resolveEvidenceBucketName,
+}));
+vi.mock('@/lib/tenant/tenant-hosts', () => ({
+  resolveTenantFromHost: hoisted.resolveTenantFromHost,
+}));
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    query: {
+      claims: {
+        findFirst: hoisted.findClaimFirst,
+      },
+    },
+  },
+  claims: {
+    id: 'claims.id',
+    tenantId: 'claims.tenantId',
+    userId: 'claims.userId',
+  },
+  createAdminClient: hoisted.createAdminClient,
+}));
+vi.mock('drizzle-orm', () => ({
+  and: hoisted.and,
+  eq: hoisted.eq,
+}));
+vi.mock('@/features/admin/claims/actions', () => ({
+  confirmAdminUpload: hoisted.confirmAdminUpload,
+}));
+vi.mock('@/features/member/claims/actions', () => ({
+  confirmUpload: hoisted.confirmUpload,
+}));
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: hoisted.captureMessage,
+}));
+
+import { POST } from './route';
+
+describe('POST /api/claims/evidence-upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'staff-1', role: 'staff', branchId: 'branch-1', tenantId: 'tenant-1' },
+    });
+    hoisted.ensureTenantId.mockReturnValue('tenant-1');
+    hoisted.resolveEvidenceBucketName.mockReturnValue('claim-evidence');
+    hoisted.resolveTenantFromHost.mockReturnValue('tenant-1');
+    hoisted.findClaimFirst.mockResolvedValue({
+      id: 'claim-1',
+      branchId: 'branch-1',
+      staffId: 'staff-1',
+      userId: 'member-1',
+    });
+    hoisted.upload.mockResolvedValue({ error: null });
+    hoisted.createAdminClient.mockReturnValue({
+      storage: {
+        from: () => ({
+          upload: hoisted.upload,
+        }),
+      },
+    });
+    hoisted.confirmAdminUpload.mockResolvedValue({ success: true });
+    hoisted.confirmUpload.mockResolvedValue({ success: true });
+  });
+
+  it('denies staff uploads outside branch or assignment scope before storage upload', async () => {
+    hoisted.findClaimFirst.mockResolvedValueOnce({
+      id: 'claim-1',
+      branchId: 'branch-2',
+      staffId: 'staff-9',
+      userId: 'member-1',
+    });
+
+    const form = new FormData();
+    form.set('claimId', 'claim-1');
+    form.set('category', 'evidence');
+    form.set('locale', 'mk');
+    form.set('file', new File(['test'], 'evidence.pdf', { type: 'application/pdf' }));
+    const request = {
+      headers: new Headers({
+        host: 'tenant.example.test',
+        'x-forwarded-host': 'tenant.example.test',
+      }),
+      formData: vi.fn().mockResolvedValue(form),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toEqual({ error: 'Claim not found' });
+    expect(hoisted.upload).not.toHaveBeenCalled();
+    expect(hoisted.confirmAdminUpload).not.toHaveBeenCalled();
+  });
+
+  it('captures orphan-upload telemetry when metadata confirmation fails after storage upload', async () => {
+    hoisted.confirmAdminUpload.mockResolvedValueOnce({
+      success: false,
+      error: 'Failed to save document metadata',
+      status: 500,
+    });
+
+    const form = new FormData();
+    form.set('claimId', 'claim-1');
+    form.set('category', 'evidence');
+    form.set('locale', 'mk');
+    form.set('file', new File(['test'], 'evidence.pdf', { type: 'application/pdf' }));
+    const request = {
+      headers: new Headers({
+        host: 'tenant.example.test',
+        'x-forwarded-host': 'tenant.example.test',
+      }),
+      formData: vi.fn().mockResolvedValue(form),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({ error: 'Failed to save document metadata' });
+    expect(hoisted.captureMessage).toHaveBeenCalledWith(
+      'claim.evidence_upload.confirm_failed_after_storage_upload',
+      expect.objectContaining({
+        level: 'warning',
+      })
+    );
+  });
+});

--- a/apps/web/src/app/api/claims/evidence-upload/route.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.ts
@@ -3,7 +3,7 @@ import {
   resolveStorageUploadContentType,
   resolveUploadMimeType,
 } from '@/features/admin/claims/components/ops/file-upload-meta';
-import { canAccessClaimFromAdminUploadSurface } from '@/features/claims/upload/server/access';
+import { findAccessibleAdminUploadClaim } from '@/features/claims/upload/server/access';
 import { confirmUpload } from '@/features/member/claims/actions';
 import { LOCALES } from '@/i18n/locales';
 import { auth } from '@/lib/auth';
@@ -40,31 +40,26 @@ async function validateClaimAccess(params: {
   const { claimId, role, tenantId, host, userId } = params;
   const isAdminSurface = isAdminUploadRole(role) && resolveTenantFromHost(host) === tenantId;
 
+  if (isAdminSurface) {
+    const claim = await findAccessibleAdminUploadClaim({
+      branchId: params.branchId ?? null,
+      claimId,
+      role,
+      tenantId,
+      userId,
+    });
+
+    return claim ? { success: true, isAdminSurface } : { success: false, status: 404 };
+  }
+
   const claim = await db.query.claims.findFirst({
-    where: isAdminSurface
-      ? and(eq(claims.id, claimId), eq(claims.tenantId, tenantId))
-      : and(eq(claims.id, claimId), eq(claims.tenantId, tenantId), eq(claims.userId, userId)),
+    where: and(eq(claims.id, claimId), eq(claims.tenantId, tenantId), eq(claims.userId, userId)),
     columns: {
       id: true,
-      branchId: true,
-      staffId: true,
-      userId: true,
     },
   });
 
   if (!claim) {
-    return { success: false, status: 404 };
-  }
-
-  if (
-    isAdminSurface &&
-    !canAccessClaimFromAdminUploadSurface({
-      branchId: params.branchId ?? null,
-      claim,
-      role,
-      userId,
-    })
-  ) {
     return { success: false, status: 404 };
   }
 

--- a/apps/web/src/app/api/claims/evidence-upload/route.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.ts
@@ -3,6 +3,7 @@ import {
   resolveStorageUploadContentType,
   resolveUploadMimeType,
 } from '@/features/admin/claims/components/ops/file-upload-meta';
+import { canAccessClaimFromAdminUploadSurface } from '@/features/claims/upload/server/access';
 import { confirmUpload } from '@/features/member/claims/actions';
 import { LOCALES } from '@/i18n/locales';
 import { auth } from '@/lib/auth';
@@ -10,6 +11,7 @@ import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
 import { resolveTenantFromHost } from '@/lib/tenant/tenant-hosts';
 import { claims, createAdminClient, db } from '@interdomestik/database';
 import { ensureTenantId } from '@interdomestik/shared-auth';
+import * as Sentry from '@sentry/nextjs';
 import { randomUUID } from 'crypto';
 import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
@@ -28,6 +30,7 @@ function isAdminUploadRole(role: string | null | undefined): boolean {
 }
 
 async function validateClaimAccess(params: {
+  branchId?: string | null;
   claimId: string;
   role: string | null | undefined;
   tenantId: string;
@@ -43,10 +46,25 @@ async function validateClaimAccess(params: {
       : and(eq(claims.id, claimId), eq(claims.tenantId, tenantId), eq(claims.userId, userId)),
     columns: {
       id: true,
+      branchId: true,
+      staffId: true,
+      userId: true,
     },
   });
 
   if (!claim) {
+    return { success: false, status: 404 };
+  }
+
+  if (
+    isAdminSurface &&
+    !canAccessClaimFromAdminUploadSurface({
+      branchId: params.branchId ?? null,
+      claim,
+      role,
+      userId,
+    })
+  ) {
     return { success: false, status: 404 };
   }
 
@@ -104,6 +122,7 @@ export async function POST(request: Request) {
   const role = session.user.role ?? null;
   const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? '';
   const claimAccess = await validateClaimAccess({
+    branchId: session.user.branchId ?? null,
     claimId,
     role,
     tenantId,
@@ -162,6 +181,21 @@ export async function POST(request: Request) {
       });
 
   if (!confirmResult.success) {
+    Sentry.captureMessage('claim.evidence_upload.confirm_failed_after_storage_upload', {
+      level: 'warning',
+      extra: {
+        claimId,
+        tenantId,
+        userId: session.user.id,
+        role,
+        fileId,
+        bucket,
+        storagePath,
+        category,
+        confirmStatus: confirmResult.status,
+        confirmError: confirmResult.error,
+      },
+    });
     return NextResponse.json({ error: confirmResult.error }, { status: confirmResult.status });
   }
 

--- a/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
+++ b/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
@@ -15,6 +15,8 @@ const hoisted = vi.hoisted(() => {
     insertValues: vi.fn(),
     insert: vi.fn(),
     transaction: vi.fn(),
+    createSignedUploadUrl: vi.fn(),
+    persistClaimDocumentAndQueueWorkflows: vi.fn(),
     and,
     eq,
   };
@@ -42,14 +44,8 @@ vi.mock('@interdomestik/database', () => ({
 vi.mock('drizzle-orm', () => ({ and: hoisted.and, eq: hoisted.eq }));
 vi.mock('next/cache', () => ({ revalidatePath: hoisted.revalidatePath }));
 vi.mock('@/features/claims/upload/server/shared-upload', () => ({
-  createSignedUploadUrl: vi.fn().mockResolvedValue({
-    success: true,
-    bucket: 'claim-evidence',
-    path: 'pii/tenants/tenant-1/claims/claim-1/file.pdf',
-    token: 'upload-token',
-    id: 'file-id',
-  }),
-  persistClaimDocumentAndQueueWorkflows: vi.fn().mockResolvedValue(undefined),
+  createSignedUploadUrl: hoisted.createSignedUploadUrl,
+  persistClaimDocumentAndQueueWorkflows: hoisted.persistClaimDocumentAndQueueWorkflows,
   revalidatePathForAllLocales: (path: string) => hoisted.revalidatePath(`/mk${path}`),
 }));
 
@@ -70,11 +66,23 @@ describe('admin claim evidence upload actions', () => {
     hoisted.ensureTenantId.mockReturnValue('tenant-1');
     hoisted.resolveTenantFromHost.mockReturnValue('tenant-1');
     hoisted.resolveEvidenceBucketName.mockReturnValue('claim-evidence');
-    hoisted.findClaimFirst.mockResolvedValue({ id: 'claim-1' });
+    hoisted.findClaimFirst.mockResolvedValue({
+      id: 'claim-1',
+      branchId: 'branch-1',
+      staffId: 'staff-1',
+    });
     hoisted.insert.mockReturnValue({ values: hoisted.insertValues });
     hoisted.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) =>
       callback({ insert: hoisted.insert })
     );
+    hoisted.createSignedUploadUrl.mockResolvedValue({
+      success: true,
+      bucket: 'claim-evidence',
+      path: 'pii/tenants/tenant-1/claims/claim-1/file.pdf',
+      token: 'upload-token',
+      id: 'file-id',
+    });
+    hoisted.persistClaimDocumentAndQueueWorkflows.mockResolvedValue(undefined);
   });
 
   it('rejects upload URL issuance when the admin host tenant drifts', async () => {
@@ -93,6 +101,53 @@ describe('admin claim evidence upload actions', () => {
     await expect(
       generateAdminUploadUrl('claim-1', 'evidence.pdf', 'application/pdf', 1024)
     ).resolves.toEqual({ success: false, error: 'Unauthorized', status: 401 });
+  });
+
+  it('denies upload URL issuance for staff outside claim scope', async () => {
+    hoisted.authGetSession.mockResolvedValueOnce({
+      user: { id: 'staff-2', tenantId: 'tenant-1', role: 'staff', branchId: 'branch-2' },
+    });
+    hoisted.findClaimFirst.mockResolvedValueOnce({
+      id: 'claim-1',
+      branchId: 'branch-1',
+      staffId: 'staff-1',
+    });
+
+    await expect(
+      generateAdminUploadUrl('claim-1', 'evidence.pdf', 'application/pdf', 1024)
+    ).resolves.toEqual({ success: false, error: 'Claim not found', status: 404 });
+
+    expect(hoisted.createSignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('denies confirm for branch managers outside claim branch scope', async () => {
+    hoisted.authGetSession.mockResolvedValueOnce({
+      user: {
+        id: 'branch-manager-1',
+        tenantId: 'tenant-1',
+        role: 'branch_manager',
+        branchId: 'branch-2',
+      },
+    });
+    hoisted.findClaimFirst.mockResolvedValueOnce({
+      id: 'claim-1',
+      branchId: 'branch-1',
+      staffId: 'staff-1',
+    });
+
+    await expect(
+      confirmAdminUpload({
+        claimId: 'claim-1',
+        storagePath: 'pii/tenants/tenant-1/claims/claim-1/file.pdf',
+        originalName: 'evidence.pdf',
+        mimeType: 'application/pdf',
+        fileSize: 1024,
+        fileId: 'file-id',
+        uploadedBucket: 'claim-evidence',
+      })
+    ).resolves.toEqual({ success: false, error: 'Claim not found', status: 404 });
+
+    expect(hoisted.persistClaimDocumentAndQueueWorkflows).not.toHaveBeenCalled();
   });
 
   it('revalidates admin and staff claim surfaces after confirming upload metadata', async () => {

--- a/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
+++ b/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
@@ -1,26 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const hoisted = vi.hoisted(() => {
-  const and = vi.fn((...args: unknown[]) => ({ op: 'and', args }));
-  const eq = vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right }));
-
-  return {
-    authGetSession: vi.fn(),
-    headers: vi.fn(),
-    ensureTenantId: vi.fn(),
-    resolveTenantFromHost: vi.fn(),
-    resolveEvidenceBucketName: vi.fn(),
-    findClaimFirst: vi.fn(),
-    revalidatePath: vi.fn(),
-    insertValues: vi.fn(),
-    insert: vi.fn(),
-    transaction: vi.fn(),
-    createSignedUploadUrl: vi.fn(),
-    persistClaimDocumentAndQueueWorkflows: vi.fn(),
-    and,
-    eq,
-  };
-});
+const hoisted = vi.hoisted(() => ({
+  authGetSession: vi.fn(),
+  headers: vi.fn(),
+  ensureTenantId: vi.fn(),
+  resolveTenantFromHost: vi.fn(),
+  resolveEvidenceBucketName: vi.fn(),
+  findAccessibleAdminUploadClaim: vi.fn(),
+  revalidatePath: vi.fn(),
+  createSignedUploadUrl: vi.fn(),
+  persistClaimDocumentAndQueueWorkflows: vi.fn(),
+}));
 
 vi.mock('@/lib/auth', () => ({
   auth: { api: { getSession: hoisted.authGetSession } },
@@ -33,16 +23,10 @@ vi.mock('@/lib/tenant/tenant-hosts', () => ({
 vi.mock('@/lib/storage/evidence-bucket', () => ({
   resolveEvidenceBucketName: hoisted.resolveEvidenceBucketName,
 }));
-vi.mock('@interdomestik/database', () => ({
-  db: {
-    query: { claims: { findFirst: hoisted.findClaimFirst } },
-    insert: hoisted.insert,
-    transaction: hoisted.transaction,
-  },
-  claims: { id: 'claims.id', tenantId: 'claims.tenant_id' },
-}));
-vi.mock('drizzle-orm', () => ({ and: hoisted.and, eq: hoisted.eq }));
 vi.mock('next/cache', () => ({ revalidatePath: hoisted.revalidatePath }));
+vi.mock('@/features/claims/upload/server/access', () => ({
+  findAccessibleAdminUploadClaim: hoisted.findAccessibleAdminUploadClaim,
+}));
 vi.mock('@/features/claims/upload/server/shared-upload', () => ({
   createSignedUploadUrl: hoisted.createSignedUploadUrl,
   persistClaimDocumentAndQueueWorkflows: hoisted.persistClaimDocumentAndQueueWorkflows,
@@ -66,15 +50,10 @@ describe('admin claim evidence upload actions', () => {
     hoisted.ensureTenantId.mockReturnValue('tenant-1');
     hoisted.resolveTenantFromHost.mockReturnValue('tenant-1');
     hoisted.resolveEvidenceBucketName.mockReturnValue('claim-evidence');
-    hoisted.findClaimFirst.mockResolvedValue({
-      id: 'claim-1',
+    hoisted.findAccessibleAdminUploadClaim.mockResolvedValue({
       branchId: 'branch-1',
       staffId: 'staff-1',
     });
-    hoisted.insert.mockReturnValue({ values: hoisted.insertValues });
-    hoisted.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) =>
-      callback({ insert: hoisted.insert })
-    );
     hoisted.createSignedUploadUrl.mockResolvedValue({
       success: true,
       bucket: 'claim-evidence',
@@ -107,11 +86,7 @@ describe('admin claim evidence upload actions', () => {
     hoisted.authGetSession.mockResolvedValueOnce({
       user: { id: 'staff-2', tenantId: 'tenant-1', role: 'staff', branchId: 'branch-2' },
     });
-    hoisted.findClaimFirst.mockResolvedValueOnce({
-      id: 'claim-1',
-      branchId: 'branch-1',
-      staffId: 'staff-1',
-    });
+    hoisted.findAccessibleAdminUploadClaim.mockResolvedValueOnce(null);
 
     await expect(
       generateAdminUploadUrl('claim-1', 'evidence.pdf', 'application/pdf', 1024)
@@ -129,11 +104,7 @@ describe('admin claim evidence upload actions', () => {
         branchId: 'branch-2',
       },
     });
-    hoisted.findClaimFirst.mockResolvedValueOnce({
-      id: 'claim-1',
-      branchId: 'branch-1',
-      staffId: 'staff-1',
-    });
+    hoisted.findAccessibleAdminUploadClaim.mockResolvedValueOnce(null);
 
     await expect(
       confirmAdminUpload({

--- a/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
+++ b/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
@@ -95,6 +95,25 @@ describe('admin claim evidence upload actions', () => {
     expect(hoisted.createSignedUploadUrl).not.toHaveBeenCalled();
   });
 
+  it('allows assigned staff even when the claim branch differs', async () => {
+    hoisted.authGetSession.mockResolvedValueOnce({
+      user: { id: 'staff-2', tenantId: 'tenant-1', role: 'staff', branchId: 'branch-2' },
+    });
+    hoisted.findAccessibleAdminUploadClaim.mockResolvedValueOnce({
+      branchId: 'branch-1',
+      staffId: 'staff-2',
+    });
+
+    await expect(
+      generateAdminUploadUrl('claim-1', 'evidence.pdf', 'application/pdf', 1024)
+    ).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        id: 'file-id',
+      })
+    );
+  });
+
   it('denies confirm for branch managers outside claim branch scope', async () => {
     hoisted.authGetSession.mockResolvedValueOnce({
       user: {

--- a/apps/web/src/features/admin/claims/actions/evidence-upload.ts
+++ b/apps/web/src/features/admin/claims/actions/evidence-upload.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { canAccessClaimFromAdminUploadSurface } from '@/features/claims/upload/server/access';
+import { findAccessibleAdminUploadClaim } from '@/features/claims/upload/server/access';
 import {
   createSignedUploadUrl,
   persistClaimDocumentAndQueueWorkflows,
@@ -9,9 +9,7 @@ import {
 import { auth } from '@/lib/auth';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
 import { resolveTenantFromHost } from '@/lib/tenant/tenant-hosts';
-import { claims, db } from '@interdomestik/database';
 import { ensureTenantId } from '@interdomestik/shared-auth';
-import { and, eq } from 'drizzle-orm';
 import { headers } from 'next/headers';
 const ALLOWED_ADMIN_UPLOAD_ROLES = new Set([
   'admin',
@@ -109,24 +107,15 @@ export async function generateAdminUploadUrl(
   }
 
   const { tenantId, resolvedBucket } = uploadContext;
-  const claim = await db.query.claims.findFirst({
-    where: and(eq(claims.id, claimId), eq(claims.tenantId, tenantId)),
-    columns: {
-      id: true,
-      branchId: true,
-      staffId: true,
-    },
+  const claim = await findAccessibleAdminUploadClaim({
+    branchId: uploadContext.session.user.branchId ?? null,
+    claimId,
+    role: uploadContext.session.user.role ?? null,
+    tenantId,
+    userId: uploadContext.session.user.id,
   });
 
-  if (
-    !claim ||
-    !canAccessClaimFromAdminUploadSurface({
-      branchId: uploadContext.session.user.branchId ?? null,
-      claim,
-      role: uploadContext.session.user.role ?? null,
-      userId: uploadContext.session.user.id,
-    })
-  ) {
+  if (!claim) {
     return { success: false, error: 'Claim not found', status: 404 };
   }
 
@@ -156,24 +145,15 @@ export async function confirmAdminUpload({
   }
 
   const { session, tenantId, resolvedBucket } = uploadContext;
-  const claim = await db.query.claims.findFirst({
-    where: and(eq(claims.id, claimId), eq(claims.tenantId, tenantId)),
-    columns: {
-      id: true,
-      branchId: true,
-      staffId: true,
-    },
+  const claim = await findAccessibleAdminUploadClaim({
+    branchId: session.user.branchId ?? null,
+    claimId,
+    role: session.user.role ?? null,
+    tenantId,
+    userId: session.user.id,
   });
 
-  if (
-    !claim ||
-    !canAccessClaimFromAdminUploadSurface({
-      branchId: session.user.branchId ?? null,
-      claim,
-      role: session.user.role ?? null,
-      userId: session.user.id,
-    })
-  ) {
+  if (!claim) {
     return { success: false, error: 'Claim not found', status: 404 };
   }
 

--- a/apps/web/src/features/admin/claims/actions/evidence-upload.ts
+++ b/apps/web/src/features/admin/claims/actions/evidence-upload.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { canAccessClaimFromAdminUploadSurface } from '@/features/claims/upload/server/access';
 import {
   createSignedUploadUrl,
   persistClaimDocumentAndQueueWorkflows,
@@ -110,9 +111,22 @@ export async function generateAdminUploadUrl(
   const { tenantId, resolvedBucket } = uploadContext;
   const claim = await db.query.claims.findFirst({
     where: and(eq(claims.id, claimId), eq(claims.tenantId, tenantId)),
+    columns: {
+      id: true,
+      branchId: true,
+      staffId: true,
+    },
   });
 
-  if (!claim) {
+  if (
+    !claim ||
+    !canAccessClaimFromAdminUploadSurface({
+      branchId: uploadContext.session.user.branchId ?? null,
+      claim,
+      role: uploadContext.session.user.role ?? null,
+      userId: uploadContext.session.user.id,
+    })
+  ) {
     return { success: false, error: 'Claim not found', status: 404 };
   }
 
@@ -144,9 +158,22 @@ export async function confirmAdminUpload({
   const { session, tenantId, resolvedBucket } = uploadContext;
   const claim = await db.query.claims.findFirst({
     where: and(eq(claims.id, claimId), eq(claims.tenantId, tenantId)),
+    columns: {
+      id: true,
+      branchId: true,
+      staffId: true,
+    },
   });
 
-  if (!claim) {
+  if (
+    !claim ||
+    !canAccessClaimFromAdminUploadSurface({
+      branchId: session.user.branchId ?? null,
+      claim,
+      role: session.user.role ?? null,
+      userId: session.user.id,
+    })
+  ) {
     return { success: false, error: 'Claim not found', status: 404 };
   }
 

--- a/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.test.ts
+++ b/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  ensureClaimsAccess: vi.fn(),
+  setTag: vi.fn(),
+  withServerActionInstrumentation: vi.fn(
+    async (_name: string, _options: unknown, callback: () => Promise<unknown>) => callback()
+  ),
+  buildClaimVisibilityWhere: vi.fn(),
+  findManyUsers: vi.fn(),
+  selectWhere: vi.fn(),
+  findManyClaims: vi.fn(),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  inArray: vi.fn((left: unknown, right: unknown) => ({ op: 'inArray', left, right })),
+  ne: vi.fn((left: unknown, right: unknown) => ({ op: 'ne', left, right })),
+  desc: vi.fn((value: unknown) => ({ op: 'desc', value })),
+}));
+
+vi.mock('../../../../server/domains/claims/guards', () => ({
+  ensureClaimsAccess: hoisted.ensureClaimsAccess,
+}));
+vi.mock('@sentry/nextjs', () => ({
+  setTag: hoisted.setTag,
+  withServerActionInstrumentation: hoisted.withServerActionInstrumentation,
+}));
+vi.mock('../utils', () => ({
+  buildClaimVisibilityWhere: hoisted.buildClaimVisibilityWhere,
+}));
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    query: {
+      user: {
+        findMany: hoisted.findManyUsers,
+      },
+      claims: {
+        findMany: hoisted.findManyClaims,
+      },
+    },
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: hoisted.selectWhere,
+      })),
+    })),
+  },
+}));
+vi.mock('@interdomestik/database/schema', () => ({
+  claims: {
+    userId: 'claims.userId',
+    status: 'claims.status',
+    updatedAt: 'claims.updatedAt',
+  },
+  user: {
+    tenantId: 'user.tenantId',
+    agentId: 'user.agentId',
+    id: 'user.id',
+  },
+  agentClients: {
+    memberId: 'agentClients.memberId',
+    tenantId: 'agentClients.tenantId',
+    agentId: 'agentClients.agentId',
+    status: 'agentClients.status',
+  },
+}));
+vi.mock('drizzle-orm', () => ({
+  and: hoisted.and,
+  desc: hoisted.desc,
+  eq: hoisted.eq,
+  inArray: hoisted.inArray,
+  ne: hoisted.ne,
+}));
+
+import { getAgentMemberClaims } from './getAgentMemberClaims';
+
+describe('getAgentMemberClaims', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.ensureClaimsAccess.mockReturnValue({
+      tenantId: 'tenant-1',
+      userId: 'agent-1',
+      role: 'agent',
+      branchId: 'branch-1',
+    });
+    hoisted.buildClaimVisibilityWhere.mockReturnValue({ op: 'visibility' });
+    hoisted.findManyUsers.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: 'member-2',
+        name: 'Member Two',
+        email: 'member2@example.com',
+      },
+    ]);
+    hoisted.selectWhere.mockResolvedValue([{ memberId: 'member-2' }]);
+    hoisted.findManyClaims.mockResolvedValue([
+      {
+        id: 'claim-2',
+        title: 'Claim Two',
+        status: 'submitted',
+        createdAt: new Date('2026-04-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+        userId: 'member-2',
+      },
+    ]);
+  });
+
+  it('includes members linked through active agent_clients when user.agentId is empty', async () => {
+    const result = await getAgentMemberClaims({
+      user: { id: 'agent-1', role: 'agent', branchId: 'branch-1', tenantId: 'tenant-1' },
+    });
+
+    expect(result).toEqual([
+      {
+        memberId: 'member-2',
+        memberName: 'Member Two',
+        memberEmail: 'member2@example.com',
+        claims: [
+          {
+            id: 'claim-2',
+            title: 'Claim Two',
+            status: 'submitted',
+            statusLabelKey: 'claims-tracking.status.submitted',
+            createdAt: new Date('2026-04-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+          },
+        ],
+      },
+    ]);
+
+    expect(hoisted.buildClaimVisibilityWhere).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      userId: 'agent-1',
+      role: 'agent',
+      branchId: 'branch-1',
+      agentMemberIds: ['member-2'],
+    });
+  });
+});

--- a/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.ts
+++ b/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.ts
@@ -1,5 +1,5 @@
 import { db } from '@interdomestik/database';
-import { claims, user } from '@interdomestik/database/schema';
+import { agentClients, claims, user } from '@interdomestik/database/schema';
 import * as Sentry from '@sentry/nextjs';
 import { and, desc, eq, inArray, ne } from 'drizzle-orm';
 import 'server-only';
@@ -42,18 +42,52 @@ export async function getAgentMemberClaims(session: any): Promise<AgentMemberCla
         // allowing broader roles for flexibility if they visit the page.
       }
 
-      // 2. Fetch Members assigned to this agent
-      // We need to know which members this agent manages.
-      // Logic: User.agentId == session.userId
+      const [membersByUserAgent, activeAgentClientRows] = await Promise.all([
+        db.query.user.findMany({
+          where: and(eq(user.tenantId, tenantId), eq(user.agentId, userId)),
+          columns: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        }),
+        db
+          .select({ memberId: agentClients.memberId })
+          .from(agentClients)
+          .where(
+            and(
+              eq(agentClients.tenantId, tenantId),
+              eq(agentClients.agentId, userId),
+              eq(agentClients.status, 'active')
+            )
+          ),
+      ]);
 
-      const members = await db.query.user.findMany({
-        where: and(eq(user.tenantId, tenantId), eq(user.agentId, userId)),
-        columns: {
-          id: true,
-          name: true,
-          email: true,
-        },
-      });
+      const memberById = new Map<string, { id: string; name: string; email: string }>();
+      for (const member of membersByUserAgent) {
+        memberById.set(member.id, member);
+      }
+
+      const memberIdsFromAgentClients = activeAgentClientRows
+        .map(row => row.memberId)
+        .filter(memberId => typeof memberId === 'string' && !memberById.has(memberId));
+
+      if (memberIdsFromAgentClients.length > 0) {
+        const additionalMembers = await db.query.user.findMany({
+          where: and(eq(user.tenantId, tenantId), inArray(user.id, memberIdsFromAgentClients)),
+          columns: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        });
+
+        for (const member of additionalMembers) {
+          memberById.set(member.id, member);
+        }
+      }
+
+      const members = Array.from(memberById.values());
 
       if (members.length === 0) {
         return [];

--- a/apps/web/src/features/claims/upload/server/access.test.ts
+++ b/apps/web/src/features/claims/upload/server/access.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { canAccessClaimFromAdminUploadSurface } from './access';
+
+describe('canAccessClaimFromAdminUploadSurface', () => {
+  it('allows assigned staff even when the claim branch differs', () => {
+    expect(
+      canAccessClaimFromAdminUploadSurface({
+        branchId: 'branch-2',
+        claim: { branchId: 'branch-1', staffId: 'staff-2' },
+        role: 'staff',
+        userId: 'staff-2',
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/features/claims/upload/server/access.ts
+++ b/apps/web/src/features/claims/upload/server/access.ts
@@ -1,0 +1,38 @@
+type ClaimScopeRecord = {
+  branchId?: string | null;
+  staffId?: string | null;
+};
+
+const FULL_TENANT_CLAIMS_ROLES = new Set(['admin', 'tenant_admin', 'super_admin']);
+
+export function canAccessClaimFromAdminUploadSurface(args: {
+  branchId?: string | null;
+  claim: ClaimScopeRecord;
+  role: string | null | undefined;
+  userId: string;
+}): boolean {
+  const { claim, role, userId } = args;
+  const branchId = args.branchId ?? null;
+
+  if (!role) {
+    return false;
+  }
+
+  if (FULL_TENANT_CLAIMS_ROLES.has(role)) {
+    return true;
+  }
+
+  if (role === 'branch_manager') {
+    return branchId !== null && claim.branchId === branchId;
+  }
+
+  if (role !== 'staff') {
+    return false;
+  }
+
+  if (branchId !== null) {
+    return claim.branchId === branchId;
+  }
+
+  return claim.staffId === userId || claim.staffId == null;
+}

--- a/apps/web/src/features/claims/upload/server/access.ts
+++ b/apps/web/src/features/claims/upload/server/access.ts
@@ -34,7 +34,7 @@ export function canAccessClaimFromAdminUploadSurface(args: {
   }
 
   if (branchId !== null) {
-    return claim.branchId === branchId;
+    return claim.branchId === branchId || claim.staffId === userId;
   }
 
   return claim.staffId === userId || claim.staffId == null;

--- a/apps/web/src/features/claims/upload/server/access.ts
+++ b/apps/web/src/features/claims/upload/server/access.ts
@@ -1,3 +1,6 @@
+import { claims, db } from '@interdomestik/database';
+import { and, eq } from 'drizzle-orm';
+
 type ClaimScopeRecord = {
   branchId?: string | null;
   staffId?: string | null;
@@ -35,4 +38,34 @@ export function canAccessClaimFromAdminUploadSurface(args: {
   }
 
   return claim.staffId === userId || claim.staffId == null;
+}
+
+export async function findAccessibleAdminUploadClaim(args: {
+  branchId?: string | null;
+  claimId: string;
+  role: string | null | undefined;
+  tenantId: string;
+  userId: string;
+}): Promise<ClaimScopeRecord | null> {
+  const claim = await db.query.claims.findFirst({
+    where: and(eq(claims.id, args.claimId), eq(claims.tenantId, args.tenantId)),
+    columns: {
+      branchId: true,
+      staffId: true,
+    },
+  });
+
+  if (
+    !claim ||
+    !canAccessClaimFromAdminUploadSurface({
+      branchId: args.branchId ?? null,
+      claim,
+      role: args.role,
+      userId: args.userId,
+    })
+  ) {
+    return null;
+  }
+
+  return claim;
 }


### PR DESCRIPTION
## Summary
- harden admin-surface claim evidence upload by reusing scoped claim access for staff and branch managers before upload and before confirm
- align agent claim tracking visibility with active `agent_clients` membership instead of relying only on `user.agentId`
- emit Sentry telemetry when storage upload succeeds but evidence confirmation fails, and add regression coverage for the affected paths

## Why
This closes the highest-signal lifecycle gaps left after the earlier claim RBAC hardening slice:
- staff and branch-manager upload surfaces were still tenant-wide on the confirm path
- one agent tracking path could drift from the rest of the agent visibility rules
- orphaned post-upload failures were silent

## Test Plan
- `pnpm --filter @interdomestik/web test:unit --run src/features/admin/claims/actions/evidence-upload.test.ts src/app/api/claims/evidence-upload/route.test.ts src/features/claims/tracking/server/getAgentMemberClaims.test.ts`
- `pnpm check:fast`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate`
