### PR TITLE
[codex] PC02 ownership attribution unification

### DIFF
--- a/apps/web/src/actions/claims.test.ts
+++ b/apps/web/src/actions/claims.test.ts
@@ -70,6 +70,9 @@ vi.mock('@interdomestik/database', () => ({
           status: 'active',
         }),
       },
+      agentClients: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
       tenantSettings: {
         findFirst: vi.fn().mockResolvedValue(null),
       },
@@ -101,6 +104,11 @@ vi.mock('@interdomestik/database', () => ({
     tenantId: { name: 'tenantId' },
     branchId: { name: 'branchId' },
     agentId: { name: 'agentId' },
+  },
+  agentClients: {
+    tenantId: { name: 'tenantId' },
+    memberId: { name: 'memberId' },
+    status: { name: 'status' },
   },
   claims: { id: { name: 'id' }, tenantId: { name: 'tenantId' } },
   claimStageHistory: { id: { name: 'id' }, tenantId: { name: 'tenantId' } },

--- a/apps/web/src/app/[locale]/(agent)/agent/claims/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/claims/_core.test.ts
@@ -60,8 +60,8 @@ describe('getAgentClaimsCore', () => {
       { id: 'c2', userId: 'm1', title: 'Claim 2', status: 'evaluation', createdAt: new Date() },
     ];
 
+    mockParams.mocks.selectWhere.mockResolvedValue([{ memberId: 'm1' }, { memberId: 'm2' }]);
     mockParams.db.query.user.findMany.mockResolvedValue(mockMembers);
-    mockParams.mocks.selectWhere.mockResolvedValue([]);
     mockParams.db.query.claims.findMany.mockResolvedValue(mockClaims);
 
     const result = await getAgentClaimsCore(mockParams);
@@ -75,9 +75,9 @@ describe('getAgentClaimsCore', () => {
 
   it('includes claims for members linked via active agent_clients relation', async () => {
     const mockParams = createMockParams();
-    mockParams.db.query.user.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ id: 'm3', name: 'Member 3', email: 'm3@test.com' }]);
+    mockParams.db.query.user.findMany.mockResolvedValue([
+      { id: 'm3', name: 'Member 3', email: 'm3@test.com' },
+    ]);
     mockParams.mocks.selectWhere.mockResolvedValue([{ memberId: 'm3' }]);
     mockParams.db.query.claims.findMany.mockResolvedValue([
       { id: 'c3', userId: 'm3', title: 'Claim 3', status: 'submitted', createdAt: new Date() },
@@ -94,17 +94,15 @@ describe('getAgentClaimsCore', () => {
         }),
       ]);
     }
-    expect(mockParams.db.query.user.findMany).toHaveBeenCalledTimes(2);
+    expect(mockParams.db.query.user.findMany).toHaveBeenCalledTimes(1);
   });
 
-  it('does not duplicate members present in both direct and agent_clients sources', async () => {
+  it('deduplicates repeated member ids from active agent_clients rows', async () => {
     const mockParams = createMockParams();
     const overlappingMember = { id: 'm4', name: 'Member 4', email: 'm4@test.com' };
 
-    mockParams.db.query.user.findMany
-      .mockResolvedValueOnce([overlappingMember])
-      .mockResolvedValueOnce([overlappingMember]);
-    mockParams.mocks.selectWhere.mockResolvedValue([{ memberId: 'm4' }]);
+    mockParams.db.query.user.findMany.mockResolvedValue([overlappingMember]);
+    mockParams.mocks.selectWhere.mockResolvedValue([{ memberId: 'm4' }, { memberId: 'm4' }]);
     mockParams.db.query.claims.findMany.mockResolvedValue([
       { id: 'c4', userId: 'm4', title: 'Claim 4', status: 'submitted', createdAt: new Date() },
     ]);
@@ -120,6 +118,27 @@ describe('getAgentClaimsCore', () => {
       ]);
     }
     expect(mockParams.db.query.user.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not include members from stale user.agentId linkage when no active agent_clients row exists', async () => {
+    const mockParams = createMockParams();
+    mockParams.mocks.selectWhere.mockResolvedValue([]);
+    mockParams.db.query.claims.findMany.mockResolvedValue([
+      {
+        id: 'c-stale',
+        userId: 'm-stale',
+        title: 'Stale Claim',
+        status: 'submitted',
+        createdAt: new Date(),
+      },
+    ]);
+
+    const result = await getAgentClaimsCore(mockParams);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual([]);
+    }
   });
 });
 

