### PR TITLE
fix: remove deprecated claim pack copy fallback

### DIFF
--- a/apps/web/src/app/[locale]/components/home/claim-pack-result.tsx
+++ b/apps/web/src/app/[locale]/components/home/claim-pack-result.tsx
@@ -78,25 +78,6 @@ function evidenceTextClass(item: ClaimPack['evidenceChecklist']['items'][number]
   return 'text-slate-400';
 }
 
-function fallbackCopyText(text: string) {
-  const textarea = document.createElement('textarea');
-  textarea.value = text;
-  textarea.setAttribute('readonly', '');
-  textarea.style.position = 'fixed';
-  textarea.style.top = '0';
-  textarea.style.left = '0';
-  textarea.style.opacity = '0';
-  document.body.appendChild(textarea);
-  textarea.focus();
-  textarea.select();
-
-  try {
-    return document.execCommand('copy');
-  } finally {
-    document.body.removeChild(textarea);
-  }
-}
-
 function ConfidenceSection({ confidence }: Readonly<{ confidence: ClaimPack['confidence'] }>) {
   const colors = confidenceColor(confidence.level);
 
@@ -191,23 +172,16 @@ function LetterSection({ letter }: Readonly<{ letter: ClaimPack['letter'] }>) {
     setCopyError(null);
 
     try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(letter.body);
-      } else if (!fallbackCopyText(letter.body)) {
-        throw new Error('Copy command was unsuccessful.');
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('Clipboard API is unavailable.');
       }
 
+      await navigator.clipboard.writeText(letter.body);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      if (fallbackCopyText(letter.body)) {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-        return;
-      }
-
       setCopied(false);
-      setCopyError('Unable to copy the letter. Select the text and copy it manually.');
+      setCopyError('Unable to copy automatically. Select the letter text and copy it manually.');
     }
   }, [letter.body]);
 

--- a/apps/web/src/app/[locale]/components/home/free-start-intake-shell.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/free-start-intake-shell.test.tsx
@@ -335,6 +335,17 @@ describe('FreeStartIntakeShell', () => {
       '/member/claims/new'
     );
     expect(screen.getByText(/not legal advice/i)).toBeInTheDocument();
+
+    const writeTextMock = vi.fn().mockRejectedValue(new Error('clipboard denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: writeTextMock },
+    });
+
+    await user.click(screen.getByRole('button', { name: /copy/i }));
+
+    expect(writeTextMock).toHaveBeenCalledWith('Draft property damage letter');
+    expect(await screen.findByText(/unable to copy automatically/i)).toBeInTheDocument();
   });
 
   it.each(CATEGORY_EVIDENCE_EXPECTATIONS)(

--- a/apps/web/src/app/[locale]/components/home/free-start-intake-shell.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/free-start-intake-shell.test.tsx
@@ -170,6 +170,28 @@ function renderFreeStart(locale: LocaleId, continueHref = '/pricing') {
   );
 }
 
