### PR TITLE
PC05: membership lifecycle reporting truth

### DIFF
--- a/apps/web/e2e/pc05-membership-lifecycle-truth.spec.ts
+++ b/apps/web/e2e/pc05-membership-lifecycle-truth.spec.ts
@@ -52,23 +52,29 @@ async function watchStep(page: Page, label: string) {
   if (WATCH_DELAY_MS <= 0) return;
 
   console.log(`[PC05 Watch] ${label}`);
-  await page.evaluate(text => {
+  await page.evaluate(message => {
     const id = 'pc05-watch-step';
-    document.getElementById(id)?.remove();
+    const marker = document.getElementById(id) ?? document.createElement('output');
 
-    const marker = document.createElement('div');
     marker.id = id;
-    marker.textContent = text;
-    marker.style.position = 'fixed';
-    marker.style.inset = '16px auto auto 16px';
-    marker.style.zIndex = '2147483647';
-    marker.style.padding = '10px 12px';
-    marker.style.borderRadius = '8px';
-    marker.style.background = '#111827';
-    marker.style.color = '#f9fafb';
-    marker.style.font = '600 14px/1.3 system-ui, sans-serif';
-    marker.style.boxShadow = '0 10px 30px rgba(0,0,0,0.25)';
-    document.body.appendChild(marker);
+    marker.setAttribute('aria-live', 'polite');
+    marker.textContent = `PC05 lifecycle: ${message}`;
+    marker.style.cssText = [
+      'position:fixed',
+      'left:16px',
+      'top:16px',
+      'z-index:2147483647',
+      'max-width:min(520px,calc(100vw - 32px))',
+      'padding:10px 12px',
+      'border:1px solid #1d4ed8',
+      'border-radius:6px',
+      'background:#eff6ff',
+      'color:#1e3a8a',
+      'font:600 14px/1.35 system-ui,sans-serif',
+      'box-shadow:0 8px 24px rgba(30,58,138,0.18)',
+    ].join(';');
+
+    if (!marker.isConnected) document.body.appendChild(marker);
   }, label);
   await page.waitForTimeout(WATCH_DELAY_MS);
 }

--- a/apps/web/e2e/pc05-membership-lifecycle-truth.spec.ts
+++ b/apps/web/e2e/pc05-membership-lifecycle-truth.spec.ts
@@ -1,0 +1,132 @@
+import type { Page, TestInfo } from '@playwright/test';
+import { and, db, eq, subscriptions } from '@interdomestik/database';
+import { expect, test } from './fixtures/auth.fixture';
+import { routes } from './routes';
+import { gotoApp } from './utils/navigation';
+
+const KS_TENANT_ID = 'tenant_ks';
+const KS_MEMBER_ID = 'golden_ks_a_member_1';
+const KS_SUBSCRIPTION_ID = 'golden_sub_ks_a_1';
+const FIXED_NOW = new Date('2026-04-21T12:00:00.000Z');
+const FUTURE_GRACE_END = new Date('2026-04-23T12:00:00.000Z');
+const EXPIRED_GRACE_END = new Date('2026-04-20T12:00:00.000Z');
+const PERIOD_END = new Date('2026-05-21T12:00:00.000Z');
+const WATCH_DELAY_MS = Number(process.env.PC05_WATCH_DELAY_MS ?? 0);
+
+type SubscriptionStatus = 'active' | 'past_due' | 'paused' | 'canceled' | 'trialing' | 'expired';
+
+async function setWatchedSubscriptionState({
+  status,
+  cancelAtPeriodEnd = false,
+  gracePeriodEndsAt = null,
+}: {
+  status: SubscriptionStatus;
+  cancelAtPeriodEnd?: boolean;
+  gracePeriodEndsAt?: Date | null;
+}) {
+  const updated = await db
+    .update(subscriptions)
+    .set({
+      status,
+      cancelAtPeriodEnd,
+      gracePeriodEndsAt,
+      pastDueAt: status === 'past_due' ? FIXED_NOW : null,
+      currentPeriodEnd: PERIOD_END,
+      updatedAt: FIXED_NOW,
+    })
+    .where(and(eq(subscriptions.id, KS_SUBSCRIPTION_ID), eq(subscriptions.tenantId, KS_TENANT_ID)))
+    .returning({ id: subscriptions.id });
+
+  expect(updated, 'Golden KS subscription must exist for PC05 lifecycle scenario').toHaveLength(1);
+}
+
+async function resetWatchedSubscription() {
+  await setWatchedSubscriptionState({
+    status: 'active',
+    cancelAtPeriodEnd: false,
+    gracePeriodEndsAt: null,
+  });
+}
+
+async function watchStep(page: Page, label: string) {
+  if (WATCH_DELAY_MS <= 0) return;
+
+  console.log(`[PC05 Watch] ${label}`);
+  await page.evaluate(text => {
+    const id = 'pc05-watch-step';
+    document.getElementById(id)?.remove();
+
+    const marker = document.createElement('div');
+    marker.id = id;
+    marker.textContent = text;
+    marker.style.position = 'fixed';
+    marker.style.inset = '16px auto auto 16px';
+    marker.style.zIndex = '2147483647';
+    marker.style.padding = '10px 12px';
+    marker.style.borderRadius = '8px';
+    marker.style.background = '#111827';
+    marker.style.color = '#f9fafb';
+    marker.style.font = '600 14px/1.3 system-ui, sans-serif';
+    marker.style.boxShadow = '0 10px 30px rgba(0,0,0,0.25)';
+    document.body.appendChild(marker);
+  }, label);
+  await page.waitForTimeout(WATCH_DELAY_MS);
+}
+
+async function openMemberDetail(page: Page, testInfo: TestInfo, label: string) {
+  await watchStep(page, label);
+  await gotoApp(page, `${routes.adminUsers(testInfo)}/${KS_MEMBER_ID}`, testInfo, {
+    marker: 'body',
+  });
+  await expect(page.getByTestId('membership-lifecycle-status')).toBeVisible({ timeout: 30_000 });
+}
+
+async function expectLifecycleStatus(page: Page, status: string) {
+  await expect(page.getByTestId('membership-lifecycle-status')).toHaveAttribute(
+    'data-lifecycle-status',
+    status
+  );
+}
+
+test.describe('PC05 membership lifecycle reporting truth', () => {
+  test.afterEach(async () => {
+    await resetWatchedSubscription();
+  });
+
+  test('admin member detail derives lifecycle badges from the shared subscription read model', async ({
+    adminPage: page,
+  }, testInfo) => {
+    test.skip(!testInfo.project.name.includes('ks'), 'KS golden seed scenario');
+
+    await setWatchedSubscriptionState({
+      status: 'past_due',
+      gracePeriodEndsAt: FUTURE_GRACE_END,
+    });
+    await openMemberDetail(page, testInfo, 'Open member detail with subscription inside grace');
+
+    await watchStep(page, 'Admin badge reports active_in_grace and shows grace end context');
+    await expectLifecycleStatus(page, 'active_in_grace');
+    await expect(page.getByTestId('membership-lifecycle-status-detail')).toBeVisible();
+
+    await setWatchedSubscriptionState({
+      status: 'past_due',
+      gracePeriodEndsAt: EXPIRED_GRACE_END,
+    });
+    await openMemberDetail(page, testInfo, 'Reload member detail after grace expiry');
+
+    await watchStep(page, 'Admin badge reports grace_expired from the same subscription row');
+    await expectLifecycleStatus(page, 'grace_expired');
+    await expect(page.getByTestId('membership-lifecycle-status-detail')).toHaveCount(0);
+
+    await setWatchedSubscriptionState({
+      status: 'active',
+      cancelAtPeriodEnd: true,
+      gracePeriodEndsAt: null,
+    });
+    await openMemberDetail(page, testInfo, 'Reload member detail with scheduled cancellation');
+
+    await watchStep(page, 'Admin badge reports scheduled_cancel and shows access end context');
+    await expectLifecycleStatus(page, 'scheduled_cancel');
+    await expect(page.getByTestId('membership-lifecycle-status-detail')).toBeVisible();
+  });
+});

--- a/apps/web/src/actions/analytics/get-admin.core.ts
+++ b/apps/web/src/actions/analytics/get-admin.core.ts
@@ -1,5 +1,6 @@
 import { db } from '@interdomestik/database';
 import { membershipPlans, subscriptions } from '@interdomestik/database/schema';
+import { getTenantMembershipLifecycleCounts } from '@interdomestik/domain-membership-billing';
 import { and, eq, gte, sql } from 'drizzle-orm';
 
 import { isStaffOrAdmin } from '@/lib/roles.core';
@@ -67,24 +68,10 @@ export async function getAdminAnalyticsCore(params: {
       }
     }
 
-    const allSubsCount = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(subscriptions)
-      .where(eq(subscriptions.tenantId, tenantId));
-
-    const activeSubsCount = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(subscriptions)
-      .where(and(eq(subscriptions.status, 'active'), eq(subscriptions.tenantId, tenantId)));
-
-    const canceledSubsCount = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(subscriptions)
-      .where(and(eq(subscriptions.status, 'canceled'), eq(subscriptions.tenantId, tenantId)));
-
-    const totalMembers = Number(allSubsCount[0]?.count || 0);
-    const activeMembers = Number(activeSubsCount[0]?.count || 0);
-    const canceledMembers = Number(canceledSubsCount[0]?.count || 0);
+    const lifecycleCounts = await getTenantMembershipLifecycleCounts({ tenantId });
+    const totalMembers = lifecycleCounts.total;
+    const activeMembers = lifecycleCounts.accessActive;
+    const canceledMembers = lifecycleCounts.canceled;
     const churnRate = totalMembers > 0 ? (canceledMembers / totalMembers) * 100 : 0;
 
     const lookbackDate = new Date();

--- a/apps/web/src/actions/analytics/get-admin.test.ts
+++ b/apps/web/src/actions/analytics/get-admin.test.ts
@@ -54,7 +54,6 @@ vi.mock('@interdomestik/domain-membership-billing', () => ({
     graceExpired: 0,
     scheduledCancel: 1,
     canceled: 1,
-    paused: 0,
     none: 0,
     accessActive: 4,
   })),

--- a/apps/web/src/actions/analytics/get-admin.test.ts
+++ b/apps/web/src/actions/analytics/get-admin.test.ts
@@ -45,6 +45,21 @@ vi.mock('@interdomestik/database/schema', () => ({
   },
 }));
 
+vi.mock('@interdomestik/domain-membership-billing', () => ({
+  getTenantMembershipLifecycleCounts: vi.fn(async () => ({
+    total: 5,
+    active: 1,
+    trialing: 1,
+    activeInGrace: 1,
+    graceExpired: 0,
+    scheduledCancel: 1,
+    canceled: 1,
+    paused: 0,
+    none: 0,
+    accessActive: 4,
+  })),
+}));
+
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn(),
   and: vi.fn(),
@@ -103,6 +118,11 @@ describe('actions/analytics getAdminAnalyticsCore', () => {
     });
 
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.totalMembers).toBe(5);
+      expect(result.data.activeMembers).toBe(4);
+      expect(result.data.churnRate).toBe(20);
+    }
     expect(eq).toHaveBeenCalledWith('subscriptions.planKey', 'membershipPlans.id');
     expect(eq).toHaveBeenCalledWith('subscriptions.tenantId', 'membershipPlans.tenantId');
     expect(and).toHaveBeenCalled();

