### PR TITLE
fix: launch repo qa mcp without pnpm exec

### DIFF
--- a/scripts/start-repo-qa.sh
+++ b/scripts/start-repo-qa.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # Wrapper to start the repo-local Interdomestik QA MCP server with a stable repo root.
+# Do not launch stdio MCP servers through `pnpm exec`; the extra wrapper can interfere
+# with the initialize handshake by sitting in the stdin/stdout path.
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export MCP_REPO_ROOT="$REPO_ROOT"
 cd "$REPO_ROOT"
 
-exec pnpm exec tsx packages/qa/src/index.ts
+exec "$REPO_ROOT/node_modules/.bin/tsx" packages/qa/src/index.ts


### PR DESCRIPTION
## Summary
- Launch the repo QA MCP server directly through the repo-local `tsx` binary.
- Avoid wrapping the stdio MCP server in `pnpm exec`, which can interfere with MCP initialize handshakes.
- Keep `MCP_REPO_ROOT` and the repo-root working directory contract unchanged.

## Test Plan
- `git diff --check HEAD~1..HEAD`
- `bash -n scripts/start-repo-qa.sh`
- `test -x node_modules/.bin/tsx`
- `pnpm test:ci:contracts` (73/73 passing)
