### PR TITLE
[codex] Canonicalize annual membership fulfillment

### DIFF
--- a/apps/web/src/actions/billing-test.ts
+++ b/apps/web/src/actions/billing-test.ts
@@ -2,6 +2,7 @@
 
 import { auth } from '@/lib/auth';
 import { db, subscriptions } from '@interdomestik/database';
+import { createActiveAnnualMembershipState } from '@interdomestik/domain-membership-billing/annual-membership';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
@@ -24,6 +25,7 @@ export async function mockActivateSubscription(planId: string, priceId: string) 
   }
 
   const tenantId = ensureTenantId(session);
+  const activeAnnualMembershipState = createActiveAnnualMembershipState(new Date());
 
   // Create or update mock subscription
   await db
@@ -33,17 +35,13 @@ export async function mockActivateSubscription(planId: string, priceId: string) 
       userId: session.user.id,
       tenantId,
       planId,
-      status: 'active',
-      currentPeriodStart: new Date(),
-      currentPeriodEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year
+      ...activeAnnualMembershipState,
     })
     .onConflictDoUpdate({
       target: [subscriptions.userId],
       set: {
-        status: 'active',
         planId,
-        currentPeriodStart: new Date(),
-        currentPeriodEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+        ...activeAnnualMembershipState,
       },
     });
 

--- a/apps/web/src/actions/subscription.core.ts
+++ b/apps/web/src/actions/subscription.core.ts
@@ -4,6 +4,7 @@ import { logAuditEvent } from '@/lib/audit';
 import { getSponsoredMembershipState } from '@/components/ops/adapters/membership';
 import { revalidatePath } from 'next/cache';
 import { and, db, eq, subscriptions } from '@interdomestik/database';
+import { createActiveAnnualMembershipState } from '@interdomestik/domain-membership-billing/annual-membership';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { cancelSubscriptionCore } from './subscription/cancel';
 import { getActionContext } from './subscription/context';
@@ -61,15 +62,12 @@ export async function activateSponsoredMembership(subscriptionId: string) {
   }
 
   const currentPeriodStart = new Date();
-  const currentPeriodEnd = new Date(currentPeriodStart);
-  currentPeriodEnd.setFullYear(currentPeriodEnd.getFullYear() + 1);
+  const activeAnnualMembershipState = createActiveAnnualMembershipState(currentPeriodStart);
 
   await db
     .update(subscriptions)
     .set({
-      status: 'active',
-      currentPeriodStart,
-      currentPeriodEnd,
+      ...activeAnnualMembershipState,
       updatedAt: currentPeriodStart,
     })
     .where(eq(subscriptions.id, subscriptionId));

--- a/apps/web/src/lib/actions/agent/register-member.core.ts
+++ b/apps/web/src/lib/actions/agent/register-member.core.ts
@@ -1,5 +1,6 @@
 import { sendMemberWelcomeEmail } from '@/lib/email';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