--- a/apps/web/src/app/[locale]/admin/users/[id]/_components/membership-info-card.test.tsx
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_components/membership-info-card.test.tsx
@@ -46,6 +46,65 @@ describe('MembershipInfoCard', () => {
     expect(screen.getByText('sections.membership')).toBeInTheDocument();
     expect(screen.getByText('Premium Plan')).toBeInTheDocument();
     expect(screen.getByText('status.active')).toBeInTheDocument();
+    expect(screen.getByTestId('membership-lifecycle-status')).toHaveTextContent('status.active');
+  });
+
+  it('renders grace-period lifecycle context for admin reporting', async () => {
+    const jsx = await MembershipInfoCard({
+      subscription: {
+        planId: 'Premium Plan',
+        currentPeriodEnd: new Date('2026-12-22T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+        gracePeriodEndsAt: new Date('2026-04-23T00:00:00.000Z'),
+      },
+      membershipStatus: 'active_in_grace',
+      membershipBadgeClass: 'bg-amber',
+      isMembershipProfile: true,
+      role: 'member',
+      currentTenantId: 'tenant_ks',
+      canReassignTenant: false,
+      tenantOptions: [],
+      userId: 'user-1',
+      tenantClassificationPending: false,
+    });
+
+    render(jsx);
+
+    expect(screen.getByTestId('membership-lifecycle-status')).toHaveTextContent(
+      'status.active_in_grace'
+    );
+    expect(screen.getByTestId('membership-lifecycle-status-detail')).toHaveTextContent(
+      'status_context.active_in_grace'
+    );
+  });
+
+  it('renders scheduled-cancel lifecycle context for admin reporting', async () => {
+    const jsx = await MembershipInfoCard({
+      subscription: {
+        planId: 'Premium Plan',
+        currentPeriodEnd: new Date('2026-12-22T00:00:00.000Z'),
+        cancelAtPeriodEnd: true,
+        gracePeriodEndsAt: null,
+      },
+      membershipStatus: 'scheduled_cancel',
+      membershipBadgeClass: 'bg-blue',
+      isMembershipProfile: true,
+      role: 'member',
+      currentTenantId: 'tenant_ks',
+      canReassignTenant: false,
+      tenantOptions: [],
+      userId: 'user-1',
+      tenantClassificationPending: false,
+    });
+
+    render(jsx);
+
+    expect(screen.getByTestId('membership-lifecycle-status')).toHaveTextContent(
+      'status.scheduled_cancel'
+    );
+    expect(screen.getByTestId('membership-lifecycle-status-detail')).toHaveTextContent(
+      'status_context.scheduled_cancel'
+    );
   });
 
   it('renders empty state when no subscription', async () => {

--- a/apps/web/src/app/[locale]/admin/users/[id]/_components/membership-info-card.tsx
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_components/membership-info-card.tsx
@@ -22,6 +22,7 @@ export async function MembershipInfoCard({
     planId: string;
     currentPeriodEnd: Date | null;
     cancelAtPeriodEnd: boolean;
+    gracePeriodEndsAt?: Date | null;
   } | null;
   membershipStatus: string;
   membershipBadgeClass: string;
@@ -41,6 +42,17 @@ export async function MembershipInfoCard({
     cancellationStatus = subscription.cancelAtPeriodEnd ? tCommon('yes') : tCommon('no');
   }
 
+  const lifecycleDetail =
+    subscription && isMembershipProfile
+      ? getLifecycleDetail({
+          status: membershipStatus,
+          periodEnd: subscription.currentPeriodEnd,
+          gracePeriodEndsAt: subscription.gracePeriodEndsAt ?? null,
+          fallback: tCommon('none'),
+          formatMessage: (key, date) => t(`status_context.${key}`, { date }),
+        })
+      : null;
+
   return (
     <Card>
       <CardHeader>
@@ -53,9 +65,25 @@ export async function MembershipInfoCard({
           <span className="text-muted-foreground">
             {t(isMembershipProfile ? 'labels.status' : 'labels.account_type')}
           </span>
-          <Badge className={membershipBadgeClass} variant="outline">
-            {t(`status.${isMembershipProfile ? membershipStatus : 'operator'}`)}
-          </Badge>
+          <div className="flex flex-col items-end gap-1 text-right">
+            <Badge
+              className={membershipBadgeClass}
+              variant="outline"
+              data-testid="membership-lifecycle-status"
+              data-lifecycle-status={isMembershipProfile ? membershipStatus : 'operator'}
+              title={lifecycleDetail ?? undefined}
+            >
+              {t(`status.${isMembershipProfile ? membershipStatus : 'operator'}`)}
+            </Badge>
+            {lifecycleDetail ? (
+              <span
+                className="max-w-[12rem] text-xs text-muted-foreground"
+                data-testid="membership-lifecycle-status-detail"
+              >
+                {lifecycleDetail}
+              </span>
+            ) : null}
+          </div>
         </div>
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground">
@@ -101,4 +129,22 @@ export async function MembershipInfoCard({
       </CardContent>
     </Card>
   );
+}
+
+function getLifecycleDetail(args: {
+  status: string;
+  periodEnd: Date | null;
+  gracePeriodEndsAt: Date | null;
+  fallback: string;
+  formatMessage: (key: 'active_in_grace' | 'scheduled_cancel', date: string) => string;
+}): string | null {
+  if (args.status === 'active_in_grace') {
+    return args.formatMessage('active_in_grace', formatDate(args.gracePeriodEndsAt, args.fallback));
+  }
+
+  if (args.status === 'scheduled_cancel') {
+    return args.formatMessage('scheduled_cancel', formatDate(args.periodEnd, args.fallback));
+  }
+
+  return null;
 }

--- a/apps/web/src/app/[locale]/admin/users/[id]/_core.test.ts
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_core.test.ts
@@ -18,12 +18,29 @@ describe('admin user profile core', () => {
     expect(counts).toEqual({ total: 10, open: 7, resolved: 2, rejected: 1 });
   });
 
-  it('getAdminUserMembershipStatus normalizes unknown to none', () => {
-    expect(getAdminUserMembershipStatus('active')).toBe('active');
-    expect(getAdminUserMembershipStatus('past_due')).toBe('past_due');
-    expect(getAdminUserMembershipStatus('paused')).toBe('paused');
-    expect(getAdminUserMembershipStatus('canceled')).toBe('canceled');
-    expect(getAdminUserMembershipStatus('something_else')).toBe('none');
+  it('getAdminUserMembershipStatus normalizes subscription lifecycle buckets', () => {
+    const now = new Date('2026-04-21T00:00:00.000Z');
+
+    expect(getAdminUserMembershipStatus({ status: 'active' }, now)).toBe('active');
+    expect(
+      getAdminUserMembershipStatus(
+        { status: 'past_due', gracePeriodEndsAt: new Date('2026-04-22T00:00:00.000Z') },
+        now
+      )
+    ).toBe('active_in_grace');
+    expect(
+      getAdminUserMembershipStatus(
+        { status: 'past_due', gracePeriodEndsAt: new Date('2026-04-20T00:00:00.000Z') },
+        now
+      )
+    ).toBe('grace_expired');
+    expect(getAdminUserMembershipStatus({ status: 'active', cancelAtPeriodEnd: true }, now)).toBe(
+      'scheduled_cancel'
+    );
+    expect(getAdminUserMembershipStatus({ status: 'trialing' }, now)).toBe('trialing');
+    expect(getAdminUserMembershipStatus({ status: 'paused' }, now)).toBe('canceled');
+    expect(getAdminUserMembershipStatus({ status: 'canceled' }, now)).toBe('canceled');
+    expect(getAdminUserMembershipStatus({ status: 'something_else' }, now)).toBe('canceled');
     expect(getAdminUserMembershipStatus(null)).toBe('none');
     expect(getAdminUserMembershipStatus(undefined)).toBe('none');
   });

--- a/apps/web/src/app/[locale]/admin/users/[id]/_core.ts
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_core.ts
@@ -5,6 +5,10 @@ import {
   userNotificationPreferences,
   user as userTable,
 } from '@interdomestik/database/schema';
+import {
+  getMembershipLifecycleBucket,
+  type MembershipLifecycleBucket,
+} from '@interdomestik/domain-membership-billing';
 import { and, count, desc, eq } from 'drizzle-orm';
 
 export type AdminUserClaimCounts = {
@@ -14,7 +18,7 @@ export type AdminUserClaimCounts = {
   rejected: number;
 };
 
-export type AdminUserMembershipStatus = 'active' | 'past_due' | 'paused' | 'canceled' | 'none';
+export type AdminUserMembershipStatus = MembershipLifecycleBucket;
 
 export function computeAdminUserClaimCounts(
   rows: Array<{ status: string | null; total: unknown }>
@@ -39,13 +43,10 @@ export function computeAdminUserClaimCounts(
 }
 
 export function getAdminUserMembershipStatus(
-  rawStatus: string | null | undefined
+  subscription: SubscriptionLifecycleInput,
+  now?: Date
 ): AdminUserMembershipStatus {
-  if (rawStatus === 'active') return 'active';
-  if (rawStatus === 'past_due') return 'past_due';
-  if (rawStatus === 'paused') return 'paused';
-  if (rawStatus === 'canceled') return 'canceled';
-  return 'none';
+  return getMembershipLifecycleBucket({ subscription, now });
 }
 
 export type AdminUserProfileOk = {
@@ -119,7 +120,7 @@ export async function getAdminUserProfileCore(args: {
   ]);
 
   const counts = computeAdminUserClaimCounts(claimCounts);
-  const membershipStatus = getAdminUserMembershipStatus(subscription?.status);
+  const membershipStatus = getAdminUserMembershipStatus(subscription);
 
   return {
     kind: 'ok',
@@ -135,6 +136,15 @@ export async function getAdminUserProfileCore(args: {
 type MemberWithAgent = NonNullable<Awaited<ReturnType<typeof getMemberWithAgent>>>;
 
 type SubscriptionRow = NonNullable<Awaited<ReturnType<typeof db.query.subscriptions.findFirst>>>;
+
+type SubscriptionLifecycleInput =
+  | {
+      status?: string | null;
+      cancelAtPeriodEnd?: boolean | null;
+      gracePeriodEndsAt?: Date | null;
+    }
+  | null
+  | undefined;
 
 type PreferencesRow = NonNullable<
   Awaited<ReturnType<typeof db.query.userNotificationPreferences.findFirst>>

--- a/apps/web/src/app/[locale]/admin/users/[id]/_core.ts
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_core.ts
@@ -8,6 +8,7 @@ import {
 import {
   getMembershipLifecycleBucket,
   type MembershipLifecycleBucket,
+  type MembershipLifecycleInput,
 } from '@interdomestik/domain-membership-billing';
 import { and, count, desc, eq } from 'drizzle-orm';
 
@@ -43,7 +44,7 @@ export function computeAdminUserClaimCounts(
 }
 
 export function getAdminUserMembershipStatus(
-  subscription: SubscriptionLifecycleInput,
+  subscription: MembershipLifecycleInput,
   now?: Date
 ): AdminUserMembershipStatus {
   return getMembershipLifecycleBucket({ subscription, now });
@@ -136,15 +137,6 @@ export async function getAdminUserProfileCore(args: {
 type MemberWithAgent = NonNullable<Awaited<ReturnType<typeof getMemberWithAgent>>>;
 
 type SubscriptionRow = NonNullable<Awaited<ReturnType<typeof db.query.subscriptions.findFirst>>>;
-
-type SubscriptionLifecycleInput =
-  | {
-      status?: string | null;
-      cancelAtPeriodEnd?: boolean | null;
-      gracePeriodEndsAt?: Date | null;
-    }
-  | null
-  | undefined;
 
 type PreferencesRow = NonNullable<
   Awaited<ReturnType<typeof db.query.userNotificationPreferences.findFirst>>

--- a/apps/web/src/features/admin/dashboard-v2/server/fetchers/fetchKpis.ts
+++ b/apps/web/src/features/admin/dashboard-v2/server/fetchers/fetchKpis.ts
@@ -5,7 +5,8 @@ import {
 } from '@/features/admin/kpis/kpi-definitions';
 import { db } from '@interdomestik/database';
 import { branches, claims, leadPaymentAttempts, user } from '@interdomestik/database/schema';
-import { and, count, eq, inArray } from 'drizzle-orm';
+import { getTenantMembershipLifecycleCounts } from '@interdomestik/domain-membership-billing';
+import { and, count, eq } from 'drizzle-orm';
 
 export async function fetchKpis(tenantId: string) {
   // 1. Branch Count
@@ -21,10 +22,7 @@ export async function fetchKpis(tenantId: string) {
     .where(and(eq(user.tenantId, tenantId), eq(user.role, 'agent')));
 
   // 3. Member Count (users with role='user' or 'member')
-  const [membersData] = await db
-    .select({ count: count() })
-    .from(user)
-    .where(and(eq(user.tenantId, tenantId), inArray(user.role, ['user', 'member'])));
+  const lifecycleCounts = await getTenantMembershipLifecycleCounts({ tenantId });
 
   // 4. Open Claims
   const [openClaimsData] = await db
@@ -47,7 +45,7 @@ export async function fetchKpis(tenantId: string) {
   return {
     branches: branchesData?.count ?? 0,
     agents: agentsData?.count ?? 0,
-    members: membersData?.count ?? 0,
+    members: lifecycleCounts.accessActive,
     claimsOpen: openClaimsData?.count ?? 0,
     cashPending: cashPendingData?.count ?? 0,
     slaBreaches: slaBreachesData?.count ?? 0,

--- a/apps/web/src/features/admin/dashboard-v2/server/fetchers/fetchKpis.ts
+++ b/apps/web/src/features/admin/dashboard-v2/server/fetchers/fetchKpis.ts
@@ -21,7 +21,7 @@ export async function fetchKpis(tenantId: string) {
     .from(user)
     .where(and(eq(user.tenantId, tenantId), eq(user.role, 'agent')));
 
-  // 3. Member Count (users with role='user' or 'member')
+  // 3. Member Count (access-active subscriptions)
   const lifecycleCounts = await getTenantMembershipLifecycleCounts({ tenantId });
 
   // 4. Open Claims

--- a/apps/web/src/features/admin/users/components/AdminUserDetailV2Page.tsx
+++ b/apps/web/src/features/admin/users/components/AdminUserDetailV2Page.tsx
@@ -19,8 +19,10 @@ const RECENT_CLAIMS_LIMIT = 6;
 
 const membershipStatusStyles: Record<string, string> = {
   active: 'bg-emerald-100 text-emerald-700 border-emerald-200',
-  past_due: 'bg-amber-100 text-amber-700 border-amber-200',
-  paused: 'bg-slate-100 text-slate-700 border-slate-200',
+  active_in_grace: 'bg-amber-100 text-amber-700 border-amber-200',
+  grace_expired: 'bg-rose-100 text-rose-700 border-rose-200',
+  scheduled_cancel: 'bg-blue-100 text-blue-700 border-blue-200',
+  trialing: 'bg-indigo-100 text-indigo-700 border-indigo-200',
   canceled: 'bg-rose-100 text-rose-700 border-rose-200',
   none: 'bg-muted text-muted-foreground border-transparent',
   registered: 'bg-blue-100 text-blue-700 border-blue-200',
@@ -145,6 +147,7 @@ export async function AdminUserDetailV2Page({
                   planId: subscription.planId ?? 'none',
                   currentPeriodEnd: subscription.currentPeriodEnd,
                   cancelAtPeriodEnd: subscription.cancelAtPeriodEnd ?? false,
+                  gracePeriodEndsAt: subscription.gracePeriodEndsAt,
                 }
               : null
           }

--- a/apps/web/src/messages/en/admin-users.json
+++ b/apps/web/src/messages/en/admin-users.json
@@ -138,12 +138,18 @@
       },
       "status": {
         "active": "Active",
-        "past_due": "Past due",
-        "paused": "Paused",
+        "active_in_grace": "Active in grace",
+        "grace_expired": "Grace expired",
+        "scheduled_cancel": "Scheduled to cancel",
+        "trialing": "Trialing",
         "canceled": "Canceled",
         "none": "Not subscribed",
         "registered": "Registered member",
         "operator": "Operational account"
+      },
+      "status_context": {
+        "active_in_grace": "Grace ends {date}",
+        "scheduled_cancel": "Access ends {date}"
       },
       "preferences": {
         "email_claims": "Email claim updates",

--- a/apps/web/src/messages/mk/admin-users.json
+++ b/apps/web/src/messages/mk/admin-users.json
@@ -138,12 +138,18 @@
       },
       "status": {
         "active": "Активно",
-        "past_due": "Во доцнење",
-        "paused": "Паузирано",
+        "active_in_grace": "Активно во грејс период",
+        "grace_expired": "Грејс периодот истече",
+        "scheduled_cancel": "Закажано за откажување",
+        "trialing": "Пробен период",
         "canceled": "Откажано",
         "none": "Не е претплатен",
         "registered": "Регистриран член",
         "operator": "Оперативна сметка"
+      },
+      "status_context": {
+        "active_in_grace": "Грејс периодот завршува на {date}",
+        "scheduled_cancel": "Пристапот завршува на {date}"
       },
       "preferences": {
         "email_claims": "Е-пошта за ажурирања на барања",

--- a/apps/web/src/messages/sq/admin-users.json
+++ b/apps/web/src/messages/sq/admin-users.json
@@ -138,12 +138,18 @@
       },
       "status": {
         "active": "Aktive",
-        "past_due": "Me vonesë",
-        "paused": "Pezull",
+        "active_in_grace": "Aktive në periudhë faljeje",
+        "grace_expired": "Periudha e faljes ka skaduar",
+        "scheduled_cancel": "E planifikuar për anulim",
+        "trialing": "Në provë",
         "canceled": "Anuluar",
         "none": "Pa anëtarësim",
         "registered": "Anëtar i regjistruar",
         "operator": "Llogari operative"
+      },
+      "status_context": {
+        "active_in_grace": "Periudha e faljes përfundon më {date}",
+        "scheduled_cancel": "Qasja përfundon më {date}"
       },
       "preferences": {
         "email_claims": "Email përditësime të kërkesave",

--- a/apps/web/src/messages/sr/admin-users.json
+++ b/apps/web/src/messages/sr/admin-users.json
@@ -138,12 +138,18 @@
       },
       "status": {
         "active": "Aktivan",
-        "past_due": "U kašnjenju",
-        "paused": "Pauziran",
+        "active_in_grace": "Aktivan u grejs periodu",
+        "grace_expired": "Grejs period je istekao",
+        "scheduled_cancel": "Zakazano za otkazivanje",
+        "trialing": "Probni period",
         "canceled": "Otkazan",
         "none": "Nije pretplaćen",
         "registered": "Registrovani član",
         "operator": "Operativni nalog"
+      },
+      "status_context": {
+        "active_in_grace": "Grejs period se završava {date}",
+        "scheduled_cancel": "Pristup se završava {date}"
       },
       "preferences": {
         "email_claims": "E-pošta ažuriranja zahteva",

--- a/packages/domain-membership-billing/src/index.ts
+++ b/packages/domain-membership-billing/src/index.ts
@@ -25,6 +25,7 @@ export * from './success-fees/policy';
 export * from './subscription';
 export * from './subscription/cancel';
 export * from './subscription/get-payment-update-url';
+export * from './subscription/lifecycle-reporting';
 export type {
   SubscriptionSession,
   PaymentUpdateUrlResult,

--- a/packages/domain-membership-billing/src/subscription.test.ts
+++ b/packages/domain-membership-billing/src/subscription.test.ts
@@ -70,6 +70,22 @@ describe('subscription claim eligibility', () => {
     await expect(getActiveSubscription('member-1', 'tenant_ks')).resolves.toEqual(subscription);
   });
 
+  it('treats scheduled cancellation as active membership until the provider closes the term', async () => {
+    const subscription = {
+      id: 'sub_scheduled_cancel',
+      status: 'active',
+      tenantId: 'tenant_ks',
+      userId: 'member-1',
+      cancelAtPeriodEnd: true,
+      gracePeriodEndsAt: null,
+    };
+
+    hoisted.findSubscriptionFirst.mockResolvedValue(subscription);
+
+    await expect(hasActiveMembership('member-1', 'tenant_ks')).resolves.toBe(true);
+    await expect(getActiveSubscription('member-1', 'tenant_ks')).resolves.toEqual(subscription);
+  });
+
   it('rejects past_due subscriptions after grace expires', async () => {
     hoisted.findSubscriptionFirst.mockResolvedValue({
       id: 'sub_expired',

--- a/packages/domain-membership-billing/src/subscription.ts
+++ b/packages/domain-membership-billing/src/subscription.ts
@@ -1,5 +1,10 @@
 import { and, db, eq, subscriptions } from '@interdomestik/database';
 
+import {
+  getMembershipLifecycleBucket,
+  membershipLifecycleGrantsAccess,
+} from './subscription/lifecycle-reporting';
+
 /**
  * Checks if a user has an active membership that grants access to benefits.
  * Allowed statuses:
@@ -23,16 +28,7 @@ export async function hasActiveMembership(
 
   if (!sub) return false;
 
-  if (sub.status === 'active' || sub.status === 'trialing') {
-    return true;
-  }
-
-  if (sub.status === 'past_due' && sub.gracePeriodEndsAt) {
-    // Check if grace period is still valid
-    return new Date() < sub.gracePeriodEndsAt;
-  }
-
-  return false;
+  return membershipLifecycleGrantsAccess(getMembershipLifecycleBucket({ subscription: sub }));
 }
 
 export async function findSubscriptionByProviderReference(reference: string | null | undefined) {
@@ -70,14 +66,8 @@ export async function getActiveSubscription(userId: string, tenantId: string) {
 
   if (!sub) return null;
 
-  const isActive =
-    sub.status === 'active' ||
-    sub.status === 'trialing' ||
-    (sub.status === 'past_due' && sub.gracePeriodEndsAt
-      ? new Date() < sub.gracePeriodEndsAt
-      : false);
-
-  if (!isActive) return null;
+  const bucket = getMembershipLifecycleBucket({ subscription: sub });
+  if (!membershipLifecycleGrantsAccess(bucket)) return null;
 
   return sub;
 }

--- a/packages/domain-membership-billing/src/subscription.ts
+++ b/packages/domain-membership-billing/src/subscription.ts
@@ -7,10 +7,11 @@ import {
 
 /**
  * Checks if a user has an active membership that grants access to benefits.
- * Allowed statuses:
- * - 'active'
- * - 'trialing'
- * - 'past_due' (ONLY if still within grace period)
+ * Access-active lifecycle buckets:
+ * - active
+ * - trialing
+ * - active_in_grace
+ * - scheduled_cancel
  *
  * @param userId - The user ID to check
  * @param tenantId - Required tenant ID for multi-tenant isolation

--- a/packages/domain-membership-billing/src/subscription/lifecycle-reporting.test.ts
+++ b/packages/domain-membership-billing/src/subscription/lifecycle-reporting.test.ts
@@ -8,14 +8,20 @@ const hoisted = vi.hoisted(() => ({
     cancelAtPeriodEnd: 'subscriptions.cancel_at_period_end',
     gracePeriodEndsAt: 'subscriptions.grace_period_ends_at',
   },
-  rows: [] as Array<{
-    status: string | null;
-    cancelAtPeriodEnd: boolean | null;
-    gracePeriodEndsAt: Date | null;
+  aggregateRows: [] as Array<{
+    total: number;
+    active: number;
+    trialing: number;
+    activeInGrace: number;
+    graceExpired: number;
+    scheduledCancel: number;
+    canceled: number;
+    accessActive: number;
   }>,
   where: vi.fn(),
   from: vi.fn(),
   select: vi.fn(),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
 }));
 
 vi.mock('@interdomestik/database', () => ({
@@ -23,6 +29,7 @@ vi.mock('@interdomestik/database', () => ({
     select: hoisted.select,
   },
   eq: hoisted.eq,
+  sql: hoisted.sql,
   subscriptions: hoisted.subscriptions,
 }));
 
@@ -36,8 +43,8 @@ import {
 describe('membership lifecycle reporting', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    hoisted.rows.length = 0;
-    hoisted.where.mockResolvedValue(hoisted.rows);
+    hoisted.aggregateRows.length = 0;
+    hoisted.where.mockResolvedValue(hoisted.aggregateRows);
     hoisted.from.mockReturnValue({ where: hoisted.where });
     hoisted.select.mockReturnValue({ from: hoisted.from });
   });
@@ -112,11 +119,17 @@ describe('membership lifecycle reporting', () => {
     });
   });
 
-  it('loads tenant subscriptions through the shared reporting query', async () => {
-    hoisted.rows.push(
-      { status: 'active', cancelAtPeriodEnd: false, gracePeriodEndsAt: null },
-      { status: 'past_due', cancelAtPeriodEnd: false, gracePeriodEndsAt: null }
-    );
+  it('loads tenant lifecycle counts through an aggregate reporting query', async () => {
+    hoisted.aggregateRows.push({
+      total: 2,
+      active: 1,
+      trialing: 0,
+      activeInGrace: 0,
+      graceExpired: 1,
+      scheduledCancel: 0,
+      canceled: 0,
+      accessActive: 1,
+    });
 
     const counts = await getTenantMembershipLifecycleCounts({
       tenantId: 'tenant_ks',
@@ -124,6 +137,13 @@ describe('membership lifecycle reporting', () => {
     });
 
     expect(hoisted.eq).toHaveBeenCalledWith('subscriptions.tenant_id', 'tenant_ks');
+    expect(hoisted.select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeInGrace: expect.anything(),
+        scheduledCancel: expect.anything(),
+        accessActive: expect.anything(),
+      })
+    );
     expect(counts.accessActive).toBe(1);
     expect(counts.graceExpired).toBe(1);
   });

--- a/packages/domain-membership-billing/src/subscription/lifecycle-reporting.test.ts
+++ b/packages/domain-membership-billing/src/subscription/lifecycle-reporting.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  subscriptions: {
+    tenantId: 'subscriptions.tenant_id',
+    status: 'subscriptions.status',
+    cancelAtPeriodEnd: 'subscriptions.cancel_at_period_end',
+    gracePeriodEndsAt: 'subscriptions.grace_period_ends_at',
+  },
+  rows: [] as Array<{
+    status: string | null;
+    cancelAtPeriodEnd: boolean | null;
+    gracePeriodEndsAt: Date | null;
+  }>,
+  where: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    select: hoisted.select,
+  },
+  eq: hoisted.eq,
+  subscriptions: hoisted.subscriptions,
+}));
+
+import {
+  deriveMembershipStatus,
+  getTenantMembershipLifecycleCounts,
+  membershipLifecycleGrantsAccess,
+  summarizeMembershipLifecycle,
+} from './lifecycle-reporting';
+
+describe('membership lifecycle reporting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.rows.length = 0;
+    hoisted.where.mockResolvedValue(hoisted.rows);
+    hoisted.from.mockReturnValue({ where: hoisted.where });
+    hoisted.select.mockReturnValue({ from: hoisted.from });
+  });
+
+  it('derives deterministic lifecycle buckets at the grace-period boundary', () => {
+    const now = new Date('2026-04-21T12:00:00.000Z');
+    const gracePeriodEndsAt = new Date('2026-04-21T12:00:00.001Z');
+
+    expect(deriveMembershipStatus({ status: 'past_due', gracePeriodEndsAt }, now)).toBe(
+      'active_in_grace'
+    );
+
+    expect(
+      deriveMembershipStatus({ status: 'past_due', gracePeriodEndsAt }, gracePeriodEndsAt)
+    ).toBe('grace_expired');
+  });
+
+  it('classifies scheduled cancellation as access-active until period end', () => {
+    const bucket = deriveMembershipStatus(
+      {
+        status: 'active',
+        cancelAtPeriodEnd: true,
+        gracePeriodEndsAt: null,
+      },
+      new Date('2026-04-21T12:00:00.000Z')
+    );
+
+    expect(bucket).toBe('scheduled_cancel');
+    expect(membershipLifecycleGrantsAccess(bucket)).toBe(true);
+  });
+
+  it('maps legacy past_due rows without grace date to grace_expired instead of throwing', () => {
+    const bucket = deriveMembershipStatus(
+      { status: 'past_due', gracePeriodEndsAt: null },
+      new Date('2026-04-21T12:00:00.000Z')
+    );
+
+    expect(bucket).toBe('grace_expired');
+    expect(membershipLifecycleGrantsAccess(bucket)).toBe(false);
+  });
+
+  it('maps paused, expired, and unknown persisted statuses to the non-access canceled bucket', () => {
+    const now = new Date('2026-04-21T12:00:00.000Z');
+
+    expect(deriveMembershipStatus({ status: 'paused' }, now)).toBe('canceled');
+    expect(deriveMembershipStatus({ status: 'expired' }, now)).toBe('canceled');
+    expect(deriveMembershipStatus({ status: 'provider_unknown' }, now)).toBe('canceled');
+  });
+
+  it('summarizes lifecycle rows into reporting counts', () => {
+    const counts = summarizeMembershipLifecycle(
+      [
+        { status: 'active', cancelAtPeriodEnd: false, gracePeriodEndsAt: null },
+        { status: 'trialing', cancelAtPeriodEnd: false, gracePeriodEndsAt: null },
+        { status: 'past_due', gracePeriodEndsAt: new Date('2026-04-22T00:00:00.000Z') },
+        { status: 'past_due', gracePeriodEndsAt: new Date('2026-04-20T00:00:00.000Z') },
+        { status: 'active', cancelAtPeriodEnd: true, gracePeriodEndsAt: null },
+        { status: 'canceled', cancelAtPeriodEnd: false, gracePeriodEndsAt: null },
+      ],
+      new Date('2026-04-21T00:00:00.000Z')
+    );
+
+    expect(counts).toMatchObject({
+      total: 6,
+      active: 1,
+      trialing: 1,
+      activeInGrace: 1,
+      graceExpired: 1,
+      scheduledCancel: 1,
+      canceled: 1,
+      accessActive: 4,
+    });
+  });
+
+  it('loads tenant subscriptions through the shared reporting query', async () => {
+    hoisted.rows.push(
+      { status: 'active', cancelAtPeriodEnd: false, gracePeriodEndsAt: null },
+      { status: 'past_due', cancelAtPeriodEnd: false, gracePeriodEndsAt: null }
+    );
+
+    const counts = await getTenantMembershipLifecycleCounts({
+      tenantId: 'tenant_ks',
+      now: new Date('2026-04-21T00:00:00.000Z'),
+    });
+
+    expect(hoisted.eq).toHaveBeenCalledWith('subscriptions.tenant_id', 'tenant_ks');
+    expect(counts.accessActive).toBe(1);
+    expect(counts.graceExpired).toBe(1);
+  });
+});

--- a/packages/domain-membership-billing/src/subscription/lifecycle-reporting.ts
+++ b/packages/domain-membership-billing/src/subscription/lifecycle-reporting.ts
@@ -131,16 +131,17 @@ export async function getTenantMembershipLifecycleCounts(args: {
   now?: Date;
 }): Promise<MembershipLifecycleCounts> {
   const now = args.now ?? new Date();
+  const nowTimestamp = now.toISOString();
   const [row] = await db
     .select({
       total: sql<number>`COUNT(*)::int`,
       active: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'active' AND COALESCE(${subscriptions.cancelAtPeriodEnd}, false) = false THEN 1 ELSE 0 END), 0)::int`,
       trialing: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'trialing' AND COALESCE(${subscriptions.cancelAtPeriodEnd}, false) = false THEN 1 ELSE 0 END), 0)::int`,
-      activeInGrace: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'past_due' AND ${subscriptions.gracePeriodEndsAt} IS NOT NULL AND ${subscriptions.gracePeriodEndsAt} > ${now} THEN 1 ELSE 0 END), 0)::int`,
-      graceExpired: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'past_due' AND (${subscriptions.gracePeriodEndsAt} IS NULL OR ${subscriptions.gracePeriodEndsAt} <= ${now}) THEN 1 ELSE 0 END), 0)::int`,
+      activeInGrace: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'past_due' AND ${subscriptions.gracePeriodEndsAt} IS NOT NULL AND ${subscriptions.gracePeriodEndsAt} > ${nowTimestamp}::timestamp THEN 1 ELSE 0 END), 0)::int`,
+      graceExpired: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'past_due' AND (${subscriptions.gracePeriodEndsAt} IS NULL OR ${subscriptions.gracePeriodEndsAt} <= ${nowTimestamp}::timestamp) THEN 1 ELSE 0 END), 0)::int`,
       scheduledCancel: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} IN ('active', 'trialing') AND COALESCE(${subscriptions.cancelAtPeriodEnd}, false) = true THEN 1 ELSE 0 END), 0)::int`,
       canceled: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} IN ('canceled', 'paused', 'expired') THEN 1 ELSE 0 END), 0)::int`,
-      accessActive: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} IN ('active', 'trialing') OR (${subscriptions.status} = 'past_due' AND ${subscriptions.gracePeriodEndsAt} IS NOT NULL AND ${subscriptions.gracePeriodEndsAt} > ${now}) THEN 1 ELSE 0 END), 0)::int`,
+      accessActive: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} IN ('active', 'trialing') OR (${subscriptions.status} = 'past_due' AND ${subscriptions.gracePeriodEndsAt} IS NOT NULL AND ${subscriptions.gracePeriodEndsAt} > ${nowTimestamp}::timestamp) THEN 1 ELSE 0 END), 0)::int`,
     })
     .from(subscriptions)
     .where(eq(subscriptions.tenantId, args.tenantId));

--- a/packages/domain-membership-billing/src/subscription/lifecycle-reporting.ts
+++ b/packages/domain-membership-billing/src/subscription/lifecycle-reporting.ts
@@ -1,0 +1,143 @@
+import { db, eq, subscriptions } from '@interdomestik/database';
+
+export type MembershipLifecycleStatus =
+  | 'active'
+  | 'trialing'
+  | 'active_in_grace'
+  | 'grace_expired'
+  | 'scheduled_cancel'
+  | 'canceled';
+
+export type LifecycleStatus = MembershipLifecycleStatus;
+export type MembershipLifecycleBucket = MembershipLifecycleStatus | 'none';
+
+export type MembershipLifecycleInput =
+  | {
+      status?: string | null;
+      cancelAtPeriodEnd?: boolean | null;
+      gracePeriodEndsAt?: Date | null;
+    }
+  | null
+  | undefined;
+
+export type MembershipLifecycleCounts = {
+  total: number;
+  active: number;
+  trialing: number;
+  activeInGrace: number;
+  graceExpired: number;
+  scheduledCancel: number;
+  canceled: number;
+  none: number;
+  accessActive: number;
+};
+
+export function getMembershipLifecycleBucket(args: {
+  subscription: MembershipLifecycleInput;
+  now?: Date;
+}): MembershipLifecycleBucket {
+  if (!args.subscription) return 'none';
+
+  return deriveMembershipStatus(args.subscription, args.now ?? new Date());
+}
+
+export function deriveMembershipStatus(
+  subscription: NonNullable<MembershipLifecycleInput>,
+  now: Date
+): MembershipLifecycleStatus {
+  const status = subscription.status;
+  if (status === 'canceled' || status === 'paused' || status === 'expired') return 'canceled';
+
+  if (status === 'past_due') {
+    return isSubscriptionInsideGracePeriod({
+      gracePeriodEndsAt: subscription.gracePeriodEndsAt ?? null,
+      now,
+    })
+      ? 'active_in_grace'
+      : 'grace_expired';
+  }
+
+  if (subscription.cancelAtPeriodEnd === true && (status === 'active' || status === 'trialing')) {
+    return 'scheduled_cancel';
+  }
+
+  if (status === 'trialing') return 'trialing';
+  if (status === 'active') return 'active';
+
+  return 'canceled';
+}
+
+export function membershipLifecycleGrantsAccess(bucket: MembershipLifecycleBucket): boolean {
+  return (
+    bucket === 'active' ||
+    bucket === 'trialing' ||
+    bucket === 'active_in_grace' ||
+    bucket === 'scheduled_cancel'
+  );
+}
+
+export function isSubscriptionInsideGracePeriod(args: {
+  gracePeriodEndsAt: Date | null;
+  now: Date;
+}): boolean {
+  const gracePeriodEndsAt = args.gracePeriodEndsAt;
+  if (!gracePeriodEndsAt) return false;
+
+  return args.now.getTime() < gracePeriodEndsAt.getTime();
+}
+
+export function createEmptyMembershipLifecycleCounts(): MembershipLifecycleCounts {
+  return {
+    total: 0,
+    active: 0,
+    trialing: 0,
+    activeInGrace: 0,
+    graceExpired: 0,
+    scheduledCancel: 0,
+    canceled: 0,
+    none: 0,
+    accessActive: 0,
+  };
+}
+
+export function summarizeMembershipLifecycle(
+  rows: MembershipLifecycleInput[],
+  now?: Date
+): MembershipLifecycleCounts {
+  const counts = createEmptyMembershipLifecycleCounts();
+
+  for (const subscription of rows) {
+    const bucket = getMembershipLifecycleBucket({ subscription, now });
+    counts.total += 1;
+
+    if (bucket === 'active') counts.active += 1;
+    else if (bucket === 'trialing') counts.trialing += 1;
+    else if (bucket === 'active_in_grace') counts.activeInGrace += 1;
+    else if (bucket === 'grace_expired') counts.graceExpired += 1;
+    else if (bucket === 'scheduled_cancel') counts.scheduledCancel += 1;
+    else if (bucket === 'canceled') counts.canceled += 1;
+    else counts.none += 1;
+
+    if (membershipLifecycleGrantsAccess(bucket)) {
+      counts.accessActive += 1;
+    }
+  }
+
+  return counts;
+}
+
+export async function getTenantMembershipLifecycleCounts(args: {
+  tenantId: string;
+  now?: Date;
+}): Promise<MembershipLifecycleCounts> {
+  const rows = await db
+    .select({
+      status: subscriptions.status,
+      cancelAtPeriodEnd: subscriptions.cancelAtPeriodEnd,
+      gracePeriodEndsAt: subscriptions.gracePeriodEndsAt,
+    })
+    .from(subscriptions)
+    .where(eq(subscriptions.tenantId, args.tenantId));
+
+  return summarizeMembershipLifecycle(rows, args.now);
+}

--- a/packages/domain-membership-billing/src/subscription/lifecycle-reporting.ts
+++ b/packages/domain-membership-billing/src/subscription/lifecycle-reporting.ts
@@ -43,7 +43,7 @@ export function getMembershipLifecycleBucket(args: {
 
 export function deriveMembershipStatus(
   subscription: NonNullable<MembershipLifecycleInput>,
-  now: Date
+  now: Date = new Date()
 ): MembershipLifecycleStatus {
   const status = subscription.status;
   if (status === 'canceled' || status === 'paused' || status === 'expired') return 'canceled';

--- a/packages/domain-membership-billing/src/subscription/lifecycle-reporting.ts
+++ b/packages/domain-membership-billing/src/subscription/lifecycle-reporting.ts
@@ -1,4 +1,4 @@
-import { db, eq, subscriptions } from '@interdomestik/database';
+import { db, eq, sql, subscriptions } from '@interdomestik/database';
 
 export type MembershipLifecycleStatus =
   | 'active'
@@ -130,14 +130,30 @@ export async function getTenantMembershipLifecycleCounts(args: {
   tenantId: string;
   now?: Date;
 }): Promise<MembershipLifecycleCounts> {
-  const rows = await db
+  const now = args.now ?? new Date();
+  const [row] = await db
     .select({
-      status: subscriptions.status,
-      cancelAtPeriodEnd: subscriptions.cancelAtPeriodEnd,
-      gracePeriodEndsAt: subscriptions.gracePeriodEndsAt,
+      total: sql<number>`COUNT(*)::int`,
+      active: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'active' AND COALESCE(${subscriptions.cancelAtPeriodEnd}, false) = false THEN 1 ELSE 0 END), 0)::int`,
+      trialing: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'trialing' AND COALESCE(${subscriptions.cancelAtPeriodEnd}, false) = false THEN 1 ELSE 0 END), 0)::int`,
+      activeInGrace: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'past_due' AND ${subscriptions.gracePeriodEndsAt} IS NOT NULL AND ${subscriptions.gracePeriodEndsAt} > ${now} THEN 1 ELSE 0 END), 0)::int`,
+      graceExpired: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} = 'past_due' AND (${subscriptions.gracePeriodEndsAt} IS NULL OR ${subscriptions.gracePeriodEndsAt} <= ${now}) THEN 1 ELSE 0 END), 0)::int`,
+      scheduledCancel: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} IN ('active', 'trialing') AND COALESCE(${subscriptions.cancelAtPeriodEnd}, false) = true THEN 1 ELSE 0 END), 0)::int`,
+      canceled: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} IN ('canceled', 'paused', 'expired') THEN 1 ELSE 0 END), 0)::int`,
+      accessActive: sql<number>`COALESCE(SUM(CASE WHEN ${subscriptions.status} IN ('active', 'trialing') OR (${subscriptions.status} = 'past_due' AND ${subscriptions.gracePeriodEndsAt} IS NOT NULL AND ${subscriptions.gracePeriodEndsAt} > ${now}) THEN 1 ELSE 0 END), 0)::int`,
     })
     .from(subscriptions)
     .where(eq(subscriptions.tenantId, args.tenantId));
 
-  return summarizeMembershipLifecycle(rows, args.now);
+  return {
+    total: Number(row?.total ?? 0),
+    active: Number(row?.active ?? 0),
+    trialing: Number(row?.trialing ?? 0),
+    activeInGrace: Number(row?.activeInGrace ?? 0),
+    graceExpired: Number(row?.graceExpired ?? 0),
+    scheduledCancel: Number(row?.scheduledCancel ?? 0),
+    canceled: Number(row?.canceled ?? 0),
+    none: 0,
+    accessActive: Number(row?.accessActive ?? 0),
+  };
 }


### PR DESCRIPTION
## Summary
- Add a shared membership lifecycle read model for canonical subscription buckets and access-active reporting truth.
- Reuse the read model in member access/admin user detail/admin analytics/branch KPI reporting.
- Add semantic lifecycle badges with stable selectors and localized status/context copy.
- Add focused unit coverage and a KS Playwright scenario for grace, expired grace, and scheduled cancel states.

## Verification
- pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/subscription/lifecycle-reporting.test.ts src/subscription.test.ts
- pnpm --filter @interdomestik/web test:unit --run src/app/[locale]/admin/users/[id]/_core.test.ts src/app/[locale]/admin/users/[id]/_components/membership-info-card.test.tsx src/actions/analytics/get-admin.test.ts src/i18n/messages.test.ts
- pnpm --filter @interdomestik/domain-membership-billing type-check
- pnpm --filter @interdomestik/web type-check
- NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web exec playwright test e2e/pc05-membership-lifecycle-truth.spec.ts --project=ks-sq --workers=1
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate
