### PR TITLE
test: add new claim ready marker

### DIFF
--- a/apps/web/e2e/production.spec.ts
+++ b/apps/web/e2e/production.spec.ts
@@ -114,7 +114,9 @@ test.describe.serial('@smoke Production Smoke Test Plan', () => {
       });
 
       // 3. Wizard
-      await gotoApp(page, routes.memberNewClaim(testInfo), testInfo, { marker: 'page-ready' });
+      await gotoApp(page, routes.memberNewClaim(testInfo), testInfo, {
+        marker: 'new-claim-page-ready',
+      });
       await dismissCookieConsentIfVisible(page);
       const bodyText = await page.textContent('body');
       expect(bodyText).not.toContain('MISSING_MESSAGE');

--- a/apps/web/src/app/[locale]/(app)/member/claims/new/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/new/_core.entry.tsx
@@ -78,7 +78,7 @@ export default async function NewClaimPage({ params, searchParams }: Props) {
 
   if (!hasAccess) {
     return (
-      <div className="flex flex-col h-full">
+      <div className="flex flex-col h-full" data-testid="new-claim-page-ready">
         <div className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <div className="flex h-16 items-center px-6">
             <h1 className="text-lg font-semibold">{t('new')}</h1>
@@ -101,7 +101,7 @@ export default async function NewClaimPage({ params, searchParams }: Props) {
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full" data-testid="new-claim-page-ready">
       <div className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="flex h-16 items-center px-6">
           <h1 className="text-lg font-semibold">{t('new')}</h1>

--- a/apps/web/src/app/[locale]/(app)/member/claims/new/page.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/new/page.test.tsx
@@ -127,6 +127,7 @@ describe('NewClaimPage diaspora claim handoff', () => {
         incidentLocation: 'abroad',
       },
     });
+    expect(screen.getByTestId('new-claim-page-ready')).toBeInTheDocument();
     expect(screen.getByTestId('claim-wizard-props')).toBeInTheDocument();
   });
 
@@ -140,6 +141,7 @@ describe('NewClaimPage diaspora claim handoff', () => {
 
     render(tree);
 
+    expect(screen.getByTestId('new-claim-page-ready')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'gate.view_plans' })).toHaveAttribute(
       'href',
       '/en/pricing'


### PR DESCRIPTION
## Summary
- Add the `new-claim-page-ready` clarity marker to both member new-claim render branches.
- Assert the marker in the page unit tests.
- Update production smoke navigation to wait for `new-claim-page-ready` instead of the generic `page-ready` marker.

## Validation
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(app)/member/claims/new/page.test.tsx'`
- Live headed Chrome check: `/sq/member` -> `/sq/member/claims/new`, marker present, no page errors/non-favicon 4xx.
- `pnpm verify-slice -- --static`
- Pre-PR reviewer pool: security, architecture/contracts, QA; QA P1 resolved on re-review.
- `PW_EXTERNAL_SERVER=1 INTERDOMESTIK_AUTOMATED=1 PLAYWRIGHT=1 NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web test:e2e -- e2e/production.spec.ts --project=smoke --grep "can login, see dashboard, and create a claim" --workers=1`
- `pnpm verify-slice -- --required-gates`
