### PR TITLE
fix: allow assigned agents claim evidence access

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "start:ci": "next start",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
-    "test:unit": "vitest run",
+    "test:unit": "node scripts/vitest-unit.mjs",
     "test:e2e": "playwright test",
     "e2e:gate": "NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm run build:ci && NEXT_PUBLIC_BILLING_TEST_MODE=1 playwright test --project=gate-ks-sq --project=gate-mk-mk --workers=1",
     "e2e:gate:pr": "NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm run build:ci && NEXT_PUBLIC_BILLING_TEST_MODE=1 playwright test --project=gate-ks-sq --project=gate-mk-contract --workers=1",

--- a/apps/web/scripts/vitest-unit.mjs
+++ b/apps/web/scripts/vitest-unit.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+
+while (args[0] === '--' || args[0] === '--run') {
+  args.shift();
+}
+
+const vitestBin = fileURLToPath(new URL('../node_modules/vitest/vitest.mjs', import.meta.url));
+const child = spawn(process.execPath, [vitestBin, 'run', '--maxWorkers=2', ...args], {
+  stdio: 'inherit',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});

--- a/apps/web/src/app/api/documents/_core.test.ts
+++ b/apps/web/src/app/api/documents/_core.test.ts
@@ -10,11 +10,13 @@ const otherMemberSession = { user: { id: 'member-2', role: 'member', tenantId: '
 const branchManagerSession = {
   user: { id: 'manager-1', role: 'branch_manager', tenantId: 't1', branchId: 'branch-a' },
 };
+const agentSession = { user: { id: 'agent-1', role: 'agent', tenantId: 't1' } };
 
 const branchScopedClaimRow = {
   claimOwnerId: 'member-1',
   claimBranchId: 'branch-a',
   claimStaffId: 'staff-2',
+  claimAgentId: null,
 };
 
 const polymorphicDocs = {
@@ -123,6 +125,26 @@ describe('getDocumentAccessCore Hardening', () => {
       expect(res).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
     });
 
+    it('allows assigned agent access to claim document', async () => {
+      setupMocks([polymorphicDocs.claim], [{ ...branchScopedClaimRow, claimAgentId: 'agent-1' }]);
+      expect((await execAccess(agentSession, 'doc1')).ok).toBe(true);
+    });
+
+    it('denies unassigned agent access to claim document', async () => {
+      setupMocks([polymorphicDocs.claim], [{ ...branchScopedClaimRow, claimAgentId: 'agent-2' }]);
+      const res = await execAccess(agentSession, 'doc1');
+      expect(res).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
+    });
+
+    it('denies unassigned agent access to claim document they uploaded', async () => {
+      setupMocks(
+        [{ ...polymorphicDocs.claim, uploadedBy: 'agent-1' }],
+        [{ ...branchScopedClaimRow, claimAgentId: 'agent-2' }]
+      );
+      const res = await execAccess(agentSession, 'doc1');
+      expect(res).toEqual({ ok: false, code: 'FORBIDDEN', message: 'Forbidden' });
+    });
+
     it('allows access to own policy document', async () => {
       setupMocks([polymorphicDocs.policy], [{ policyOwnerId: 'member-1' }]);
       expect((await execAccess(memberSession, 'doc-policy')).ok).toBe(true);
@@ -150,6 +172,38 @@ describe('getDocumentAccessCore Hardening', () => {
     it('allows claim owner access to legacy docs', async () => {
       setupMocks([], [{ doc: legacyDoc, ...branchScopedClaimRow }]);
       expect((await execAccess(memberSession, 'doc1')).ok).toBe(true);
+    });
+
+    it('allows assigned agent access to legacy docs', async () => {
+      setupMocks([], [{ doc: legacyDoc, ...branchScopedClaimRow, claimAgentId: 'agent-1' }]);
+      expect((await execAccess(agentSession, 'doc1')).ok).toBe(true);
+    });
+
+    it('denies unassigned agent access to legacy docs', async () => {
+      setupMocks([], [{ doc: legacyDoc, ...branchScopedClaimRow, claimAgentId: 'agent-2' }]);
+      expect(await execAccess(agentSession, 'doc1')).toEqual({
+        ok: false,
+        code: 'FORBIDDEN',
+        message: 'Forbidden',
+      });
+    });
+
+    it('denies unassigned agent access to legacy docs they uploaded', async () => {
+      setupMocks(
+        [],
+        [
+          {
+            doc: { ...legacyDoc, uploadedBy: 'agent-1' },
+            ...branchScopedClaimRow,
+            claimAgentId: 'agent-2',
+          },
+        ]
+      );
+      expect(await execAccess(agentSession, 'doc1')).toEqual({
+        ok: false,
+        code: 'FORBIDDEN',
+        message: 'Forbidden',
+      });
     });
   });
 

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -41,6 +41,12 @@ type DocumentRow = {
 };
 
 type DocumentAccessMode = 'signed_url' | 'download';
+type PolymorphicDocumentRow = {
+  id: string;
+  entityId: string;
+  entityType: string;
+  uploadedBy: string | null;
+};
 
 export type DocumentAccessResult =
   | { ok: true; document: DocumentRow; audit: AuditContext }
@@ -59,15 +65,23 @@ function isFullTenantClaimsRole(role: string | null | undefined): boolean {
 }
 
 function isScopedClaimReaderRole(role: string | null | undefined): boolean {
-  return role === 'staff' || role === 'branch_manager';
+  return role === 'staff' || role === 'branch_manager' || role === 'agent';
 }
 
 function hasScopedClaimReadAccess(args: {
   branchId?: string | null;
-  claim: { branchId?: string | null; staffId?: string | null; userId: string | null };
+  claim: {
+    branchId?: string | null;
+    staffId?: string | null;
+    userId: string | null;
+    agentId?: string | null;
+  };
   role: string | null | undefined;
   userId: string;
 }): boolean {
+  if (args.role === 'agent') {
+    return args.claim.agentId === args.userId;
+  }
   const branchId = args.branchId ?? null;
 
   if (args.role === 'branch_manager') {
@@ -153,7 +167,7 @@ function buildDocumentAudit(args: {
 
 async function canReadPolymorphicDocument(args: {
   db: any;
-  polyDoc: { id: string; entityId: string; entityType: string; uploadedBy: string | null };
+  polyDoc: PolymorphicDocumentRow;
   session: SessionDTO;
   tenantId: string;
   userRole: string | undefined;
@@ -165,8 +179,11 @@ async function canReadPolymorphicDocument(args: {
     return true;
   }
 
-  // 2. Uploader always has access to their own upload
-  if (polyDoc.uploadedBy === session.user.id) {
+  // 2. Uploader access, except agents must still be assigned to claim documents.
+  if (
+    polyDoc.uploadedBy === session.user.id &&
+    !(userRole === 'agent' && polyDoc.entityType === 'claim')
+  ) {
     return true;
   }
 
@@ -177,35 +194,7 @@ async function canReadPolymorphicDocument(args: {
 
   // 4. Claim Document Access
   if (polyDoc.entityType === 'claim') {
-    const [claimRow] = await db
-      .select({
-        claimOwnerId: claims.userId,
-        claimBranchId: claims.branchId,
-        claimStaffId: claims.staffId,
-      })
-      .from(claims)
-      .where(and(eq(claims.id, polyDoc.entityId), eq(claims.tenantId, tenantId)));
-
-    if (!claimRow) return false;
-
-    // Member can read any document attached to their own claim
-    if (claimRow.claimOwnerId === session.user.id) {
-      return true;
-    }
-
-    // Staff/Branch Manager access via scoped permissions
-    if (isScopedClaimReaderRole(userRole)) {
-      return hasScopedClaimReadAccess({
-        branchId: session.user.branchId ?? null,
-        claim: {
-          branchId: claimRow.claimBranchId ?? null,
-          staffId: claimRow.claimStaffId ?? null,
-          userId: claimRow.claimOwnerId ?? null,
-        },
-        role: userRole,
-        userId: session.user.id,
-      });
-    }
+    return canReadPolymorphicClaimDocument(args);
   }
 
   // 5. Policy Document Access
@@ -226,8 +215,55 @@ async function canReadPolymorphicDocument(args: {
   return false;
 }
 
+async function canReadPolymorphicClaimDocument(args: {
+  db: any;
+  polyDoc: PolymorphicDocumentRow;
+  session: SessionDTO;
+  tenantId: string;
+  userRole: string | undefined;
+}): Promise<boolean> {
+  const { db, polyDoc, session, tenantId, userRole } = args;
+  const [claimRow] = await db
+    .select({
+      claimOwnerId: claims.userId,
+      claimBranchId: claims.branchId,
+      claimStaffId: claims.staffId,
+      claimAgentId: claims.agentId,
+    })
+    .from(claims)
+    .where(and(eq(claims.id, polyDoc.entityId), eq(claims.tenantId, tenantId)));
+
+  if (!claimRow) return false;
+
+  // Member can read any document attached to their own claim.
+  if (userRole !== 'agent' && claimRow.claimOwnerId === session.user.id) {
+    return true;
+  }
+
+  if (!isScopedClaimReaderRole(userRole)) {
+    return false;
+  }
+
+  return hasScopedClaimReadAccess({
+    branchId: session.user.branchId ?? null,
+    claim: {
+      branchId: claimRow.claimBranchId ?? null,
+      staffId: claimRow.claimStaffId ?? null,
+      userId: claimRow.claimOwnerId ?? null,
+      agentId: claimRow.claimAgentId ?? null,
+    },
+    role: userRole,
+    userId: session.user.id,
+  });
+}
+
 function canReadLegacyClaimDocument(args: {
-  claim: { branchId: string | null; ownerId: string | null; staffId: string | null };
+  claim: {
+    branchId: string | null;
+    ownerId: string | null;
+    staffId: string | null;
+    agentId: string | null;
+  };
   document: DocumentRow;
   session: SessionDTO;
   userRole: string | undefined;
@@ -238,7 +274,10 @@ function canReadLegacyClaimDocument(args: {
     return true;
   }
 
-  if (document.uploadedBy === session.user.id || claim.ownerId === session.user.id) {
+  if (
+    userRole !== 'agent' &&
+    (document.uploadedBy === session.user.id || claim.ownerId === session.user.id)
+  ) {
     return true;
   }
 
@@ -252,6 +291,7 @@ function canReadLegacyClaimDocument(args: {
       branchId: claim.branchId,
       staffId: claim.staffId,
       userId: claim.ownerId,
+      agentId: claim.agentId,
     },
     role: userRole,
     userId: session.user.id,
@@ -312,6 +352,7 @@ export async function getDocumentAccessCore(args: {
       claimOwnerId: claims.userId,
       claimBranchId: claims.branchId,
       claimStaffId: claims.staffId,
+      claimAgentId: claims.agentId,
     })
     .from(claimDocuments)
     .leftJoin(claims, eq(claimDocuments.claimId, claims.id))
@@ -327,6 +368,7 @@ export async function getDocumentAccessCore(args: {
       branchId: row.claimBranchId ?? null,
       ownerId: row.claimOwnerId ?? null,
       staffId: row.claimStaffId ?? null,
+      agentId: row.claimAgentId ?? null,
     },
     document: doc,
     session,

--- a/apps/web/src/app/api/uploads/_core.ts
+++ b/apps/web/src/app/api/uploads/_core.ts
@@ -88,6 +88,7 @@ export async function createSignedUploadCore(args: {
       columns: {
         id: true,
         userId: true,
+        agentId: true,
       },
     });
 
@@ -95,7 +96,12 @@ export async function createSignedUploadCore(args: {
       return { ok: false, status: 404, error: 'Claim not found' };
     }
 
-    if (claim.userId !== session.user.id) {
+    const role = session.user.role;
+
+    const canUpload =
+      claim.userId === session.user.id || (role === 'agent' && claim.agentId === session.user.id);
+
+    if (!canUpload) {
       return { ok: false, status: 403, error: 'Forbidden' };
     }
   }

--- a/apps/web/src/app/api/uploads/route.test.ts
+++ b/apps/web/src/app/api/uploads/route.test.ts
@@ -188,6 +188,59 @@ describe('POST /api/uploads', () => {
     expect(hoisted.createSignedUploadUrl).not.toHaveBeenCalled();
   });
 
+  it('returns 403 when agent is not assigned to the claim', async () => {
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'agent-1', role: 'agent', tenantId: 'tenant_mk' },
+    });
+    hoisted.findClaimFirst.mockResolvedValue({
+      id: 'claim-1',
+      userId: 'user-OTHER',
+      agentId: 'agent-OTHER',
+    });
+
+    const req = new Request('http://localhost:3000/api/uploads', {
+      method: 'POST',
+      body: JSON.stringify({
+        fileName: 'file.pdf',
+        fileType: 'application/pdf',
+        fileSize: 100,
+        claimId: 'claim-1',
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    expect(hoisted.createSignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 when agent is assigned to the claim', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_EVIDENCE_BUCKET', 'claim-evidence');
+
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'agent-1', role: 'agent', tenantId: 'tenant_mk' },
+    });
+    hoisted.findClaimFirst.mockResolvedValue({
+      id: 'claim-1',
+      userId: 'user-OTHER',
+      agentId: 'agent-1',
+    });
+
+    const req = new Request('http://localhost:3000/api/uploads', {
+      method: 'POST',
+      body: JSON.stringify({
+        fileName: 'file.pdf',
+        fileType: 'application/pdf',
+        fileSize: 100,
+        claimId: 'claim-1',
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(hoisted.createSignedUploadUrl).toHaveBeenCalled();
+  });
+
   it('returns 200 with signed upload details', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_EVIDENCE_BUCKET', 'claim-evidence');


### PR DESCRIPTION
## Summary
- allow assigned agents to create signed claim evidence uploads for their assigned claims
- allow assigned agents to read claim documents only through current claim assignment, including legacy claim documents
- fix the web unit-test script wrapper so pnpm-forwarded `--` / `--run` forms do not hang Vitest

## Verification
- `pnpm --filter @interdomestik/web test:unit -- src/app/api/uploads/route.test.ts`
- `pnpm --filter @interdomestik/web test:unit -- src/app/api/documents/_core.test.ts`
- `pnpm --filter @interdomestik/web test:unit --run -- src/lib/storage/evidence-bucket.test.ts`
- `pnpm exec prettier --check apps/web/src/app/api/documents/_core.ts apps/web/src/app/api/documents/_core.test.ts apps/web/scripts/vitest-unit.mjs`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`

MCP note: `interdomestik_qa` is configured in `.codex/config.toml` but was not exposed in this session's MCP tool registry, so repo inspection used shell fallback after checking tool exposure.