+async function withNavigatorClipboard(
+  clipboard: Pick<Clipboard, 'writeText'> | undefined,
+  run: () => Promise<void>
+) {
+  const previousClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+
+  try {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: clipboard,
+    });
+
+    await run();
+  } finally {
+    if (previousClipboardDescriptor) {
+      Object.defineProperty(navigator, 'clipboard', previousClipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, 'clipboard');
+    }
+  }
+}
+
 describe('FreeStartIntakeShell', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -337,14 +359,98 @@ describe('FreeStartIntakeShell', () => {
     expect(screen.getByText(/not legal advice/i)).toBeInTheDocument();
 
     const writeTextMock = vi.fn().mockRejectedValue(new Error('clipboard denied'));
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText: writeTextMock },
+
+    await withNavigatorClipboard({ writeText: writeTextMock }, async () => {
+      await user.click(screen.getByRole('button', { name: /copy/i }));
     });
 
-    await user.click(screen.getByRole('button', { name: /copy/i }));
-
     expect(writeTextMock).toHaveBeenCalledWith('Draft property damage letter');
+    expect(await screen.findByText(/unable to copy automatically/i)).toBeInTheDocument();
+  });
+
+  it('shows manual copy guidance when the Clipboard API is unavailable', async () => {
+    const user = userEvent.setup();
+    hoisted.submitFreeStartIntakeMock.mockResolvedValue({
+      success: true,
+      data: {
+        claimCategory: 'property',
+        desiredOutcome: 'repair',
+        intakeIssue: 'water_damage',
+      },
+    });
+    hoisted.generateClaimPackActionMock.mockResolvedValue({
+      success: true,
+      data: {
+        generatedAt: '2026-04-24T08:00:00.000Z',
+        claimType: 'property',
+        intakeAnswers: {
+          incidentDate: '2026-03-01',
+          description: 'Water entered through the roof after a storm and damaged two rooms.',
+        },
+        confidence: {
+          score: 72,
+          level: 'high',
+          factors: [
+            {
+              name: 'Incident recency',
+              pointsEarned: 20,
+              maxPoints: 20,
+              explanation: 'Recent incident',
+            },
+          ],
+        },
+        evidenceChecklist: {
+          claimType: 'property',
+          requiredCount: 3,
+          likelyAvailableCount: 1,
+          items: [
+            {
+              id: 'property_photos',
+              name: 'Damage photographs',
+              description: 'Photos showing the property damage clearly',
+              required: true,
+              status: 'missing',
+              likelyAvailable: false,
+            },
+          ],
+        },
+        letter: {
+          locale: 'en',
+          body: 'Draft property damage letter',
+          placeholders: ['[YOUR_FULL_NAME]'],
+        },
+        timeline: {
+          claimType: 'property',
+          confidenceLevel: 'high',
+          milestones: [
+            {
+              id: 'first_letter',
+              label: 'First letter sent',
+              estimatedRange: '1-2 days',
+              description: 'Send your complaint letter',
+            },
+          ],
+        },
+        recommendedNextStep: {
+          level: 'high',
+          title: 'Strong case',
+          description: 'Join Asistenca for human triage.',
+          ctaLabel: 'Join Asistenca',
+          ctaHref: '/pricing',
+        },
+        disclaimer: 'This is informational guidance only, not legal advice.',
+      },
+    });
+
+    renderFreeStart('en', '/member/claims/new');
+
+    await completeFreeStartIntake(user, 'en');
+    expect(await screen.findByTestId('claim-pack-result')).toBeInTheDocument();
+
+    await withNavigatorClipboard(undefined, async () => {
+      await user.click(screen.getByRole('button', { name: /copy/i }));
+    });
+
     expect(await screen.findByText(/unable to copy automatically/i)).toBeInTheDocument();
   });
 

--- a/apps/web/src/app/[locale]/components/home/free-start-intake-shell.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/free-start-intake-shell.test.tsx
@@ -192,6 +192,84 @@ async function withNavigatorClipboard(
   }
 }
 
