### PR TITLE
PC06: Add enterprise-safe commission controls

### DIFF
--- a/apps/web/e2e/pc06-enterprise-controls.spec.ts
+++ b/apps/web/e2e/pc06-enterprise-controls.spec.ts
@@ -1,0 +1,108 @@
+import { and, db, eq } from '@interdomestik/database';
+import { agentCommissions, subscriptions } from '@interdomestik/database/schema';
+import { expect, test } from './fixtures/auth.fixture';
+import { gotoApp } from './utils/navigation';
+
+const KS_TENANT_ID = 'tenant_ks';
+const KS_MEMBER_ID = 'golden_ks_a_member_1';
+const KS_SUBSCRIPTION_ID = 'golden_sub_ks_a_1';
+const KS_CANONICAL_AGENT_ID = 'golden_ks_agent_a1';
+const KS_DRIFT_AGENT_ID = 'golden_ks_b_agent_1';
+const PC06_COMMISSION_ID = 'pc06_unresolved_ownership_commission';
+
+async function seedUnresolvedOwnershipCommission() {
+  await db
+    .delete(agentCommissions)
+    .where(
+      and(eq(agentCommissions.id, PC06_COMMISSION_ID), eq(agentCommissions.tenantId, KS_TENANT_ID))
+    );
+
+  await db
+    .update(subscriptions)
+    .set({
+      status: 'active',
+      agentId: KS_DRIFT_AGENT_ID,
+      cancelAtPeriodEnd: false,
+      gracePeriodEndsAt: null,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(subscriptions.id, KS_SUBSCRIPTION_ID), eq(subscriptions.tenantId, KS_TENANT_ID)));
+
+  await db.insert(agentCommissions).values({
+    id: PC06_COMMISSION_ID,
+    tenantId: KS_TENANT_ID,
+    agentId: KS_DRIFT_AGENT_ID,
+    memberId: KS_MEMBER_ID,
+    subscriptionId: KS_SUBSCRIPTION_ID,
+    type: 'upgrade',
+    status: 'pending',
+    amount: '19.00',
+    currency: 'EUR',
+    earnedAt: new Date(),
+    paidAt: null,
+    metadata: { source: 'pc06-enterprise-controls' },
+  });
+}
+
+async function resetUnresolvedOwnershipCommission() {
+  await db
+    .delete(agentCommissions)
+    .where(
+      and(eq(agentCommissions.id, PC06_COMMISSION_ID), eq(agentCommissions.tenantId, KS_TENANT_ID))
+    );
+
+  await db
+    .update(subscriptions)
+    .set({
+      status: 'active',
+      agentId: KS_CANONICAL_AGENT_ID,
+      cancelAtPeriodEnd: false,
+      gracePeriodEndsAt: null,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(subscriptions.id, KS_SUBSCRIPTION_ID), eq(subscriptions.tenantId, KS_TENANT_ID)));
+}
+
+async function getCommissionStatus() {
+  const [row] = await db
+    .select({ status: agentCommissions.status })
+    .from(agentCommissions)
+    .where(
+      and(eq(agentCommissions.id, PC06_COMMISSION_ID), eq(agentCommissions.tenantId, KS_TENANT_ID))
+    );
+
+  return row?.status ?? null;
+}
+
+test.describe('PC06 enterprise-safe controls', () => {
+  test.afterEach(async () => {
+    await resetUnresolvedOwnershipCommission();
+  });
+
+  test('admin bulk approve returns a typed control violation for unresolved ownership', async ({
+    adminPage: page,
+  }, testInfo) => {
+    test.skip(!testInfo.project.name.includes('ks'), 'KS golden seed scenario');
+
+    await seedUnresolvedOwnershipCommission();
+
+    await gotoApp(page, '/admin/commissions', testInfo, { marker: 'bulk-approve-commissions' });
+    await expect(page.getByRole('heading', { level: 1, name: /commission|komision/i })).toBeVisible(
+      {
+        timeout: 30_000,
+      }
+    );
+    await expect(page.getByTestId(`commission-row-${PC06_COMMISSION_ID}`)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page.getByTestId(`commission-select-${PC06_COMMISSION_ID}`).click();
+    await page.getByTestId('bulk-approve-commissions').click();
+
+    const violation = page.getByTestId('commission-control-violation');
+    await expect(violation).toContainText('FINANCE_BATCH_PAYABILITY_BLOCKED');
+    await expect(violation).toContainText(PC06_COMMISSION_ID);
+
+    await expect.poll(getCommissionStatus).toBe('pending');
+  });
+});

--- a/apps/web/src/actions/branch-dashboard.core.test.ts
+++ b/apps/web/src/actions/branch-dashboard.core.test.ts
@@ -128,11 +128,31 @@ describe('Branch Dashboard Core', () => {
       const { getBranchStats } = await import('./branch-dashboard.core');
       const result = await getBranchStats('branch-1', 'tenant-1', true);
 
-      expect(result.totalAgents).toBe(0);
-      expect(result.totalMembers).toBe(0);
-      expect(result.openClaims).toBe(0);
-      expect(result.cashPending).toBe(0);
-      expect(result.slaBreaches).toBe(0);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.totalAgents).toBe(0);
+        expect(result.value.totalMembers).toBe(0);
+        expect(result.value.openClaims).toBe(0);
+        expect(result.value.cashPending).toBe(0);
+        expect(result.value.slaBreaches).toBe(0);
+      }
+    });
+
+    it('returns a branch control violation before aggregate reads when branchId is missing', async () => {
+      const mockSelect = vi.fn();
+      mockDb.select = mockSelect;
+
+      const { getBranchStats } = await import('./branch-dashboard.core');
+      const result = await getBranchStats('', 'tenant-1', true);
+
+      expect(result).toEqual({
+        ok: false,
+        violation: expect.objectContaining({
+          control: 'branch',
+          code: 'BRANCH_ID_MISSING',
+        }),
+      });
+      expect(mockSelect).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/actions/branch-dashboard.core.ts
+++ b/apps/web/src/actions/branch-dashboard.core.ts
@@ -13,6 +13,10 @@ import { computeHealthScore, computeSeverity } from '@/features/admin/branches/u
 import { getOpenClaimsFilter, getSlaBreachesFilter } from '@/features/admin/kpis/kpi-definitions';
 import { db } from '@interdomestik/database/db';
 import { claims, user } from '@interdomestik/database/schema';
+import {
+  guardBranchStatsScope,
+  type ControlResult,
+} from '@interdomestik/domain-membership-billing';
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 
 /**
@@ -47,8 +51,14 @@ export async function getBranchById(
 export async function getBranchStats(
   branchId: string,
   tenantId: string,
-  isActive: boolean
-): Promise<BranchStats> {
+  isActive: boolean,
+  branchTenantId?: string | null
+): Promise<ControlResult<BranchStats>> {
+  const scopeGuard = guardBranchStatsScope({ branchId, tenantId, branchTenantId });
+  if (!scopeGuard.ok) {
+    return scopeGuard;
+  }
+
   const [agentCount, memberCount, openClaimsCount, cashPendingCount, slaBreachesCount] =
     await Promise.all([
       // Count agents in branch
@@ -100,15 +110,18 @@ export async function getBranchStats(
   };
 
   return {
-    ...stats,
-    healthScore: computeHealthScore({
+    ok: true,
+    value: {
       ...stats,
-      isActive,
-    }),
-    severity: computeSeverity({
-      ...stats,
-      isActive,
-    }),
+      healthScore: computeHealthScore({
+        ...stats,
+        isActive,
+      }),
+      severity: computeSeverity({
+        ...stats,
+        isActive,
+      }),
+    },
   };
 }
 

--- a/apps/web/src/actions/branch-dashboard.ts
+++ b/apps/web/src/actions/branch-dashboard.ts
@@ -10,6 +10,7 @@ import * as Sentry from '@sentry/nextjs';
 import { getBranchAgents, getBranchById, getBranchStats } from '@/actions/branch-dashboard.core';
 import type { BranchDashboardDTO } from '@/actions/branch-dashboard.types';
 import type { ActionResult } from '@/types/actions';
+import { formatControlViolation } from '@interdomestik/domain-membership-billing';
 import { ROLES, scopeFilter } from '@interdomestik/shared-auth';
 
 import { getActionContext } from './admin-users/context';
@@ -71,15 +72,22 @@ export async function getBranchDashboard(
     }
 
     const [stats, agents] = await Promise.all([
-      getBranchStats(branchId, tenantId, branch.isActive),
+      getBranchStats(branchId, tenantId, branch.isActive, branch.tenantId),
       getBranchAgents(branchId, tenantId),
     ]);
+
+    if (!stats.ok) {
+      return {
+        success: false,
+        error: formatControlViolation(stats.violation),
+      };
+    }
 
     return {
       success: true,
       data: {
         branch,
-        stats,
+        stats: stats.value,
         agents,
       },
     };

--- a/apps/web/src/app/[locale]/admin/commissions/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/admin/commissions/_core.entry.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AdminCommissionsPage from './_core.entry';
 
 vi.mock('@/actions/commissions.admin', () => ({
+  bulkApproveCommissions: vi.fn(),
   getAllCommissions: vi.fn(),
   getGlobalCommissionSummary: vi.fn(),
   updateCommissionStatus: vi.fn(),
@@ -81,6 +82,8 @@ vi.mock('next-intl', () => ({
       'rewards.title': 'Member Referral Rewards',
       'rewards.reward_label': 'Reward {id} • {amount}',
       'commissions.title': 'All Commissions',
+      'commissions.bulk_approve': 'Bulk approve',
+      'commissions.action_failed': 'Commission action failed',
     };
 
     return Object.entries(values ?? {}).reduce(
@@ -127,6 +130,10 @@ describe('Admin commissions page', () => {
         approvedCount: 1,
         paidCount: 1,
       },
+    });
+    vi.mocked(commissionsAdmin.bulkApproveCommissions).mockResolvedValue({
+      success: true,
+      data: { count: 1 },
     });
 
     const memberReferrals = await import('@/actions/member-referrals');
@@ -185,6 +192,33 @@ describe('Admin commissions page', () => {
       expect(screen.getByDisplayValue('750')).toBeInTheDocument();
       expect(screen.getByText(/Reward reward-1/i)).toBeInTheDocument();
       expect(screen.getByText('All Commissions')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a deterministic enterprise-control violation when bulk approval is blocked', async () => {
+    const commissionsAdmin = await import('@/actions/commissions.admin');
+    vi.mocked(commissionsAdmin.bulkApproveCommissions).mockResolvedValueOnce({
+      success: false,
+      error:
+        'FINANCE_BATCH_PAYABILITY_BLOCKED: One or more commissions are not payable under enterprise controls: commission-1',
+      violation: {
+        control: 'finance',
+        code: 'FINANCE_BATCH_PAYABILITY_BLOCKED',
+        detail: 'One or more commissions are not payable under enterprise controls: commission-1',
+        recoverable: false,
+        entityIds: ['commission-1'],
+      },
+    });
+
+    render(<AdminCommissionsPage />);
+
+    expect(await screen.findByTestId('commission-select-commission-1')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('commission-select-commission-1'));
+    fireEvent.click(screen.getByTestId('bulk-approve-commissions'));
+
+    await waitFor(() => {
+      expect(commissionsAdmin.bulkApproveCommissions).toHaveBeenCalledWith(['commission-1']);
+      expect(screen.getByTestId('commission-control-violation')).toHaveTextContent('commission-1');
     });
   });
 

--- a/apps/web/src/app/[locale]/admin/commissions/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/admin/commissions/_core.entry.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  bulkApproveCommissions,
   getAllCommissions,
   getGlobalCommissionSummary,
   updateCommissionStatus,
@@ -57,12 +58,30 @@ const REFERRAL_STATUS_TRANSITIONS: Record<
   void: [],
 };
 
+function removeCommissionId(ids: string[], id: string) {
+  return ids.filter(selectedId => selectedId !== id);
+}
+
+function updateCommissionSelection(ids: string[], id: string, checked: boolean) {
+  return checked ? [...new Set([...ids, id])] : removeCommissionId(ids, id);
+}
+
+function createCommissionRemovalUpdater(id: string) {
+  return (current: string[]) => removeCommissionId(current, id);
+}
+
+function createCommissionSelectionUpdater(id: string, checked: boolean) {
+  return (current: string[]) => updateCommissionSelection(current, id, checked);
+}
+
 export default function AdminCommissionsPage() {
   const t = useTranslations('admin.commissions_page');
   const locale = useLocale();
   const [commissions, setCommissions] = useState<Commission[]>([]);
   const [summary, setSummary] = useState<CommissionSummary | null>(null);
   const [referralRewards, setReferralRewards] = useState<MemberReferralAdminRewardRow[]>([]);
+  const [selectedCommissionIds, setSelectedCommissionIds] = useState<string[]>([]);
+  const [commissionActionError, setCommissionActionError] = useState<string | null>(null);
   const [referralSettings, setReferralSettings] =
     useState<MemberReferralProgramSettings>(EMPTY_REFERRAL_SETTINGS);
   const [isPending, startTransition] = useTransition();
@@ -72,27 +91,61 @@ export default function AdminCommissionsPage() {
   }, []);
 
   async function loadData() {
-    const [commResult, sumResult, settingsResult, rewardsResult] = await Promise.all([
+    const [commSettled, sumSettled, settingsSettled, rewardsSettled] = await Promise.allSettled([
       getAllCommissions(),
       getGlobalCommissionSummary(),
       getMemberReferralProgramSettings(),
       listMemberReferralRewards({ limit: 50 }),
     ]);
-    if (commResult.success && commResult.data) setCommissions(commResult.data);
-    if (sumResult.success && sumResult.data) setSummary(sumResult.data);
-    if (settingsResult.success && settingsResult.data) {
+
+    const commResult =
+      commSettled.status === 'fulfilled'
+        ? commSettled.value
+        : { success: false as const, error: t('commissions.action_failed') };
+    const sumResult = sumSettled.status === 'fulfilled' ? sumSettled.value : null;
+    const settingsResult = settingsSettled.status === 'fulfilled' ? settingsSettled.value : null;
+    const rewardsResult = rewardsSettled.status === 'fulfilled' ? rewardsSettled.value : null;
+
+    if (commResult.success && commResult.data) {
+      setCommissions(commResult.data);
+    } else if (!commResult.success) {
+      setCommissionActionError(commResult.error ?? t('commissions.action_failed'));
+    }
+    if (sumResult?.success && sumResult.data) setSummary(sumResult.data);
+    if (settingsResult?.success && settingsResult.data) {
       setReferralSettings(settingsResult.data);
     }
-    if (rewardsResult.success && rewardsResult.data) {
+    if (rewardsResult?.success && rewardsResult.data) {
       setReferralRewards(rewardsResult.data);
     }
   }
 
   function handleStatusChange(id: string, newStatus: CommissionStatus) {
     startTransition(async () => {
+      setCommissionActionError(null);
       const result = await updateCommissionStatus(id, newStatus);
       if (result.success) {
+        setSelectedCommissionIds(createCommissionRemovalUpdater(id));
         await loadData();
+      } else {
+        setCommissionActionError(result.error ?? t('commissions.action_failed'));
+      }
+    });
+  }
+
+  function handleCommissionSelection(id: string, checked: boolean) {
+    setSelectedCommissionIds(createCommissionSelectionUpdater(id, checked));
+  }
+
+  function handleBulkApprove() {
+    startTransition(async () => {
+      setCommissionActionError(null);
+      const result = await bulkApproveCommissions(selectedCommissionIds);
+      if (result.success) {
+        setSelectedCommissionIds([]);
+        await loadData();
+      } else {
+        setCommissionActionError(result.error ?? t('commissions.action_failed'));
       }
     });
   }
@@ -479,22 +532,53 @@ export default function AdminCommissionsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>{t('commissions.title')}</CardTitle>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle>{t('commissions.title')}</CardTitle>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isPending || selectedCommissionIds.length === 0}
+              onClick={handleBulkApprove}
+              data-testid="bulk-approve-commissions"
+            >
+              {t('commissions.bulk_approve')}
+            </Button>
+          </div>
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
+            {commissionActionError ? (
+              <div
+                className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                data-testid="commission-control-violation"
+              >
+                {commissionActionError}
+              </div>
+            ) : null}
             {commissions.length === 0 ? (
               <p className="text-center py-8 text-muted-foreground">{t('commissions.empty')}</p>
             ) : (
               commissions.map(c => (
-                <div key={c.id} className="flex items-center justify-between rounded-lg border p-4">
-                  <div className="space-y-1">
-                    <p className="font-medium">{c.agentName}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {c.memberName || t('commissions.unknown_member')} •{' '}
-                      {t(`commission_types.${c.type}`)}
-                    </p>
-                    <p className="text-xs text-muted-foreground">{formatDate(c.earnedAt)}</p>
+                <div
+                  key={c.id}
+                  className="flex items-center justify-between rounded-lg border p-4"
+                  data-testid={`commission-row-${c.id}`}
+                >
+                  <div className="flex items-start gap-3">
+                    <Checkbox
+                      checked={selectedCommissionIds.includes(c.id)}
+                      onCheckedChange={checked => handleCommissionSelection(c.id, Boolean(checked))}
+                      disabled={isPending || c.status !== 'pending'}
+                      data-testid={`commission-select-${c.id}`}
+                    />
+                    <div className="space-y-1">
+                      <p className="font-medium">{c.agentName}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {c.memberName || t('commissions.unknown_member')} •{' '}
+                        {t(`commission_types.${c.type}`)}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{formatDate(c.earnedAt)}</p>
+                    </div>
                   </div>
                   <div className="flex items-center gap-4">
                     <span className="font-semibold text-lg">{formatAmount(c.amount)}</span>

--- a/apps/web/src/messages/en/admin-commissions.json
+++ b/apps/web/src/messages/en/admin-commissions.json
@@ -47,7 +47,9 @@
       "commissions": {
         "title": "All Commissions",
         "empty": "No commissions yet",
-        "unknown_member": "Unknown Member"
+        "unknown_member": "Unknown Member",
+        "bulk_approve": "Bulk approve",
+        "action_failed": "Commission action failed"
       },
       "statuses": {
         "pending": "Pending",
@@ -57,6 +59,10 @@
         "void": "Void"
       },
       "commission_types": {
+        "new_membership": "new membership",
+        "renewal": "renewal",
+        "upgrade": "upgrade",
+        "b2b": "business membership",
         "signup_bonus": "signup bonus",
         "membership_sale": "membership sale",
         "referral_bonus": "referral bonus",

--- a/apps/web/src/messages/mk/admin-commissions.json
+++ b/apps/web/src/messages/mk/admin-commissions.json
@@ -47,7 +47,9 @@
       "commissions": {
         "title": "Сите провизии",
         "empty": "Сè уште нема провизии",
-        "unknown_member": "Непознат член"
+        "unknown_member": "Непознат член",
+        "bulk_approve": "Групно одобри",
+        "action_failed": "Дејството за провизија не успеа"
       },
       "statuses": {
         "pending": "На чекање",
@@ -57,6 +59,10 @@
         "void": "Поништено"
       },
       "commission_types": {
+        "new_membership": "ново членство",
+        "renewal": "обновување",
+        "upgrade": "надградба",
+        "b2b": "бизнис членство",
         "signup_bonus": "бонус за регистрација",
         "membership_sale": "продажба на членство",
         "referral_bonus": "бонус за препорака",

--- a/apps/web/src/messages/sq/admin-commissions.json
+++ b/apps/web/src/messages/sq/admin-commissions.json
@@ -47,7 +47,9 @@
       "commissions": {
         "title": "Të gjitha komisionet",
         "empty": "Ende nuk ka komisione",
-        "unknown_member": "Anëtar i panjohur"
+        "unknown_member": "Anëtar i panjohur",
+        "bulk_approve": "Mirato në grup",
+        "action_failed": "Veprimi i komisionit dështoi"
       },
       "statuses": {
         "pending": "Në pritje",
@@ -57,6 +59,10 @@
         "void": "Anuluar"
       },
       "commission_types": {
+        "new_membership": "anëtarësim i ri",
+        "renewal": "rinovim",
+        "upgrade": "përmirësim",
+        "b2b": "anëtarësim biznesi",
         "signup_bonus": "bonus regjistrimi",
         "membership_sale": "shitje anëtarësimi",
         "referral_bonus": "bonus referimi",

--- a/apps/web/src/messages/sr/admin-commissions.json
+++ b/apps/web/src/messages/sr/admin-commissions.json
@@ -47,7 +47,9 @@
       "commissions": {
         "title": "Sve provizije",
         "empty": "Još nema provizija",
-        "unknown_member": "Nepoznat član"
+        "unknown_member": "Nepoznat član",
+        "bulk_approve": "Grupno odobri",
+        "action_failed": "Radnja provizije nije uspela"
       },
       "statuses": {
         "pending": "Na čekanju",
@@ -57,6 +59,10 @@
         "void": "Poništeno"
       },
       "commission_types": {
+        "new_membership": "novo članstvo",
+        "renewal": "obnova",
+        "upgrade": "nadogradnja",
+        "b2b": "poslovno članstvo",
         "signup_bonus": "bonus za registraciju",
         "membership_sale": "prodaja članstva",
         "referral_bonus": "bonus za preporuku",

--- a/packages/domain-membership-billing/package.json
+++ b/packages/domain-membership-billing/package.json
@@ -29,6 +29,7 @@
     "./commissions/create": "./src/commissions/create.ts",
     "./commissions/get-my": "./src/commissions/get-my.ts",
     "./commissions/summary": "./src/commissions/summary.ts",
+    "./enterprise-controls": "./src/enterprise-controls.ts",
     "./commissions/admin/access": "./src/commissions/admin/access.ts",
     "./commissions/admin/get-all": "./src/commissions/admin/get-all.ts",
     "./commissions/admin/update-status": "./src/commissions/admin/update-status.ts",

--- a/packages/domain-membership-billing/src/commissions/admin/access.ts
+++ b/packages/domain-membership-billing/src/commissions/admin/access.ts
@@ -2,15 +2,21 @@ import type { CommissionSession } from '../types';
 
 export type AdminAuthError = { success: false; error: string };
 
+const ADMIN_ROLES = new Set(['admin', 'tenant_admin', 'super_admin']);
+
+function isAdminRole(role: string | null | undefined): boolean {
+  return Boolean(role && ADMIN_ROLES.has(role));
+}
+
 export function ensureAdmin(session: CommissionSession | null): AdminAuthError | null {
   if (!session?.user) return { success: false, error: 'Unauthorized' };
-  if (session.user.role !== 'admin') return { success: false, error: 'Admin access required' };
+  if (!isAdminRole(session.user.role)) return { success: false, error: 'Admin access required' };
   return null;
 }
 
 export function ensureAdminOrStaff(session: CommissionSession | null): AdminAuthError | null {
   if (!session?.user) return { success: false, error: 'Unauthorized' };
-  if (session.user.role !== 'admin' && session.user.role !== 'staff') {
+  if (!isAdminRole(session.user.role) && session.user.role !== 'staff') {
     return { success: false, error: 'Admin or staff access required' };
   }
   return null;

--- a/packages/domain-membership-billing/src/commissions/admin/bulk-approve.test.ts
+++ b/packages/domain-membership-billing/src/commissions/admin/bulk-approve.test.ts
@@ -1,0 +1,117 @@
+import { db } from '@interdomestik/database';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { preflightCommissionPayability } from './payability';
+import { bulkApproveCommissionsCore } from './bulk-approve';
+
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(),
+      })),
+    })),
+  },
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  agentCommissions: {
+    id: 'id',
+    tenantId: 'tenantId',
+    status: 'status',
+  },
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: vi.fn(() => 'tenant-1'),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+vi.mock('./payability', () => ({
+  preflightCommissionPayability: vi.fn(),
+}));
+
+describe('bulkApproveCommissionsCore', () => {
+  const adminSession = {
+    user: { id: 'admin-1', role: 'admin', tenantId: 'tenant-1', email: 'admin@example.com' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(preflightCommissionPayability).mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          id: 'comm-ok',
+          status: 'pending',
+          memberId: 'member-1',
+          subscriptionStatus: 'active',
+          subscriptionAgentId: 'agent-1',
+          userAgentId: 'agent-1',
+          cancelAtPeriodEnd: false,
+          gracePeriodEndsAt: null,
+        },
+      ],
+    });
+  });
+
+  it('runs enterprise-control preflight before bulk approving pending commissions', async () => {
+    const result = await bulkApproveCommissionsCore({
+      session: adminSession,
+      ids: ['comm-ok'],
+    });
+
+    expect(result).toEqual({ success: true, data: { count: 1 } });
+    expect(preflightCommissionPayability).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      ids: ['comm-ok'],
+    });
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it('allows tenant admins through the admin gate before enterprise-control preflight', async () => {
+    const result = await bulkApproveCommissionsCore({
+      session: {
+        user: {
+          id: 'tenant-admin-1',
+          role: 'tenant_admin',
+          tenantId: 'tenant-1',
+          email: 'tenant-admin@example.com',
+        },
+      },
+      ids: ['comm-ok'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(preflightCommissionPayability).toHaveBeenCalled();
+  });
+
+  it('blocks a mixed batch and lists every unresolved commission id', async () => {
+    vi.mocked(preflightCommissionPayability).mockResolvedValueOnce({
+      ok: false,
+      violation: {
+        control: 'finance',
+        code: 'FINANCE_BATCH_PAYABILITY_BLOCKED',
+        detail:
+          'One or more commissions are not payable under enterprise controls: comm-bad-a, comm-bad-b',
+        recoverable: false,
+        entityIds: ['comm-bad-a', 'comm-bad-b'],
+      },
+    });
+
+    const result = await bulkApproveCommissionsCore({
+      session: adminSession,
+      ids: ['comm-ok', 'comm-bad-a', 'comm-bad-b'],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.violation?.entityIds).toEqual(['comm-bad-a', 'comm-bad-b']);
+    expect(result.error).toContain('comm-bad-a, comm-bad-b');
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-membership-billing/src/commissions/admin/bulk-approve.ts
+++ b/packages/domain-membership-billing/src/commissions/admin/bulk-approve.ts
@@ -1,9 +1,12 @@
 import { db } from '@interdomestik/database';
 import { agentCommissions } from '@interdomestik/database/schema';
-import { sql } from 'drizzle-orm';
+import { ensureTenantId } from '@interdomestik/shared-auth';
+import { and, eq, inArray } from 'drizzle-orm';
 
 import type { ActionResult, CommissionSession } from '../types';
+import { formatControlViolation } from '../../enterprise-controls';
 import { ensureAdmin } from './access';
+import { preflightCommissionPayability } from './payability';
 
 /** Bulk approve pending commissions (admin only) */
 export async function bulkApproveCommissionsCore(params: {
@@ -13,14 +16,36 @@ export async function bulkApproveCommissionsCore(params: {
   const { session, ids } = params;
   const authError = ensureAdmin(session);
   if (authError) return authError;
+  if (!session) return { success: false, error: 'Unauthorized' };
 
   try {
+    const tenantId = ensureTenantId(session);
+    const preflight = await preflightCommissionPayability({ tenantId, ids });
+    if (!preflight.ok) {
+      return {
+        success: false,
+        error: formatControlViolation(preflight.violation),
+        violation: preflight.violation,
+      };
+    }
+
+    const pendingIds = preflight.value.filter(row => row.status === 'pending').map(row => row.id);
+    if (pendingIds.length === 0) {
+      return { success: true, data: { count: 0 } };
+    }
+
     await db
       .update(agentCommissions)
       .set({ status: 'approved' })
-      .where(sql`${agentCommissions.id} IN ${ids} AND ${agentCommissions.status} = 'pending'`);
+      .where(
+        and(
+          eq(agentCommissions.tenantId, tenantId),
+          inArray(agentCommissions.id, pendingIds),
+          eq(agentCommissions.status, 'pending')
+        )
+      );
 
-    return { success: true, data: { count: ids.length } };
+    return { success: true, data: { count: pendingIds.length } };
   } catch (error) {
     console.error('Error bulk approving:', error);
     return { success: false, error: 'Failed to approve commissions' };

--- a/packages/domain-membership-billing/src/commissions/admin/get-all.test.ts
+++ b/packages/domain-membership-billing/src/commissions/admin/get-all.test.ts
@@ -106,4 +106,14 @@ describe('getAllCommissionsCore', () => {
       expect(result.data?.[0].agentName).toBe('Agent One');
     }
   });
+
+  it('fetches commissions for tenant admin', async () => {
+    const result = await getAllCommissionsCore({
+      session: {
+        user: { id: 'tenant-admin-1', role: 'tenant_admin', tenantId: 'tenant-1' },
+      } as any,
+    });
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/domain-membership-billing/src/commissions/admin/payability.ts
+++ b/packages/domain-membership-billing/src/commissions/admin/payability.ts
@@ -1,0 +1,177 @@
+import { db } from '@interdomestik/database';
+import {
+  agentClients,
+  agentCommissions,
+  subscriptions,
+  user as userTable,
+} from '@interdomestik/database/schema';
+import { and, eq, inArray } from 'drizzle-orm';
+
+import {
+  assertFinancePayability,
+  combineControlViolations,
+  type ControlViolation,
+  type ControlResult,
+} from '../../enterprise-controls';
+
+type CommissionPayabilityRow = {
+  id: string;
+  status: string;
+  memberId: string | null;
+  subscriptionStatus: string | null;
+  subscriptionAgentId: string | null;
+  userAgentId: string | null;
+  cancelAtPeriodEnd: boolean | null;
+  gracePeriodEndsAt: Date | null;
+};
+
+type AgentClientBindingRow = {
+  memberId: string;
+  agentId: string;
+};
+
+export async function preflightCommissionPayability(args: {
+  tenantId: string;
+  ids: string[];
+  now?: Date;
+}): Promise<ControlResult<CommissionPayabilityRow[]>> {
+  const ids = [...new Set(args.ids.filter(id => id.trim().length > 0))];
+  if (ids.length === 0) {
+    return { ok: true, value: [] };
+  }
+
+  const rows = await fetchCommissionPayabilityRows({
+    tenantId: args.tenantId,
+    ids,
+  });
+  const rowsById = new Map(rows.map(row => [row.id, row]));
+  const missingIds = ids.filter(id => !rowsById.has(id));
+  const violations: ControlViolation[] =
+    missingIds.length > 0
+      ? [
+          {
+            control: 'finance' as const,
+            code: 'COMMISSION_NOT_FOUND',
+            detail: `Commission ids were not found for tenant: ${missingIds.join(', ')}`,
+            recoverable: false,
+            entityIds: missingIds,
+          },
+        ]
+      : [];
+
+  const agentClientBindings = await fetchActiveAgentClientBindings({
+    tenantId: args.tenantId,
+    memberIds: rows.map(row => row.memberId).filter((id): id is string => Boolean(id)),
+  });
+  const agentClientAgentIdsByMemberId = groupAgentClientBindings(agentClientBindings);
+
+  for (const row of rows) {
+    const agentClientAgentIds = row.memberId
+      ? (agentClientAgentIdsByMemberId.get(row.memberId) ?? [])
+      : undefined;
+    const subscription =
+      row.subscriptionStatus == null
+        ? null
+        : {
+            status: row.subscriptionStatus,
+            cancelAtPeriodEnd: row.cancelAtPeriodEnd,
+            gracePeriodEndsAt: row.gracePeriodEndsAt,
+          };
+    const payability = assertFinancePayability({
+      commissionId: row.id,
+      subscriptionAgentId: row.subscriptionAgentId,
+      userAgentId: row.userAgentId,
+      agentClientAgentIds,
+      subscription,
+      now: args.now,
+    });
+
+    if (!payability.ok) {
+      violations.push(payability.violation);
+    }
+  }
+
+  if (violations.length > 0) {
+    return {
+      ok: false,
+      violation: combineControlViolations({
+        control: 'finance',
+        code: 'FINANCE_BATCH_PAYABILITY_BLOCKED',
+        detail: 'One or more commissions are not payable under enterprise controls',
+        violations,
+      }),
+    };
+  }
+
+  return { ok: true, value: rows };
+}
+
+async function fetchCommissionPayabilityRows(args: {
+  tenantId: string;
+  ids: string[];
+}): Promise<CommissionPayabilityRow[]> {
+  if (args.ids.length === 0) return [];
+
+  return db
+    .select({
+      id: agentCommissions.id,
+      status: agentCommissions.status,
+      memberId: agentCommissions.memberId,
+      subscriptionStatus: subscriptions.status,
+      subscriptionAgentId: subscriptions.agentId,
+      userAgentId: userTable.agentId,
+      cancelAtPeriodEnd: subscriptions.cancelAtPeriodEnd,
+      gracePeriodEndsAt: subscriptions.gracePeriodEndsAt,
+    })
+    .from(agentCommissions)
+    .leftJoin(
+      subscriptions,
+      and(
+        eq(agentCommissions.tenantId, subscriptions.tenantId),
+        eq(agentCommissions.subscriptionId, subscriptions.id)
+      )
+    )
+    .leftJoin(
+      userTable,
+      and(
+        eq(agentCommissions.tenantId, userTable.tenantId),
+        eq(agentCommissions.memberId, userTable.id)
+      )
+    )
+    .where(
+      and(eq(agentCommissions.tenantId, args.tenantId), inArray(agentCommissions.id, args.ids))
+    );
+}
+
+async function fetchActiveAgentClientBindings(args: {
+  tenantId: string;
+  memberIds: string[];
+}): Promise<AgentClientBindingRow[]> {
+  const memberIds = [...new Set(args.memberIds)];
+  if (memberIds.length === 0) return [];
+
+  return db
+    .select({
+      memberId: agentClients.memberId,
+      agentId: agentClients.agentId,
+    })
+    .from(agentClients)
+    .where(
+      and(
+        eq(agentClients.tenantId, args.tenantId),
+        eq(agentClients.status, 'active'),
+        inArray(agentClients.memberId, memberIds)
+      )
+    );
+}
+
+function groupAgentClientBindings(rows: AgentClientBindingRow[]): Map<string, string[]> {
+  const bindings = new Map<string, string[]>();
+  for (const row of rows) {
+    const existing = bindings.get(row.memberId) ?? [];
+    existing.push(row.agentId);
+    bindings.set(row.memberId, existing);
+  }
+
+  return bindings;
+}

--- a/packages/domain-membership-billing/src/commissions/admin/update-status.test.ts
+++ b/packages/domain-membership-billing/src/commissions/admin/update-status.test.ts
@@ -1,5 +1,6 @@
 import { db } from '@interdomestik/database';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { preflightCommissionPayability } from './payability';
 import { updateCommissionStatusCore } from './update-status';
 
 // Mock dependencies
@@ -33,6 +34,20 @@ vi.mock('@interdomestik/shared-auth', () => ({
   ensureTenantId: vi.fn(() => 'tenant-1'),
 }));
 
+vi.mock('./payability', () => ({
+  preflightCommissionPayability: vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      value: [
+        {
+          id: 'c1',
+          status: 'pending',
+        },
+      ],
+    })
+  ),
+}));
+
 vi.mock('drizzle-orm', () => ({
   eq: vi.fn(),
   and: vi.fn(),
@@ -41,6 +56,21 @@ vi.mock('drizzle-orm', () => ({
 describe('updateCommissionStatusCore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(preflightCommissionPayability).mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          id: 'c1',
+          status: 'pending',
+          memberId: 'member-1',
+          subscriptionStatus: 'active',
+          subscriptionAgentId: 'agent-1',
+          userAgentId: 'agent-1',
+          cancelAtPeriodEnd: false,
+          gracePeriodEndsAt: null,
+        },
+      ],
+    });
   });
 
   const mockAdminSession = {
@@ -106,5 +136,36 @@ describe('updateCommissionStatusCore', () => {
 
     expect(result.success).toBe(true);
     expect(db.update).toHaveBeenCalled();
+  });
+
+  it('blocks payable transitions when enterprise controls return a violation', async () => {
+    vi.mocked(preflightCommissionPayability).mockResolvedValueOnce({
+      ok: false,
+      violation: {
+        control: 'finance',
+        code: 'FINANCE_PAYABILITY_BLOCKED',
+        detail: 'Commission is not payable under enterprise controls: c1',
+        recoverable: false,
+        entityIds: ['c1'],
+      },
+    });
+
+    (db.select as any).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue([{ id: 'c1', agentId: 'agent-1', status: 'pending' }]),
+        }),
+      }),
+    });
+
+    const result = await updateCommissionStatusCore({
+      session: mockAdminSession as any,
+      commissionId: 'c1',
+      newStatus: 'approved',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.violation?.entityIds).toEqual(['c1']);
+    expect(db.update).not.toHaveBeenCalled();
   });
 });

