### PR TITLE
fix: harden document access and isolation logic

### DIFF
--- a/apps/web/src/app/api/documents/_core.test.ts
+++ b/apps/web/src/app/api/documents/_core.test.ts
@@ -1,25 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DocumentAccessDeps, getDocumentAccessCore } from './_core';
 
-const mockDb = {
-  select: vi.fn(),
-} as any;
-
-const mockStorage = {
-  createSignedUrl: vi.fn(),
-  download: vi.fn(),
-};
-
-const mockDeps: DocumentAccessDeps = {
-  db: mockDb,
-  storage: mockStorage,
-};
+const mockDb = { select: vi.fn() } as any;
+const mockStorage = { createSignedUrl: vi.fn(), download: vi.fn() };
+const mockDeps: DocumentAccessDeps = { db: mockDb, storage: mockStorage };
 
 const memberSession = { user: { id: 'member-1', role: 'member', tenantId: 't1' } };
 const otherMemberSession = { user: { id: 'member-2', role: 'member', tenantId: 't1' } };
 const branchManagerSession = {
   user: { id: 'manager-1', role: 'branch_manager', tenantId: 't1', branchId: 'branch-a' },
-} as const;
+};
 
 const branchScopedClaimRow = {
   claimOwnerId: 'member-1',
@@ -27,247 +17,123 @@ const branchScopedClaimRow = {
   claimStaffId: 'staff-2',
 };
 
-const memberPolymorphicDocument = {
-  id: 'doc-profile',
-  entityType: 'member',
-  entityId: 'member-1',
-  storagePath: 'path/to/profile',
-  uploadedBy: 'staff-1',
-  fileName: 'id.pdf',
-  mimeType: 'application/pdf',
-  fileSize: 100,
-  tenantId: 't1',
+const polymorphicDocs = {
+  profile: {
+    id: 'doc-profile',
+    entityType: 'member',
+    entityId: 'member-1',
+    storagePath: 'path/to/profile',
+    uploadedBy: 'staff-1',
+    tenantId: 't1',
+  },
+  claim: {
+    id: 'doc1',
+    entityType: 'claim',
+    entityId: 'claim-1',
+    storagePath: 'path',
+    uploadedBy: 'other',
+    tenantId: 't1',
+  },
+  policy: {
+    id: 'doc-policy',
+    entityType: 'policy',
+    entityId: 'policy-1',
+    storagePath: 'path/to/policy',
+    uploadedBy: 'staff-1',
+    tenantId: 't1',
+  },
 };
 
-const claimScopedPolymorphicDocument = {
-  id: 'doc1',
-  entityType: 'claim',
-  entityId: 'claim-1',
-  storagePath: 'path',
-  uploadedBy: 'other',
-  fileName: 'evidence.pdf',
-  mimeType: 'application/pdf',
-  fileSize: 123,
-  tenantId: 't1',
-};
-
-const policyPolymorphicDocument = {
-  id: 'doc-policy',
-  entityType: 'policy',
-  entityId: 'policy-1',
-  storagePath: 'path/to/policy',
-  uploadedBy: 'staff-1',
-  fileName: 'policy.pdf',
-  mimeType: 'application/pdf',
-  fileSize: 200,
-  tenantId: 't1',
-};
-
-const legacyDocument = {
+const legacyDoc = {
   id: 'doc1',
   claimId: 'claim-1',
   bucket: 'claim-evidence',
   filePath: 'path',
   uploadedBy: 'other-user',
-  name: 'evidence.pdf',
-  fileType: 'application/pdf',
-  fileSize: 123,
 };
 
-function createWhereSelectResult(result: any[]) {
-  return {
-    from: vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(result),
-    }),
-  };
+function createSelectMock(result: any[], isLegacy = false) {
+  const chain: any = { where: vi.fn().mockResolvedValue(result) };
+  if (isLegacy) chain.leftJoin = vi.fn().mockReturnValue(chain);
+  return { from: vi.fn().mockReturnValue(chain) };
 }
 
-function createLegacySelectResult(result: any[]) {
-  return {
-    from: vi.fn().mockReturnValue({
-      leftJoin: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(result),
-      }),
-    }),
-  };
-}
-
-function queueSelectResults(...results: any[]) {
+function setupMocks(poly: any[] = [], legacy: any[] = []) {
   mockDb.select.mockReset();
-  results.forEach(result => mockDb.select.mockReturnValueOnce(result));
+  mockDb.select.mockReturnValueOnce(createSelectMock(poly));
+  mockDb.select.mockReturnValueOnce(createSelectMock(legacy, true));
+}
+
+async function execAccess(session: any, docId: string) {
+  return getDocumentAccessCore({ session, documentId: docId, mode: 'download', deps: mockDeps });
 }
 
 describe('getDocumentAccessCore Hardening', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  beforeEach(() => vi.clearAllMocks());
 
   describe('Polymorphic Documents', () => {
-    it('allows a member to access their own member entity document uploaded by staff', async () => {
-      queueSelectResults(createWhereSelectResult([memberPolymorphicDocument]));
-
-      const result = await getDocumentAccessCore({
-        session: memberSession as any,
-        documentId: 'doc-profile',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result.ok).toBe(true);
+    it('allows access to own profile document', async () => {
+      setupMocks([polymorphicDocs.profile]);
+      expect((await execAccess(memberSession, 'doc-profile')).ok).toBe(true);
     });
 
-    it('denies a member from accessing another member profile document', async () => {
-      queueSelectResults(createWhereSelectResult([memberPolymorphicDocument]));
-
-      const result = await getDocumentAccessCore({
-        session: otherMemberSession as any,
-        documentId: 'doc-profile',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
+    it('denies access to other member profile', async () => {
+      setupMocks([polymorphicDocs.profile]);
+      const res = await execAccess(otherMemberSession, 'doc-profile');
+      expect(res).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
     });
 
-    it('allows a member to access documents in their own claim even if uploaded by others', async () => {
-      queueSelectResults(
-        createWhereSelectResult([claimScopedPolymorphicDocument]),
-        createWhereSelectResult([branchScopedClaimRow]) // claimOwnerId is member-1
-      );
-
-      const result = await getDocumentAccessCore({
-        session: memberSession as any,
-        documentId: 'doc1',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result.ok).toBe(true);
+    it('allows access to documents in own claim', async () => {
+      setupMocks([polymorphicDocs.claim], [branchScopedClaimRow]);
+      expect((await execAccess(memberSession, 'doc1')).ok).toBe(true);
     });
 
-    it('denies a member from accessing documents in another member claim', async () => {
-      queueSelectResults(
-        createWhereSelectResult([claimScopedPolymorphicDocument]),
-        createWhereSelectResult([branchScopedClaimRow]) // claimOwnerId is member-1
-      );
-
-      const result = await getDocumentAccessCore({
-        session: otherMemberSession as any,
-        documentId: 'doc1',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
+    it('denies access to other member claim', async () => {
+      setupMocks([polymorphicDocs.claim], [branchScopedClaimRow]);
+      const res = await execAccess(otherMemberSession, 'doc1');
+      expect(res).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
     });
 
-    it('allows a member to access their own policy document', async () => {
-      queueSelectResults(
-        createWhereSelectResult([policyPolymorphicDocument]),
-        createWhereSelectResult([{ policyOwnerId: 'member-1' }])
-      );
-
-      const result = await getDocumentAccessCore({
-        session: memberSession as any,
-        documentId: 'doc-policy',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result.ok).toBe(true);
+    it('allows access to own policy document', async () => {
+      setupMocks([polymorphicDocs.policy], [{ policyOwnerId: 'member-1' }]);
+      expect((await execAccess(memberSession, 'doc-policy')).ok).toBe(true);
     });
 
-    it('denies access if document is from a different tenant', async () => {
-      // getDocumentAccessCore first queries documents table with tenantId from session
-      // If we return empty list, it fails closed or moves to legacy
-      queueSelectResults(createWhereSelectResult([]), createLegacySelectResult([]));
-
-      const result = await getDocumentAccessCore({
-        session: { user: { id: 'member-1', role: 'member', tenantId: 'tenant-wrong' } } as any,
-        documentId: 'doc1',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result).toEqual({ ok: false, code: 'NOT_FOUND', message: 'Document not found' });
+    it('denies access if tenant mismatches', async () => {
+      setupMocks([], []);
+      const session = { user: { ...memberSession.user, tenantId: 'wrong' } };
+      const res = await execAccess(session, 'doc1');
+      expect(res).toEqual({ ok: false, code: 'NOT_FOUND', message: 'Document not found' });
     });
   });
 
   describe('Legacy Claim Documents', () => {
-    it('denies staff access to a legacy claim document outside their scoped branch', async () => {
-      queueSelectResults(
-        createWhereSelectResult([]), // Not in polymorphic
-        createLegacySelectResult([
-          {
-            doc: legacyDocument,
-            ...branchScopedClaimRow,
-            claimBranchId: 'branch-b', // Different branch
-          },
-        ])
-      );
-
-      const result = await getDocumentAccessCore({
-        session: {
-          user: { id: 'staff-1', role: 'staff', tenantId: 't1', branchId: 'branch-a' },
-        } as any,
-        documentId: 'doc1',
-        mode: 'download',
-        deps: mockDeps,
+    it('denies staff access outside branch', async () => {
+      setupMocks([], [{ doc: legacyDoc, ...branchScopedClaimRow, claimBranchId: 'branch-b' }]);
+      const session = { user: { id: 's1', role: 'staff', tenantId: 't1', branchId: 'branch-a' } };
+      expect(await execAccess(session, 'doc1')).toEqual({
+        ok: false,
+        code: 'FORBIDDEN',
+        message: 'Forbidden',
       });
-
-      expect(result).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
     });
 
-    it('allows claim owner to access legacy document even if uploaded by someone else', async () => {
-      queueSelectResults(
-        createWhereSelectResult([]),
-        createLegacySelectResult([
-          {
-            doc: legacyDocument,
-            ...branchScopedClaimRow, // owner is member-1
-          },
-        ])
-      );
-
-      const result = await getDocumentAccessCore({
-        session: memberSession as any,
-        documentId: 'doc1',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result.ok).toBe(true);
+    it('allows claim owner access to legacy docs', async () => {
+      setupMocks([], [{ doc: legacyDoc, ...branchScopedClaimRow }]);
+      expect((await execAccess(memberSession, 'doc1')).ok).toBe(true);
     });
   });
 
   describe('Role-based Access', () => {
-    it('allows admin full access regardless of ownership', async () => {
-      queueSelectResults(createWhereSelectResult([memberPolymorphicDocument]));
-
-      const result = await getDocumentAccessCore({
-        session: { user: { id: 'admin-1', role: 'admin', tenantId: 't1' } } as any,
-        documentId: 'doc-profile',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result.ok).toBe(true);
+    it('allows admin full access', async () => {
+      setupMocks([polymorphicDocs.profile]);
+      const session = { user: { id: 'a1', role: 'admin', tenantId: 't1' } };
+      expect((await execAccess(session, 'doc-profile')).ok).toBe(true);
     });
 
-    it('allows branch manager access to claim documents in their branch', async () => {
-      queueSelectResults(
-        createWhereSelectResult([claimScopedPolymorphicDocument]),
-        createWhereSelectResult([branchScopedClaimRow]) // branch-a
-      );
-
-      const result = await getDocumentAccessCore({
-        session: branchManagerSession as any,
-        documentId: 'doc1',
-        mode: 'download',
-        deps: mockDeps,
-      });
-
-      expect(result.ok).toBe(true);
+    it('allows branch manager access within branch', async () => {
+      setupMocks([polymorphicDocs.claim], [branchScopedClaimRow]);
+      expect((await execAccess(branchManagerSession, 'doc1')).ok).toBe(true);
     });
   });
 });

--- a/apps/web/src/app/api/documents/_core.test.ts
+++ b/apps/web/src/app/api/documents/_core.test.ts
@@ -15,7 +15,8 @@ const mockDeps: DocumentAccessDeps = {
   storage: mockStorage,
 };
 
-const mockSession = { user: { id: 'u1', role: 'member', tenantId: 't1' } };
+const memberSession = { user: { id: 'member-1', role: 'member', tenantId: 't1' } };
+const otherMemberSession = { user: { id: 'member-2', role: 'member', tenantId: 't1' } };
 const branchManagerSession = {
   user: { id: 'manager-1', role: 'branch_manager', tenantId: 't1', branchId: 'branch-a' },
 } as const;
@@ -24,6 +25,18 @@ const branchScopedClaimRow = {
   claimOwnerId: 'member-1',
   claimBranchId: 'branch-a',
   claimStaffId: 'staff-2',
+};
+
+const memberPolymorphicDocument = {
+  id: 'doc-profile',
+  entityType: 'member',
+  entityId: 'member-1',
+  storagePath: 'path/to/profile',
+  uploadedBy: 'staff-1',
+  fileName: 'id.pdf',
+  mimeType: 'application/pdf',
+  fileSize: 100,
+  tenantId: 't1',
 };
 
 const claimScopedPolymorphicDocument = {
@@ -35,6 +48,18 @@ const claimScopedPolymorphicDocument = {
   fileName: 'evidence.pdf',
   mimeType: 'application/pdf',
   fileSize: 123,
+  tenantId: 't1',
+};
+
+const policyPolymorphicDocument = {
+  id: 'doc-policy',
+  entityType: 'policy',
+  entityId: 'policy-1',
+  storagePath: 'path/to/policy',
+  uploadedBy: 'staff-1',
+  fileName: 'policy.pdf',
+  mimeType: 'application/pdf',
+  fileSize: 200,
   tenantId: 't1',
 };
 
@@ -72,127 +97,177 @@ function queueSelectResults(...results: any[]) {
   results.forEach(result => mockDb.select.mockReturnValueOnce(result));
 }
 
-function queueScopedPolymorphicDocumentAccess() {
-  queueSelectResults(
-    createWhereSelectResult([claimScopedPolymorphicDocument]),
-    createWhereSelectResult([branchScopedClaimRow])
-  );
-}
-
-function queueLegacyDocumentAccess(claimBranchId: string) {
-  queueSelectResults(
-    createWhereSelectResult([]),
-    createLegacySelectResult([
-      {
-        doc: legacyDocument,
-        ...branchScopedClaimRow,
-        claimBranchId,
-      },
-    ])
-  );
-}
-
-describe('getDocumentAccessCore', () => {
+describe('getDocumentAccessCore Hardening', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('denies staff access to a legacy claim document outside their scoped branch', async () => {
-    queueLegacyDocumentAccess('branch-b');
+  describe('Polymorphic Documents', () => {
+    it('allows a member to access their own member entity document uploaded by staff', async () => {
+      queueSelectResults(createWhereSelectResult([memberPolymorphicDocument]));
 
-    const result = await getDocumentAccessCore({
-      session: {
-        user: { id: 'staff-1', role: 'staff', tenantId: 't1', branchId: 'branch-a' },
-      } as never,
-      documentId: 'doc1',
-      mode: 'signed_url',
-      deps: mockDeps,
+      const result = await getDocumentAccessCore({
+        session: memberSession as any,
+        documentId: 'doc-profile',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result.ok).toBe(true);
     });
 
-    expect(result).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
+    it('denies a member from accessing another member profile document', async () => {
+      queueSelectResults(createWhereSelectResult([memberPolymorphicDocument]));
+
+      const result = await getDocumentAccessCore({
+        session: otherMemberSession as any,
+        documentId: 'doc-profile',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
+    });
+
+    it('allows a member to access documents in their own claim even if uploaded by others', async () => {
+      queueSelectResults(
+        createWhereSelectResult([claimScopedPolymorphicDocument]),
+        createWhereSelectResult([branchScopedClaimRow]) // claimOwnerId is member-1
+      );
+
+      const result = await getDocumentAccessCore({
+        session: memberSession as any,
+        documentId: 'doc1',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('denies a member from accessing documents in another member claim', async () => {
+      queueSelectResults(
+        createWhereSelectResult([claimScopedPolymorphicDocument]),
+        createWhereSelectResult([branchScopedClaimRow]) // claimOwnerId is member-1
+      );
+
+      const result = await getDocumentAccessCore({
+        session: otherMemberSession as any,
+        documentId: 'doc1',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
+    });
+
+    it('allows a member to access their own policy document', async () => {
+      queueSelectResults(
+        createWhereSelectResult([policyPolymorphicDocument]),
+        createWhereSelectResult([{ policyOwnerId: 'member-1' }])
+      );
+
+      const result = await getDocumentAccessCore({
+        session: memberSession as any,
+        documentId: 'doc-policy',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('denies access if document is from a different tenant', async () => {
+      // getDocumentAccessCore first queries documents table with tenantId from session
+      // If we return empty list, it fails closed or moves to legacy
+      queueSelectResults(createWhereSelectResult([]), createLegacySelectResult([]));
+
+      const result = await getDocumentAccessCore({
+        session: { user: { id: 'member-1', role: 'member', tenantId: 'tenant-wrong' } } as any,
+        documentId: 'doc1',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result).toEqual({ ok: false, code: 'NOT_FOUND', message: 'Document not found' });
+    });
   });
 
-  it('returns NOT_FOUND if document does not exist', async () => {
-    queueSelectResults(createWhereSelectResult([]), createLegacySelectResult([]));
+  describe('Legacy Claim Documents', () => {
+    it('denies staff access to a legacy claim document outside their scoped branch', async () => {
+      queueSelectResults(
+        createWhereSelectResult([]), // Not in polymorphic
+        createLegacySelectResult([
+          {
+            doc: legacyDocument,
+            ...branchScopedClaimRow,
+            claimBranchId: 'branch-b', // Different branch
+          },
+        ])
+      );
 
-    const result = await getDocumentAccessCore({
-      session: mockSession,
-      documentId: 'doc1',
-      mode: 'signed_url',
-      deps: mockDeps,
+      const result = await getDocumentAccessCore({
+        session: {
+          user: { id: 'staff-1', role: 'staff', tenantId: 't1', branchId: 'branch-a' },
+        } as any,
+        documentId: 'doc1',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
     });
 
-    expect(result).toEqual({ ok: false, code: 'NOT_FOUND', message: 'Document not found' });
-  });
+    it('allows claim owner to access legacy document even if uploaded by someone else', async () => {
+      queueSelectResults(
+        createWhereSelectResult([]),
+        createLegacySelectResult([
+          {
+            doc: legacyDocument,
+            ...branchScopedClaimRow, // owner is member-1
+          },
+        ])
+      );
 
-  it('returns FORBIDDEN if user is not owner/privileged', async () => {
-    queueSelectResults(
-      createWhereSelectResult([
-        {
-          id: 'doc1',
-          storagePath: 'path',
-          uploadedBy: 'other',
-          tenantId: 't1',
-        },
-      ])
-    );
+      const result = await getDocumentAccessCore({
+        session: memberSession as any,
+        documentId: 'doc1',
+        mode: 'download',
+        deps: mockDeps,
+      });
 
-    const result = await getDocumentAccessCore({
-      session: mockSession,
-      documentId: 'doc1',
-      mode: 'signed_url',
-      deps: mockDeps,
-    });
-
-    expect(result).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
-  });
-
-  it('allows branch manager access to claim-scoped polymorphic documents in their branch', async () => {
-    queueScopedPolymorphicDocumentAccess();
-
-    const result = await getDocumentAccessCore({
-      session: branchManagerSession as never,
-      documentId: 'doc1',
-      mode: 'signed_url',
-      deps: mockDeps,
-    });
-
-    expect(result.ok).toBe(true);
-  });
-
-  it('records signed-url audit metadata for polymorphic documents', async () => {
-    queueScopedPolymorphicDocumentAccess();
-
-    const result = await getDocumentAccessCore({
-      session: branchManagerSession as never,
-      documentId: 'doc1',
-      mode: 'signed_url',
-      deps: mockDeps,
-    });
-
-    expect(result).toMatchObject({
-      ok: true,
-      audit: {
-        action: 'document.signed_url_issued',
-        metadata: {
-          bucket: 'claim-evidence',
-          expiresInSeconds: 300,
-          filePath: 'path',
-        },
-      },
+      expect(result.ok).toBe(true);
     });
   });
 
-  it('allows branch manager access to legacy claim documents in their branch', async () => {
-    queueLegacyDocumentAccess('branch-a');
+  describe('Role-based Access', () => {
+    it('allows admin full access regardless of ownership', async () => {
+      queueSelectResults(createWhereSelectResult([memberPolymorphicDocument]));
 
-    const result = await getDocumentAccessCore({
-      session: branchManagerSession as never,
-      documentId: 'doc1',
-      mode: 'signed_url',
-      deps: mockDeps,
+      const result = await getDocumentAccessCore({
+        session: { user: { id: 'admin-1', role: 'admin', tenantId: 't1' } } as any,
+        documentId: 'doc-profile',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result.ok).toBe(true);
     });
 
-    expect(result.ok).toBe(true);
+    it('allows branch manager access to claim documents in their branch', async () => {
+      queueSelectResults(
+        createWhereSelectResult([claimScopedPolymorphicDocument]),
+        createWhereSelectResult([branchScopedClaimRow]) // branch-a
+      );
+
+      const result = await getDocumentAccessCore({
+        session: branchManagerSession as any,
+        documentId: 'doc1',
+        mode: 'download',
+        deps: mockDeps,
+      });
+
+      expect(result.ok).toBe(true);
+    });
   });
 });

--- a/apps/web/src/app/api/documents/_core.test.ts
+++ b/apps/web/src/app/api/documents/_core.test.ts
@@ -64,8 +64,12 @@ function setupMocks(poly: any[] = [], legacy: any[] = []) {
   mockDb.select.mockReturnValueOnce(createSelectMock(legacy, true));
 }
 
-async function execAccess(session: any, docId: string) {
-  return getDocumentAccessCore({ session, documentId: docId, mode: 'download', deps: mockDeps });
+async function execAccess(
+  session: any,
+  docId: string,
+  mode: 'download' | 'signed_url' = 'download'
+) {
+  return getDocumentAccessCore({ session, documentId: docId, mode, deps: mockDeps });
 }
 
 describe('getDocumentAccessCore Hardening', () => {
@@ -86,6 +90,31 @@ describe('getDocumentAccessCore Hardening', () => {
     it('allows access to documents in own claim', async () => {
       setupMocks([polymorphicDocs.claim], [branchScopedClaimRow]);
       expect((await execAccess(memberSession, 'doc1')).ok).toBe(true);
+    });
+
+    it('returns signed-url audit metadata for claim documents', async () => {
+      setupMocks([polymorphicDocs.claim], [branchScopedClaimRow]);
+
+      expect(await execAccess(memberSession, 'doc1', 'signed_url')).toEqual({
+        ok: true,
+        document: expect.objectContaining({
+          id: 'doc1',
+          bucket: 'claim-evidence',
+          filePath: 'path',
+        }),
+        audit: {
+          action: 'document.signed_url_issued',
+          entityType: 'claim_document',
+          entityId: 'doc1',
+          actorRole: 'member',
+          metadata: {
+            claimId: null,
+            bucket: 'claim-evidence',
+            filePath: 'path',
+            expiresInSeconds: 300,
+          },
+        },
+      });
     });
 
     it('denies access to other member claim', async () => {

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -344,7 +344,7 @@ export async function getDocumentAccessCore(args: {
       actorRole: userRole,
       disposition: finalDisposition,
       document: doc,
-      documentId: mode === 'download' ? documentId : doc.id,
+      documentId,
       mode,
     }),
   };

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -1,5 +1,5 @@
 import { ApiErrorCode } from '@/core-contracts';
-import { claimDocuments, claims, documents } from '@interdomestik/database/schema';
+import { claimDocuments, claims, documents, policies } from '@interdomestik/database/schema';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { and, eq } from 'drizzle-orm';
 
@@ -151,50 +151,79 @@ function buildDocumentAudit(args: {
   };
 }
 
-async function canReadPolymorphicClaimDocument(args: {
+async function canReadPolymorphicDocument(args: {
   db: any;
-  polyDoc: { entityId: string; entityType: string; uploadedBy: string | null };
+  polyDoc: { id: string; entityId: string; entityType: string; uploadedBy: string | null };
   session: SessionDTO;
   tenantId: string;
   userRole: string | undefined;
 }): Promise<boolean> {
   const { db, polyDoc, session, tenantId, userRole } = args;
 
+  // 1. Full Tenant Roles always have access
   if (isFullTenantClaimsRole(userRole)) {
     return true;
   }
 
+  // 2. Uploader always has access to their own upload
   if (polyDoc.uploadedBy === session.user.id) {
     return true;
   }
 
-  if (!isScopedClaimReaderRole(userRole) || polyDoc.entityType !== 'claim') {
-    return false;
+  // 3. Member Access to their own User/Member profile documents
+  if (polyDoc.entityType === 'member' || polyDoc.entityType === 'user') {
+    return polyDoc.entityId === session.user.id;
   }
 
-  const [claimRow] = await db
-    .select({
-      claimOwnerId: claims.userId,
-      claimBranchId: claims.branchId,
-      claimStaffId: claims.staffId,
-    })
-    .from(claims)
-    .where(and(eq(claims.id, polyDoc.entityId), eq(claims.tenantId, tenantId)));
+  // 4. Claim Document Access
+  if (polyDoc.entityType === 'claim') {
+    const [claimRow] = await db
+      .select({
+        claimOwnerId: claims.userId,
+        claimBranchId: claims.branchId,
+        claimStaffId: claims.staffId,
+      })
+      .from(claims)
+      .where(and(eq(claims.id, polyDoc.entityId), eq(claims.tenantId, tenantId)));
 
-  if (!claimRow) {
-    return false;
+    if (!claimRow) return false;
+
+    // Member can read any document attached to their own claim
+    if (claimRow.claimOwnerId === session.user.id) {
+      return true;
+    }
+
+    // Staff/Branch Manager access via scoped permissions
+    if (isScopedClaimReaderRole(userRole)) {
+      return hasScopedClaimReadAccess({
+        branchId: session.user.branchId ?? null,
+        claim: {
+          branchId: claimRow.claimBranchId ?? null,
+          staffId: claimRow.claimStaffId ?? null,
+          userId: claimRow.claimOwnerId ?? null,
+        },
+        role: userRole,
+        userId: session.user.id,
+      });
+    }
   }
 
-  return hasScopedClaimReadAccess({
-    branchId: session.user.branchId ?? null,
-    claim: {
-      branchId: claimRow.claimBranchId ?? null,
-      staffId: claimRow.claimStaffId ?? null,
-      userId: claimRow.claimOwnerId ?? null,
-    },
-    role: userRole,
-    userId: session.user.id,
-  });
+  // 5. Policy Document Access
+  if (polyDoc.entityType === 'policy') {
+    const [policyRow] = await db
+      .select({ policyOwnerId: policies.userId })
+      .from(policies)
+      .where(and(eq(policies.id, polyDoc.entityId), eq(policies.tenantId, tenantId)));
+
+    if (!policyRow) return false;
+
+    return policyRow.policyOwnerId === session.user.id;
+  }
+
+  // 6. Thread / Communication Access (Future-proofing)
+  // Logic for threads would go here, currently returning false to fail-closed.
+
+  return false;
 }
 
 function canReadLegacyClaimDocument(args: {
@@ -249,7 +278,7 @@ export async function getDocumentAccessCore(args: {
     .where(and(eq(documents.id, documentId), eq(documents.tenantId, tenantId)));
 
   if (polyDoc) {
-    const canRead = await canReadPolymorphicClaimDocument({
+    const canRead = await canReadPolymorphicDocument({
       db,
       polyDoc,
       session,
@@ -315,7 +344,7 @@ export async function getDocumentAccessCore(args: {
       actorRole: userRole,
       disposition: finalDisposition,
       document: doc,
-      documentId,
+      documentId: mode === 'download' ? documentId : doc.id,
       mode,
     }),
   };

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -82,7 +82,7 @@ function hasScopedClaimReadAccess(args: {
 }
 
 export function safeFilename(value: string) {
-  return value.replaceAll(/[\r\n"]/g, '_');
+  return value.split('\r').join('_').split('\n').join('_').split('"').join('_');
 }
 
 function getFinalDisposition(disposition?: 'inline' | 'attachment'): 'inline' | 'attachment' {


### PR DESCRIPTION
### Summary
This PR hardens the document access logic in the V3 Pilot to prevent unauthorized cross-member and cross-tenant access.

### Changes
- Renamed polymorphic access helper to reflect support for multiple entity types (member, claim, policy).
- Implemented ownership checks allowing members to access documents attached to their own claims or profile.
- Enforced strict tenant isolation by using the session's tenant ID in all document queries.
- Added comprehensive unit tests in apps/web/src/app/api/documents/_core.test.ts to verify authorization boundaries and fail-closed behavior.

### Verification
- [x] Unit tests passed: pnpm test:unit src/app/api/documents/_core.test.ts
- [x] Manual logic audit of ownership paths.