### PR TITLE
feat: canonicalize paid membership fulfillment state

### DIFF
--- a/apps/web/src/actions/analytics/get-admin.core.ts
+++ b/apps/web/src/actions/analytics/get-admin.core.ts
@@ -50,9 +50,13 @@ export async function getAdminAnalyticsCore(params: {
       .from(subscriptions)
       .innerJoin(
         membershipPlans,
-        or(
-          eq(subscriptions.planId, membershipPlans.id),
-          eq(subscriptions.planId, membershipPlans.paddlePriceId)
+        and(
+          eq(subscriptions.tenantId, membershipPlans.tenantId),
+          or(
+            eq(subscriptions.planKey, membershipPlans.id),
+            eq(subscriptions.planId, membershipPlans.id),
+            eq(subscriptions.planId, membershipPlans.paddlePriceId)
+          )
         )
       )
       .where(and(eq(subscriptions.status, 'active'), eq(subscriptions.tenantId, tenantId)));

--- a/apps/web/src/actions/analytics/get-admin.core.ts
+++ b/apps/web/src/actions/analytics/get-admin.core.ts
@@ -1,6 +1,6 @@
 import { db } from '@interdomestik/database';
 import { membershipPlans, subscriptions } from '@interdomestik/database/schema';
-import { and, eq, gte, sql } from 'drizzle-orm';
+import { and, eq, gte, or, sql } from 'drizzle-orm';
 
 import { isStaffOrAdmin } from '@/lib/roles.core';
 
@@ -48,7 +48,13 @@ export async function getAdminAnalyticsCore(params: {
         createdAt: subscriptions.createdAt,
       })
       .from(subscriptions)
-      .innerJoin(membershipPlans, eq(subscriptions.planId, membershipPlans.paddlePriceId))
+      .innerJoin(
+        membershipPlans,
+        or(
+          eq(subscriptions.planId, membershipPlans.id),
+          eq(subscriptions.planId, membershipPlans.paddlePriceId)
+        )
+      )
       .where(and(eq(subscriptions.status, 'active'), eq(subscriptions.tenantId, tenantId)));
 
     let mrr = 0;

--- a/apps/web/src/actions/analytics/get-admin.test.ts
+++ b/apps/web/src/actions/analytics/get-admin.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { and, eq, or } from 'drizzle-orm';
 
 import type { Session } from './context';
 import { getAdminAnalyticsCore } from './get-admin';
@@ -24,14 +25,26 @@ vi.mock('@interdomestik/database', () => {
         from: vi.fn(() => queryBuilder),
       })),
     },
-    membershipPlans: { price: 'membershipPlans.price' },
-    subscriptions: {
-      id: 'subscriptions.id',
-      tenantId: 'subscriptions.tenantId',
-      createdAt: 'subscriptions.createdAt',
-    },
   };
 });
+
+vi.mock('@interdomestik/database/schema', () => ({
+  subscriptions: {
+    id: 'subscriptions.id',
+    planId: 'subscriptions.planId',
+    planKey: 'subscriptions.planKey',
+    tenantId: 'subscriptions.tenantId',
+    status: 'subscriptions.status',
+    createdAt: 'subscriptions.createdAt',
+  },
+  membershipPlans: {
+    id: 'membershipPlans.id',
+    paddlePriceId: 'membershipPlans.paddlePriceId',
+    tenantId: 'membershipPlans.tenantId',
+    price: 'membershipPlans.price',
+    interval: 'membershipPlans.interval',
+  },
+}));
 
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn(),
@@ -92,5 +105,11 @@ describe('actions/analytics getAdminAnalyticsCore', () => {
     });
 
     expect(result.success).toBe(true);