+function createGeneratedClaimPackFixture() {
+  return {
+    generatedAt: '2026-04-24T08:00:00.000Z',
+    claimType: 'property',
+    intakeAnswers: {
+      incidentDate: '2026-03-01',
+      description: 'Water entered through the roof after a storm and damaged two rooms.',
+    },
+    confidence: {
+      score: 72,
+      level: 'high',
+      factors: [
+        {
+          name: 'Incident recency',
+          pointsEarned: 20,
+          maxPoints: 20,
+          explanation: 'Recent incident',
+        },
+      ],
+    },
+    evidenceChecklist: {
+      claimType: 'property',
+      requiredCount: 3,
+      likelyAvailableCount: 1,
+      items: [
+        {
+          id: 'property_photos',
+          name: 'Damage photographs',
+          description: 'Photos showing the property damage clearly',
+          required: true,
+          status: 'missing',
+          likelyAvailable: false,
+        },
+      ],
+    },
+    letter: {
+      locale: 'en',
+      body: 'Draft property damage letter',
+      placeholders: ['[YOUR_FULL_NAME]'],
+    },
+    timeline: {
+      claimType: 'property',
+      confidenceLevel: 'high',
+      milestones: [
+        {
+          id: 'first_letter',
+          label: 'First letter sent',
+          estimatedRange: '1-2 days',
+          description: 'Send your complaint letter',
+        },
+      ],
+    },
+    recommendedNextStep: {
+      level: 'high',
+      title: 'Strong case',
+      description: 'Join Asistenca for human triage.',
+      ctaLabel: 'Join Asistenca',
+      ctaHref: '/pricing',
+    },
+    disclaimer: 'This is informational guidance only, not legal advice.',
+  };
+}
+
+function mockSuccessfulGeneratedClaimPack() {
+  hoisted.submitFreeStartIntakeMock.mockResolvedValue({
+    success: true,
+    data: {
+      claimCategory: 'property',
+      desiredOutcome: 'repair',
+      intakeIssue: 'water_damage',
+    },
+  });
+  hoisted.generateClaimPackActionMock.mockResolvedValue({
+    success: true,
+    data: createGeneratedClaimPackFixture(),
+  });
+}
+
 describe('FreeStartIntakeShell', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -269,77 +347,7 @@ describe('FreeStartIntakeShell', () => {
 
   it('renders the generated claim pack when the pack action succeeds', async () => {
     const user = userEvent.setup();
-    hoisted.submitFreeStartIntakeMock.mockResolvedValue({
-      success: true,
-      data: {
-        claimCategory: 'property',
-        desiredOutcome: 'repair',
-        intakeIssue: 'water_damage',
-      },
-    });
-    hoisted.generateClaimPackActionMock.mockResolvedValue({
-      success: true,
-      data: {
-        generatedAt: '2026-04-24T08:00:00.000Z',
-        claimType: 'property',
-        intakeAnswers: {
-          incidentDate: '2026-03-01',
-          description: 'Water entered through the roof after a storm and damaged two rooms.',
-        },
-        confidence: {
-          score: 72,
-          level: 'high',
-          factors: [
-            {
-              name: 'Incident recency',
-              pointsEarned: 20,
-              maxPoints: 20,
-              explanation: 'Recent incident',
-            },
-          ],
-        },
-        evidenceChecklist: {
-          claimType: 'property',
-          requiredCount: 3,
-          likelyAvailableCount: 1,
-          items: [
-            {
-              id: 'property_photos',
-              name: 'Damage photographs',
-              description: 'Photos showing the property damage clearly',
-              required: true,
-              status: 'missing',
-              likelyAvailable: false,
-            },
-          ],
-        },
-        letter: {
-          locale: 'en',
-          body: 'Draft property damage letter',
-          placeholders: ['[YOUR_FULL_NAME]'],
-        },
-        timeline: {
-          claimType: 'property',
-          confidenceLevel: 'high',
-          milestones: [
-            {
-              id: 'first_letter',
-              label: 'First letter sent',
-              estimatedRange: '1-2 days',
-              description: 'Send your complaint letter',
-            },
-          ],
-        },
-        recommendedNextStep: {
-          level: 'high',
-          title: 'Strong case',
-          description: 'Join Asistenca for human triage.',
-          ctaLabel: 'Join Asistenca',
-          ctaHref: '/pricing',
-        },
-        disclaimer: 'This is informational guidance only, not legal advice.',
-      },
-    });
+    mockSuccessfulGeneratedClaimPack();
 
     renderFreeStart('en', '/member/claims/new');
 
@@ -370,77 +378,7 @@ describe('FreeStartIntakeShell', () => {
 
   it('shows manual copy guidance when the Clipboard API is unavailable', async () => {
     const user = userEvent.setup();
-    hoisted.submitFreeStartIntakeMock.mockResolvedValue({
-      success: true,
-      data: {
-        claimCategory: 'property',
-        desiredOutcome: 'repair',
-        intakeIssue: 'water_damage',
-      },
-    });
-    hoisted.generateClaimPackActionMock.mockResolvedValue({
-      success: true,
-      data: {
-        generatedAt: '2026-04-24T08:00:00.000Z',
-        claimType: 'property',
-        intakeAnswers: {
-          incidentDate: '2026-03-01',
-          description: 'Water entered through the roof after a storm and damaged two rooms.',
-        },
-        confidence: {
-          score: 72,
-          level: 'high',
-          factors: [
-            {
-              name: 'Incident recency',
-              pointsEarned: 20,
-              maxPoints: 20,
-              explanation: 'Recent incident',
-            },
-          ],
-        },
-        evidenceChecklist: {
-          claimType: 'property',
-          requiredCount: 3,
-          likelyAvailableCount: 1,
-          items: [
-            {
-              id: 'property_photos',
-              name: 'Damage photographs',
-              description: 'Photos showing the property damage clearly',
-              required: true,
-              status: 'missing',
-              likelyAvailable: false,
-            },
-          ],
-        },
-        letter: {
-          locale: 'en',
-          body: 'Draft property damage letter',
-          placeholders: ['[YOUR_FULL_NAME]'],
-        },
-        timeline: {
-          claimType: 'property',
-          confidenceLevel: 'high',
-          milestones: [
-            {
-              id: 'first_letter',
-              label: 'First letter sent',
-              estimatedRange: '1-2 days',
-              description: 'Send your complaint letter',
-            },
-          ],
-        },
-        recommendedNextStep: {
-          level: 'high',
-          title: 'Strong case',
-          description: 'Join Asistenca for human triage.',
-          ctaLabel: 'Join Asistenca',
-          ctaHref: '/pricing',
-        },
-        disclaimer: 'This is informational guidance only, not legal advice.',
-      },
-    });
+    mockSuccessfulGeneratedClaimPack();
 
     renderFreeStart('en', '/member/claims/new');
 


### PR DESCRIPTION
## Summary
- remove the deprecated textarea/document.execCommand copy fallback from ClaimPackResult
- fall back to inline manual-copy guidance when Clipboard API access is unavailable or denied
- add focused coverage for the clipboard rejection path

## Verification
- pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/components/home/free-start-intake-shell.test.tsx'
- pnpm verify-slice -- --static --run-id p13-sonar-clipboard-static-final
- pnpm verify-slice -- --required-gates --run-id p13-sonar-clipboard-required-gates