### PR TITLE
PC02: unify ownership attribution and read models

### DIFF
--- a/apps/web/src/features/agent/import/server/get-group-dashboard-summary.test.ts
+++ b/apps/web/src/features/agent/import/server/get-group-dashboard-summary.test.ts
@@ -9,6 +9,7 @@ function sortStrings(values: string[]): string[] {
 describe('getGroupDashboardSummaryCore', () => {
   const mockDb = {
     groupBy: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
     select: vi.fn().mockReturnThis(),
     from: vi.fn().mockReturnThis(),
     where: vi.fn(),
@@ -18,6 +19,7 @@ describe('getGroupDashboardSummaryCore', () => {
 
   beforeEach(() => {
     mockDb.groupBy.mockClear();
+    mockDb.innerJoin.mockClear();
     mockDb.select.mockClear();
     mockDb.from.mockClear();
     mockDb.where.mockReset();
@@ -26,19 +28,14 @@ describe('getGroupDashboardSummaryCore', () => {
   it('aggregates activation, usage, and SLA-safe case metrics for an office portfolio', async () => {
     mockDb.where
       .mockImplementationOnce(async () => [
-        { memberId: 'member-1' },
-        { memberId: 'member-2' },
-        { memberId: 'member-3' },
-      ])
-      .mockImplementationOnce(async () => [
         { id: 'sub-1', userId: 'member-1' },
         { id: 'sub-2', userId: 'member-2' },
         { id: 'sub-3', userId: 'member-3' },
       ])
       .mockImplementationOnce(async () => [
-        { subscriptionId: 'sub-1' },
-        { subscriptionId: 'sub-1' },
-        { subscriptionId: 'sub-3' },
+        { memberId: 'member-1' },
+        { memberId: 'member-1' },
+        { memberId: 'member-3' },
       ])
       .mockImplementationOnce(() => mockDb)
       .mockImplementationOnce(async () => [{ count: '2' }]);
@@ -84,10 +81,10 @@ describe('getGroupDashboardSummaryCore', () => {
     expect(summary).not.toHaveProperty('memberIds');
     expect(summary).not.toHaveProperty('notes');
 
-    expect(mockDb.from).toHaveBeenCalledWith(agentClients);
     expect(mockDb.from).toHaveBeenCalledWith(subscriptions);
     expect(mockDb.from).toHaveBeenCalledWith(serviceUsage);
     expect(mockDb.from).toHaveBeenCalledWith(claims);
+    expect(mockDb.innerJoin).toHaveBeenCalledWith(agentClients, expect.anything());
     expect(mockDb.groupBy).toHaveBeenCalledWith(claims.status);
   });
 
@@ -123,12 +120,11 @@ describe('getGroupDashboardSummaryCore', () => {
 
   it('uses active member assignments even when subscription ownership is stale', async () => {
     mockDb.where
-      .mockImplementationOnce(async () => [{ memberId: 'member-1' }, { memberId: 'member-2' }])
       .mockImplementationOnce(async () => [
         { id: 'sub-1', userId: 'member-1' },
         { id: 'sub-2', userId: 'member-2' },
       ])
-      .mockImplementationOnce(async () => [{ subscriptionId: 'sub-2' }])
+      .mockImplementationOnce(async () => [{ memberId: 'member-2' }])
       .mockImplementationOnce(() => mockDb)
       .mockImplementationOnce(async () => [{ count: '1' }]);
     mockDb.groupBy.mockResolvedValueOnce([{ count: '2', status: 'submitted' }]);

--- a/apps/web/src/features/agent/import/server/get-group-dashboard-summary.test.ts
+++ b/apps/web/src/features/agent/import/server/get-group-dashboard-summary.test.ts
@@ -1,4 +1,4 @@
-import { claims, serviceUsage, subscriptions } from '@interdomestik/database/schema';
+import { agentClients, claims, serviceUsage, subscriptions } from '@interdomestik/database/schema';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getGroupDashboardSummaryCore } from './get-group-dashboard-summary';
 
@@ -25,7 +25,16 @@ describe('getGroupDashboardSummaryCore', () => {
 
   it('aggregates activation, usage, and SLA-safe case metrics for an office portfolio', async () => {
     mockDb.where
-      .mockImplementationOnce(async () => [{ id: 'sub-1' }, { id: 'sub-2' }, { id: 'sub-3' }])
+      .mockImplementationOnce(async () => [
+        { memberId: 'member-1' },
+        { memberId: 'member-2' },
+        { memberId: 'member-3' },
+      ])
+      .mockImplementationOnce(async () => [
+        { id: 'sub-1', userId: 'member-1' },
+        { id: 'sub-2', userId: 'member-2' },
+        { id: 'sub-3', userId: 'member-3' },
+      ])
       .mockImplementationOnce(async () => [
         { subscriptionId: 'sub-1' },
         { subscriptionId: 'sub-1' },
@@ -75,13 +84,14 @@ describe('getGroupDashboardSummaryCore', () => {
     expect(summary).not.toHaveProperty('memberIds');
     expect(summary).not.toHaveProperty('notes');
 
+    expect(mockDb.from).toHaveBeenCalledWith(agentClients);
     expect(mockDb.from).toHaveBeenCalledWith(subscriptions);
     expect(mockDb.from).toHaveBeenCalledWith(serviceUsage);
     expect(mockDb.from).toHaveBeenCalledWith(claims);
     expect(mockDb.groupBy).toHaveBeenCalledWith(claims.status);
   });
 
-  it('returns zero aggregates when the agent has no activated sponsored members', async () => {
+  it('returns zero aggregates when the agent has no active member assignments', async () => {
     mockDb.where.mockResolvedValueOnce([]);
 
     const summary = await getGroupDashboardSummaryCore(
@@ -109,5 +119,36 @@ describe('getGroupDashboardSummaryCore', () => {
       'usageRatePercent',
     ]);
     expect(mockDb.where).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses active member assignments even when subscription ownership is stale', async () => {
+    mockDb.where
+      .mockImplementationOnce(async () => [{ memberId: 'member-1' }, { memberId: 'member-2' }])
+      .mockImplementationOnce(async () => [
+        { id: 'sub-1', userId: 'member-1' },
+        { id: 'sub-2', userId: 'member-2' },
+      ])
+      .mockImplementationOnce(async () => [{ subscriptionId: 'sub-2' }])
+      .mockImplementationOnce(() => mockDb)
+      .mockImplementationOnce(async () => [{ count: '1' }]);
+    mockDb.groupBy.mockResolvedValueOnce([{ count: '2', status: 'submitted' }]);
+
+    const summary = await getGroupDashboardSummaryCore(
+      { agentId: 'agent-1', tenantId: 'tenant-1' },
+      services
+    );
+
+    expect(summary).toEqual({
+      activatedMembersCount: 2,
+      membersUsingBenefitsCount: 1,
+      usageRatePercent: 50,
+      openClaimsCount: 2,
+      sla: {
+        breachCount: 1,
+        incompleteCount: 0,
+        notApplicableCount: 0,
+        runningCount: 2,
+      },
+    });
   });
 });

--- a/apps/web/src/features/agent/import/server/get-group-dashboard-summary.ts
+++ b/apps/web/src/features/agent/import/server/get-group-dashboard-summary.ts
@@ -3,7 +3,7 @@ import { deriveClaimSlaPhase } from '@/features/claims/policy/slaPolicy';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import { db } from '@interdomestik/database/db';
 import { agentClients, claims, serviceUsage, subscriptions } from '@interdomestik/database/schema';
-import { and, count, eq, inArray } from 'drizzle-orm';
+import { and, count, eq } from 'drizzle-orm';
 
 export type GroupDashboardSummary = {
   activatedMembersCount: number;
@@ -21,6 +21,7 @@ export type GroupDashboardSummary = {
 export interface GroupDashboardSummaryServices {
   db: {
     groupBy?: any;
+    innerJoin?: any;
     select: any;
   };
 }
@@ -51,88 +52,60 @@ export async function getGroupDashboardSummaryCore(
 ): Promise<GroupDashboardSummary> {
   const { agentId, tenantId } = params;
   const { db } = services;
-
-  const activeAssignments: Array<{ memberId: string }> = await db
-    .select({ memberId: agentClients.memberId })
-    .from(agentClients)
-    .where(
-      and(
-        eq(agentClients.tenantId, tenantId),
-        eq(agentClients.agentId, agentId),
-        eq(agentClients.status, 'active')
-      )
-    );
-
-  if (activeAssignments.length === 0) {
-    return emptySummary();
-  }
-
-  const assignedMemberIds = [...new Set(activeAssignments.map(assignment => assignment.memberId))];
+  const assignmentScope = and(
+    eq(agentClients.tenantId, tenantId),
+    eq(agentClients.agentId, agentId),
+    eq(agentClients.status, 'active')
+  );
 
   const activeSubscriptions: Array<{ id: string; userId: string | null }> = await db
     .select({ id: subscriptions.id, userId: subscriptions.userId })
     .from(subscriptions)
+    .innerJoin(agentClients, eq(agentClients.memberId, subscriptions.userId))
     .where(
-      and(
-        eq(subscriptions.tenantId, tenantId),
-        eq(subscriptions.status, 'active'),
-        inArray(subscriptions.userId, assignedMemberIds)
-      )
+      and(eq(subscriptions.tenantId, tenantId), eq(subscriptions.status, 'active'), assignmentScope)
     );
 
   if (activeSubscriptions.length === 0) {
     return emptySummary();
   }
 
-  const subscriptionIds = activeSubscriptions.map(subscription => subscription.id);
-  const subscriptionMemberById = new Map(
+  const activeMemberIds = new Set(
     activeSubscriptions
-      .filter(
-        (subscription): subscription is { id: string; userId: string } =>
-          typeof subscription.userId === 'string'
-      )
-      .map(subscription => [subscription.id, subscription.userId])
+      .map(subscription => subscription.userId)
+      .filter((userId): userId is string => typeof userId === 'string')
   );
 
-  const usageRows: Array<{ subscriptionId: string | null }> = await db
-    .select({ subscriptionId: serviceUsage.subscriptionId })
+  const usageRows: Array<{ memberId: string | null }> = await db
+    .select({ memberId: subscriptions.userId })
     .from(serviceUsage)
+    .innerJoin(subscriptions, eq(subscriptions.id, serviceUsage.subscriptionId))
+    .innerJoin(agentClients, eq(agentClients.memberId, subscriptions.userId))
     .where(
       and(
         eq(serviceUsage.tenantId, tenantId),
-        inArray(serviceUsage.subscriptionId, subscriptionIds)
+        eq(subscriptions.tenantId, tenantId),
+        eq(subscriptions.status, 'active'),
+        assignmentScope
       )
     );
 
   const openClaimStatusCounts: OpenClaimStatusCountRow[] = await db
     .select({ count: count(), status: claims.status })
     .from(claims)
-    .where(
-      and(
-        eq(claims.tenantId, tenantId),
-        inArray(claims.userId, assignedMemberIds),
-        getOpenClaimsFilter()
-      )
-    )
+    .innerJoin(agentClients, eq(agentClients.memberId, claims.userId))
+    .where(and(eq(claims.tenantId, tenantId), assignmentScope, getOpenClaimsFilter()))
     .groupBy(claims.status);
 
   const [slaBreaches] = await db
     .select({ count: count() })
     .from(claims)
-    .where(
-      and(
-        eq(claims.tenantId, tenantId),
-        inArray(claims.userId, assignedMemberIds),
-        getSlaBreachesFilter()
-      )
-    );
+    .innerJoin(agentClients, eq(agentClients.memberId, claims.userId))
+    .where(and(eq(claims.tenantId, tenantId), assignmentScope, getSlaBreachesFilter()));
 
   const usedMemberIds = new Set(
     usageRows
-      .map(row => row.subscriptionId)
-      .map(subscriptionId =>
-        typeof subscriptionId === 'string' ? subscriptionMemberById.get(subscriptionId) : null
-      )
+      .map(row => row.memberId)
       .filter((memberId): memberId is string => typeof memberId === 'string')
   );
 
@@ -155,7 +128,7 @@ export async function getGroupDashboardSummaryCore(
     }
   );
 
-  const activatedMembersCount = assignedMemberIds.length;
+  const activatedMembersCount = activeMemberIds.size;
   const membersUsingBenefitsCount = usedMemberIds.size;
   const openClaimsCount = openClaimStatusCounts.reduce(
     (total, claimGroup) => total + Number(claimGroup.count),

--- a/apps/web/src/features/agent/import/server/get-group-dashboard-summary.ts
+++ b/apps/web/src/features/agent/import/server/get-group-dashboard-summary.ts
@@ -2,7 +2,7 @@ import { getOpenClaimsFilter, getSlaBreachesFilter } from '@/features/admin/kpis
 import { deriveClaimSlaPhase } from '@/features/claims/policy/slaPolicy';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import { db } from '@interdomestik/database/db';
-import { claims, serviceUsage, subscriptions } from '@interdomestik/database/schema';
+import { agentClients, claims, serviceUsage, subscriptions } from '@interdomestik/database/schema';
 import { and, count, eq, inArray } from 'drizzle-orm';
 
 export type GroupDashboardSummary = {
@@ -52,14 +52,31 @@ export async function getGroupDashboardSummaryCore(
   const { agentId, tenantId } = params;
   const { db } = services;
 
-  const activeSubscriptions: Array<{ id: string }> = await db
-    .select({ id: subscriptions.id })
+  const activeAssignments: Array<{ memberId: string }> = await db
+    .select({ memberId: agentClients.memberId })
+    .from(agentClients)
+    .where(
+      and(
+        eq(agentClients.tenantId, tenantId),
+        eq(agentClients.agentId, agentId),
+        eq(agentClients.status, 'active')
+      )
+    );
+
+  if (activeAssignments.length === 0) {
+    return emptySummary();
+  }
+
+  const assignedMemberIds = [...new Set(activeAssignments.map(assignment => assignment.memberId))];
+
+  const activeSubscriptions: Array<{ id: string; userId: string | null }> = await db
+    .select({ id: subscriptions.id, userId: subscriptions.userId })
     .from(subscriptions)
     .where(
       and(
         eq(subscriptions.tenantId, tenantId),
-        eq(subscriptions.agentId, agentId),
-        eq(subscriptions.status, 'active')
+        eq(subscriptions.status, 'active'),
+        inArray(subscriptions.userId, assignedMemberIds)
       )
     );
 
@@ -68,6 +85,14 @@ export async function getGroupDashboardSummaryCore(
   }
 
   const subscriptionIds = activeSubscriptions.map(subscription => subscription.id);
+  const subscriptionMemberById = new Map(
+    activeSubscriptions
+      .filter(
+        (subscription): subscription is { id: string; userId: string } =>
+          typeof subscription.userId === 'string'
+      )
+      .map(subscription => [subscription.id, subscription.userId])
+  );
 
   const usageRows: Array<{ subscriptionId: string | null }> = await db
     .select({ subscriptionId: serviceUsage.subscriptionId })
@@ -82,18 +107,33 @@ export async function getGroupDashboardSummaryCore(
   const openClaimStatusCounts: OpenClaimStatusCountRow[] = await db
     .select({ count: count(), status: claims.status })
     .from(claims)
-    .where(and(eq(claims.tenantId, tenantId), eq(claims.agentId, agentId), getOpenClaimsFilter()))
+    .where(
+      and(
+        eq(claims.tenantId, tenantId),
+        inArray(claims.userId, assignedMemberIds),
+        getOpenClaimsFilter()
+      )
+    )
     .groupBy(claims.status);
 
   const [slaBreaches] = await db
     .select({ count: count() })
     .from(claims)
-    .where(and(eq(claims.tenantId, tenantId), eq(claims.agentId, agentId), getSlaBreachesFilter()));
+    .where(
+      and(
+        eq(claims.tenantId, tenantId),
+        inArray(claims.userId, assignedMemberIds),
+        getSlaBreachesFilter()
+      )
+    );
 
-  const usedSubscriptionIds = new Set(
+  const usedMemberIds = new Set(
     usageRows
       .map(row => row.subscriptionId)
-      .filter((subscriptionId): subscriptionId is string => typeof subscriptionId === 'string')
+      .map(subscriptionId =>
+        typeof subscriptionId === 'string' ? subscriptionMemberById.get(subscriptionId) : null
+      )
+      .filter((memberId): memberId is string => typeof memberId === 'string')
   );
 
   const sla = openClaimStatusCounts.reduce(
@@ -115,8 +155,8 @@ export async function getGroupDashboardSummaryCore(
     }
   );
 
-  const activatedMembersCount = activeSubscriptions.length;
-  const membersUsingBenefitsCount = usedSubscriptionIds.size;
+  const activatedMembersCount = assignedMemberIds.length;
+  const membersUsingBenefitsCount = usedMemberIds.size;
   const openClaimsCount = openClaimStatusCounts.reduce(
     (total, claimGroup) => total + Number(claimGroup.count),
     0

--- a/apps/web/src/lib/actions/agent/register-member.core.ts
+++ b/apps/web/src/lib/actions/agent/register-member.core.ts
@@ -7,12 +7,7 @@ import {
   resolveCanonicalMembershipPlanState,
   syncActiveAgentClientBinding,
 } from '@interdomestik/domain-membership-billing';
-import {
-  account,
-  agentClients,
-  subscriptions,
-  user as userTable,
-} from '@interdomestik/database/schema';
+import { account, subscriptions, user as userTable } from '@interdomestik/database/schema';
 import { circuitBreakers } from '@interdomestik/shared-utils/circuit-breaker';
 import { withTransactionRetry } from '@interdomestik/shared-utils/resilience';
 import { hash } from 'bcryptjs';

--- a/apps/web/src/lib/actions/agent/register-member.core.ts
+++ b/apps/web/src/lib/actions/agent/register-member.core.ts
@@ -5,6 +5,7 @@ import {
   createAgentAssistedOwnershipAttribution,
   createCanonicalMembershipPlanState,
   resolveCanonicalMembershipPlanState,
+  syncActiveAgentClientBinding,
 } from '@interdomestik/domain-membership-billing';
 import {
   account,
@@ -93,14 +94,12 @@ export async function registerMemberCore(
         joinedAt: now,
       });
 
-      await tx.insert(agentClients).values({
-        id: nanoid(),
+      await syncActiveAgentClientBinding(tx, {
         tenantId,
-        agentId: agent.id,
         memberId: userId,
-        status: 'active',
-        joinedAt: now,
-        createdAt: now,
+        agentId: agent.id,
+        now,
+        idFactory: () => nanoid(),
       });
 
       const subscriptionValues =

--- a/apps/web/src/lib/actions/agent/register-member.core.ts
+++ b/apps/web/src/lib/actions/agent/register-member.core.ts
@@ -2,6 +2,7 @@ import { sendMemberWelcomeEmail } from '@/lib/email';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
 import {
   createActiveAnnualMembershipFulfillment,
+  createAgentAssistedOwnershipAttribution,
   createCanonicalMembershipPlanState,
   resolveCanonicalMembershipPlanState,
 } from '@interdomestik/domain-membership-billing';
@@ -54,6 +55,7 @@ export async function registerMemberCore(
     tenantId,
     planId: data.planId,
   });
+  const attribution = createAgentAssistedOwnershipAttribution(agent.id);
 
   try {
     await withTransactionRetry(async tx => {
@@ -69,7 +71,7 @@ export async function registerMemberCore(
         email: data.email,
         emailVerified: false,
         role: 'member', // Critical change: was 'user'
-        agentId: agent.id,
+        ...attribution,
         createdAt: now,
         updatedAt: now,
       });

--- a/apps/web/src/lib/actions/agent/register-member.wrapper.test.ts
+++ b/apps/web/src/lib/actions/agent/register-member.wrapper.test.ts
@@ -102,6 +102,14 @@ describe('registerMemberCore', () => {
     );
     expect(insertValues).toContainEqual(
       expect.objectContaining({
+        role: 'member',
+        agentId: 'agent1',
+        createdBy: 'agent',
+        assistedByAgentId: 'agent1',
+      })
+    );
+    expect(insertValues).toContainEqual(
+      expect.objectContaining({
         status: 'active',
         planId: 'standard',
         planKey: 'tenant-standard-plan',

--- a/apps/web/src/lib/actions/agent/register-member.wrapper.test.ts
+++ b/apps/web/src/lib/actions/agent/register-member.wrapper.test.ts
@@ -27,6 +27,11 @@ vi.mock('@interdomestik/database', async () => {
   const helper = await import('@/test/canonical-membership-db-mock');
 
   return {
+    agentClients: {
+      tenantId: 'agent_clients.tenant_id',
+      memberId: 'agent_clients.member_id',
+      agentId: 'agent_clients.agent_id',
+    },
     and: vi.fn((...conditions: unknown[]) => ({ kind: 'and', conditions })),
     asc: vi.fn((value: unknown) => ({ kind: 'asc', value })),
     eq: vi.fn((column: unknown, value: unknown) => ({ kind: 'eq', column, value })),
@@ -70,11 +75,19 @@ describe('registerMemberCore', () => {
     mocks.selectResults.push([], [], [{ id: 'tenant-standard-plan', tier: 'standard' }]);
     mocks.withTransactionRetry.mockImplementation(async callback => {
       const tx = {
-        insert: vi.fn().mockReturnThis(),
-        values: vi.fn().mockImplementation(async (value: unknown) => {
-          insertValues.push(value);
-          return true;
-        }),
+        insert: vi.fn().mockImplementation(() => ({
+          values: vi.fn().mockImplementation((value: unknown) => {
+            insertValues.push(value);
+            return {
+              onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+            };
+          }),
+        })),
+        update: vi.fn().mockImplementation(() => ({
+          set: vi.fn().mockImplementation(() => ({
+            where: vi.fn().mockResolvedValue(undefined),
+          })),
+        })),
       };
       return await callback(tx);
     });

--- a/apps/web/src/lib/paddle-webhooks/subscriptions-handler.test.ts
+++ b/apps/web/src/lib/paddle-webhooks/subscriptions-handler.test.ts
@@ -121,6 +121,6 @@ describe('handleSubscriptionChanged tenant guardrail', () => {
     const inserted = mocks.insertValues.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
     expect(inserted?.tenantId).toBe('tenant_mk');
     expect(inserted?.branchId).toBe('branch-mk-bitola-main');
-    expect(inserted?.agentId).toBeUndefined();
+    expect(inserted?.agentId).toBeNull();
   });
 });

--- a/packages/domain-agent/src/get-agent-members-list.test.ts
+++ b/packages/domain-agent/src/get-agent-members-list.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => {
       memberId: 'agent_clients.member_id',
       agentId: 'agent_clients.agent_id',
       tenantId: 'agent_clients.tenant_id',
+      status: 'agent_clients.status',
       joinedAt: 'agent_clients.joined_at',
     },
     claims: {
@@ -166,6 +167,7 @@ describe('getAgentMembersList', () => {
 
     expect(mocks.eq).toHaveBeenCalledWith(mocks.agentClients.agentId, 'agent-4');
     expect(mocks.eq).toHaveBeenCalledWith(mocks.agentClients.tenantId, 'tenant-4');
+    expect(mocks.eq).toHaveBeenCalledWith(mocks.agentClients.status, 'active');
     expect(mocks.eq).toHaveBeenCalledWith(mocks.user.role, 'member');
     expect(mocks.asc).toHaveBeenCalledWith(mocks.agentClients.memberId);
   });

--- a/packages/domain-agent/src/get-agent-members-list.ts
+++ b/packages/domain-agent/src/get-agent-members-list.ts
@@ -71,6 +71,7 @@ export async function getAgentMembersList(params: {
       and(
         eq(agentClients.agentId, agentId),
         eq(agentClients.tenantId, tenantId),
+        eq(agentClients.status, 'active'),
         eq(user.role, 'member'),
         ...(searchFilter ? [searchFilter] : [])
       )

--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  agentClients: tableRefs.agentClients,
   and: mocks.and,
   asc: mocks.asc,
   db: mocks.db,

--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -190,6 +190,12 @@ describe('convertLeadToMember', () => {
     const subscriptionInsert = insertRecords.find(
       record => record.table === tableRefs.subscriptions
     )?.values;
+    const userInsert = insertRecords.find(record => record.table === tableRefs.user)?.values;
+    expect(userInsert).toMatchObject({
+      agentId: 'agent-1',
+      createdBy: 'agent',
+      assistedByAgentId: 'agent-1',
+    });
     expect(subscriptionInsert).toMatchObject({
       id: 'sub_subscription-seed',
       tenantId: 'tenant-1',

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -1,4 +1,4 @@
-import { and, db, eq } from '@interdomestik/database';
+import { db, eq } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
 import {
   createActiveAnnualMembershipFulfillment,

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -4,9 +4,9 @@ import {
   createActiveAnnualMembershipFulfillment,
   createAgentAssistedOwnershipAttribution,
   resolveCanonicalMembershipPlanState,
+  syncActiveAgentClientBinding,
 } from '@interdomestik/domain-membership-billing';
 import {
-  agentClients,
   memberLeads,
   membershipCards,
   subscriptions,
@@ -95,31 +95,12 @@ export async function convertLeadToMember(
       updatedAt: now,
     });
 
-    if (lead.agentId) {
-      await tx
-        .update(agentClients)
-        .set({ status: 'inactive' })
-        .where(and(eq(agentClients.tenantId, ctx.tenantId), eq(agentClients.memberId, userId)));
-
-      await tx
-        .insert(agentClients)
-        .values({
-          id: nanoid(),
-          tenantId: ctx.tenantId,
-          agentId: lead.agentId,
-          memberId: userId,
-          status: 'active',
-          joinedAt: now,
-          createdAt: now,
-        })
-        .onConflictDoUpdate({
-          target: [agentClients.tenantId, agentClients.agentId, agentClients.memberId],
-          set: {
-            status: 'active',
-            joinedAt: now,
-          },
-        });
-    }
+    await syncActiveAgentClientBinding(tx, {
+      tenantId: ctx.tenantId,
+      memberId: userId,
+      agentId: lead.agentId,
+      now,
+    });
 
     // D. Issue Membership Card
     const cardNumber = `MEM-${nanoid(8).toUpperCase()}`;

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -2,6 +2,7 @@ import { and, db, eq } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
 import {
   createActiveAnnualMembershipFulfillment,
+  createAgentAssistedOwnershipAttribution,
   resolveCanonicalMembershipPlanState,
 } from '@interdomestik/domain-membership-billing';
 import {
@@ -69,6 +70,7 @@ export async function convertLeadToMember(
       name: `${lead.firstName} ${lead.lastName}`,
       role: 'member',
       emailVerified: true,
+      ...(lead.agentId ? createAgentAssistedOwnershipAttribution(lead.agentId) : {}),
       createdAt: now,
       updatedAt: now,
       branchId: lead.branchId,

--- a/packages/domain-membership-billing/src/commissions/create-renewal.test.ts
+++ b/packages/domain-membership-billing/src/commissions/create-renewal.test.ts
@@ -40,6 +40,7 @@ describe('createRenewalCommissionCore', () => {
     (resolveCommissionOwnership as any).mockReturnValue({
       ownerType: 'agent',
       agentId: 'agent-current',
+      resolvedFrom: 'agent_clients',
       diagnostics: [
         {
           source: 'user.agentId',
@@ -85,7 +86,7 @@ describe('createRenewalCommissionCore', () => {
           saleOwnerType: 'agent',
           saleOwnerId: 'agent-current',
           originalSellerAgentId: 'agent-original',
-          ownershipResolvedFrom: ['subscription.agentId', 'user.agentId'],
+          ownershipResolvedFrom: ['agent_clients', 'user.agentId'],
         }),
       })
     );
@@ -104,6 +105,7 @@ describe('createRenewalCommissionCore', () => {
     (resolveCommissionOwnership as any).mockReturnValue({
       ownerType: 'company',
       agentId: null,
+      resolvedFrom: 'agent_clients',
       diagnostics: [],
     });
 
@@ -139,6 +141,7 @@ describe('createRenewalCommissionCore', () => {
     (resolveCommissionOwnership as any).mockReturnValue({
       ownerType: 'agent',
       agentId: 'agent-current',
+      resolvedFrom: 'agent_clients',
       diagnostics: [],
     });
     (createCommissionCore as any).mockResolvedValue({
@@ -172,15 +175,14 @@ describe('createRenewalCommissionCore', () => {
     const { createCommissionCore } = await import('./create');
 
     (resolveCommissionOwnership as any).mockReturnValue({
-      ownerType: 'unresolved',
-      agentId: null,
-      diagnostics: [
-        {
-          source: 'subscription.agentId',
-          expectedAgentId: null,
-          actualAgentId: null,
-        },
-      ],
+      ownerType: 'agent',
+      agentId: 'agent-current',
+      resolvedFrom: 'agent_clients',
+      diagnostics: [],
+    });
+    (createCommissionCore as any).mockResolvedValue({
+      success: true,
+      data: { id: 'comm-renewal-fallback' },
     });
 
     const result = await createRenewalCommissionCore({
@@ -204,18 +206,17 @@ describe('createRenewalCommissionCore', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data).toEqual({
-        kind: 'no-op',
-        noCommissionReason: 'unresolved',
-        ownerType: 'unresolved',
-        ownershipDiagnostics: [
-          {
-            source: 'subscription.agentId',
-            expectedAgentId: null,
-            actualAgentId: null,
-          },
-        ],
+        kind: 'created',
+        id: 'comm-renewal-fallback',
       });
     }
-    expect(createCommissionCore).not.toHaveBeenCalled();
+    expect(createCommissionCore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'agent-current',
+        metadata: expect.objectContaining({
+          ownershipResolvedFrom: ['agent_clients'],
+        }),
+      })
+    );
   });
 });

--- a/packages/domain-membership-billing/src/commissions/create-renewal.ts
+++ b/packages/domain-membership-billing/src/commissions/create-renewal.ts
@@ -63,10 +63,10 @@ export async function createRenewalCommissionCore(data: {
     const customRates = agentSettings?.commissionRates as Record<string, number> | undefined;
     const amount = calculateCommission('renewal', data.transactionTotal, customRates);
     const ownershipResolvedFrom = [
-      'subscription.agentId',
+      ownership.resolvedFrom,
       ...ownership.diagnostics
         .map(diagnostic => diagnostic.source)
-        .filter(source => source !== 'subscription.agentId'),
+        .filter(source => source !== ownership.resolvedFrom),
     ];
 
     const commissionResult = await createCommissionCore({

--- a/packages/domain-membership-billing/src/commissions/ownership.test.ts
+++ b/packages/domain-membership-billing/src/commissions/ownership.test.ts
@@ -9,36 +9,32 @@ describe('resolveCommissionOwnership', () => {
       agentClientAgentIds: ['agent-legacy'],
     });
 
-    expect(result.ownerType).toBe('unresolved');
-    expect(result.agentId).toBeNull();
-    expect(result.diagnostics).toEqual([
-      {
-        source: 'subscription.agentId',
-        expectedAgentId: null,
-        actualAgentId: null,
-      },
-    ]);
+    expect(result.ownerType).toBe('agent');
+    expect(result.agentId).toBe('agent-legacy');
+    expect(result.resolvedFrom).toBe('agent_clients');
+    expect(result.diagnostics).toEqual([]);
   });
 
-  it('keeps subscriptions.agentId as the canonical owner and reports drift diagnostics', () => {
+  it('prefers agent_clients as the canonical owner and reports drift on older sources', () => {
     const result = resolveCommissionOwnership({
       subscriptionAgentId: 'agent-canonical',
       userAgentId: 'agent-legacy',
-      agentClientAgentIds: ['agent-legacy', 'agent-shadow'],
+      agentClientAgentIds: ['agent-current'],
     });
 
     expect(result.ownerType).toBe('agent');
-    expect(result.agentId).toBe('agent-canonical');
+    expect(result.agentId).toBe('agent-current');
+    expect(result.resolvedFrom).toBe('agent_clients');
     expect(result.diagnostics).toEqual([
       {
-        source: 'user.agentId',
-        expectedAgentId: 'agent-canonical',
-        actualAgentId: 'agent-legacy',
+        source: 'subscription.agentId',
+        expectedAgentId: 'agent-current',
+        actualAgentId: 'agent-canonical',
       },
       {
-        source: 'agent_clients',
-        expectedAgentId: 'agent-canonical',
-        actualAgentIds: ['agent-legacy', 'agent-shadow'],
+        source: 'user.agentId',
+        expectedAgentId: 'agent-current',
+        actualAgentId: 'agent-legacy',
       },
     ]);
   });
@@ -52,28 +48,44 @@ describe('resolveCommissionOwnership', () => {
 
     expect(result.ownerType).toBe('agent');
     expect(result.agentId).toBe('agent-canonical');
+    expect(result.resolvedFrom).toBe('agent_clients');
     expect(result.diagnostics).toEqual([]);
   });
 
-  it('treats a null subscription owner as company-owned', () => {
+  it('treats an empty active binding set as company-owned even when older sources are stale', () => {
     const result = resolveCommissionOwnership({
       subscriptionAgentId: null,
       userAgentId: 'agent-legacy',
-      agentClientAgentIds: ['agent-legacy'],
+      agentClientAgentIds: [],
     });
 
     expect(result.ownerType).toBe('company');
     expect(result.agentId).toBeNull();
+    expect(result.resolvedFrom).toBe('agent_clients');
     expect(result.diagnostics).toEqual([
       {
         source: 'user.agentId',
         expectedAgentId: null,
         actualAgentId: 'agent-legacy',
       },
+    ]);
+  });
+
+  it('returns unresolved when multiple active agent bindings disagree', () => {
+    const result = resolveCommissionOwnership({
+      subscriptionAgentId: 'agent-canonical',
+      userAgentId: 'agent-canonical',
+      agentClientAgentIds: ['agent-a', 'agent-b'],
+    });
+
+    expect(result.ownerType).toBe('unresolved');
+    expect(result.agentId).toBeNull();
+    expect(result.resolvedFrom).toBe('agent_clients');
+    expect(result.diagnostics).toEqual([
       {
         source: 'agent_clients',
         expectedAgentId: null,
-        actualAgentIds: ['agent-legacy'],
+        actualAgentIds: ['agent-a', 'agent-b'],
       },
     ]);
   });

--- a/packages/domain-membership-billing/src/commissions/ownership.ts
+++ b/packages/domain-membership-billing/src/commissions/ownership.ts
@@ -1,7 +1,8 @@
 export type CommissionOwnershipOwnerType = 'agent' | 'company' | 'unresolved';
+export type CommissionOwnershipSource = 'subscription.agentId' | 'user.agentId' | 'agent_clients';
 
 export interface CommissionOwnershipDriftDiagnostic {
-  source: 'subscription.agentId' | 'user.agentId' | 'agent_clients';
+  source: CommissionOwnershipSource;
   expectedAgentId: string | null;
   actualAgentId?: string | null;
   actualAgentIds?: string[];
@@ -10,6 +11,7 @@ export interface CommissionOwnershipDriftDiagnostic {
 export interface CommissionOwnershipResolution {
   ownerType: CommissionOwnershipOwnerType;
   agentId: string | null;
+  resolvedFrom: CommissionOwnershipSource | null;
   diagnostics: CommissionOwnershipDriftDiagnostic[];
 }
 
@@ -29,13 +31,55 @@ function normalizeAgentIds(
   return [...new Set(agentIds.filter((agentId): agentId is string => Boolean(agentId)))];
 }
 
+function normalizeAgentId(agentId: string | null | undefined): string | null | undefined {
+  if (agentId === undefined) {
+    return undefined;
+  }
+
+  if (agentId === null) {
+    return null;
+  }
+
+  const normalized = agentId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 export function resolveCommissionOwnership(
   input: ResolveCommissionOwnershipInput
 ): CommissionOwnershipResolution {
-  if (input.subscriptionAgentId === undefined) {
+  const subscriptionAgentId = normalizeAgentId(input.subscriptionAgentId);
+  const userAgentId = normalizeAgentId(input.userAgentId);
+  const agentClientAgentIds = normalizeAgentIds(input.agentClientAgentIds);
+
+  if (agentClientAgentIds && agentClientAgentIds.length > 1) {
     return {
       ownerType: 'unresolved',
       agentId: null,
+      resolvedFrom: 'agent_clients',
+      diagnostics: [
+        {
+          source: 'agent_clients',
+          expectedAgentId: null,
+          actualAgentIds: agentClientAgentIds,
+        },
+      ],
+    };
+  }
+
+  const resolvedFrom =
+    agentClientAgentIds !== null
+      ? 'agent_clients'
+      : userAgentId !== undefined
+        ? 'user.agentId'
+        : subscriptionAgentId !== undefined
+          ? 'subscription.agentId'
+          : null;
+
+  if (!resolvedFrom) {
+    return {
+      ownerType: 'unresolved',
+      agentId: null,
+      resolvedFrom: null,
       diagnostics: [
         {
           source: 'subscription.agentId',
@@ -46,34 +90,56 @@ export function resolveCommissionOwnership(
     };
   }
 
-  const resolvedAgentId = input.subscriptionAgentId;
+  const resolvedAgentId =
+    resolvedFrom === 'agent_clients'
+      ? (agentClientAgentIds?.[0] ?? null)
+      : resolvedFrom === 'user.agentId'
+        ? (userAgentId ?? null)
+        : (subscriptionAgentId ?? null);
   const diagnostics: CommissionOwnershipDriftDiagnostic[] = [];
 
-  if (input.userAgentId !== undefined && input.userAgentId !== resolvedAgentId) {
+  if (resolvedFrom !== 'subscription.agentId' && subscriptionAgentId !== undefined) {
+    if (subscriptionAgentId !== resolvedAgentId) {
+      diagnostics.push({
+        source: 'subscription.agentId',
+        expectedAgentId: resolvedAgentId,
+        actualAgentId: subscriptionAgentId,
+      });
+    }
+  }
+
+  if (
+    resolvedFrom !== 'user.agentId' &&
+    userAgentId !== undefined &&
+    userAgentId !== resolvedAgentId
+  ) {
     diagnostics.push({
       source: 'user.agentId',
       expectedAgentId: resolvedAgentId,
-      actualAgentId: input.userAgentId,
+      actualAgentId: userAgentId,
     });
   }
 
-  const agentClientAgentIds = normalizeAgentIds(input.agentClientAgentIds);
-  if (
-    agentClientAgentIds &&
-    ((resolvedAgentId === null && agentClientAgentIds.length > 0) ||
+  if (resolvedFrom !== 'agent_clients' && agentClientAgentIds !== null) {
+    const matchesCanonical =
+      (resolvedAgentId === null && agentClientAgentIds.length === 0) ||
       (resolvedAgentId !== null &&
-        (agentClientAgentIds.length !== 1 || agentClientAgentIds[0] !== resolvedAgentId)))
-  ) {
-    diagnostics.push({
-      source: 'agent_clients',
-      expectedAgentId: resolvedAgentId,
-      actualAgentIds: agentClientAgentIds,
-    });
+        agentClientAgentIds.length === 1 &&
+        agentClientAgentIds[0] === resolvedAgentId);
+
+    if (!matchesCanonical) {
+      diagnostics.push({
+        source: 'agent_clients',
+        expectedAgentId: resolvedAgentId,
+        actualAgentIds: agentClientAgentIds,
+      });
+    }
   }
 
   return {
     ownerType: resolvedAgentId === null ? 'company' : 'agent',
     agentId: resolvedAgentId,
+    resolvedFrom,
     diagnostics,
   };
 }

--- a/packages/domain-membership-billing/src/commissions/ownership.ts
+++ b/packages/domain-membership-billing/src/commissions/ownership.ts
@@ -21,6 +21,12 @@ export interface ResolveCommissionOwnershipInput {
   agentClientAgentIds?: Array<string | null | undefined>;
 }
 
+type NormalizedOwnershipSignals = {
+  subscriptionAgentId: string | null | undefined;
+  userAgentId: string | null | undefined;
+  agentClientAgentIds: string[] | null;
+};
+
 function normalizeAgentIds(
   agentIds: Array<string | null | undefined> | undefined
 ): string[] | null {
@@ -44,96 +50,158 @@ function normalizeAgentId(agentId: string | null | undefined): string | null | u
   return normalized.length > 0 ? normalized : null;
 }
 
+function normalizeOwnershipSignals(
+  input: ResolveCommissionOwnershipInput
+): NormalizedOwnershipSignals {
+  return {
+    subscriptionAgentId: normalizeAgentId(input.subscriptionAgentId),
+    userAgentId: normalizeAgentId(input.userAgentId),
+    agentClientAgentIds: normalizeAgentIds(input.agentClientAgentIds),
+  };
+}
+
+function buildMissingOwnershipResult(): CommissionOwnershipResolution {
+  return {
+    ownerType: 'unresolved',
+    agentId: null,
+    resolvedFrom: null,
+    diagnostics: [
+      {
+        source: 'subscription.agentId',
+        expectedAgentId: null,
+        actualAgentId: null,
+      },
+    ],
+  };
+}
+
+function buildConflictingAssignmentsResult(
+  agentClientAgentIds: string[]
+): CommissionOwnershipResolution {
+  return {
+    ownerType: 'unresolved',
+    agentId: null,
+    resolvedFrom: 'agent_clients',
+    diagnostics: [
+      {
+        source: 'agent_clients',
+        expectedAgentId: null,
+        actualAgentIds: agentClientAgentIds,
+      },
+    ],
+  };
+}
+
+function resolveCanonicalSource(
+  signals: NormalizedOwnershipSignals
+): CommissionOwnershipSource | null {
+  if (signals.agentClientAgentIds !== null) {
+    return 'agent_clients';
+  }
+
+  if (signals.userAgentId !== undefined) {
+    return 'user.agentId';
+  }
+
+  if (signals.subscriptionAgentId !== undefined) {
+    return 'subscription.agentId';
+  }
+
+  return null;
+}
+
+function resolveCanonicalAgentId(
+  resolvedFrom: CommissionOwnershipSource,
+  signals: NormalizedOwnershipSignals
+): string | null {
+  if (resolvedFrom === 'agent_clients') {
+    return signals.agentClientAgentIds?.[0] ?? null;
+  }
+
+  if (resolvedFrom === 'user.agentId') {
+    return signals.userAgentId ?? null;
+  }
+
+  return signals.subscriptionAgentId ?? null;
+}
+
+function addScalarDiagnostic(
+  diagnostics: CommissionOwnershipDriftDiagnostic[],
+  source: Extract<CommissionOwnershipSource, 'subscription.agentId' | 'user.agentId'>,
+  expectedAgentId: string | null,
+  actualAgentId: string | null | undefined
+) {
+  if (actualAgentId === undefined || actualAgentId === expectedAgentId) {
+    return;
+  }
+
+  diagnostics.push({
+    source,
+    expectedAgentId,
+    actualAgentId,
+  });
+}
+
+function agentClientsMatchCanonical(expectedAgentId: string | null, agentClientAgentIds: string[]) {
+  if (expectedAgentId === null) {
+    return agentClientAgentIds.length === 0;
+  }
+
+  return agentClientAgentIds.length === 1 && agentClientAgentIds[0] === expectedAgentId;
+}
+
+function addAgentClientDiagnostic(
+  diagnostics: CommissionOwnershipDriftDiagnostic[],
+  expectedAgentId: string | null,
+  agentClientAgentIds: string[] | null
+) {
+  if (
+    agentClientAgentIds === null ||
+    agentClientsMatchCanonical(expectedAgentId, agentClientAgentIds)
+  ) {
+    return;
+  }
+
+  diagnostics.push({
+    source: 'agent_clients',
+    expectedAgentId,
+    actualAgentIds: agentClientAgentIds,
+  });
+}
+
 export function resolveCommissionOwnership(
   input: ResolveCommissionOwnershipInput
 ): CommissionOwnershipResolution {
-  const subscriptionAgentId = normalizeAgentId(input.subscriptionAgentId);
-  const userAgentId = normalizeAgentId(input.userAgentId);
-  const agentClientAgentIds = normalizeAgentIds(input.agentClientAgentIds);
+  const signals = normalizeOwnershipSignals(input);
 
-  if (agentClientAgentIds && agentClientAgentIds.length > 1) {
-    return {
-      ownerType: 'unresolved',
-      agentId: null,
-      resolvedFrom: 'agent_clients',
-      diagnostics: [
-        {
-          source: 'agent_clients',
-          expectedAgentId: null,
-          actualAgentIds: agentClientAgentIds,
-        },
-      ],
-    };
+  if (signals.agentClientAgentIds && signals.agentClientAgentIds.length > 1) {
+    return buildConflictingAssignmentsResult(signals.agentClientAgentIds);
   }
 
-  const resolvedFrom =
-    agentClientAgentIds !== null
-      ? 'agent_clients'
-      : userAgentId !== undefined
-        ? 'user.agentId'
-        : subscriptionAgentId !== undefined
-          ? 'subscription.agentId'
-          : null;
+  const resolvedFrom = resolveCanonicalSource(signals);
 
   if (!resolvedFrom) {
-    return {
-      ownerType: 'unresolved',
-      agentId: null,
-      resolvedFrom: null,
-      diagnostics: [
-        {
-          source: 'subscription.agentId',
-          expectedAgentId: null,
-          actualAgentId: null,
-        },
-      ],
-    };
+    return buildMissingOwnershipResult();
   }
 
-  const resolvedAgentId =
-    resolvedFrom === 'agent_clients'
-      ? (agentClientAgentIds?.[0] ?? null)
-      : resolvedFrom === 'user.agentId'
-        ? (userAgentId ?? null)
-        : (subscriptionAgentId ?? null);
+  const resolvedAgentId = resolveCanonicalAgentId(resolvedFrom, signals);
   const diagnostics: CommissionOwnershipDriftDiagnostic[] = [];
 
-  if (resolvedFrom !== 'subscription.agentId' && subscriptionAgentId !== undefined) {
-    if (subscriptionAgentId !== resolvedAgentId) {
-      diagnostics.push({
-        source: 'subscription.agentId',
-        expectedAgentId: resolvedAgentId,
-        actualAgentId: subscriptionAgentId,
-      });
-    }
+  if (resolvedFrom !== 'subscription.agentId') {
+    addScalarDiagnostic(
+      diagnostics,
+      'subscription.agentId',
+      resolvedAgentId,
+      signals.subscriptionAgentId
+    );
   }
 
-  if (
-    resolvedFrom !== 'user.agentId' &&
-    userAgentId !== undefined &&
-    userAgentId !== resolvedAgentId
-  ) {
-    diagnostics.push({
-      source: 'user.agentId',
-      expectedAgentId: resolvedAgentId,
-      actualAgentId: userAgentId,
-    });
+  if (resolvedFrom !== 'user.agentId') {
+    addScalarDiagnostic(diagnostics, 'user.agentId', resolvedAgentId, signals.userAgentId);
   }
 
-  if (resolvedFrom !== 'agent_clients' && agentClientAgentIds !== null) {
-    const matchesCanonical =
-      (resolvedAgentId === null && agentClientAgentIds.length === 0) ||
-      (resolvedAgentId !== null &&
-        agentClientAgentIds.length === 1 &&
-        agentClientAgentIds[0] === resolvedAgentId);
-
-    if (!matchesCanonical) {
-      diagnostics.push({
-        source: 'agent_clients',
-        expectedAgentId: resolvedAgentId,
-        actualAgentIds: agentClientAgentIds,
-      });
-    }
+  if (resolvedFrom !== 'agent_clients') {
+    addAgentClientDiagnostic(diagnostics, resolvedAgentId, signals.agentClientAgentIds);
   }
 
   return {

--- a/packages/domain-membership-billing/src/index.ts
+++ b/packages/domain-membership-billing/src/index.ts
@@ -8,6 +8,7 @@ export * from './commissions/create';
 export * from './commissions/create-renewal';
 export * from './commissions/get-my';
 export * from './commissions/ownership';
+export * from './ownership-attribution';
 export * from './commissions/summary';
 export * from './commissions/types';
 export * from './paddle';

--- a/packages/domain-membership-billing/src/ownership-attribution.test.ts
+++ b/packages/domain-membership-billing/src/ownership-attribution.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createAgentAssistedOwnershipAttribution,
+  createSelfServeOwnershipAttribution,
+} from './ownership-attribution';
+
+describe('ownership attribution helpers', () => {
+  it('creates self-serve attribution with optional assisting agent', () => {
+    expect(createSelfServeOwnershipAttribution(' agent_1 ')).toEqual({
+      agentId: 'agent_1',
+      createdBy: 'self',
+      assistedByAgentId: 'agent_1',
+    });
+    expect(createSelfServeOwnershipAttribution()).toEqual({
+      agentId: null,
+      createdBy: 'self',
+      assistedByAgentId: null,
+    });
+  });
+
+  it('creates agent-assisted attribution for durable assisted ownership writes', () => {
+    expect(createAgentAssistedOwnershipAttribution(' agent_2 ')).toEqual({
+      agentId: 'agent_2',
+      createdBy: 'agent',
+      assistedByAgentId: 'agent_2',
+    });
+  });
+
+  it('rejects blank agent ids for agent-assisted attribution', () => {
+    expect(() => createAgentAssistedOwnershipAttribution('   ')).toThrow(
+      'Agent-assisted ownership attribution requires an agentId'
+    );
+  });
+});

--- a/packages/domain-membership-billing/src/ownership-attribution.ts
+++ b/packages/domain-membership-billing/src/ownership-attribution.ts
@@ -1,3 +1,6 @@
+import { agentClients, and, db, eq } from '@interdomestik/database';
+import { nanoid } from 'nanoid';
+
 function normalizeAgentId(agentId: string | null | undefined): string | null {
   if (typeof agentId !== 'string') return null;
   const normalized = agentId.trim();
@@ -25,4 +28,48 @@ export function createAgentAssistedOwnershipAttribution(agentId: string) {
     createdBy: 'agent' as const,
     assistedByAgentId: normalizedAgentId,
   };
+}
+
+type AgentClientBindingWriter = Pick<typeof db, 'update' | 'insert'>;
+
+export async function syncActiveAgentClientBinding(
+  tx: AgentClientBindingWriter,
+  args: {
+    tenantId: string;
+    memberId: string;
+    agentId?: string | null;
+    now?: Date;
+    idFactory?: () => string;
+  }
+) {
+  const now = args.now ?? new Date();
+  const normalizedAgentId = normalizeAgentId(args.agentId);
+
+  await tx
+    .update(agentClients)
+    .set({ status: 'inactive' })
+    .where(and(eq(agentClients.tenantId, args.tenantId), eq(agentClients.memberId, args.memberId)));
+
+  if (!normalizedAgentId) {
+    return;
+  }
+
+  await tx
+    .insert(agentClients)
+    .values({
+      id: args.idFactory?.() ?? nanoid(),
+      tenantId: args.tenantId,
+      agentId: normalizedAgentId,
+      memberId: args.memberId,
+      status: 'active',
+      joinedAt: now,
+      createdAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [agentClients.tenantId, agentClients.agentId, agentClients.memberId],
+      set: {
+        status: 'active',
+        joinedAt: now,
+      },
+    });
 }

--- a/packages/domain-membership-billing/src/ownership-attribution.ts
+++ b/packages/domain-membership-billing/src/ownership-attribution.ts
@@ -1,0 +1,28 @@
+function normalizeAgentId(agentId: string | null | undefined): string | null {
+  if (typeof agentId !== 'string') return null;
+  const normalized = agentId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function createSelfServeOwnershipAttribution(agentId?: string | null) {
+  const normalizedAgentId = normalizeAgentId(agentId);
+
+  return {
+    agentId: normalizedAgentId,
+    createdBy: 'self' as const,
+    assistedByAgentId: normalizedAgentId,
+  };
+}
+
+export function createAgentAssistedOwnershipAttribution(agentId: string) {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  if (!normalizedAgentId) {
+    throw new Error('Agent-assisted ownership attribution requires an agentId');
+  }
+
+  return {
+    agentId: normalizedAgentId,
+    createdBy: 'agent' as const,
+    assistedByAgentId: normalizedAgentId,
+  };
+}

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -381,7 +381,18 @@ describe('Paddle Webhook Handlers', () => {
       expect(mockWhere).toHaveBeenCalled();
     });
 
-    it('prefers the reconciled user agent over webhook customData when persisting subscription ownership', async () => {
+    it.each([
+      {
+        name: 'prefers the reconciled user agent over webhook customData when persisting subscription ownership',
+        resolvedAgentId: 'agent_user',
+        subscriptionId: 'sub_agent_owner',
+      },
+      {
+        name: 'clears subscription ownership when the reconciled user is company-owned',
+        resolvedAgentId: null,
+        subscriptionId: 'sub_company_owner',
+      },
+    ])('$name', async ({ resolvedAgentId, subscriptionId }) => {
       const insertedValues = vi.fn().mockResolvedValue(undefined);
 
       hoisted.db.insert.mockReturnValue({
@@ -394,7 +405,7 @@ describe('Paddle Webhook Handlers', () => {
           email: 'test@example.com',
           name: 'Test User',
           memberNumber: 'MEM-2026-000001',
-          agentId: 'agent_user',
+          agentId: resolvedAgentId,
         })
         .mockResolvedValueOnce({
           branchId: 'branch_abc',
@@ -404,7 +415,7 @@ describe('Paddle Webhook Handlers', () => {
         {
           eventType: 'subscription.updated',
           data: {
-            id: 'sub_agent_owner',
+            id: subscriptionId,
             status: 'active',
             customData: { userId: 'user_123', agentId: 'agent_stale' },
             items: [
@@ -421,52 +432,7 @@ describe('Paddle Webhook Handlers', () => {
       expect(insertedValues).toHaveBeenCalledWith(
         expect.objectContaining({
           userId: 'user_123',
-          agentId: 'agent_user',
-        })
-      );
-    });
-
-    it('clears subscription ownership when the reconciled user is company-owned', async () => {
-      const insertedValues = vi.fn().mockResolvedValue(undefined);
-
-      hoisted.db.insert.mockReturnValue({
-        values: insertedValues,
-      });
-      hoisted.db.query.subscriptions.findFirst.mockResolvedValueOnce(null);
-      hoisted.db.query.user.findFirst
-        .mockResolvedValueOnce({
-          tenantId: 'tenant_abc',
-          email: 'test@example.com',
-          name: 'Test User',
-          memberNumber: 'MEM-2026-000001',
-          agentId: null,
-        })
-        .mockResolvedValueOnce({
-          branchId: 'branch_abc',
-        });
-
-      await handleSubscriptionChanged(
-        {
-          eventType: 'subscription.updated',
-          data: {
-            id: 'sub_company_owner',
-            status: 'active',
-            customData: { userId: 'user_123', agentId: 'agent_stale' },
-            items: [
-              {
-                price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
-              },
-            ],
-            currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
-          },
-        },
-        { logAuditEvent }
-      );
-
-      expect(insertedValues).toHaveBeenCalledWith(
-        expect.objectContaining({
-          userId: 'user_123',
-          agentId: null,
+          agentId: resolvedAgentId,
         })
       );
     });

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -425,6 +425,51 @@ describe('Paddle Webhook Handlers', () => {
         })
       );
     });
+
+    it('clears subscription ownership when the reconciled user is company-owned', async () => {
+      const insertedValues = vi.fn().mockResolvedValue(undefined);
+
+      hoisted.db.insert.mockReturnValue({
+        values: insertedValues,
+      });
+      hoisted.db.query.subscriptions.findFirst.mockResolvedValueOnce(null);
+      hoisted.db.query.user.findFirst
+        .mockResolvedValueOnce({
+          tenantId: 'tenant_abc',
+          email: 'test@example.com',
+          name: 'Test User',
+          memberNumber: 'MEM-2026-000001',
+          agentId: null,
+        })
+        .mockResolvedValueOnce({
+          branchId: 'branch_abc',
+        });
+
+      await handleSubscriptionChanged(
+        {
+          eventType: 'subscription.updated',
+          data: {
+            id: 'sub_company_owner',
+            status: 'active',
+            customData: { userId: 'user_123', agentId: 'agent_stale' },
+            items: [
+              {
+                price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
+              },
+            ],
+            currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
+          },
+        },
+        { logAuditEvent }
+      );
+
+      expect(insertedValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user_123',
+          agentId: null,
+        })
+      );
+    });
   });
 
   describe('handleSubscriptionPastDue', () => {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -43,6 +43,11 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  agentClients: {
+    tenantId: 'agent_clients.tenant_id',
+    memberId: 'agent_clients.member_id',
+    agentId: 'agent_clients.agent_id',
+  },
   and: hoisted.and,
   asc: hoisted.asc,
   db: hoisted.db,
@@ -374,6 +379,51 @@ describe('Paddle Webhook Handlers', () => {
         })
       );
       expect(mockWhere).toHaveBeenCalled();
+    });
+
+    it('prefers the reconciled user agent over webhook customData when persisting subscription ownership', async () => {
+      const insertedValues = vi.fn().mockResolvedValue(undefined);
+
+      hoisted.db.insert.mockReturnValue({
+        values: insertedValues,
+      });
+      hoisted.db.query.subscriptions.findFirst.mockResolvedValueOnce(null);
+      hoisted.db.query.user.findFirst
+        .mockResolvedValueOnce({
+          tenantId: 'tenant_abc',
+          email: 'test@example.com',
+          name: 'Test User',
+          memberNumber: 'MEM-2026-000001',
+          agentId: 'agent_user',
+        })
+        .mockResolvedValueOnce({
+          branchId: 'branch_abc',
+        });
+
+      await handleSubscriptionChanged(
+        {
+          eventType: 'subscription.updated',
+          data: {
+            id: 'sub_agent_owner',
+            status: 'active',
+            customData: { userId: 'user_123', agentId: 'agent_stale' },
+            items: [
+              {
+                price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
+              },
+            ],
+            currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
+          },
+        },
+        { logAuditEvent }
+      );
+
+      expect(insertedValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user_123',
+          agentId: 'agent_user',
+        })
+      );
     });
   });
 

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
@@ -48,7 +48,7 @@ export async function handleSubscriptionChanged(
     sub,
     tenantId,
     userId,
-    agentId: resolvedAgentId ?? undefined,
+    agentId: resolvedAgentId,
     branchId,
     mappedStatus,
     planState: canonicalPlanState,
@@ -94,7 +94,7 @@ async function upsertSubscription(args: {
   sub: any;
   tenantId: string;
   userId: string;
-  agentId?: string;
+  agentId?: string | null;
   branchId?: string;
   mappedStatus: InternalSubscriptionStatus;
   planState: {
@@ -181,7 +181,7 @@ function normalizeAgentId(agentId: string | null | undefined): string | null {
 
 function resolveSubscriptionAgentId(args: {
   userRecord?: { agentId?: string | null } | null;
-  customData?: { agentId?: string } | undefined;
+  customData?: { agentId?: string };
 }) {
   if (args.userRecord) {
     return normalizeAgentId(args.userRecord.agentId);

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
@@ -34,6 +34,7 @@ export async function handleSubscriptionChanged(
   }
 
   const { userId, tenantId, branchId, customData, userRecord } = context;
+  const resolvedAgentId = resolveSubscriptionAgentId({ userRecord, customData });
 
   const priceId = sub.items?.[0]?.price?.id || sub.items?.[0]?.priceId || 'unknown';
   const canonicalPlanState = await resolveCanonicalMembershipPlanState({
@@ -47,7 +48,7 @@ export async function handleSubscriptionChanged(
     sub,
     tenantId,
     userId,
-    agentId: customData?.agentId,
+    agentId: resolvedAgentId ?? undefined,
     branchId,
     mappedStatus,
     planState: canonicalPlanState,
@@ -167,6 +168,26 @@ async function findExistingSubscription(subId: string, userId: string) {
 
 async function updateSubscription(subscriptionId: string, values: Record<string, unknown>) {
   await db.update(subscriptions).set(values).where(eq(subscriptions.id, subscriptionId));
+}
+
+function normalizeAgentId(agentId: string | null | undefined): string | null {
+  if (typeof agentId !== 'string') {
+    return null;
+  }
+
+  const normalized = agentId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function resolveSubscriptionAgentId(args: {
+  userRecord?: { agentId?: string | null } | null;
+  customData?: { agentId?: string } | undefined;
+}) {
+  if (args.userRecord) {
+    return normalizeAgentId(args.userRecord.agentId);
+  }
+
+  return normalizeAgentId(args.customData?.agentId);
 }
 
 function mapToSubscriptionValues(

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
@@ -64,7 +64,7 @@ export async function resolveSubscriptionContext(sub: any) {
 
   const userRecord = await db.query.user.findFirst({
     where: (users, { eq }) => eq(users.id, userId),
-    columns: { tenantId: true, email: true, name: true, memberNumber: true },
+    columns: { tenantId: true, email: true, name: true, memberNumber: true, agentId: true },
   });
 
   const canonicalTenantId = existingSub?.tenantId ?? userRecord?.tenantId;

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
@@ -11,6 +11,11 @@ import {
 
 // Mock dependencies
 vi.mock('@interdomestik/database', () => ({
+  agentClients: {
+    tenantId: 'agentClients.tenantId',
+    memberId: 'agentClients.memberId',
+    agentId: 'agentClients.agentId',
+  },
   db: {
     transaction: vi.fn(),
     query: {
@@ -22,6 +27,8 @@ vi.mock('@interdomestik/database', () => ({
       },
     },
   },
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
 }));
 
 vi.mock('nanoid', () => ({

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
@@ -1,11 +1,11 @@
 import { db } from '@interdomestik/database';
-import { agentClients, referrals } from '@interdomestik/database/schema';
+import { referrals } from '@interdomestik/database/schema';
 import { and, eq } from 'drizzle-orm';
-import { nanoid } from 'nanoid';
 import { createMemberReferralRewardCore } from '../../../../../domain-referrals/src';
 import { createCommissionCore } from '../../../commissions/create';
 import { createRenewalCommissionCore } from '../../../commissions/create-renewal';
 import { calculateCommission } from '../../../commissions/types';
+import { syncActiveAgentClientBinding } from '../../../ownership-attribution';
 import type { PaddleWebhookAuditDeps, PaddleWebhookDeps } from '../../types';
 
 export const redactEmail = (email?: string | null) => {
@@ -138,29 +138,12 @@ async function ensureAgentClientBinding(args: {
 
   const now = new Date();
   await db.transaction(async tx => {
-    await tx
-      .update(agentClients)
-      .set({ status: 'inactive' })
-      .where(and(eq(agentClients.tenantId, args.tenantId), eq(agentClients.memberId, args.userId)));
-
-    await tx
-      .insert(agentClients)
-      .values({
-        id: nanoid(),
-        tenantId: args.tenantId,
-        agentId,
-        memberId: args.userId,
-        status: 'active',
-        joinedAt: now,
-        createdAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [agentClients.tenantId, agentClients.agentId, agentClients.memberId],
-        set: {
-          status: 'active',
-          joinedAt: now,
-        },
-      });
+    await syncActiveAgentClientBinding(tx, {
+      tenantId: args.tenantId,
+      memberId: args.userId,
+      agentId,
+      now,
+    });
   });
 }
 

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts
@@ -108,6 +108,14 @@ describe('reconcileCheckoutUser', () => {
 
     expect(hoisted.db.transaction).toHaveBeenCalledTimes(1);
     expect(hoisted.tx.insert).toHaveBeenCalled();
+    expect(hoisted.insertedUserValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'member',
+        agentId: 'agent_9',
+        createdBy: 'self',
+        assistedByAgentId: 'agent_9',
+      })
+    );
     expect(hoisted.generateMemberNumber).toHaveBeenCalledWith(hoisted.tx, {
       userId: 'user_new',
       joinedAt: expect.any(Date),
@@ -363,6 +371,7 @@ describe('reconcileCheckoutUser', () => {
         memberNumber: null,
         role: 'admin',
         agentId: null,
+        createdBy: 'admin',
       })
       .mockResolvedValueOnce({
         id: 'user_admin',
@@ -400,6 +409,7 @@ describe('reconcileCheckoutUser', () => {
         branchId: 'branch-ks-main',
         agentId: 'agent_1',
         assistedByAgentId: 'agent_1',
+        createdBy: 'admin',
       })
     );
     expect(hoisted.generateMemberNumber).toHaveBeenCalledWith(hoisted.tx, {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts
@@ -21,6 +21,12 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  agentClients: {
+    tenantId: 'agent_clients.tenant_id',
+    memberId: 'agent_clients.member_id',
+    agentId: 'agent_clients.agent_id',
+  },
+  and: vi.fn((...conditions) => ({ conditions, op: 'and' })),
   db: hoisted.db,
   eq: vi.fn((left, right) => ({ left, right })),
   user: { id: 'user.id' },
@@ -41,6 +47,17 @@ describe('reconcileCheckoutUser', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.db.query.user.findFirst.mockReset();
+    hoisted.db.query.account.findFirst.mockReset();
+    hoisted.db.query.webhookEvents.findFirst.mockReset();
+    hoisted.db.query.tenantSettings.findFirst.mockReset();
+    hoisted.db.transaction.mockReset();
+    hoisted.tx.insert.mockReset();
+    hoisted.tx.update.mockReset();
+    hoisted.insertedUserValues.mockReset();
+    hoisted.updatedUserValues.mockReset();
+    hoisted.generateMemberNumber.mockReset();
+    hoisted.nanoid.mockReset();
 
     hoisted.nanoid.mockReturnValue('user_new');
     hoisted.generateMemberNumber.mockResolvedValue({
@@ -53,7 +70,9 @@ describe('reconcileCheckoutUser', () => {
     hoisted.tx.insert.mockImplementation(() => ({
       values: hoisted.insertedUserValues,
     }));
-    hoisted.insertedUserValues.mockResolvedValue(undefined);
+    hoisted.insertedUserValues.mockReturnValue({
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    });
 
     hoisted.tx.update.mockImplementation(() => ({
       set: hoisted.updatedUserValues,
@@ -114,6 +133,13 @@ describe('reconcileCheckoutUser', () => {
         agentId: 'agent_9',
         createdBy: 'self',
         assistedByAgentId: 'agent_9',
+      })
+    );
+    expect(hoisted.insertedUserValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memberId: 'user_new',
+        agentId: 'agent_9',
+        status: 'active',
       })
     );
     expect(hoisted.generateMemberNumber).toHaveBeenCalledWith(hoisted.tx, {
@@ -416,6 +442,13 @@ describe('reconcileCheckoutUser', () => {
       userId: 'user_admin',
       joinedAt: expect.any(Date),
     });
+    expect(hoisted.insertedUserValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memberId: 'user_admin',
+        agentId: 'agent_1',
+        status: 'active',
+      })
+    );
     expect(requestPasswordResetOnboarding).not.toHaveBeenCalled();
   });
 });

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts
@@ -1,7 +1,10 @@
 import { db, eq, user as userTable } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
 import { nanoid } from 'nanoid';
-import { createSelfServeOwnershipAttribution } from '../../../ownership-attribution';
+import {
+  createSelfServeOwnershipAttribution,
+  syncActiveAgentClientBinding,
+} from '../../../ownership-attribution';
 import type { RequestPasswordResetOnboarding } from '../../types';
 import { resolveBranchId } from './context';
 
@@ -177,6 +180,13 @@ export async function reconcileCheckoutUser(
           userId: newUserId,
           joinedAt: now,
         });
+
+        await syncActiveAgentClientBinding(tx, {
+          tenantId,
+          memberId: newUserId,
+          agentId: ownershipAttribution.agentId,
+          now,
+        });
       });
 
       shouldRequestOnboarding = true;
@@ -209,13 +219,14 @@ export async function reconcileCheckoutUser(
   ) {
     const nextRole = shouldPromoteRole(existingUser.role) ? 'member' : existingUser.role;
     const ownershipAttribution = createSelfServeOwnershipAttribution(mergedCustomData?.agentId);
+    const nextAgentId = existingUser.agentId ?? ownershipAttribution.agentId;
     await db.transaction(async tx => {
       await tx
         .update(userTable)
         .set({
           role: nextRole,
           branchId: existingUser.branchId ?? branchId ?? null,
-          agentId: existingUser.agentId ?? ownershipAttribution.agentId,
+          agentId: nextAgentId,
           assistedByAgentId: ownershipAttribution.assistedByAgentId,
           createdBy: existingUser.createdBy ?? ownershipAttribution.createdBy,
           updatedAt: now,
@@ -228,6 +239,13 @@ export async function reconcileCheckoutUser(
           joinedAt: now,
         });
       }
+
+      await syncActiveAgentClientBinding(tx, {
+        tenantId,
+        memberId: existingUser.id,
+        agentId: nextAgentId,
+        now,
+      });
     });
 
     shouldRequestOnboarding = !credentialAccount;
@@ -243,6 +261,7 @@ export async function reconcileCheckoutUser(
       name: true,
       role: true,
       memberNumber: true,
+      agentId: true,
     },
   });
 

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts
@@ -1,6 +1,7 @@
 import { db, eq, user as userTable } from '@interdomestik/database';
 import { generateMemberNumber } from '@interdomestik/database/member-number';
 import { nanoid } from 'nanoid';
+import { createSelfServeOwnershipAttribution } from '../../../ownership-attribution';
 import type { RequestPasswordResetOnboarding } from '../../types';
 import { resolveBranchId } from './context';
 
@@ -42,6 +43,8 @@ type ReconciledUserRecord = {
   name: string | null;
   role: string;
   memberNumber: string | null;
+  createdBy?: string | null;
+  assistedByAgentId?: string | null;
   agentId?: string | null;
 };
 
@@ -155,6 +158,7 @@ export async function reconcileCheckoutUser(
   if (!existingUser) {
     const newUserId = nanoid();
     try {
+      const ownershipAttribution = createSelfServeOwnershipAttribution(mergedCustomData?.agentId);
       await db.transaction(async tx => {
         await tx.insert(userTable).values({
           id: newUserId,
@@ -164,11 +168,9 @@ export async function reconcileCheckoutUser(
           email: customerEmail,
           emailVerified: false,
           role: 'member',
-          agentId: mergedCustomData?.agentId,
+          ...ownershipAttribution,
           createdAt: now,
           updatedAt: now,
-          createdBy: 'self',
-          assistedByAgentId: mergedCustomData?.agentId,
         });
 
         await generateMemberNumber(tx, {
@@ -206,14 +208,16 @@ export async function reconcileCheckoutUser(
     (!credentialAccount || existingUser.role !== 'member' || !existingUser.memberNumber)
   ) {
     const nextRole = shouldPromoteRole(existingUser.role) ? 'member' : existingUser.role;
+    const ownershipAttribution = createSelfServeOwnershipAttribution(mergedCustomData?.agentId);
     await db.transaction(async tx => {
       await tx
         .update(userTable)
         .set({
           role: nextRole,
           branchId: existingUser.branchId ?? branchId ?? null,
-          agentId: existingUser.agentId ?? mergedCustomData?.agentId ?? null,
-          assistedByAgentId: mergedCustomData?.agentId ?? null,
+          agentId: existingUser.agentId ?? ownershipAttribution.agentId,
+          assistedByAgentId: ownershipAttribution.assistedByAgentId,
+          createdBy: existingUser.createdBy ?? ownershipAttribution.createdBy,
           updatedAt: now,
         })
         .where(eq(userTable.id, existingUser.id));

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts
@@ -96,6 +96,8 @@ async function findUserByEmail(email: string): Promise<ReconciledUserRecord | nu
         role: true,
         memberNumber: true,
         agentId: true,
+        createdBy: true,
+        assistedByAgentId: true,
       },
     })) ?? null
   );

--- a/packages/domain-users/package.json
+++ b/packages/domain-users/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@interdomestik/database": "workspace:*",
+    "@interdomestik/domain-membership-billing": "workspace:*",
     "@interdomestik/shared-auth": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "nanoid": "^5.1.7",

--- a/packages/domain-users/src/admin/update-user-agent.test.ts
+++ b/packages/domain-users/src/admin/update-user-agent.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
     values: vi.fn(),
     onConflictDoUpdate: vi.fn(),
   };
+  const syncActiveAgentClientBinding = vi.fn();
   const tx = {
     update: vi.fn(),
     insert: vi.fn(),
@@ -51,6 +52,7 @@ const mocks = vi.hoisted(() => {
     subscriptionsUpdateChain,
     agentClientsUpdateChain,
     insertChain,
+    syncActiveAgentClientBinding,
     eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
     and: vi.fn((...parts) => ({ op: 'and', parts })),
     withTenant: vi.fn((tenantId, tenantColumn, filter) => ({
@@ -81,6 +83,10 @@ vi.mock('@interdomestik/shared-auth', () => ({
   ensureTenantId: mocks.ensureTenantId,
 }));
 
+vi.mock('@interdomestik/domain-membership-billing', () => ({
+  syncActiveAgentClientBinding: mocks.syncActiveAgentClientBinding,
+}));
+
 vi.mock('./access', () => ({
   requireTenantAdminSession: mocks.requireTenantAdminSession,
 }));
@@ -107,6 +113,7 @@ describe('updateUserAgentCore', () => {
     mocks.agentClientsUpdateChain.where.mockResolvedValue(undefined);
     mocks.insertChain.values.mockReturnValue(mocks.insertChain);
     mocks.insertChain.onConflictDoUpdate.mockResolvedValue(undefined);
+    mocks.syncActiveAgentClientBinding.mockResolvedValue(undefined);
     mocks.tx.update.mockImplementation(table => {
       if (table === mocks.user) return mocks.userUpdateChain;
       if (table === mocks.subscriptions) return mocks.subscriptionsUpdateChain;
@@ -131,16 +138,14 @@ describe('updateUserAgentCore', () => {
       throw new Error(`Expected success result, received error: ${result.error}`);
     }
     expect(result.success).toBe(true);
-    expect(mocks.tx.update).toHaveBeenCalledTimes(3);
-    expect(mocks.tx.insert).toHaveBeenCalledTimes(1);
+    expect(mocks.tx.update).toHaveBeenCalledTimes(2);
+    expect(mocks.tx.insert).not.toHaveBeenCalled();
 
     expect(mocks.tx.update).toHaveBeenNthCalledWith(1, mocks.user);
     expect(mocks.tx.update).toHaveBeenNthCalledWith(2, mocks.subscriptions);
-    expect(mocks.tx.update).toHaveBeenNthCalledWith(3, mocks.agentClients);
 
     expect(mocks.userUpdateChain.set).toHaveBeenCalledWith({ agentId: 'agent-2' });
     expect(mocks.subscriptionsUpdateChain.set).toHaveBeenCalledWith({ agentId: 'agent-2' });
-    expect(mocks.agentClientsUpdateChain.set).toHaveBeenCalledWith({ status: 'inactive' });
 
     expect(mocks.withTenant).toHaveBeenCalledWith(
       'tenant_ks',
@@ -172,14 +177,16 @@ describe('updateUserAgentCore', () => {
       })
     );
 
-    expect(mocks.insertChain.values).toHaveBeenCalledWith(
+    expect(mocks.syncActiveAgentClientBinding).toHaveBeenCalledWith(
+      mocks.tx,
       expect.objectContaining({
         tenantId: 'tenant_ks',
         agentId: 'agent-2',
         memberId: 'member-1',
-        status: 'active',
+        idFactory: expect.any(Function),
       })
     );
+    expect(mocks.syncActiveAgentClientBinding.mock.calls[0]?.[1]?.idFactory?.()).toBe('uuid-1');
   });
 
   it('moves the member to company-owned when clearing the agent', async () => {
@@ -197,7 +204,7 @@ describe('updateUserAgentCore', () => {
     }
     expect(result.success).toBe(true);
     expect(mocks.tx.insert).not.toHaveBeenCalled();
-    expect(mocks.tx.update).toHaveBeenCalledTimes(3);
+    expect(mocks.tx.update).toHaveBeenCalledTimes(2);
     expect(mocks.subscriptionsUpdateChain.set).toHaveBeenCalledWith({ agentId: null });
     expect(mocks.subscriptionsUpdateChain.where).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -219,6 +226,15 @@ describe('updateUserAgentCore', () => {
             },
           ],
         }),
+      })
+    );
+    expect(mocks.syncActiveAgentClientBinding).toHaveBeenCalledWith(
+      mocks.tx,
+      expect.objectContaining({
+        tenantId: 'tenant_ks',
+        memberId: 'member-1',
+        agentId: null,
+        idFactory: expect.any(Function),
       })
     );
   });

--- a/packages/domain-users/src/admin/update-user-agent.ts
+++ b/packages/domain-users/src/admin/update-user-agent.ts
@@ -1,5 +1,6 @@
 import { agentClients, db, eq, subscriptions, user } from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
+import { syncActiveAgentClientBinding } from '@interdomestik/domain-membership-billing';
 import { and } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 
@@ -35,27 +36,12 @@ export async function updateUserAgentCore(params: {
           )
         );
 
-      await tx
-        .update(agentClients)
-        .set({ status: 'inactive' })
-        .where(withTenant(tenantId, agentClients.tenantId, eq(agentClients.memberId, userId)));
-
-      if (agentId) {
-        await tx
-          .insert(agentClients)
-          .values({
-            id: randomUUID(),
-            tenantId,
-            agentId,
-            memberId: userId,
-            status: 'active',
-            joinedAt: new Date(),
-          })
-          .onConflictDoUpdate({
-            target: [agentClients.tenantId, agentClients.agentId, agentClients.memberId],
-            set: { status: 'active', joinedAt: new Date() },
-          });
-      }
+      await syncActiveAgentClientBinding(tx, {
+        tenantId,
+        memberId: userId,
+        agentId,
+        idFactory: () => randomUUID(),
+      });
     });
 
     return { success: true };

--- a/packages/domain-users/src/admin/update-user-agent.ts
+++ b/packages/domain-users/src/admin/update-user-agent.ts
@@ -1,4 +1,4 @@
-import { agentClients, db, eq, subscriptions, user } from '@interdomestik/database';
+import { db, eq, subscriptions, user } from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { syncActiveAgentClientBinding } from '@interdomestik/domain-membership-billing';
 import { and } from 'drizzle-orm';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,6 +761,9 @@ importers:
       '@interdomestik/database':
         specifier: workspace:*
         version: link:../database
+      '@interdomestik/domain-membership-billing':
+        specifier: workspace:*
+        version: link:../domain-membership-billing
       '@interdomestik/shared-auth':
         specifier: workspace:*
         version: link:../shared-auth


### PR DESCRIPTION
## Summary
- unify ownership attribution writes across assisted, self-serve, webhook, and admin reassignment paths
- centralize active `agent_clients` synchronization and align webhook reconciliation with canonical ownership
- align renewal commission and agent-facing read models with the active ownership graph

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/ownership-attribution.test.ts src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts src/paddle-webhooks/handlers.test.ts src/paddle-webhooks/handlers/utils/extras.test.ts src/commissions/ownership.test.ts src/commissions/create-renewal.test.ts
- pnpm --filter @interdomestik/domain-leads test:unit --run src/convert.test.ts
- pnpm --filter @interdomestik/domain-users test:unit --run src/admin/update-user-agent.test.ts
- pnpm --filter @interdomestik/web test:unit --run 'src/lib/actions/agent/register-member.wrapper.test.ts' 'src/features/agent/import/server/get-group-dashboard-summary.test.ts' 'src/features/agent/import/components/group-dashboard-summary.test.tsx' 'src/app/[locale]/(dashboard)/agent/import/page.test.tsx'
- pnpm --filter @interdomestik/domain-agent test:unit --run src/get-agent-members-list.test.ts src/get-agent-member-detail.test.ts
- pnpm --filter @interdomestik/domain-membership-billing type-check
- pnpm --filter @interdomestik/domain-leads type-check && pnpm --filter @interdomestik/domain-users type-check && pnpm --filter @interdomestik/web type-check && pnpm --filter @interdomestik/domain-agent type-check