--- a/apps/web/src/app/[locale]/(agent)/agent/claims/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/claims/_core.ts
@@ -56,64 +56,46 @@ export async function getAgentClaimsCore(params: {
   }
 
   try {
-    // 2. Resolve members via both canonical assignment sources:
-    // a) user.agentId linkage, b) active agent_clients linkage.
-    const [membersByUserAgent, activeAgentClientRows] = await Promise.all([
-      db.query.user.findMany({
-        where: and(eq(user.tenantId, tenantId), eq(user.agentId, userId)),
-        columns: {
-          id: true,
-          name: true,
-          email: true,
-        },
-      }),
-      db
-        .select({ memberId: agentClients.memberId })
-        .from(agentClients)
-        .where(
-          and(
-            eq(agentClients.tenantId, tenantId),
-            eq(agentClients.agentId, userId),
-            eq(agentClients.status, 'active')
-          )
-        ),
-    ]);
+    // 2. Resolve members only through active canonical ownership.
+    const activeAgentClientRows = await db
+      .select({ memberId: agentClients.memberId })
+      .from(agentClients)
+      .where(
+        and(
+          eq(agentClients.tenantId, tenantId),
+          eq(agentClients.agentId, userId),
+          eq(agentClients.status, 'active')
+        )
+      );
 
-    const memberById = new Map<string, { id: string; name: string | null; email: string | null }>();
-    for (const m of membersByUserAgent) {
-      memberById.set(m.id as string, m);
+    const memberIds = Array.from(
+      new Set(activeAgentClientRows.map((row: { memberId: string }) => row.memberId))
+    );
+
+    if (memberIds.length === 0) {
+      return { ok: true, data: [] };
     }
 
-    const memberIdsFromAgentClients = activeAgentClientRows
-      .map((row: { memberId: string }) => row.memberId)
-      .filter((id: string) => !memberById.has(id));
+    const members = await db.query.user.findMany({
+      where: and(eq(user.tenantId, tenantId), inArray(user.id, memberIds)),
+      columns: {
+        id: true,
+        name: true,
+        email: true,
+      },
+    });
 
-    if (memberIdsFromAgentClients.length > 0) {
-      const additionalMembers = await db.query.user.findMany({
-        where: and(eq(user.tenantId, tenantId), inArray(user.id, memberIdsFromAgentClients)),
-        columns: {
-          id: true,
-          name: true,
-          email: true,
-        },
-      });
-      for (const m of additionalMembers) {
-        memberById.set(m.id as string, m);
-      }
-    }
-
-    const members = Array.from(memberById.values());
     if (members.length === 0) {
       return { ok: true, data: [] };
     }
 
-    const memberIds = members.map((m: Record<string, unknown>) => m.id as string);
+    const resolvedMemberIds = members.map((m: Record<string, unknown>) => m.id as string);
 
     // 3. Fetch Claims for these members (excluding drafts)
     // We use a simplified visibility logic here for the core.
     const memberClaims = await db.query.claims.findMany({
       where: and(
-        buildAgentClaimsWhere({ tenantId, memberIds, branchId }),
+        buildAgentClaimsWhere({ tenantId, memberIds: resolvedMemberIds, branchId }),
         ne(claims.status, 'draft')
       ),
       orderBy: desc(claims.updatedAt),

--- a/apps/web/src/app/[locale]/(agent)/agent/claims/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/claims/_core.ts
@@ -68,8 +68,12 @@ export async function getAgentClaimsCore(params: {
         )
       );
 
-    const memberIds = Array.from(
-      new Set(activeAgentClientRows.map((row: { memberId: string }) => row.memberId))
+    const memberIds: string[] = Array.from(
+      new Set<string>(
+        activeAgentClientRows
+          .map((row: { memberId: unknown }) => row.memberId)
+          .filter((memberId: unknown): memberId is string => typeof memberId === 'string')
+      )
     );
 
     if (memberIds.length === 0) {
@@ -89,7 +93,9 @@ export async function getAgentClaimsCore(params: {
       return { ok: true, data: [] };
     }
 
-    const resolvedMemberIds = members.map((m: Record<string, unknown>) => m.id as string);
+    const resolvedMemberIds: string[] = members
+      .map((m: Record<string, unknown>) => m.id)
+      .filter((memberId: unknown): memberId is string => typeof memberId === 'string');
 
     // 3. Fetch Claims for these members (excluding drafts)
     // We use a simplified visibility logic here for the core.

--- a/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.test.ts
+++ b/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.test.ts
@@ -82,7 +82,7 @@ describe('getAgentMemberClaims', () => {
       branchId: 'branch-1',
     });
     hoisted.buildClaimVisibilityWhere.mockReturnValue({ op: 'visibility' });
-    hoisted.findManyUsers.mockResolvedValueOnce([]).mockResolvedValueOnce([
+    hoisted.findManyUsers.mockResolvedValue([
       {
         id: 'member-2',
         name: 'Member Two',
@@ -132,5 +132,34 @@ describe('getAgentMemberClaims', () => {
       branchId: 'branch-1',
       agentMemberIds: ['member-2'],
     });
+    expect(hoisted.findManyUsers).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not include members from stale user.agentId linkage when there is no active agent_clients row', async () => {
+    hoisted.findManyUsers.mockResolvedValue([
+      {
+        id: 'member-stale',
+        name: 'Stale Member',
+        email: 'stale@example.com',
+      },
+    ]);
+    hoisted.selectWhere.mockResolvedValue([]);
+    hoisted.findManyClaims.mockResolvedValue([
+      {
+        id: 'claim-stale',
+        title: 'Claim Stale',
+        status: 'submitted',
+        createdAt: new Date('2026-04-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+        userId: 'member-stale',
+      },
+    ]);
+
+    const result = await getAgentMemberClaims({
+      user: { id: 'agent-1', role: 'agent', branchId: 'branch-1', tenantId: 'tenant-1' },
+    });
+
+    expect(result).toEqual([]);
+    expect(hoisted.findManyUsers).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.ts
+++ b/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.ts
@@ -53,8 +53,8 @@ export async function getAgentMemberClaims(session: any): Promise<AgentMemberCla
           )
         );
 
-      const memberIds = Array.from(
-        new Set(
+      const memberIds: string[] = Array.from(
+        new Set<string>(
           activeAgentClientRows
             .map(row => row.memberId)
             .filter((memberId): memberId is string => typeof memberId === 'string')
@@ -78,7 +78,9 @@ export async function getAgentMemberClaims(session: any): Promise<AgentMemberCla
         return [];
       }
 
-      const resolvedMemberIds = members.map(m => m.id);
+      const resolvedMemberIds: string[] = members
+        .map(m => m.id)
+        .filter((memberId): memberId is string => typeof memberId === 'string');
 
       // 3. Fetch Claims for these members (excluding drafts per Phase 2.3 PRD)
       const visibilityCondition = buildClaimVisibilityWhere({

--- a/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.ts
+++ b/apps/web/src/features/claims/tracking/server/getAgentMemberClaims.ts
@@ -42,58 +42,43 @@ export async function getAgentMemberClaims(session: any): Promise<AgentMemberCla
         // allowing broader roles for flexibility if they visit the page.
       }
 
-      const [membersByUserAgent, activeAgentClientRows] = await Promise.all([
-        db.query.user.findMany({
-          where: and(eq(user.tenantId, tenantId), eq(user.agentId, userId)),
-          columns: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        }),
-        db
-          .select({ memberId: agentClients.memberId })
-          .from(agentClients)
-          .where(
-            and(
-              eq(agentClients.tenantId, tenantId),
-              eq(agentClients.agentId, userId),
-              eq(agentClients.status, 'active')
-            )
-          ),
-      ]);
+      const activeAgentClientRows = await db
+        .select({ memberId: agentClients.memberId })
+        .from(agentClients)
+        .where(
+          and(
+            eq(agentClients.tenantId, tenantId),
+            eq(agentClients.agentId, userId),
+            eq(agentClients.status, 'active')
+          )
+        );
 
-      const memberById = new Map<string, { id: string; name: string; email: string }>();
-      for (const member of membersByUserAgent) {
-        memberById.set(member.id, member);
+      const memberIds = Array.from(
+        new Set(
+          activeAgentClientRows
+            .map(row => row.memberId)
+            .filter((memberId): memberId is string => typeof memberId === 'string')
+        )
+      );
+
+      if (memberIds.length === 0) {
+        return [];
       }
 
-      const memberIdsFromAgentClients = activeAgentClientRows
-        .map(row => row.memberId)
-        .filter(memberId => typeof memberId === 'string' && !memberById.has(memberId));
-
-      if (memberIdsFromAgentClients.length > 0) {
-        const additionalMembers = await db.query.user.findMany({
-          where: and(eq(user.tenantId, tenantId), inArray(user.id, memberIdsFromAgentClients)),
-          columns: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        });
-
-        for (const member of additionalMembers) {
-          memberById.set(member.id, member);
-        }
-      }
-
-      const members = Array.from(memberById.values());
+      const members = await db.query.user.findMany({
+        where: and(eq(user.tenantId, tenantId), inArray(user.id, memberIds)),
+        columns: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      });
 
       if (members.length === 0) {
         return [];
       }
 
-      const memberIds = members.map(m => m.id);
+      const resolvedMemberIds = members.map(m => m.id);
 
       // 3. Fetch Claims for these members (excluding drafts per Phase 2.3 PRD)
       const visibilityCondition = buildClaimVisibilityWhere({
@@ -101,13 +86,13 @@ export async function getAgentMemberClaims(session: any): Promise<AgentMemberCla
         userId,
         role,
         branchId: access.branchId,
-        agentMemberIds: memberIds,
+        agentMemberIds: resolvedMemberIds,
       });
 
       const memberClaims = await db.query.claims.findMany({
         where: and(
           visibilityCondition,
-          inArray(claims.userId, memberIds), // Optimization redundant but safe
+          inArray(claims.userId, resolvedMemberIds), // Optimization redundant but safe
           ne(claims.status, 'draft') // PRD: Agents must not see draft claims
         ),
         orderBy: desc(claims.updatedAt),

--- a/packages/domain-claims/src/claims/submit.test.ts
+++ b/packages/domain-claims/src/claims/submit.test.ts
@@ -12,6 +12,9 @@ const hoisted = vi.hoisted(() => {
   return {
     db: {
       query: {
+        agentClients: {
+          findFirst: vi.fn().mockResolvedValue(null),
+        },
         tenantSettings: {
           findFirst: vi.fn().mockResolvedValue(null),
         },
@@ -43,6 +46,12 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock('@interdomestik/database', () => ({
+  agentClients: {
+    tenantId: 'agent_clients.tenant_id',
+    memberId: 'agent_clients.member_id',
+    agentId: 'agent_clients.agent_id',
+    status: 'agent_clients.status',
+  },
   claimDocuments: { __name: 'claim_documents' },
   claimStageHistory: { __name: 'claim_stage_history' },
   claims: { __name: 'claim' },
@@ -103,6 +112,7 @@ describe('submitClaimCore', () => {
       },
     ]);
     hoisted.generateClaimNumber.mockResolvedValue('CLM-T1-2026-000001');
+    hoisted.db.query.agentClients.findFirst.mockResolvedValue(null);
     hoisted.db.query.tenantSettings.findFirst.mockResolvedValue(null);
     hoisted.db.query.user.findFirst.mockResolvedValue(null);
     hoisted.getActiveSubscription.mockResolvedValue({
@@ -313,6 +323,63 @@ describe('submitClaimCore', () => {
           agentAttributionSource: 'subscription',
           branchId: 'branch-1',
           branchResolutionSource: 'subscription',
+        }),
+      })
+    );
+  });
+
+  it('prefers active agent_clients ownership over stale subscription ownership for claim assignment', async () => {
+    hoisted.getActiveSubscription.mockResolvedValue({
+      branchId: null,
+      agentId: 'agent-stale',
+    });
+    hoisted.db.query.agentClients.findFirst.mockResolvedValue({
+      agentId: 'agent-canonical',
+    });
+    hoisted.db.query.user.findFirst.mockResolvedValue({ branchId: 'branch-canonical' });
+
+    await submitClaimCore(
+      {
+        session: {
+          user: {
+            id: 'member-1',
+            role: 'member',
+            tenantId: 'tenant-1',
+            email: 'member@example.com',
+          },
+        },
+        requestHeaders: new Headers(),
+        data: {
+          title: 'Flight delay claim',
+          description: 'My flight was delayed overnight and I incurred hotel costs.',
+          category: 'travel',
+          companyName: 'Airline Co',
+          claimAmount: '650.00',
+          currency: 'EUR',
+          incidentDate: '2026-02-15',
+          files: [],
+        },
+      },
+      {
+        logAuditEvent: hoisted.logAuditEvent,
+      }
+    );
+
+    expect(hoisted.txInsertValues).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        branchId: 'branch-canonical',
+        agentId: 'agent-canonical',
+      })
+    );
+    expect(hoisted.logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'claim.submitted',
+        metadata: expect.objectContaining({
+          agentId: 'agent-canonical',
+          agentAttributionSource: 'agent_clients',
+          branchId: 'branch-canonical',
+          branchResolutionSource: 'agent',
         }),
       })
     );

--- a/packages/domain-claims/src/claims/submit.ts
+++ b/packages/domain-claims/src/claims/submit.ts
@@ -1,4 +1,5 @@
 import {
+  agentClients,
   claimDocuments,
   claimStageHistory,
   claims,
@@ -39,7 +40,7 @@ type ClaimAssignmentContext = {
   subscription: Awaited<ReturnType<typeof getActiveSubscription>>;
   branchId: string | null;
   agentId: string | null;
-  agentAttributionSource: 'subscription' | 'none';
+  agentAttributionSource: 'agent_clients' | 'subscription' | 'none';
   branchResolutionSource: 'subscription' | 'agent' | 'tenant_default' | 'none';
 };
 
@@ -98,9 +99,18 @@ async function loadClaimAssignmentContext(
   tenantId: string
 ): Promise<ClaimAssignmentContext> {
   const subscription = await getActiveSubscription(userId, tenantId);
+  const activeAssignment = await db.query.agentClients.findFirst({
+    where: withTenant(
+      tenantId,
+      agentClients.tenantId,
+      and(eq(agentClients.memberId, userId), eq(agentClients.status, 'active'))
+    ),
+    columns: { agentId: true },
+  });
+  const agentId = activeAssignment?.agentId ?? subscription?.agentId ?? null;
   let agentBranchId: string | null = null;
-  if (!subscription?.branchId && subscription?.agentId) {
-    agentBranchId = await resolveAgentBranchId(subscription.agentId, tenantId);
+  if (!subscription?.branchId && agentId) {
+    agentBranchId = await resolveAgentBranchId(agentId, tenantId);
   }
   const defaultBranchSetting = await db.query.tenantSettings.findFirst({
     where: withTenant(
@@ -110,8 +120,11 @@ async function loadClaimAssignmentContext(
     ),
   });
   const defaultBranchId = resolveDefaultBranchId(defaultBranchSetting?.value);
-  const agentId = subscription?.agentId ?? null;
-  const agentAttributionSource = agentId ? 'subscription' : 'none';
+  const agentAttributionSource = activeAssignment?.agentId
+    ? 'agent_clients'
+    : agentId
+      ? 'subscription'
+      : 'none';
   const subscriptionBranchId = subscription?.branchId ?? null;
   const branchId = subscriptionBranchId ?? agentBranchId ?? defaultBranchId ?? null;
   let branchResolutionSource: ClaimAssignmentContext['branchResolutionSource'] = 'none';

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers.test.ts
@@ -679,6 +679,67 @@ describe('Paddle Webhook Handlers', () => {
       expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
     });
 
+    it('prefers persisted subscription ownership over stale transaction customData agent attribution', async () => {
+      hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+        tenantId: 'tenant_real',
+        agentId: 'agent_canonical',
+      });
+
+      const payload = {
+        id: 'tx_existing_owner',
+        status: 'completed',
+        subscriptionId: 'sub_existing_owner',
+        customData: {
+          tenantId: 'tenant_bad',
+          agentId: 'agent_stale',
+        },
+        details: { totals: { total: '2000', currencyCode: 'EUR' } },
+      };
+
+      await handleTransactionCompleted({ data: payload }, { logAuditEvent });
+
+      expect(logAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: 'tenant_real',
+          metadata: expect.objectContaining({
+            agentId: 'agent_canonical',
+          }),
+        })
+      );
+      expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('uses canonical user ownership for transaction audit metadata when no subscription owner exists', async () => {
+      hoisted.db.query.subscriptions.findFirst.mockResolvedValue(undefined);
+      hoisted.db.query.user.findFirst.mockResolvedValue({
+        tenantId: 'tenant_abc',
+        agentId: null,
+      });
+
+      const payload = {
+        id: 'tx_user_owned',
+        status: 'completed',
+        customData: {
+          userId: 'user_123',
+          tenantId: 'tenant_abc',
+          agentId: 'agent_stale',
+        },
+        details: { totals: { total: '1000', currencyCode: 'USD' } },
+      };
+
+      await handleTransactionCompleted({ data: payload }, { logAuditEvent });
+
+      expect(logAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: 'tenant_abc',
+          metadata: expect.objectContaining({
+            agentId: null,
+            userId: 'user_123',
+          }),
+        })
+      );
+    });
+
     it('prefers persisted subscription tenant over client-provided tenant metadata', async () => {
       hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
         tenantId: 'tenant_real',

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
@@ -34,7 +34,11 @@ export async function handleSubscriptionChanged(
   }
 
   const { userId, tenantId, branchId, customData, userRecord } = context;
-  const resolvedAgentId = resolveSubscriptionAgentId({ userRecord, customData });
+  const canonicalUserRecord = userRecord ?? null;
+  const resolvedAgentId = resolveSubscriptionAgentId({
+    userRecord: canonicalUserRecord,
+    customData,
+  });
 
   const priceId = sub.items?.[0]?.price?.id || sub.items?.[0]?.priceId || 'unknown';
   const canonicalPlanState = await resolveCanonicalMembershipPlanState({
@@ -84,7 +88,7 @@ export async function handleSubscriptionChanged(
       tenantId,
       customData,
       priceId,
-      userRecord,
+      userRecord: canonicalUserRecord,
       deps,
     });
   }

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
@@ -3,6 +3,12 @@ import { findSubscriptionByProviderReference } from '../../subscription';
 import { transactionEventDataSchema } from '../schemas';
 import type { PaddleWebhookAuditDeps } from '../types';
 
+function normalizeAgentId(agentId: string | null | undefined): string | null {
+  if (typeof agentId !== 'string') return null;
+  const normalized = agentId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 export async function handleTransactionCompleted(
   params: { data: unknown },
   deps: PaddleWebhookAuditDeps = {}
@@ -21,21 +27,31 @@ export async function handleTransactionCompleted(
   const customerId = tx.customerId || tx.customer_id;
   const customerEmail = tx.customerEmail || tx.customer_email;
   let tenantId: string | null = null;
+  let canonicalAgentId: string | null | undefined;
 
   if (subscriptionId) {
     const subscription = await findSubscriptionByProviderReference(subscriptionId);
     tenantId = subscription?.tenantId ?? null;
+    if (subscription) {
+      canonicalAgentId = normalizeAgentId(subscription.agentId);
+    }
   }
 
   if (userId) {
     const user = await db.query.user.findFirst({
       where: (t, { eq }) => eq(t.id, userId),
-      columns: { tenantId: true },
+      columns: { tenantId: true, agentId: true },
     });
     tenantId = user?.tenantId ?? tenantId;
+    if (user) {
+      canonicalAgentId = normalizeAgentId(user.agentId);
+    }
   }
 
   tenantId ??= tenantIdFromCustomData ?? null;
+  if (canonicalAgentId === undefined) {
+    canonicalAgentId = normalizeAgentId(customData?.agentId);
+  }
 
   if (deps.logAuditEvent && tenantId) {
     await deps.logAuditEvent({
@@ -50,7 +66,7 @@ export async function handleTransactionCompleted(
         currency: tx.details?.totals?.currencyCode,
         amount: tx.details?.totals?.total,
         acquisitionSource: customData?.acquisitionSource,
-        agentId: customData?.agentId,
+        agentId: canonicalAgentId,
         customerEmail,
         customerId,
         userId: userId ?? null,

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
@@ -177,6 +177,58 @@ describe('extras', () => {
       );
     });
 
+    it('prefers the canonical user owner over stale webhook agent attribution', async () => {
+      await handleNewSubscriptionExtras({
+        sub: mockSub,
+        userId: 'user_1',
+        tenantId: 'tenant_1',
+        customData: { agentId: 'agent_stale' },
+        priceId: 'price_1',
+        userRecord: {
+          ...mockUserRecord,
+          agentId: 'agent_canonical',
+        },
+        deps: mockDeps,
+      });
+
+      expect(createCommissionCore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'agent_canonical',
+        })
+      );
+      expect(db.transaction).toHaveBeenCalled();
+      expect(tx.insert).toHaveBeenCalled();
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'agent_canonical',
+        })
+      );
+    });
+
+    it('treats company-owned canonical users as company-owned even when webhook customData is stale', async () => {
+      await handleNewSubscriptionExtras({
+        sub: mockSub,
+        userId: 'user_1',
+        tenantId: 'tenant_1',
+        customData: { agentId: 'agent_stale' },
+        priceId: 'price_1',
+        userRecord: {
+          ...mockUserRecord,
+          agentId: null,
+        },
+        deps: mockDeps,
+      });
+
+      expect(createCommissionCore).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(createMemberReferralRewardCore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: 'tenant_1',
+          subscriptionId: 'sub_123',
+        })
+      );
+    });
+
     it('should skip commission if no agentId', async () => {
       await handleNewSubscriptionExtras({
         sub: mockSub,

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
@@ -16,18 +16,37 @@ export const redactEmail = (email?: string | null) => {
   return `${maskedLocal}@${domain}`;
 };
 
+function normalizeAgentId(agentId: string | null | undefined): string | null {
+  if (typeof agentId !== 'string') return null;
+  const normalized = agentId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function resolveCanonicalOwnerAgentId(args: {
+  userRecord?: { agentId?: string | null } | null;
+  customData?: { agentId?: string } | undefined;
+}) {
+  if (args.userRecord && 'agentId' in args.userRecord) {
+    return normalizeAgentId(args.userRecord.agentId);
+  }
+
+  return normalizeAgentId(args.customData?.agentId);
+}
+
 async function processCommissions(args: {
   internalSubscriptionId?: string;
   sub: any;
   userId: string;
   tenantId: string;
   customData: { agentId?: string } | undefined;
+  userRecord?: { agentId?: string | null } | null;
   priceId: string;
   deps: PaddleWebhookAuditDeps;
 }) {
-  const { internalSubscriptionId, sub, userId, tenantId, customData, priceId, deps } = args;
+  const { internalSubscriptionId, sub, userId, tenantId, customData, userRecord, priceId, deps } =
+    args;
   const resolvedSubscriptionId = internalSubscriptionId ?? sub.id;
-  const agentId = customData?.agentId;
+  const agentId = resolveCanonicalOwnerAgentId({ userRecord, customData });
   const transactionTotal = Number.parseFloat(sub.items?.[0]?.price?.unitPrice?.amount || '0') / 100;
 
   if (!agentId || transactionTotal <= 0) return;
@@ -83,12 +102,13 @@ async function processMemberReferralRewards(args: {
   userId: string;
   tenantId: string;
   customData: { agentId?: string } | undefined;
+  userRecord?: { agentId?: string | null } | null;
   deps: PaddleWebhookAuditDeps;
 }) {
-  const { internalSubscriptionId, sub, userId, tenantId, customData, deps } = args;
+  const { internalSubscriptionId, sub, userId, tenantId, customData, userRecord, deps } = args;
   const resolvedSubscriptionId = internalSubscriptionId ?? sub.id;
 
-  if (customData?.agentId) return;
+  if (resolveCanonicalOwnerAgentId({ userRecord, customData })) return;
 
   const referralRow = await db.query.referrals.findFirst({
     where: and(eq(referrals.tenantId, tenantId), eq(referrals.referredId, userId)),
@@ -132,8 +152,9 @@ async function ensureAgentClientBinding(args: {
   tenantId: string;
   userId: string;
   customData: { agentId?: string } | undefined;
+  userRecord?: { agentId?: string | null } | null;
 }) {
-  const agentId = args.customData?.agentId?.trim();
+  const agentId = resolveCanonicalOwnerAgentId(args);
   if (!agentId) return;
 
   const now = new Date();
@@ -262,7 +283,7 @@ export async function handleNewSubscriptionExtras(args: {
   tenantId: string;
   customData: { agentId?: string } | undefined;
   priceId: string;
-  userRecord: any;
+  userRecord: { agentId?: string | null } | null;
   deps: Pick<PaddleWebhookDeps, 'sendThankYouLetter'> & PaddleWebhookAuditDeps;
 }) {
   await processCommissions(args);

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
@@ -8,6 +8,13 @@ import { calculateCommission } from '../../../commissions/types';
 import { syncActiveAgentClientBinding } from '../../../ownership-attribution';
 import type { PaddleWebhookAuditDeps, PaddleWebhookDeps } from '../../types';
 
+type WebhookUserRecord = {
+  agentId?: string | null;
+  email?: string | null;
+  name?: string | null;
+  memberNumber?: string | null;
+};
+
 export const redactEmail = (email?: string | null) => {
   if (!email) return 'unknown';
   const [local, domain] = email.split('@');
@@ -23,7 +30,7 @@ function normalizeAgentId(agentId: string | null | undefined): string | null {
 }
 
 function resolveCanonicalOwnerAgentId(args: {
-  userRecord?: { agentId?: string | null } | null;
+  userRecord?: WebhookUserRecord | null;
   customData?: { agentId?: string } | undefined;
 }) {
   if (args.userRecord && 'agentId' in args.userRecord) {
@@ -39,7 +46,7 @@ async function processCommissions(args: {
   userId: string;
   tenantId: string;
   customData: { agentId?: string } | undefined;
-  userRecord?: { agentId?: string | null } | null;
+  userRecord?: WebhookUserRecord | null;
   priceId: string;
   deps: PaddleWebhookAuditDeps;
 }) {
@@ -102,7 +109,7 @@ async function processMemberReferralRewards(args: {
   userId: string;
   tenantId: string;
   customData: { agentId?: string } | undefined;
-  userRecord?: { agentId?: string | null } | null;
+  userRecord?: WebhookUserRecord | null;
   deps: PaddleWebhookAuditDeps;
 }) {
   const { internalSubscriptionId, sub, userId, tenantId, customData, userRecord, deps } = args;
@@ -152,7 +159,7 @@ async function ensureAgentClientBinding(args: {
   tenantId: string;
   userId: string;
   customData: { agentId?: string } | undefined;
-  userRecord?: { agentId?: string | null } | null;
+  userRecord?: WebhookUserRecord | null;
 }) {
   const agentId = resolveCanonicalOwnerAgentId(args);
   if (!agentId) return;
@@ -283,7 +290,7 @@ export async function handleNewSubscriptionExtras(args: {
   tenantId: string;
   customData: { agentId?: string } | undefined;
   priceId: string;
-  userRecord: { agentId?: string | null } | null;
+  userRecord: WebhookUserRecord | null;
   deps: Pick<PaddleWebhookDeps, 'sendThankYouLetter'> & PaddleWebhookAuditDeps;
 }) {
   await processCommissions(args);


### PR DESCRIPTION
## Summary

- Canonicalizes Paddle webhook ownership attribution so persisted subscription/user ownership wins over stale webhook custom data.
- Canonicalizes claim assignment and agent read models around active `agent_clients` ownership instead of stale `user.agentId` or subscription-only attribution.
- Adds regression coverage for stale ownership paths and deduplicated active agent-client relationships.

## Notes

- No changes to `apps/web/src/proxy.ts`.
- No routing, tenancy, or architecture refactors.
- Local tooling changes are excluded from this branch.

## Validation

- `pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/submit.test.ts`
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(agent)/agent/claims/_core.test.ts' src/features/claims/tracking/server/getAgentMemberClaims.test.ts`
- `pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/paddle-webhooks/handlers.test.ts src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts src/paddle-webhooks/handlers/utils/extras.test.ts`
- `git diff --check`