### PR TITLE
PC04: branch operations cash truth

### DIFF
--- a/apps/web/e2e/pc04-branch-cash-truth.spec.ts
+++ b/apps/web/e2e/pc04-branch-cash-truth.spec.ts
@@ -1,0 +1,182 @@
+import { db, leadPaymentAttempts } from '@interdomestik/database';
+import { memberLeads } from '@interdomestik/database/schema/leads';
+import { and, eq, inArray } from 'drizzle-orm';
+import { expect, test } from './fixtures/auth.fixture';
+import { routes } from './routes';
+import { gotoApp } from './utils/navigation';
+
+const KS_TENANT_ID = 'tenant_ks';
+const KS_BRANCH_A = 'ks_branch_a';
+const KS_BRANCH_B = 'ks_branch_b';
+const KS_AGENT_A1_NAME = 'Blerim Hoxha';
+const NEEDS_INFO_ATTEMPT_ID = 'golden_attempt_ks_a_cash_lead_1';
+const RESOLVED_ATTEMPT_ID = 'golden_attempt_ks_a_cash_lead_2';
+const CASH_OPEN_STATUSES = ['pending', 'needs_info'] as const;
+const WATCH_DELAY_MS = Number(process.env.PC04_WATCH_DELAY_MS ?? 0);
+
+async function listOpenCashForBranch(branchId = KS_BRANCH_A) {
+  return db
+    .select({ id: leadPaymentAttempts.id })
+    .from(leadPaymentAttempts)
+    .innerJoin(memberLeads, eq(memberLeads.id, leadPaymentAttempts.leadId))
+    .where(
+      and(
+        eq(leadPaymentAttempts.tenantId, KS_TENANT_ID),
+        eq(memberLeads.tenantId, KS_TENANT_ID),
+        eq(memberLeads.branchId, branchId),
+        eq(leadPaymentAttempts.method, 'cash'),
+        inArray(leadPaymentAttempts.status, [...CASH_OPEN_STATUSES])
+      )
+    );
+}
+
+async function setAttemptStatus(
+  id: string,
+  status: 'pending' | 'succeeded' | 'failed' | 'canceled' | 'rejected' | 'needs_info'
+) {
+  await db
+    .update(leadPaymentAttempts)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(leadPaymentAttempts.id, id));
+}
+
+async function resetWatchedAttempts() {
+  await setAttemptStatus(NEEDS_INFO_ATTEMPT_ID, 'pending');
+  await setAttemptStatus(RESOLVED_ATTEMPT_ID, 'pending');
+}
+
+async function watchStep(page: import('@playwright/test').Page, label: string) {
+  if (WATCH_DELAY_MS <= 0) return;
+
+  console.log(`[PC04 Watch] ${label}`);
+  await page.evaluate(text => {
+    const id = 'pc04-watch-step';
+    document.getElementById(id)?.remove();
+
+    const marker = document.createElement('div');
+    marker.id = id;
+    marker.textContent = text;
+    marker.style.position = 'fixed';
+    marker.style.inset = '16px auto auto 16px';
+    marker.style.zIndex = '2147483647';
+    marker.style.padding = '10px 12px';
+    marker.style.borderRadius = '8px';
+    marker.style.background = '#111827';
+    marker.style.color = '#f9fafb';
+    marker.style.font = '600 14px/1.3 system-ui, sans-serif';
+    marker.style.boxShadow = '0 10px 30px rgba(0,0,0,0.25)';
+    document.body.appendChild(marker);
+  }, label);
+  await page.waitForTimeout(WATCH_DELAY_MS);
+}
+
+async function expectBranchCashCard(
+  page: import('@playwright/test').Page,
+  branchCode: string,
+  expectedCount: number
+) {
+  const branchCard = page.getByTestId(`branch-card-${branchCode}`);
+  await expect(branchCard).toBeVisible();
+  await expect(branchCard.getByLabel(/Pagesa cash në pritje|Cash Pending/i)).toContainText(
+    String(expectedCount)
+  );
+}
+
+test.describe('PC04 branch cash truth', () => {
+  test.afterEach(async () => {
+    await resetWatchedAttempts();
+  });
+
+  test('branch list groups durable cash pressure by branch', async ({
+    adminPage: page,
+  }, testInfo) => {
+    test.skip(!testInfo.project.name.includes('ks'), 'KS golden seed scenario');
+
+    await resetWatchedAttempts();
+
+    const branchACashAttempts = await listOpenCashForBranch(KS_BRANCH_A);
+    const branchBCashAttempts = await listOpenCashForBranch(KS_BRANCH_B);
+    expect(branchACashAttempts).toHaveLength(3);
+    expect(branchBCashAttempts).toHaveLength(1);
+
+    await watchStep(page, 'Open admin branch list');
+    await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'page-ready' });
+
+    await watchStep(page, 'KS-A shows three pending cash attempts');
+    await expectBranchCashCard(page, 'KS-A', 3);
+
+    await watchStep(page, 'KS-B keeps its own cash count isolated');
+    await expectBranchCashCard(page, 'KS-B', 1);
+  });
+
+  test('branch dashboard derives cash pressure and agent health from pending plus needs_info attempts', async ({
+    adminPage: page,
+  }, testInfo) => {
+    test.skip(!testInfo.project.name.includes('ks'), 'KS golden seed scenario');
+
+    await setAttemptStatus(NEEDS_INFO_ATTEMPT_ID, 'needs_info');
+
+    try {
+      const openCashAttempts = await listOpenCashForBranch();
+      expect(openCashAttempts.map(row => row.id)).toContain(NEEDS_INFO_ATTEMPT_ID);
+      expect(openCashAttempts).toHaveLength(3);
+
+      await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'page-ready' });
+
+      const branchCard = page.getByTestId('branch-card-KS-A');
+      await expect(branchCard).toBeVisible();
+      await expect(branchCard.getByLabel(/Pagesa cash në pritje|Cash Pending/i)).toContainText('3');
+
+      await watchStep(page, 'Open KS-A branch dashboard');
+      await gotoApp(page, routes.adminBranchDetail(KS_BRANCH_A, testInfo), testInfo, {
+        marker: 'branch-dashboard-title',
+      });
+
+      await watchStep(page, 'Dashboard KPI includes pending plus needs_info attempts');
+      await expect(page.getByTestId('branch-dashboard-title')).toBeVisible();
+      await expect(page.locator('main')).toContainText(/Pagesa cash në pritje[\s\S]*3/i);
+
+      await watchStep(page, 'Agent health row inherits the durable cash count');
+      const agentRow = page.getByRole('row', { name: new RegExp(KS_AGENT_A1_NAME, 'i') });
+      await expect(agentRow).toBeVisible();
+      await expect(agentRow).toContainText('3');
+    } finally {
+      await resetWatchedAttempts();
+    }
+  });
+
+  test('resolved cash attempts are excluded from branch cash pressure', async ({
+    adminPage: page,
+  }, testInfo) => {
+    test.skip(!testInfo.project.name.includes('ks'), 'KS golden seed scenario');
+
+    await setAttemptStatus(RESOLVED_ATTEMPT_ID, 'succeeded');
+
+    try {
+      const openCashAttempts = await listOpenCashForBranch();
+      expect(openCashAttempts.map(row => row.id)).not.toContain(RESOLVED_ATTEMPT_ID);
+      expect(openCashAttempts).toHaveLength(2);
+
+      await watchStep(page, 'Open branch list after one cash attempt is resolved');
+      await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'page-ready' });
+
+      await watchStep(page, 'KS-A cash pressure drops to two');
+      await expectBranchCashCard(page, 'KS-A', 2);
+
+      await watchStep(page, 'Open KS-A dashboard with resolved attempt excluded');
+      await gotoApp(page, routes.adminBranchDetail(KS_BRANCH_A, testInfo), testInfo, {
+        marker: 'branch-dashboard-title',
+      });
+
+      await expect(page.getByTestId('branch-dashboard-title')).toBeVisible();
+      await expect(page.locator('main')).toContainText(/Pagesa cash në pritje[\s\S]*2/i);
+
+      await watchStep(page, 'Agent row also drops to two');
+      const agentRow = page.getByRole('row', { name: new RegExp(KS_AGENT_A1_NAME, 'i') });
+      await expect(agentRow).toBeVisible();
+      await expect(agentRow).toContainText('2');
+    } finally {
+      await resetWatchedAttempts();
+    }
+  });
+});