--- a/packages/domain-membership-billing/src/commissions/admin/update-status.ts
+++ b/packages/domain-membership-billing/src/commissions/admin/update-status.ts
@@ -4,7 +4,9 @@ import { ensureTenantId } from '@interdomestik/shared-auth';
 import { and, eq } from 'drizzle-orm';
 
 import type { ActionResult, CommissionSession, CommissionStatus } from '../types';
+import { formatControlViolation } from '../../enterprise-controls';
 import { ensureAdminOrStaff } from './access';
+import { preflightCommissionPayability } from './payability';
 
 /**
  * Valid status transitions:
@@ -54,6 +56,20 @@ export async function updateCommissionStatusCore(params: {
 
     if (!commission) {
       return { success: false, error: 'Commission not found' };
+    }
+
+    if (newStatus === 'approved' || newStatus === 'paid') {
+      const preflight = await preflightCommissionPayability({
+        tenantId,
+        ids: [commissionId],
+      });
+      if (!preflight.ok) {
+        return {
+          success: false,
+          error: formatControlViolation(preflight.violation),
+          violation: preflight.violation,
+        };
+      }
     }
 
     // NO SELF-APPROVAL: Agent cannot approve or pay their own commission

--- a/packages/domain-membership-billing/src/commissions/types.ts
+++ b/packages/domain-membership-billing/src/commissions/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { ControlViolation } from '../enterprise-controls';
 
 export const commissionStatusSchema = z.enum(['pending', 'approved', 'paid', 'void']);
 export const commissionTypeSchema = z.enum(['new_membership', 'renewal', 'upgrade', 'b2b']);
@@ -37,6 +38,7 @@ export interface ActionResult<T = void> {
   success: boolean;
   data?: T;
   error?: string;
+  violation?: ControlViolation;
 }
 
 export type CommissionSession = {

--- a/packages/domain-membership-billing/src/enterprise-controls.test.ts
+++ b/packages/domain-membership-billing/src/enterprise-controls.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertFinancePayability,
+  assertLifecycleEligibleForCommission,
+  checkOwnershipControl,
+  combineControlViolations,
+  guardBranchStatsScope,
+} from './enterprise-controls';
+
+describe('ownership control', () => {
+  it('allows matching ownership signals', () => {
+    const result = checkOwnershipControl({
+      commissionId: 'comm-ok',
+      subscriptionAgentId: 'agent-1',
+      userAgentId: 'agent-1',
+      agentClientAgentIds: ['agent-1'],
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('blocks conflicting active agent-client bindings', () => {
+    const result = checkOwnershipControl({
+      commissionId: 'comm-bad',
+      subscriptionAgentId: 'agent-1',
+      userAgentId: 'agent-1',
+      agentClientAgentIds: ['agent-1', 'agent-2'],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      violation: expect.objectContaining({
+        control: 'ownership',
+        code: 'OWNERSHIP_UNRESOLVED',
+        recoverable: false,
+        entityIds: ['comm-bad'],
+      }),
+    });
+  });
+
+  it('blocks drift between canonical and legacy ownership signals', () => {
+    const result = checkOwnershipControl({
+      commissionId: 'comm-drift',
+      subscriptionAgentId: 'agent-subscription',
+      userAgentId: 'agent-user',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      violation: expect.objectContaining({
+        control: 'ownership',
+        code: 'OWNERSHIP_DRIFT',
+        entityIds: ['comm-drift'],
+      }),
+    });
+  });
+});
+
+describe('lifecycle control', () => {
+  it('delegates active buckets to PC05 access-active truth', () => {
+    const result = assertLifecycleEligibleForCommission({
+      commissionId: 'comm-active',
+      subscription: { status: 'active', cancelAtPeriodEnd: false, gracePeriodEndsAt: null },
+    });
+
+    expect(result).toEqual({ ok: true, value: 'active' });
+  });
+
+  it('blocks expired grace-period subscriptions', () => {
+    const result = assertLifecycleEligibleForCommission({
+      commissionId: 'comm-expired',
+      subscription: {
+        status: 'past_due',
+        cancelAtPeriodEnd: false,
+        gracePeriodEndsAt: new Date('2026-04-20T00:00:00.000Z'),
+      },
+      now: new Date('2026-04-21T00:00:00.000Z'),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      violation: expect.objectContaining({
+        control: 'lifecycle',
+        code: 'LIFECYCLE_INELIGIBLE',
+        entityIds: ['comm-expired'],
+      }),
+    });
+  });
+});
+
+describe('branch control', () => {
+  it('allows non-empty tenant and branch scope', () => {
+    const result = guardBranchStatsScope({
+      tenantId: 'tenant-1',
+      branchId: 'branch-1',
+      branchTenantId: 'tenant-1',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: { tenantId: 'tenant-1', branchId: 'branch-1' },
+    });
+  });
+
+  it('blocks missing branch ids before aggregate reads', () => {
+    const result = guardBranchStatsScope({ tenantId: 'tenant-1', branchId: ' ' });
+
+    expect(result).toEqual({
+      ok: false,
+      violation: expect.objectContaining({
+        control: 'branch',
+        code: 'BRANCH_ID_MISSING',
+      }),
+    });
+  });
+
+  it('blocks branch tenant mismatch when the branch tenant is known', () => {
+    const result = guardBranchStatsScope({
+      tenantId: 'tenant-1',
+      branchId: 'branch-1',
+      branchTenantId: 'tenant-2',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      violation: expect.objectContaining({
+        control: 'branch',
+        code: 'BRANCH_SCOPE_MISMATCH',
+        entityIds: ['branch-1'],
+      }),
+    });
+  });
+});
+
+describe('finance control', () => {
+  it('allows payable commissions when ownership and lifecycle controls pass', () => {
+    const result = assertFinancePayability({
+      commissionId: 'comm-payable',
+      subscriptionAgentId: 'agent-1',
+      userAgentId: 'agent-1',
+      agentClientAgentIds: ['agent-1'],
+      subscription: { status: 'active', cancelAtPeriodEnd: false, gracePeriodEndsAt: null },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('composes ownership and lifecycle violations into one finance result', () => {
+    const result = assertFinancePayability({
+      commissionId: 'comm-blocked',
+      subscriptionAgentId: 'agent-subscription',
+      userAgentId: 'agent-user',
+      subscription: { status: 'canceled', cancelAtPeriodEnd: false, gracePeriodEndsAt: null },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      violation: expect.objectContaining({
+        control: 'finance',
+        code: 'FINANCE_PAYABILITY_BLOCKED',
+        entityIds: ['comm-blocked'],
+        causes: expect.arrayContaining([
+          expect.objectContaining({ control: 'ownership' }),
+          expect.objectContaining({ control: 'lifecycle' }),
+        ]),
+      }),
+    });
+  });
+
+  it('combines mixed-batch violations with all blocked commission ids', () => {
+    const violation = combineControlViolations({
+      control: 'finance',
+      code: 'FINANCE_BATCH_PAYABILITY_BLOCKED',
+      detail: 'One or more commissions are not payable',
+      violations: [
+        {
+          control: 'finance',
+          code: 'FINANCE_PAYABILITY_BLOCKED',
+          detail: 'blocked first',
+          recoverable: false,
+          entityIds: ['comm-a'],
+        },
+        {
+          control: 'finance',
+          code: 'FINANCE_PAYABILITY_BLOCKED',
+          detail: 'blocked second',
+          recoverable: false,
+          entityIds: ['comm-b'],
+        },
+      ],
+    });
+
+    expect(violation.entityIds).toEqual(['comm-a', 'comm-b']);
+    expect(violation.detail).toContain('comm-a, comm-b');
+  });
+});

--- a/packages/domain-membership-billing/src/enterprise-controls.ts
+++ b/packages/domain-membership-billing/src/enterprise-controls.ts
@@ -1,0 +1,244 @@
+import {
+  getMembershipLifecycleBucket,
+  membershipLifecycleGrantsAccess,
+  type MembershipLifecycleBucket,
+  type MembershipLifecycleInput,
+} from './subscription/lifecycle-reporting';
+import {
+  resolveCommissionOwnership,
+  type CommissionOwnershipResolution,
+  type ResolveCommissionOwnershipInput,
+} from './commissions/ownership';
+
+export type EnterpriseControl = 'ownership' | 'lifecycle' | 'branch' | 'finance';
+
+export type ControlViolation = {
+  control: EnterpriseControl;
+  code: string;
+  detail: string;
+  recoverable: boolean;
+  entityIds?: string[];
+  causes?: ControlViolation[];
+};
+
+export type ControlResult<T> =
+  | {
+      ok: true;
+      value: T;
+    }
+  | {
+      ok: false;
+      violation: ControlViolation;
+    };
+
+export type OwnershipControlInput = ResolveCommissionOwnershipInput & {
+  commissionId?: string | null;
+};
+
+export type LifecycleCommissionInput = {
+  commissionId?: string | null;
+  bucket?: MembershipLifecycleBucket;
+  subscription?: MembershipLifecycleInput;
+  now?: Date;
+};
+
+export type FinancePayabilityInput = OwnershipControlInput &
+  LifecycleCommissionInput & {
+    commissionId: string;
+  };
+
+export function checkOwnershipControl(
+  input: OwnershipControlInput
+): ControlResult<CommissionOwnershipResolution> {
+  const resolution = resolveCommissionOwnership(input);
+  const entityIds = normalizeEntityIds(input.commissionId);
+
+  if (resolution.ownerType === 'unresolved') {
+    return {
+      ok: false,
+      violation: {
+        control: 'ownership',
+        code: 'OWNERSHIP_UNRESOLVED',
+        detail: buildEntityDetail('Commission ownership is unresolved', entityIds),
+        recoverable: false,
+        entityIds,
+      },
+    };
+  }
+
+  if (resolution.diagnostics.length > 0) {
+    return {
+      ok: false,
+      violation: {
+        control: 'ownership',
+        code: 'OWNERSHIP_DRIFT',
+        detail: buildEntityDetail('Commission ownership signals disagree', entityIds),
+        recoverable: false,
+        entityIds,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: resolution,
+  };
+}
+
+export function assertLifecycleEligibleForCommission(
+  input: LifecycleCommissionInput
+): ControlResult<MembershipLifecycleBucket> {
+  const bucket =
+    input.bucket ??
+    getMembershipLifecycleBucket({
+      subscription: input.subscription,
+      now: input.now,
+    });
+  const entityIds = normalizeEntityIds(input.commissionId);
+
+  if (!membershipLifecycleGrantsAccess(bucket)) {
+    return {
+      ok: false,
+      violation: {
+        control: 'lifecycle',
+        code: 'LIFECYCLE_INELIGIBLE',
+        detail: buildEntityDetail(
+          `Commission lifecycle bucket is not eligible for payability: ${bucket}`,
+          entityIds
+        ),
+        recoverable: false,
+        entityIds,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: bucket,
+  };
+}
+
+export function guardBranchStatsScope(args: {
+  tenantId?: string | null;
+  branchId?: string | null;
+  branchTenantId?: string | null;
+}): ControlResult<{ tenantId: string; branchId: string }> {
+  const tenantId = normalizeRequiredId(args.tenantId);
+  const branchId = normalizeRequiredId(args.branchId);
+
+  if (!tenantId) {
+    return {
+      ok: false,
+      violation: {
+        control: 'branch',
+        code: 'BRANCH_TENANT_MISSING',
+        detail: 'Branch stats require a tenantId before aggregate reads run',
+        recoverable: false,
+      },
+    };
+  }
+
+  if (!branchId) {
+    return {
+      ok: false,
+      violation: {
+        control: 'branch',
+        code: 'BRANCH_ID_MISSING',
+        detail: 'Branch stats require a branchId before aggregate reads run',
+        recoverable: false,
+      },
+    };
+  }
+
+  const branchTenantId = normalizeRequiredId(args.branchTenantId);
+  if (branchTenantId && branchTenantId !== tenantId) {
+    return {
+      ok: false,
+      violation: {
+        control: 'branch',
+        code: 'BRANCH_SCOPE_MISMATCH',
+        detail: `Branch stats scope mismatch for branch ${branchId}`,
+        recoverable: false,
+        entityIds: [branchId],
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: { tenantId, branchId },
+  };
+}
+
+export function assertFinancePayability(input: FinancePayabilityInput): ControlResult<{
+  ownership: CommissionOwnershipResolution;
+  lifecycleBucket: MembershipLifecycleBucket;
+}> {
+  const ownership = checkOwnershipControl(input);
+  const lifecycle = assertLifecycleEligibleForCommission(input);
+  if (ownership.ok && lifecycle.ok) {
+    return {
+      ok: true,
+      value: {
+        ownership: ownership.value,
+        lifecycleBucket: lifecycle.value,
+      },
+    };
+  }
+
+  const causes: ControlViolation[] = [];
+  if (!ownership.ok) causes.push(ownership.violation);
+  if (!lifecycle.ok) causes.push(lifecycle.violation);
+
+  const entityIds = [...new Set(causes.flatMap(cause => cause.entityIds ?? []))];
+  return {
+    ok: false,
+    violation: {
+      control: 'finance',
+      code: 'FINANCE_PAYABILITY_BLOCKED',
+      detail: buildEntityDetail('Commission is not payable under enterprise controls', entityIds),
+      recoverable: false,
+      entityIds,
+      causes,
+    },
+  };
+}
+
+export function combineControlViolations(args: {
+  control: EnterpriseControl;
+  code: string;
+  detail: string;
+  violations: ControlViolation[];
+}): ControlViolation {
+  const entityIds = [...new Set(args.violations.flatMap(violation => violation.entityIds ?? []))];
+  const detail = entityIds.length > 0 ? `${args.detail}: ${entityIds.join(', ')}` : args.detail;
+
+  return {
+    control: args.control,
+    code: args.code,
+    detail,
+    recoverable: args.violations.every(violation => violation.recoverable),
+    entityIds,
+    causes: args.violations,
+  };
+}
+
+export function formatControlViolation(violation: ControlViolation): string {
+  return `${violation.code}: ${violation.detail}`;
+}
+
+function normalizeRequiredId(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeEntityIds(id: string | null | undefined): string[] {
+  const normalized = normalizeRequiredId(id);
+  return normalized ? [normalized] : [];
+}
+
+function buildEntityDetail(detail: string, entityIds: string[]): string {
+  if (entityIds.length === 0) return detail;
+  return `${detail}: ${entityIds.join(', ')}`;
+}

--- a/packages/domain-membership-billing/src/index.ts
+++ b/packages/domain-membership-billing/src/index.ts
@@ -11,6 +11,7 @@ export * from './commissions/ownership';
 export * from './ownership-attribution';
 export * from './commissions/summary';
 export * from './commissions/types';
+export * from './enterprise-controls';
 export * from './paddle';
 export * from './paddle-server';
 export * from './paddle-webhooks';


### PR DESCRIPTION
## Summary
- add pure enterprise controls for ownership, lifecycle, branch scope, and finance payability
- enforce commission payability before bulk approve and status approval/paid transitions
- guard branch dashboard aggregate scope before read queries
- add admin UI bulk approve violation surface and deterministic PC06 E2E coverage

## Local verification
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate
- NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web exec playwright test e2e/pc06-enterprise-controls.spec.ts --project=ks-sq --workers=1

## Notion
- Synced implementation and local gate status to PC06 page 349036cf-f1f8-81fb-8218-c33192a456b1