+    expect(eq).toHaveBeenCalledWith('subscriptions.planKey', 'membershipPlans.id');
+    expect(eq).toHaveBeenCalledWith('subscriptions.planId', 'membershipPlans.id');
+    expect(eq).toHaveBeenCalledWith('subscriptions.planId', 'membershipPlans.paddlePriceId');
+    expect(eq).toHaveBeenCalledWith('subscriptions.tenantId', 'membershipPlans.tenantId');
+    expect(or).toHaveBeenCalled();
+    expect(and).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/actions/analytics/get-admin.test.ts
+++ b/apps/web/src/actions/analytics/get-admin.test.ts
@@ -37,6 +37,7 @@ vi.mock('drizzle-orm', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   gte: vi.fn(),
+  or: vi.fn(),
   sql: vi.fn(),
   desc: vi.fn(),
   relations: vi.fn(),

--- a/apps/web/src/actions/subscription.core.test.ts
+++ b/apps/web/src/actions/subscription.core.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   getActionContext: vi.fn(),
   revalidatePath: vi.fn(),
   findSubscriptionFirst: vi.fn(),
+  findMembershipPlan: vi.fn(),
   update: vi.fn(),
   set: vi.fn(),
   where: vi.fn(),
@@ -26,6 +27,9 @@ vi.mock('@interdomestik/database', () => ({
       subscriptions: {
         findFirst: mocks.findSubscriptionFirst,
       },
+      membershipPlans: {
+        findFirst: mocks.findMembershipPlan,
+      },
     },
     update: mocks.update,
   },
@@ -42,6 +46,10 @@ import { activateSponsoredMembership } from './subscription.core';
 describe('subscription.core activateSponsoredMembership', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.findMembershipPlan.mockResolvedValue({
+      id: 'tenant-standard-plan',
+      tier: 'standard',
+    });
     mocks.update.mockReturnValue({
       set: mocks.set.mockReturnValue({
         where: mocks.where.mockResolvedValue(undefined),
@@ -83,6 +91,8 @@ describe('subscription.core activateSponsoredMembership', () => {
     expect(mocks.set).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'active',
+        planId: 'standard',
+        planKey: 'tenant-standard-plan',
         currentPeriodStart: expect.any(Date),
         currentPeriodEnd: expect.any(Date),
       })

--- a/apps/web/src/actions/subscription.core.ts
+++ b/apps/web/src/actions/subscription.core.ts
@@ -4,7 +4,10 @@ import { logAuditEvent } from '@/lib/audit';
 import { getSponsoredMembershipState } from '@/components/ops/adapters/membership';
 import { revalidatePath } from 'next/cache';
 import { and, db, eq, subscriptions } from '@interdomestik/database';
-import { createActiveAnnualMembershipState } from '@interdomestik/domain-membership-billing/annual-membership';
+import {
+  createActiveAnnualMembershipFulfillment,
+  resolveCanonicalMembershipPlanState,
+} from '@interdomestik/domain-membership-billing';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { cancelSubscriptionCore } from './subscription/cancel';
 import { getActionContext } from './subscription/context';
@@ -62,7 +65,21 @@ export async function activateSponsoredMembership(subscriptionId: string) {
   }
 
   const currentPeriodStart = new Date();
-  const activeAnnualMembershipState = createActiveAnnualMembershipState(currentPeriodStart);
+  const canonicalPlanState =
+    subscription.planKey != null
+      ? {
+          planId: subscription.planId,
+          planKey: subscription.planKey,
+        }
+      : await resolveCanonicalMembershipPlanState({
+          tenantId,
+          planId: subscription.planId,
+        });
+  const activeAnnualMembershipState = createActiveAnnualMembershipFulfillment(
+    canonicalPlanState.planId,
+    currentPeriodStart,
+    canonicalPlanState.planKey
+  );
 
   await db
     .update(subscriptions)

--- a/apps/web/src/lib/actions/agent/register-member.core.ts
+++ b/apps/web/src/lib/actions/agent/register-member.core.ts
@@ -1,6 +1,10 @@
 import { sendMemberWelcomeEmail } from '@/lib/email';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
-import { createActiveAnnualMembershipState } from '@interdomestik/domain-membership-billing/annual-membership';
+import {
+  createActiveAnnualMembershipFulfillment,
+  createCanonicalMembershipPlanState,
+  resolveCanonicalMembershipPlanState,
+} from '@interdomestik/domain-membership-billing';
 import {
   account,
   agentClients,
@@ -46,6 +50,10 @@ export async function registerMemberCore(
   const data = validated.data;
   const userId = nanoid();
   const membershipMode = options.membershipMode ?? 'direct';
+  const canonicalPlanState = await resolveCanonicalMembershipPlanState({
+    tenantId,
+    planId: data.planId,
+  });
 
   try {
     await withTransactionRetry(async tx => {
@@ -96,13 +104,21 @@ export async function registerMemberCore(
       const subscriptionValues =
         membershipMode === 'sponsored'
           ? {
+              ...createCanonicalMembershipPlanState(
+                canonicalPlanState.planId,
+                canonicalPlanState.planKey
+              ),
               status: 'paused' as const,
               provider: 'group_sponsor',
               acquisitionSource: 'group_roster_import',
               currentPeriodStart: null,
               currentPeriodEnd: null,
             }
-          : createActiveAnnualMembershipState(now);
+          : createActiveAnnualMembershipFulfillment(
+              canonicalPlanState.planId,
+              now,
+              canonicalPlanState.planKey
+            );
 
       await tx.insert(subscriptions).values({
         id: nanoid(),
@@ -110,7 +126,6 @@ export async function registerMemberCore(
         branchId: agentBranchId,
         agentId: agent.id,
         userId,
-        planId: data.planId,
         ...subscriptionValues,
         createdAt: now,
         updatedAt: now,

--- a/apps/web/src/lib/actions/agent/register-member.wrapper.test.ts
+++ b/apps/web/src/lib/actions/agent/register-member.wrapper.test.ts
@@ -6,6 +6,10 @@ const mocks = vi.hoisted(() => ({
     memberNumber: 'MEM-2026-000001',
     isNew: true,
   }),
+  findMembershipPlan: vi.fn().mockResolvedValue({
+    id: 'tenant-standard-plan',
+    tier: 'standard',
+  }),
   withTransactionRetry: vi.fn(),
   emailExecute: vi.fn(),
 }));
@@ -18,6 +22,16 @@ vi.mock('@interdomestik/shared-utils/circuit-breaker', () => ({
   circuitBreakers: {
     email: {
       execute: mocks.emailExecute,
+    },
+  },
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    query: {
+      membershipPlans: {
+        findFirst: mocks.findMembershipPlan,
+      },
     },
   },
 }));
@@ -51,6 +65,10 @@ describe('registerMemberCore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     insertValues.length = 0;
+    mocks.findMembershipPlan.mockResolvedValue({
+      id: 'tenant-standard-plan',
+      tier: 'standard',
+    });
     mocks.withTransactionRetry.mockImplementation(async callback => {
       const tx = {
         insert: vi.fn().mockReturnThis(),
@@ -87,6 +105,7 @@ describe('registerMemberCore', () => {
       expect.objectContaining({
         status: 'active',
         planId: 'standard',
+        planKey: 'tenant-standard-plan',
       })
     );
   });

--- a/apps/web/src/lib/paddle-webhooks/subscriptions-handler.test.ts
+++ b/apps/web/src/lib/paddle-webhooks/subscriptions-handler.test.ts
@@ -9,6 +9,9 @@ const mocks = vi.hoisted(() => ({
   findTenantSetting: vi.fn<() => Promise<Record<string, unknown> | null>>(() =>
     Promise.resolve(null)
   ),
+  findMembershipPlan: vi.fn<() => Promise<Record<string, unknown> | null>>(() =>
+    Promise.resolve(null)
+  ),
   findReferral: vi.fn<() => Promise<Record<string, unknown> | null>>(() => Promise.resolve(null)),
   createMemberReferralReward: vi.fn(() =>
     Promise.resolve({
@@ -30,6 +33,9 @@ vi.mock('@interdomestik/database', () => ({
       },
       tenantSettings: {
         findFirst: () => mocks.findTenantSetting(),
+      },
+      membershipPlans: {
+        findFirst: () => mocks.findMembershipPlan(),
       },
       referrals: {
         findFirst: () => mocks.findReferral(),
@@ -55,6 +61,7 @@ describe('handleSubscriptionChanged tenant guardrail', () => {
     mocks.findSubscription.mockClear();
     mocks.findUser.mockClear();
     mocks.findTenantSetting.mockClear();
+    mocks.findMembershipPlan.mockClear();
     mocks.findReferral.mockClear();
     mocks.createMemberReferralReward.mockClear();
   });

--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -16,6 +16,9 @@ const mocks = vi.hoisted(() => ({
       memberLeads: {
         findFirst: vi.fn(),
       },
+      membershipPlans: {
+        findFirst: vi.fn(),
+      },
     },
     transaction: vi.fn(),
   },
@@ -94,6 +97,7 @@ describe('convertLeadToMember', () => {
 
   beforeEach(() => {
     mocks.db.query.memberLeads.findFirst.mockReset();
+    mocks.db.query.membershipPlans.findFirst.mockReset();
     mocks.db.transaction.mockReset();
     mocks.generateMemberNumber.mockReset();
     mocks.nanoid.mockReset();
@@ -112,6 +116,10 @@ describe('convertLeadToMember', () => {
       email: 'arben@example.com',
       status: 'new',
       convertedUserId: 'usr_existing',
+    });
+    mocks.db.query.membershipPlans.findFirst.mockResolvedValue({
+      id: 'tenant-standard-plan',
+      tier: 'standard',
     });
 
     mocks.db.transaction.mockImplementation(async () => {
@@ -140,6 +148,10 @@ describe('convertLeadToMember', () => {
       email: 'arben@example.com',
       status: 'new',
       convertedUserId: null,
+    });
+    mocks.db.query.membershipPlans.findFirst.mockResolvedValue({
+      id: 'tenant-standard-plan',
+      tier: 'standard',
     });
     mocks.generateMemberNumber.mockResolvedValue({ memberNumber: 'M-1001' });
     mocks.nanoid
@@ -170,6 +182,7 @@ describe('convertLeadToMember', () => {
       userId: 'usr_user-seed',
       status: 'active',
       planId: 'standard',
+      planKey: 'tenant-standard-plan',
       agentId: 'agent-1',
       branchId: 'branch-1',
       currentPeriodStart: now,
@@ -238,6 +251,10 @@ describe('convertLeadToMember', () => {
       status: 'new',
       convertedUserId: null,
     });
+    mocks.db.query.membershipPlans.findFirst.mockResolvedValue({
+      id: 'tenant-family-plan',
+      tier: 'family',
+    });
     mocks.generateMemberNumber.mockResolvedValue({ memberNumber: 'M-1002' });
     mocks.nanoid
       .mockReturnValueOnce('user-seed')
@@ -259,6 +276,7 @@ describe('convertLeadToMember', () => {
     )?.values;
     expect(subscriptionInsert).toMatchObject({
       planId: 'family',
+      planKey: 'tenant-family-plan',
       branchId: 'branch-1',
       currentPeriodStart: now,
       currentPeriodEnd: expectedPeriodEnd,

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -1,6 +1,9 @@
 import { and, db, eq } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
-import { createActiveAnnualMembershipState } from '@interdomestik/domain-membership-billing/annual-membership';
+import {
+  createActiveAnnualMembershipFulfillment,
+  resolveCanonicalMembershipPlanState,
+} from '@interdomestik/domain-membership-billing';
 import {
   agentClients,
   memberLeads,
@@ -47,7 +50,15 @@ export async function convertLeadToMember(
 
   const userId = `usr_${nanoid()}`;
   const now = new Date();
-  const annualMembershipState = createActiveAnnualMembershipState(now);
+  const canonicalPlanState = await resolveCanonicalMembershipPlanState({
+    tenantId: ctx.tenantId,
+    planId,
+  });
+  const annualMembershipState = createActiveAnnualMembershipFulfillment(
+    canonicalPlanState.planId,
+    now,
+    canonicalPlanState.planKey
+  );
 
   return await db.transaction(async tx => {
     // A. Insert User with role='member'
@@ -75,7 +86,6 @@ export async function convertLeadToMember(
       id: subscriptionId,
       tenantId: ctx.tenantId,
       userId,
-      planId,
       agentId: lead.agentId,
       branchId: lead.branchId,
       ...annualMembershipState,

--- a/packages/domain-leads/vitest.config.ts
+++ b/packages/domain-leads/vitest.config.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@interdomestik/domain-membership-billing': path.resolve(
+        __dirname,
+        '../domain-membership-billing/src'
+      ),
+    },
+  },
+});

--- a/packages/domain-membership-billing/src/annual-membership.test.ts
+++ b/packages/domain-membership-billing/src/annual-membership.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { createActiveAnnualMembershipState } from './annual-membership';
+import {
+  createActiveAnnualMembershipFulfillment,
+  createActiveAnnualMembershipState,
+  createCanonicalMembershipPlanState,
+} from './annual-membership';
 
 describe('createActiveAnnualMembershipState', () => {
   it('builds an active annual membership term from a single baseline timestamp', () => {
@@ -20,6 +24,29 @@ describe('createActiveAnnualMembershipState', () => {
       status: 'active',
       currentPeriodStart: now,
       currentPeriodEnd: new Date('2025-03-01T12:30:00.000Z'),
+    });
+  });
+});
+
+describe('createCanonicalMembershipPlanState', () => {
+  it('stores a tenant-resolved plan key alongside the canonical annual plan id', () => {
+    expect(createCanonicalMembershipPlanState('standard', 'tenant-standard-plan')).toEqual({
+      planId: 'standard',
+      planKey: 'tenant-standard-plan',
+    });
+  });
+});
+
+describe('createActiveAnnualMembershipFulfillment', () => {
+  it('builds the canonical commercial shape for an active annual membership', () => {
+    const now = new Date('2026-04-16T09:00:00.000Z');
+
+    expect(createActiveAnnualMembershipFulfillment('family', now, 'tenant-family-plan')).toEqual({
+      status: 'active',
+      planId: 'family',
+      planKey: 'tenant-family-plan',
+      currentPeriodStart: now,
+      currentPeriodEnd: new Date('2027-04-16T09:00:00.000Z'),
     });
   });
 });

--- a/packages/domain-membership-billing/src/annual-membership.test.ts
+++ b/packages/domain-membership-billing/src/annual-membership.test.ts
@@ -1,10 +1,29 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  db: {
+    query: {
+      membershipPlans: {
+        findFirst: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  db: hoisted.db,
+}));
 
 import {
   createActiveAnnualMembershipFulfillment,
   createActiveAnnualMembershipState,
   createCanonicalMembershipPlanState,
+  resolveCanonicalMembershipPlanState,
 } from './annual-membership';
+
+beforeEach(() => {
+  hoisted.db.query.membershipPlans.findFirst.mockReset();
+});
 
 describe('createActiveAnnualMembershipState', () => {
   it('builds an active annual membership term from a single baseline timestamp', () => {
@@ -34,6 +53,22 @@ describe('createCanonicalMembershipPlanState', () => {
       planId: 'standard',
       planKey: 'tenant-standard-plan',
     });
+  });
+});
+
+describe('resolveCanonicalMembershipPlanState', () => {
+  it('falls back to an explicit unknown plan id when the incoming value is blank', async () => {
+    await expect(
+      resolveCanonicalMembershipPlanState({
+        tenantId: 'tenant-mk',
+        planId: '   ',
+      })
+    ).resolves.toEqual({
+      planId: 'unknown',
+      planKey: null,
+    });
+
+    expect(hoisted.db.query.membershipPlans.findFirst).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/domain-membership-billing/src/annual-membership.ts
+++ b/packages/domain-membership-billing/src/annual-membership.ts
@@ -26,7 +26,7 @@ export async function resolveCanonicalMembershipPlanState(params: {
   const rawPlanId = params.planId.trim();
   if (!rawPlanId) {
     return {
-      planId: params.planId,
+      planId: 'unknown',
       planKey: null,
     };
   }

--- a/packages/domain-membership-billing/src/annual-membership.ts
+++ b/packages/domain-membership-billing/src/annual-membership.ts
@@ -1,3 +1,5 @@
+import { db } from '@interdomestik/database';
+
 export function createActiveAnnualMembershipState(now: Date): {
   status: 'active';
   currentPeriodStart: Date;
@@ -11,5 +13,72 @@ export function createActiveAnnualMembershipState(now: Date): {
     status: 'active',
     currentPeriodStart,
     currentPeriodEnd,
+  };
+}
+
+export async function resolveCanonicalMembershipPlanState(params: {
+  tenantId: string;
+  planId: string;
+}): Promise<{
+  planId: string;
+  planKey: string | null;
+}> {
+  const rawPlanId = params.planId.trim();
+  if (!rawPlanId) {
+    return {
+      planId: params.planId,
+      planKey: null,
+    };
+  }
+
+  const plan = await db.query.membershipPlans.findFirst({
+    where: (membershipPlans, { and, eq, or }) =>
+      and(
+        eq(membershipPlans.tenantId, params.tenantId),
+        or(
+          eq(membershipPlans.id, rawPlanId),
+          eq(membershipPlans.paddlePriceId, rawPlanId),
+          eq(membershipPlans.tier, rawPlanId as 'standard' | 'family')
+        )
+      ),
+    columns: {
+      id: true,
+      tier: true,
+    },
+  });
+
+  return {
+    planId: plan?.tier ?? rawPlanId,
+    planKey: plan?.id ?? null,
+  };
+}
+
+export function createCanonicalMembershipPlanState(
+  planId: string,
+  planKey?: string | null
+): {
+  planId: string;
+  planKey?: string;
+} {
+  return {
+    planId,
+    ...(planKey ? { planKey } : {}),
+  };
+}
+
+export function createActiveAnnualMembershipFulfillment(
+  planId: string,
+  now: Date,
+  planKey?: string | null
+): {
+  status: 'active';
+  planId: string;
+  planKey?: string;
+  currentPeriodStart: Date;
+  currentPeriodEnd: Date;
+} {
+  return {
+    ...createCanonicalMembershipPlanState(planId, planKey),
+    ...createActiveAnnualMembershipState(now),
   };
 }

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -10,6 +10,7 @@ const hoisted = vi.hoisted(() => ({
       user: { findFirst: vi.fn() },
       account: { findFirst: vi.fn() },
       agentClients: { findFirst: vi.fn() },
+      membershipPlans: { findFirst: vi.fn() },
       subscriptions: { findFirst: vi.fn() },
       tenantSettings: { findFirst: vi.fn() },
       webhookEvents: { findFirst: vi.fn() },
@@ -54,6 +55,7 @@ describe('Paddle Webhook Handlers', () => {
       values: vi.fn().mockResolvedValue(undefined),
     }));
     hoisted.db.query.agentClients.findFirst.mockResolvedValue(null);
+    hoisted.db.query.membershipPlans.findFirst.mockResolvedValue(null);
     hoisted.db.update.mockImplementation(() => ({
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue(undefined),
@@ -260,6 +262,53 @@ describe('Paddle Webhook Handlers', () => {
       expect(mockWhere).toHaveBeenCalled();
     });
 
+    it('stores the canonical annual plan id instead of the Paddle price id', async () => {
+      const insertedValues = vi.fn().mockResolvedValue(undefined);
+
+      hoisted.db.insert.mockReturnValue({
+        values: insertedValues,
+      });
+      hoisted.db.query.subscriptions.findFirst.mockResolvedValueOnce(null);
+      hoisted.db.query.user.findFirst.mockResolvedValue({
+        id: 'user_123',
+        email: 'test@example.com',
+        tenantId: 'tenant_mk',
+      });
+      hoisted.db.query.membershipPlans.findFirst.mockResolvedValue({
+        id: 'mk-standard-plan',
+        tier: 'standard',
+      });
+
+      await handleSubscriptionChanged(
+        {
+          eventType: 'subscription.updated',
+          data: {
+            id: 'sub_paddle_annual',
+            status: 'active',
+            customData: { userId: 'user_123' },
+            items: [
+              {
+                price: {
+                  id: 'pri_standard_year_mk',
+                  unitPrice: { amount: '2000', currencyCode: 'EUR' },
+                },
+              },
+            ],
+            currentBillingPeriod: { startsAt: '2026-01-01', endsAt: '2027-01-01' },
+          },
+        },
+        { logAuditEvent }
+      );
+
+      expect(hoisted.db.query.membershipPlans.findFirst).toHaveBeenCalled();
+      expect(insertedValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          planId: 'standard',
+          planKey: 'mk-standard-plan',
+        })
+      );
+    });
+
     it('retries as an update when a raced insert hits a unique constraint', async () => {
       const uniqueViolation = Object.assign(new Error('duplicate key'), { code: '23505' });
       const mockWhere = vi.fn().mockResolvedValue(undefined);
@@ -442,6 +491,50 @@ describe('Paddle Webhook Handlers', () => {
         })
       );
       expect(mockWhere).toHaveBeenCalled();
+    });
+
+    it('normalizes past-due subscriptions to the canonical annual plan id', async () => {
+      const insertedValues = vi.fn().mockResolvedValue(undefined);
+
+      hoisted.db.insert.mockReturnValue({
+        values: insertedValues,
+      });
+      hoisted.db.query.subscriptions.findFirst.mockResolvedValueOnce(null);
+      hoisted.db.query.user.findFirst.mockResolvedValue({
+        id: 'user_123',
+        email: 'test@example.com',
+        name: 'Member',
+        tenantId: 'tenant_mk',
+      });
+      hoisted.db.query.membershipPlans.findFirst.mockResolvedValue({
+        id: 'mk-family-plan',
+        tier: 'family',
+      });
+
+      await handleSubscriptionPastDue({
+        data: {
+          id: 'sub_paddle_annual',
+          status: 'past_due',
+          customData: { userId: 'user_123' },
+          items: [
+            {
+              price: {
+                id: 'pri_family_year_mk',
+                description: 'Asistenca Family',
+                unitPrice: { amount: '3000', currencyCode: 'EUR' },
+              },
+            },
+          ],
+          currentBillingPeriod: { startsAt: '2026-01-01', endsAt: '2027-01-01' },
+        },
+      });
+
+      expect(insertedValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          planId: 'family',
+          planKey: 'mk-family-plan',
+        })
+      );
     });
   });
 

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts
@@ -26,6 +26,7 @@ type PastDueValues = {
   userId: string;
   status: 'past_due';
   planId: string;
+  planKey?: string;
   providerSubscriptionId: string;
   providerCustomerId: string | null | undefined;
   pastDueAt: Date;

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts
@@ -1,5 +1,9 @@
 import { db, eq, subscriptions } from '@interdomestik/database';
 import { findSubscriptionByProviderReference } from '../../subscription';
+import {
+  createCanonicalMembershipPlanState,
+  resolveCanonicalMembershipPlanState,
+} from '../../annual-membership';
 
 import { subscriptionEventDataSchema } from '../schemas';
 import type { PaddleWebhookAuditDeps, PaddleWebhookDeps } from '../types';
@@ -65,12 +69,18 @@ export async function handleSubscriptionPastDue(
   }
 
   const existingSub = await findExistingPastDueSubscription(sub.id, userId);
+  const priceId = sub.items?.[0]?.price?.id || sub.items?.[0]?.priceId || 'unknown';
+  const canonicalPlanState = await resolveCanonicalMembershipPlanState({
+    tenantId: userRecord.tenantId,
+    planId: priceId,
+  });
   const pastDueState = buildPastDueState({
     sub,
     userId,
     userRecord,
     existingSub,
     now: new Date(),
+    planState: canonicalPlanState,
   });
 
   await persistPastDueSubscription({
@@ -145,10 +155,13 @@ function buildPastDueState(args: {
   userRecord: PastDueUserRecord;
   existingSub: ExistingSubscriptionRecord;
   now: Date;
+  planState: {
+    planId: string;
+    planKey: string | null;
+  };
 }): { values: PastDueValues; gracePeriodEnd: Date; newDunningCount: number } {
   const gracePeriodEnd = args.existingSub?.gracePeriodEndsAt ?? calculateGracePeriodEnd(args.now);
   const newDunningCount = (args.existingSub?.dunningAttemptCount ?? 0) + 1;
-  const priceId = args.sub.items?.[0]?.price?.id || args.sub.items?.[0]?.priceId || 'unknown';
 
   return {
     gracePeriodEnd,
@@ -157,7 +170,7 @@ function buildPastDueState(args: {
       tenantId: args.userRecord.tenantId,
       userId: args.userId,
       status: 'past_due',
-      planId: priceId,
+      ...createCanonicalMembershipPlanState(args.planState.planId, args.planState.planKey),
       providerSubscriptionId: args.sub.id,
       providerCustomerId: args.sub.customerId || args.sub.customer_id,
       pastDueAt: args.existingSub?.pastDueAt ?? args.now,

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
@@ -1,5 +1,9 @@
 import { db, eq, subscriptions } from '@interdomestik/database';
 import { findSubscriptionByProviderReference } from '../../subscription';
+import {
+  createCanonicalMembershipPlanState,
+  resolveCanonicalMembershipPlanState,
+} from '../../annual-membership';
 import { subscriptionEventDataSchema } from '../schemas';
 import { mapPaddleStatus, type InternalSubscriptionStatus } from '../subscription-status';
 
@@ -32,6 +36,10 @@ export async function handleSubscriptionChanged(
   const { userId, tenantId, branchId, customData, userRecord } = context;
 
   const priceId = sub.items?.[0]?.price?.id || sub.items?.[0]?.priceId || 'unknown';
+  const canonicalPlanState = await resolveCanonicalMembershipPlanState({
+    tenantId,
+    planId: priceId,
+  });
   const mappedStatus = mapPaddleStatus(sub.status);
 
   // 2. Upsert Subscription
@@ -42,7 +50,7 @@ export async function handleSubscriptionChanged(
     agentId: customData?.agentId,
     branchId,
     mappedStatus,
-    priceId,
+    planState: canonicalPlanState,
   });
 
   // 3. Audit Log
@@ -88,10 +96,13 @@ async function upsertSubscription(args: {
   agentId?: string;
   branchId?: string;
   mappedStatus: InternalSubscriptionStatus;
-  priceId: string;
+  planState: {
+    planId: string;
+    planKey: string | null;
+  };
 }) {
-  const { sub, tenantId, userId, agentId, branchId, mappedStatus, priceId } = args;
-  const values = mapToSubscriptionValues(sub, mappedStatus, priceId);
+  const { sub, tenantId, userId, agentId, branchId, mappedStatus, planState } = args;
+  const values = mapToSubscriptionValues(sub, mappedStatus, planState);
   const existingSubscription = await findExistingSubscription(sub.id, userId);
 
   if (existingSubscription) {
@@ -161,7 +172,10 @@ async function updateSubscription(subscriptionId: string, values: Record<string,
 function mapToSubscriptionValues(
   sub: any,
   mappedStatus: InternalSubscriptionStatus,
-  priceId: string
+  planState: {
+    planId: string;
+    planKey: string | null;
+  }
 ) {
   const currentStartsAt =
     sub.currentBillingPeriod?.startsAt || (sub.current_billing_period?.starts_at as string);
@@ -170,7 +184,7 @@ function mapToSubscriptionValues(
 
   const baseValues = {
     status: mappedStatus,
-    planId: priceId,
+    ...createCanonicalMembershipPlanState(planState.planId, planState.planKey),
     providerCustomerId: (sub.customerId || sub.customer_id) as string | null,
     currentPeriodStart: parseDate(currentStartsAt),
     currentPeriodEnd: parseDate(currentEndsAt),


### PR DESCRIPTION
## Summary
- canonicalize paid annual membership fulfillment across direct signup, lead conversion, sponsored activation, and Paddle webhook/dunning updates
- persist canonical annual `planId` while resolving tenant-backed `planKey` to the real `membership_plans.id`
- keep admin analytics compatible with legacy provider-shaped subscription rows during the transition

## Verification
- pnpm security:guard
- pnpm pr:verify
- pnpm e2e:gate