+import { createActiveAnnualMembershipState } from '@interdomestik/domain-membership-billing/annual-membership';
 import {
   account,
   agentClients,
@@ -101,16 +102,7 @@ export async function registerMemberCore(
               currentPeriodStart: null,
               currentPeriodEnd: null,
             }
-          : (() => {
-              const expiry = new Date();
-              expiry.setFullYear(expiry.getFullYear() + 1);
-
-              return {
-                status: 'active' as const,
-                currentPeriodStart: now,
-                currentPeriodEnd: expiry,
-              };
-            })();
+          : createActiveAnnualMembershipState(now);
 
       await tx.insert(subscriptions).values({
         id: nanoid(),

--- a/apps/web/src/lib/actions/agent/register-member.wrapper.test.ts
+++ b/apps/web/src/lib/actions/agent/register-member.wrapper.test.ts
@@ -39,6 +39,7 @@ vi.mock('@interdomestik/database/member-number', () => ({
 
 vi.mock('nanoid', () => ({
   nanoid: vi.fn().mockReturnValue('new-id'),
+  customAlphabet: vi.fn(() => () => 'REFCODE01'),
 }));
 
 describe('registerMemberCore', () => {

--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -37,6 +37,7 @@ vi.mock('@interdomestik/database/schema', () => tableRefs);
 
 vi.mock('nanoid', () => ({
   nanoid: mocks.nanoid,
+  customAlphabet: vi.fn(() => () => 'REFCODE01'),
 }));
 
 import { convertLeadToMember } from './convert';
@@ -125,6 +126,7 @@ describe('convertLeadToMember', () => {
 
   it('defaults lead conversion to the standard annual plan and creates agent binding', async () => {
     const now = new Date('2026-04-16T09:00:00.000Z');
+    const expectedPeriodEnd = new Date('2027-04-16T09:00:00.000Z');
     vi.useFakeTimers();
     vi.setSystemTime(now);
 
@@ -170,6 +172,8 @@ describe('convertLeadToMember', () => {
       planId: 'standard',
       agentId: 'agent-1',
       branchId: 'branch-1',
+      currentPeriodStart: now,
+      currentPeriodEnd: expectedPeriodEnd,
       createdAt: now,
       updatedAt: now,
     });
@@ -219,6 +223,7 @@ describe('convertLeadToMember', () => {
 
   it('does not create an agent binding when the lead has no agent', async () => {
     const now = new Date('2026-04-16T10:00:00.000Z');
+    const expectedPeriodEnd = new Date('2027-04-16T10:00:00.000Z');
     vi.useFakeTimers();
     vi.setSystemTime(now);
 
@@ -255,6 +260,8 @@ describe('convertLeadToMember', () => {
     expect(subscriptionInsert).toMatchObject({
       planId: 'family',
       branchId: 'branch-1',
+      currentPeriodStart: now,
+      currentPeriodEnd: expectedPeriodEnd,
       updatedAt: now,
     });
   });

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -1,5 +1,6 @@
 import { and, db, eq } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
+import { createActiveAnnualMembershipState } from '@interdomestik/domain-membership-billing/annual-membership';
 import {
   agentClients,
   memberLeads,
@@ -46,6 +47,7 @@ export async function convertLeadToMember(
 
   const userId = `usr_${nanoid()}`;
   const now = new Date();
+  const annualMembershipState = createActiveAnnualMembershipState(now);
 
   return await db.transaction(async tx => {
     // A. Insert User with role='member'
@@ -73,10 +75,10 @@ export async function convertLeadToMember(
       id: subscriptionId,
       tenantId: ctx.tenantId,
       userId,
-      status: 'active',
       planId,
       agentId: lead.agentId,
       branchId: lead.branchId,
+      ...annualMembershipState,
       createdAt: now,
       updatedAt: now,
     });

--- a/packages/domain-membership-billing/package.json
+++ b/packages/domain-membership-billing/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./annual-membership": "./src/annual-membership.ts",
     "./paddle": "./src/paddle.ts",
     "./paddle-server": "./src/paddle-server.ts",
     "./subscription": "./src/subscription.ts",

--- a/packages/domain-membership-billing/src/annual-membership.test.ts
+++ b/packages/domain-membership-billing/src/annual-membership.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { createActiveAnnualMembershipState } from './annual-membership';
+
+describe('createActiveAnnualMembershipState', () => {
+  it('builds an active annual membership term from a single baseline timestamp', () => {
+    const now = new Date('2026-04-16T09:00:00.000Z');
+
+    expect(createActiveAnnualMembershipState(now)).toEqual({
+      status: 'active',
+      currentPeriodStart: now,
+      currentPeriodEnd: new Date('2027-04-16T09:00:00.000Z'),
+    });
+  });
+
+  it('keeps leap-day memberships anchored to the same baseline instant', () => {
+    const now = new Date('2024-02-29T12:30:00.000Z');
+
+    expect(createActiveAnnualMembershipState(now)).toEqual({
+      status: 'active',
+      currentPeriodStart: now,
+      currentPeriodEnd: new Date('2025-03-01T12:30:00.000Z'),
+    });
+  });
+});

--- a/packages/domain-membership-billing/src/annual-membership.ts
+++ b/packages/domain-membership-billing/src/annual-membership.ts
@@ -1,0 +1,15 @@
+export function createActiveAnnualMembershipState(now: Date): {
+  status: 'active';
+  currentPeriodStart: Date;
+  currentPeriodEnd: Date;
+} {
+  const currentPeriodStart = now;
+  const currentPeriodEnd = new Date(now);
+  currentPeriodEnd.setFullYear(currentPeriodEnd.getFullYear() + 1);
+
+  return {
+    status: 'active',
+    currentPeriodStart,
+    currentPeriodEnd,
+  };
+}

--- a/packages/domain-membership-billing/src/index.ts
+++ b/packages/domain-membership-billing/src/index.ts
@@ -3,6 +3,7 @@ export * from './commissions/admin/bulk-approve';
 export * from './commissions/admin/get-all';
 export * from './commissions/admin/summary';
 export * from './commissions/admin/update-status';
+export * from './annual-membership';
 export * from './commissions/create';
 export * from './commissions/create-renewal';
 export * from './commissions/get-my';


### PR DESCRIPTION
## What changed
- added a shared `createActiveAnnualMembershipState` helper in `@interdomestik/domain-membership-billing`
- switched manual paid-member activation paths to use the same durable annual fulfillment shape
- covered the helper and lead-conversion/manual activation paths with focused regression tests

## Why
`PC01` requires all paid-member paths to converge on the same durable annual-membership fulfillment state so member-facing success stays aligned with back-office truth. Lead conversion was fixed first; this follow-up removes the remaining duplicated manual annual-membership writers.

## Scope
- `packages/domain-membership-billing`
- `packages/domain-leads`
- manual activation paths in `apps/web`

## Verification
- passed: `pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/annual-membership.test.ts`
- passed: `pnpm --filter @interdomestik/domain-leads test:unit --run src/convert.test.ts`
- passed: `pnpm --filter @interdomestik/web test:unit --run src/lib/actions/agent/register-member.wrapper.test.ts`
- passed: `pnpm --filter @interdomestik/web test:unit --run src/actions/subscription.core.test.ts`
- passed earlier in this change line: `pnpm security:guard`
- not yet completed for this published commit: `pnpm pr:verify`, `pnpm e2e:gate`

## Notes
This PR intentionally excludes unrelated local claim-upload and tooling changes already present in the worktree.