--- a/apps/web/e2e/pc04-branch-cash-truth.spec.ts
+++ b/apps/web/e2e/pc04-branch-cash-truth.spec.ts
@@ -1,3 +1,4 @@
+import type { Page, TestInfo } from '@playwright/test';
 import { db, leadPaymentAttempts } from '@interdomestik/database';
 import { memberLeads } from '@interdomestik/database/schema/leads';
 import { and, eq, inArray } from 'drizzle-orm';
@@ -45,7 +46,7 @@ async function resetWatchedAttempts() {
   await setAttemptStatus(RESOLVED_ATTEMPT_ID, 'pending');
 }
 
-async function watchStep(page: import('@playwright/test').Page, label: string) {
+async function watchStep(page: Page, label: string) {
   if (WATCH_DELAY_MS <= 0) return;
 
   console.log(`[PC04 Watch] ${label}`);
@@ -70,16 +71,54 @@ async function watchStep(page: import('@playwright/test').Page, label: string) {
   await page.waitForTimeout(WATCH_DELAY_MS);
 }
 
-async function expectBranchCashCard(
-  page: import('@playwright/test').Page,
-  branchCode: string,
-  expectedCount: number
-) {
+async function openBranchList(page: Page, testInfo: TestInfo, label: string) {
+  await watchStep(page, label);
+  await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'page-ready' });
+}
+
+async function openBranchDashboard(page: Page, testInfo: TestInfo, label: string) {
+  await watchStep(page, label);
+  await gotoApp(page, routes.adminBranchDetail(KS_BRANCH_A, testInfo), testInfo, {
+    marker: 'branch-dashboard-title',
+  });
+}
+
+async function expectBranchCashCard(page: Page, branchCode: string, expectedCount: number) {
   const branchCard = page.getByTestId(`branch-card-${branchCode}`);
   await expect(branchCard).toBeVisible();
   await expect(branchCard.getByLabel(/Pagesa cash në pritje|Cash Pending/i)).toContainText(
     String(expectedCount)
   );
+}
+
+async function expectOpenCashState({
+  branchId = KS_BRANCH_A,
+  count,
+  includes,
+  excludes,
+}: {
+  branchId?: string;
+  count: number;
+  includes?: string;
+  excludes?: string;
+}) {
+  const openCashAttempts = await listOpenCashForBranch(branchId);
+  const ids = openCashAttempts.map(row => row.id);
+
+  if (includes) expect(ids).toContain(includes);
+  if (excludes) expect(ids).not.toContain(excludes);
+  expect(openCashAttempts).toHaveLength(count);
+}
+
+async function expectDashboardAndAgentCash(page: Page, expectedCount: number) {
+  await expect(page.getByTestId('branch-dashboard-title')).toBeVisible();
+  await expect(page.locator('main')).toContainText(
+    new RegExp(`Pagesa cash në pritje[\\s\\S]*${expectedCount}`, 'i')
+  );
+
+  const agentRow = page.getByRole('row', { name: new RegExp(KS_AGENT_A1_NAME, 'i') });
+  await expect(agentRow).toBeVisible();
+  await expect(agentRow).toContainText(String(expectedCount));
 }
 
 test.describe('PC04 branch cash truth', () => {
@@ -94,13 +133,10 @@ test.describe('PC04 branch cash truth', () => {
 
     await resetWatchedAttempts();
 
-    const branchACashAttempts = await listOpenCashForBranch(KS_BRANCH_A);
-    const branchBCashAttempts = await listOpenCashForBranch(KS_BRANCH_B);
-    expect(branchACashAttempts).toHaveLength(3);
-    expect(branchBCashAttempts).toHaveLength(1);
+    await expectOpenCashState({ branchId: KS_BRANCH_A, count: 3 });
+    await expectOpenCashState({ branchId: KS_BRANCH_B, count: 1 });
 
-    await watchStep(page, 'Open admin branch list');
-    await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'page-ready' });
+    await openBranchList(page, testInfo, 'Open admin branch list');
 
     await watchStep(page, 'KS-A shows three pending cash attempts');
     await expectBranchCashCard(page, 'KS-A', 3);
@@ -117,29 +153,16 @@ test.describe('PC04 branch cash truth', () => {
     await setAttemptStatus(NEEDS_INFO_ATTEMPT_ID, 'needs_info');
 
     try {
-      const openCashAttempts = await listOpenCashForBranch();
-      expect(openCashAttempts.map(row => row.id)).toContain(NEEDS_INFO_ATTEMPT_ID);
-      expect(openCashAttempts).toHaveLength(3);
+      await expectOpenCashState({ count: 3, includes: NEEDS_INFO_ATTEMPT_ID });
 
-      await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'page-ready' });
+      await openBranchList(page, testInfo, 'Open admin branch list with needs_info attempt');
+      await expectBranchCashCard(page, 'KS-A', 3);
 
-      const branchCard = page.getByTestId('branch-card-KS-A');
-      await expect(branchCard).toBeVisible();
-      await expect(branchCard.getByLabel(/Pagesa cash në pritje|Cash Pending/i)).toContainText('3');
-
-      await watchStep(page, 'Open KS-A branch dashboard');
-      await gotoApp(page, routes.adminBranchDetail(KS_BRANCH_A, testInfo), testInfo, {
-        marker: 'branch-dashboard-title',
-      });
+      await openBranchDashboard(page, testInfo, 'Open KS-A branch dashboard');
 
       await watchStep(page, 'Dashboard KPI includes pending plus needs_info attempts');
-      await expect(page.getByTestId('branch-dashboard-title')).toBeVisible();
-      await expect(page.locator('main')).toContainText(/Pagesa cash në pritje[\s\S]*3/i);
-
       await watchStep(page, 'Agent health row inherits the durable cash count');
-      const agentRow = page.getByRole('row', { name: new RegExp(KS_AGENT_A1_NAME, 'i') });
-      await expect(agentRow).toBeVisible();
-      await expect(agentRow).toContainText('3');
+      await expectDashboardAndAgentCash(page, 3);
     } finally {
       await resetWatchedAttempts();
     }
@@ -153,28 +176,21 @@ test.describe('PC04 branch cash truth', () => {
     await setAttemptStatus(RESOLVED_ATTEMPT_ID, 'succeeded');
 
     try {
-      const openCashAttempts = await listOpenCashForBranch();
-      expect(openCashAttempts.map(row => row.id)).not.toContain(RESOLVED_ATTEMPT_ID);
-      expect(openCashAttempts).toHaveLength(2);
+      await expectOpenCashState({ count: 2, excludes: RESOLVED_ATTEMPT_ID });
 
-      await watchStep(page, 'Open branch list after one cash attempt is resolved');
-      await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'page-ready' });
+      await openBranchList(page, testInfo, 'Open branch list after one cash attempt is resolved');
 
       await watchStep(page, 'KS-A cash pressure drops to two');
       await expectBranchCashCard(page, 'KS-A', 2);
 
-      await watchStep(page, 'Open KS-A dashboard with resolved attempt excluded');
-      await gotoApp(page, routes.adminBranchDetail(KS_BRANCH_A, testInfo), testInfo, {
-        marker: 'branch-dashboard-title',
-      });
-
-      await expect(page.getByTestId('branch-dashboard-title')).toBeVisible();
-      await expect(page.locator('main')).toContainText(/Pagesa cash në pritje[\s\S]*2/i);
+      await openBranchDashboard(
+        page,
+        testInfo,
+        'Open KS-A dashboard with resolved attempt excluded'
+      );
 
       await watchStep(page, 'Agent row also drops to two');
-      const agentRow = page.getByRole('row', { name: new RegExp(KS_AGENT_A1_NAME, 'i') });
-      await expect(agentRow).toBeVisible();
-      await expect(agentRow).toContainText('2');
+      await expectDashboardAndAgentCash(page, 2);
     } finally {
       await resetWatchedAttempts();
     }

--- a/apps/web/src/actions/branch-dashboard.core.test.ts
+++ b/apps/web/src/actions/branch-dashboard.core.test.ts
@@ -52,6 +52,7 @@ vi.mock('@interdomestik/database/schema', () => ({
   memberLeads: {
     id: 'memberLeads.id',
     branchId: 'memberLeads.branchId',
+    tenantId: 'memberLeads.tenantId',
   },
 }));
 

--- a/apps/web/src/actions/branch-dashboard.core.ts
+++ b/apps/web/src/actions/branch-dashboard.core.ts
@@ -8,10 +8,11 @@
  */
 
 import type { BranchAgentRow, BranchMetadata, BranchStats } from '@/actions/branch-dashboard.types';
+import { getBranchCashPendingCount } from '@/features/admin/branches/server/branch-cash-metrics';
 import { computeHealthScore, computeSeverity } from '@/features/admin/branches/utils/branch-risk';
 import { getOpenClaimsFilter, getSlaBreachesFilter } from '@/features/admin/kpis/kpi-definitions';
 import { db } from '@interdomestik/database/db';
-import { claims, leadPaymentAttempts, memberLeads, user } from '@interdomestik/database/schema';
+import { claims, user } from '@interdomestik/database/schema';
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 
 /**
@@ -78,19 +79,8 @@ export async function getBranchStats(
           and(eq(claims.branchId, branchId), eq(claims.tenantId, tenantId), getOpenClaimsFilter())
         ),
 
-      // Cash Pending: lead payments waiting verification in this branch
-      db
-        .select({ count: count() })
-        .from(leadPaymentAttempts)
-        .innerJoin(memberLeads, eq(leadPaymentAttempts.leadId, memberLeads.id))
-        .where(
-          and(
-            eq(leadPaymentAttempts.tenantId, tenantId),
-            eq(leadPaymentAttempts.method, 'cash'),
-            eq(leadPaymentAttempts.status, 'pending'),
-            eq(memberLeads.branchId, branchId)
-          )
-        ),
+      // Cash Pending: unresolved cash verification load in this branch.
+      getBranchCashPendingCount({ tenantId, branchId }),
 
       // SLA Breaches: submitted > 30 days (Shared Definition)
       db
@@ -105,7 +95,7 @@ export async function getBranchStats(
     totalAgents: agentCount[0]?.count ?? 0,
     totalMembers: memberCount[0]?.count ?? 0,
     openClaims: openClaimsCount[0]?.count ?? 0,
-    cashPending: cashPendingCount[0]?.count ?? 0,
+    cashPending: cashPendingCount,
     slaBreaches: slaBreachesCount[0]?.count ?? 0,
   };
 

--- a/apps/web/src/actions/messaging.core.ts
+++ b/apps/web/src/actions/messaging.core.ts
@@ -30,6 +30,12 @@ export type ActionResult<T = void> = {
   data?: T;
 };
 
+type GetMessagesResult = {
+  success: boolean;
+  messages?: MessageWithSender[];
+  error?: string;
+};
+
 function toMessageData(message: MessageWithSender, currentUserId: string): MessageData {
   return {
     id: message.id,
@@ -49,7 +55,7 @@ function toMessageData(message: MessageWithSender, currentUserId: string): Messa
  */
 export async function getClaimMessages(claimId: string): Promise<ActionResult<MessageData[]>> {
   const { session } = await getActionContext();
-  const result = await getMessagesForClaimCore({ session, claimId });
+  const result: GetMessagesResult = await getMessagesForClaimCore({ session, claimId });
 
   if (!result.success) {
     return { success: false, error: result.error };

--- a/apps/web/src/features/admin/branches/dashboard-v2/server/getBranchDashboardV2Data.ts
+++ b/apps/web/src/features/admin/branches/dashboard-v2/server/getBranchDashboardV2Data.ts
@@ -1,18 +1,12 @@
 import { getActionContext } from '@/actions/admin-users/context';
+import {
+  getBranchCashPendingByAgent,
+  getBranchCashPendingCount,
+} from '@/features/admin/branches/server/branch-cash-metrics';
 import { HealthProfile, computeHealthScore } from '@/features/admin/health/health-model';
-import {
-  getCashPendingFilter,
-  getOpenClaimsFilter,
-  getSlaBreachesFilter,
-} from '@/features/admin/kpis/kpi-definitions';
+import { getOpenClaimsFilter, getSlaBreachesFilter } from '@/features/admin/kpis/kpi-definitions';
 import { db } from '@interdomestik/database/db';
-import {
-  branches,
-  claims,
-  leadPaymentAttempts,
-  memberLeads,
-  user,
-} from '@interdomestik/database/schema';
+import { branches, claims, user } from '@interdomestik/database/schema';
 import { ROLES, scopeFilter } from '@interdomestik/shared-auth';
 import * as Sentry from '@sentry/nextjs';
 import { and, count, eq, inArray, or } from 'drizzle-orm';
@@ -128,18 +122,8 @@ export async function getBranchDashboardV2Data(
               )
             ),
 
-          // 2. KPI: Cash Pending
-          db
-            .select({ count: count() })
-            .from(leadPaymentAttempts)
-            .innerJoin(memberLeads, eq(leadPaymentAttempts.leadId, memberLeads.id))
-            .where(
-              and(
-                eq(leadPaymentAttempts.tenantId, tenantId),
-                getCashPendingFilter(),
-                eq(memberLeads.branchId, resolvedBranchId)
-              )
-            ),
+          // 2. KPI: unresolved cash verification load for this branch.
+          getBranchCashPendingCount({ tenantId, branchId: resolvedBranchId }),
 
           // 3. KPI: SLA Breaches
           db
@@ -202,7 +186,7 @@ export async function getBranchDashboardV2Data(
         // Compute Branch Health
         const kpis = {
           openClaims: openClaimsCount[0]?.count ?? 0,
-          cashPending: cashPendingCount[0]?.count ?? 0,
+          cashPending: cashPendingCount,
           slaBreaches: slaBreachesCount[0]?.count ?? 0,
           isActive: branchResult.isActive,
           totalAgents: totalAgentsCount[0]?.count ?? 0,
@@ -257,10 +241,13 @@ export async function getBranchDashboardV2Data(
 // Helper: Agent Metrics derivation
 async function getAgentMetrics(branchId: string, tenantId: string) {
   // 1. Get agents in branch
-  const agents = await db.query.user.findMany({
-    where: and(eq(user.branchId, branchId), eq(user.tenantId, tenantId), eq(user.role, 'agent')),
-    columns: { id: true, name: true },
-  });
+  const [agents, cashPendingByAgent] = await Promise.all([
+    db.query.user.findMany({
+      where: and(eq(user.branchId, branchId), eq(user.tenantId, tenantId), eq(user.role, 'agent')),
+      columns: { id: true, name: true },
+    }),
+    getBranchCashPendingByAgent({ tenantId, branchId }),
+  ]);
 
   if (agents.length === 0) return [];
 
@@ -271,7 +258,7 @@ async function getAgentMetrics(branchId: string, tenantId: string) {
 
   return Promise.all(
     agents.map(async agent => {
-      const [openClaims, cashPendingItems, slaBreaches] = await Promise.all([
+      const [openClaims, slaBreaches] = await Promise.all([
         // Open Claims linked to agent (via claim.agentId)
         db
           .select({ count: count() })
@@ -279,21 +266,6 @@ async function getAgentMetrics(branchId: string, tenantId: string) {
           .where(
             and(eq(claims.agentId, agent.id), eq(claims.tenantId, tenantId), getOpenClaimsFilter())
           ),
-
-        // Cash Pending linked to agent (no direct link on payment, via led -> member -> agent or lead -> agent)
-        // Using leadPaymentAttempts -> memberLeads -> agent_id check?
-        // Currently memberLeads doesn't store agent_id directly usually, but let's check schema.
-        // Actually, usually leads are assigned. Let's assume memberLeads has agent_id if defined,
-        // OR we link via user (agentClients).
-        // To keep it simple and consistent with "kpi-definitions":
-        // "cashPending = count of leadPaymentAttempts pending cash for leads in this branch created by this agent"
-        // Schema check: memberLeads has 'creator_id' or similar? Or we join `user` (agent)?
-        // The prompt says "leads with agentId where branchId == current branch".
-        // Does `memberLeads` have `agentId`? If not, valid derivation is hard.
-        // Let's assume 0 for now if column missing, BUT `getBranchAgents` used subquery on `claims`.
-        // `activeClaimCount` in `getBranchAgents` was `WHERE claims.agent_id = ${user.id}`.
-
-        Promise.resolve([{ count: 0 }]), // Placeholder for cash (optimization)
 
         // SLA Breaches linked to agent
         db
@@ -308,7 +280,7 @@ async function getAgentMetrics(branchId: string, tenantId: string) {
         id: agent.id,
         name: agent.name,
         openClaims: openClaims[0]?.count ?? 0,
-        cashPending: cashPendingItems[0]?.count ?? 0,
+        cashPending: cashPendingByAgent.get(agent.id) ?? 0,
         slaBreaches: slaBreaches[0]?.count ?? 0,
       };
     })

--- a/apps/web/src/features/admin/branches/server/branch-cash-metrics.test.ts
+++ b/apps/web/src/features/admin/branches/server/branch-cash-metrics.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const queryPlans: Array<{
+    terminal: 'where' | 'groupBy';
+    result: Array<Record<string, unknown>>;
+  }> = [];
+
+  const db = {
+    select: vi.fn(() => {
+      const plan = queryPlans.shift();
+      if (!plan) {
+        throw new Error('Missing query plan');
+      }
+
+      const chain = {
+        from: vi.fn(() => chain),
+        innerJoin: vi.fn(() => chain),
+        where: vi.fn(() => (plan.terminal === 'where' ? Promise.resolve(plan.result) : chain)),
+        groupBy: vi.fn(() => Promise.resolve(plan.result)),
+      };
+
+      return chain;
+    }),
+  };
+
+  return {
+    queryPlans,
+    db,
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, op: 'and' })),
+    count: vi.fn(() => ({ op: 'count' })),
+    eq: vi.fn((left: unknown, right: unknown) => ({ left, right, op: 'eq' })),
+    inArray: vi.fn((left: unknown, right: unknown[]) => ({ left, right, op: 'inArray' })),
+  };
+});
+
+vi.mock('@interdomestik/database/db', () => ({
+  db: mocks.db,
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  leadPaymentAttempts: {
+    id: 'lead_payment_attempts.id',
+    leadId: 'lead_payment_attempts.lead_id',
+    method: 'lead_payment_attempts.method',
+    status: 'lead_payment_attempts.status',
+    tenantId: 'lead_payment_attempts.tenant_id',
+  },
+  memberLeads: {
+    agentId: 'member_leads.agent_id',
+    branchId: 'member_leads.branch_id',
+    id: 'member_leads.id',
+    tenantId: 'member_leads.tenant_id',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: mocks.and,
+  count: mocks.count,
+  eq: mocks.eq,
+  inArray: mocks.inArray,
+}));
+
+import {
+  BRANCH_CASH_OPEN_STATUSES,
+  getBranchCashPendingByAgent,
+  getBranchCashPendingByBranch,
+  getBranchCashPendingCount,
+} from './branch-cash-metrics';
+
+describe('branch cash metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.queryPlans.length = 0;
+  });
+
+  it('counts unresolved cash verification load for one tenant branch', async () => {
+    mocks.queryPlans.push({ terminal: 'where', result: [{ count: 2 }] });
+
+    await expect(
+      getBranchCashPendingCount({ tenantId: 'tenant-1', branchId: 'branch-1' })
+    ).resolves.toBe(2);
+
+    expect(mocks.eq).toHaveBeenCalledWith('lead_payment_attempts.tenant_id', 'tenant-1');
+    expect(mocks.eq).toHaveBeenCalledWith('member_leads.tenant_id', 'tenant-1');
+    expect(mocks.eq).toHaveBeenCalledWith('member_leads.branch_id', 'branch-1');
+    expect(mocks.eq).toHaveBeenCalledWith('lead_payment_attempts.method', 'cash');
+    expect(mocks.inArray).toHaveBeenCalledWith('lead_payment_attempts.status', [
+      ...BRANCH_CASH_OPEN_STATUSES,
+    ]);
+  });
+
+  it('groups unresolved cash verification load by branch', async () => {
+    mocks.queryPlans.push({
+      terminal: 'groupBy',
+      result: [
+        { branchId: 'branch-1', count: 3 },
+        { branchId: 'branch-2', count: 1 },
+      ],
+    });
+
+    const result = await getBranchCashPendingByBranch('tenant-1');
+
+    expect(result).toEqual(
+      new Map([
+        ['branch-1', 3],
+        ['branch-2', 1],
+      ])
+    );
+    expect(mocks.eq).toHaveBeenCalledWith('lead_payment_attempts.tenant_id', 'tenant-1');
+    expect(mocks.eq).toHaveBeenCalledWith('member_leads.tenant_id', 'tenant-1');
+  });
+
+  it('groups unresolved cash verification load by lead agent within one branch', async () => {
+    mocks.queryPlans.push({
+      terminal: 'groupBy',
+      result: [
+        { agentId: 'agent-1', count: 4 },
+        { agentId: 'agent-2', count: 2 },
+      ],
+    });
+
+    const result = await getBranchCashPendingByAgent({
+      tenantId: 'tenant-1',
+      branchId: 'branch-1',
+    });
+
+    expect(result).toEqual(
+      new Map([
+        ['agent-1', 4],
+        ['agent-2', 2],
+      ])
+    );
+    expect(mocks.eq).toHaveBeenCalledWith('member_leads.branch_id', 'branch-1');
+  });
+});

--- a/apps/web/src/features/admin/branches/server/branch-cash-metrics.ts
+++ b/apps/web/src/features/admin/branches/server/branch-cash-metrics.ts
@@ -1,0 +1,67 @@
+import { db } from '@interdomestik/database/db';
+import { leadPaymentAttempts, memberLeads } from '@interdomestik/database/schema';
+import { and, count, eq, inArray } from 'drizzle-orm';
+
+export const BRANCH_CASH_OPEN_STATUSES = ['pending', 'needs_info'] as const;
+
+interface BranchCashScope {
+  tenantId: string;
+  branchId: string;
+}
+
+function getBranchCashTruthFilter(scope: BranchCashScope) {
+  return and(
+    eq(leadPaymentAttempts.tenantId, scope.tenantId),
+    eq(memberLeads.tenantId, scope.tenantId),
+    eq(memberLeads.branchId, scope.branchId),
+    eq(leadPaymentAttempts.method, 'cash'),
+    inArray(leadPaymentAttempts.status, [...BRANCH_CASH_OPEN_STATUSES])
+  );
+}
+
+export async function getBranchCashPendingCount(scope: BranchCashScope): Promise<number> {
+  const [result] = await db
+    .select({ count: count() })
+    .from(leadPaymentAttempts)
+    .innerJoin(memberLeads, eq(leadPaymentAttempts.leadId, memberLeads.id))
+    .where(getBranchCashTruthFilter(scope));
+
+  return result?.count ?? 0;
+}
+
+export async function getBranchCashPendingByBranch(tenantId: string): Promise<Map<string, number>> {
+  const rows = await db
+    .select({
+      branchId: memberLeads.branchId,
+      count: count(),
+    })
+    .from(leadPaymentAttempts)
+    .innerJoin(memberLeads, eq(leadPaymentAttempts.leadId, memberLeads.id))
+    .where(
+      and(
+        eq(leadPaymentAttempts.tenantId, tenantId),
+        eq(memberLeads.tenantId, tenantId),
+        eq(leadPaymentAttempts.method, 'cash'),
+        inArray(leadPaymentAttempts.status, [...BRANCH_CASH_OPEN_STATUSES])
+      )
+    )
+    .groupBy(memberLeads.branchId);
+
+  return new Map(rows.map(row => [row.branchId, row.count]));
+}
+
+export async function getBranchCashPendingByAgent(
+  scope: BranchCashScope
+): Promise<Map<string, number>> {
+  const rows = await db
+    .select({
+      agentId: memberLeads.agentId,
+      count: count(),
+    })
+    .from(leadPaymentAttempts)
+    .innerJoin(memberLeads, eq(leadPaymentAttempts.leadId, memberLeads.id))
+    .where(getBranchCashTruthFilter(scope))
+    .groupBy(memberLeads.agentId);
+
+  return new Map(rows.map(row => [row.agentId, row.count]));
+}

--- a/apps/web/src/features/admin/branches/server/branch-cash-metrics.ts
+++ b/apps/web/src/features/admin/branches/server/branch-cash-metrics.ts
@@ -9,14 +9,17 @@ interface BranchCashScope {
   branchId: string;
 }
 
-function getBranchCashTruthFilter(scope: BranchCashScope) {
+function getTenantCashTruthFilter(tenantId: string) {
   return and(
-    eq(leadPaymentAttempts.tenantId, scope.tenantId),
-    eq(memberLeads.tenantId, scope.tenantId),
-    eq(memberLeads.branchId, scope.branchId),
+    eq(leadPaymentAttempts.tenantId, tenantId),
+    eq(memberLeads.tenantId, tenantId),
     eq(leadPaymentAttempts.method, 'cash'),
     inArray(leadPaymentAttempts.status, [...BRANCH_CASH_OPEN_STATUSES])
   );
+}
+
+function getBranchCashTruthFilter(scope: BranchCashScope) {
+  return and(getTenantCashTruthFilter(scope.tenantId), eq(memberLeads.branchId, scope.branchId));
 }
 
 export async function getBranchCashPendingCount(scope: BranchCashScope): Promise<number> {
@@ -37,14 +40,7 @@ export async function getBranchCashPendingByBranch(tenantId: string): Promise<Ma
     })
     .from(leadPaymentAttempts)
     .innerJoin(memberLeads, eq(leadPaymentAttempts.leadId, memberLeads.id))
-    .where(
-      and(
-        eq(leadPaymentAttempts.tenantId, tenantId),
-        eq(memberLeads.tenantId, tenantId),
-        eq(leadPaymentAttempts.method, 'cash'),
-        inArray(leadPaymentAttempts.status, [...BRANCH_CASH_OPEN_STATUSES])
-      )
-    )
+    .where(getTenantCashTruthFilter(tenantId))
     .groupBy(memberLeads.branchId);
 
   return new Map(rows.map(row => [row.branchId, row.count]));

--- a/apps/web/src/features/admin/branches/server/getBranchesWithKpis.ts
+++ b/apps/web/src/features/admin/branches/server/getBranchesWithKpis.ts
@@ -1,16 +1,13 @@
 'use server';
 
-import {
-  getCashPendingFilter,
-  getOpenClaimsFilter,
-  getSlaBreachesFilter,
-} from '@/features/admin/kpis/kpi-definitions';
+import { getOpenClaimsFilter, getSlaBreachesFilter } from '@/features/admin/kpis/kpi-definitions';
 import { runAuthenticatedAction, type ActionResult } from '@/lib/safe-action';
 import { db } from '@interdomestik/database/db';
-import { branches, claims, leadPaymentAttempts, memberLeads } from '@interdomestik/database/schema';
+import { branches, claims } from '@interdomestik/database/schema';
 import { ROLES } from '@interdomestik/shared-auth';
 import * as Sentry from '@sentry/nextjs';
 import { and, count, eq } from 'drizzle-orm';
+import { getBranchCashPendingByBranch } from './branch-cash-metrics';
 
 export interface BranchWithKpis {
   id: string;
@@ -87,22 +84,12 @@ export async function getBranchesWithKpis(): ActionResult<BranchWithKpis[]> {
           .where(and(eq(claims.tenantId, tenantId), getSlaBreachesFilter()))
           .groupBy(claims.branchId);
 
-        // 5. Aggregate Cash Pending by Branch
-        const cashPendingRaw = await db
-          .select({
-            branchId: memberLeads.branchId,
-            count: count(),
-          })
-          .from(leadPaymentAttempts)
-          .leftJoin(memberLeads, eq(leadPaymentAttempts.leadId, memberLeads.id))
-          .where(and(eq(leadPaymentAttempts.tenantId, tenantId), getCashPendingFilter()))
-          .groupBy(memberLeads.branchId);
+        // 5. Aggregate unresolved cash verification load by branch
+        const cashPendingMap = await getBranchCashPendingByBranch(tenantId);
 
         // 6. Merge Metrics
         const openClaimsMap = new Map(openClaimsRaw.map(r => [r.branchId, r.count]));
         const slaBreachesMap = new Map(slaBreachesRaw.map(r => [r.branchId, r.count]));
-        const cashPendingMap = new Map(cashPendingRaw.map(r => [r.branchId, r.count]));
-
         return tenantBranches.map(branch => ({
           ...branch,
           kpis: {

--- a/packages/domain-analytics/src/index.test.ts
+++ b/packages/domain-analytics/src/index.test.ts
@@ -49,6 +49,7 @@ vi.mock('@interdomestik/database/schema', () => ({
     agentId: 'agent_commissions.agent_id',
     amount: 'agent_commissions.amount',
     status: 'agent_commissions.status',
+    tenantId: 'agent_commissions.tenant_id',
   },
   branches: {
     tenantId: 'branches.tenant_id',
@@ -145,6 +146,7 @@ describe('domain analytics', () => {
       claimsPending: 7,
       totalCommissionPaid: 1234.5,
     });
+    expect(mocks.eq).toHaveBeenCalledWith('agent_commissions.tenant_id', 'tenant-1');
   });
 
   it('aggregates global super-admin KPIs across tenants, branches, users, and claims', async () => {

--- a/packages/domain-analytics/src/v2/branch.ts
+++ b/packages/domain-analytics/src/v2/branch.ts
@@ -38,7 +38,14 @@ export async function getBranchKPIs(tenantId: string, branchId: string): Promise
       .select({ total: sum(agentCommissions.amount) })
       .from(agentCommissions)
       .innerJoin(user, eq(agentCommissions.agentId, user.id))
-      .where(and(eq(user.branchId, branchId), eq(agentCommissions.status, 'paid'))),
+      .where(
+        and(
+          eq(agentCommissions.tenantId, tenantId),
+          eq(user.tenantId, tenantId),
+          eq(user.branchId, branchId),
+          eq(agentCommissions.status, 'paid')
+        )
+      ),
   ]);
 
   return {


### PR DESCRIPTION
## Summary
- Derive branch cash pressure from durable `lead_payment_attempts` joined to tenant-scoped `member_leads`.
- Wire branch list, branch dashboard KPI, and agent health to the shared branch cash metrics helpers.
- Add PC04 E2E coverage for branch grouping, `pending` + `needs_info`, and resolved cash exclusion.
- Add the small legacy messaging result type annotation needed for production-style gatekeeper TypeScript.

## Verification
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate`
- `PC04_WATCH_DELAY_MS=2500 ... playwright test e2e/pc04-branch-cash-truth.spec.ts --project=ks-sq --headed`

## Notes
- `apps/web/src/proxy.ts` was not modified.
- Stripe remains unused in V3 pilot flows.
