### PR TITLE
fix: harden claim upload confirmation and activity reads

### DIFF
--- a/apps/web/src/app/api/claims/evidence-upload/route.test.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.test.ts
@@ -10,6 +10,8 @@ const hoisted = vi.hoisted(() => ({
   createAdminClient: vi.fn(),
   confirmAdminUpload: vi.fn(),
   confirmUpload: vi.fn(),
+  createClaimUploadIntentToken: vi.fn(),
+  sanitizeClaimUploadExtension: vi.fn(),
   captureMessage: vi.fn(),
   and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
   eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
@@ -43,18 +45,24 @@ vi.mock('@/features/member/claims/actions', () => ({
 vi.mock('@/features/claims/upload/server/access', () => ({
   findAccessibleAdminUploadClaim: hoisted.findAccessibleAdminUploadClaim,
 }));
+vi.mock('@/features/claims/upload/server/shared-upload', () => ({
+  createClaimUploadIntentToken: hoisted.createClaimUploadIntentToken,
+  sanitizeClaimUploadExtension: hoisted.sanitizeClaimUploadExtension,
+}));
 vi.mock('@sentry/nextjs', () => ({
   captureMessage: hoisted.captureMessage,
 }));
 
 import { POST } from './route';
 
-function createEvidenceUploadRequest(): Request {
+function createEvidenceUploadRequest(
+  file = new File(['test'], 'evidence.pdf', { type: 'application/pdf' })
+): Request {
   const form = new FormData();
   form.set('claimId', 'claim-1');
   form.set('category', 'evidence');
   form.set('locale', 'mk');
-  form.set('file', new File(['test'], 'evidence.pdf', { type: 'application/pdf' }));
+  form.set('file', file);
 
   return {
     headers: new Headers({
@@ -88,6 +96,8 @@ describe('POST /api/claims/evidence-upload', () => {
     });
     hoisted.confirmAdminUpload.mockResolvedValue({ success: true });
     hoisted.confirmUpload.mockResolvedValue({ success: true });
+    hoisted.createClaimUploadIntentToken.mockReturnValue('upload-intent-token');
+    hoisted.sanitizeClaimUploadExtension.mockReturnValue('pdf');
   });
 
   it('denies staff uploads outside branch or assignment scope before storage upload', async () => {
@@ -120,5 +130,71 @@ describe('POST /api/claims/evidence-upload', () => {
         level: 'warning',
       })
     );
+  });
+
+  it('passes a server-issued upload intent token into metadata confirmation', async () => {
+    const response = await POST(createEvidenceUploadRequest());
+
+    expect(response.status).toBe(200);
+    expect(hoisted.createClaimUploadIntentToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'staff-1',
+        bucket: 'claim-evidence',
+        claimId: 'claim-1',
+        fileSize: 4,
+        mimeType: 'application/pdf',
+        storageContentType: 'application/pdf',
+        tenantId: 'tenant-1',
+      })
+    );
+    expect(hoisted.confirmAdminUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storageContentType: 'application/pdf',
+        uploadIntentToken: 'upload-intent-token',
+      })
+    );
+  });
+
+  it('rejects zero-byte files before storage upload', async () => {
+    const response = await POST(
+      createEvidenceUploadRequest(new File([], 'empty.pdf', { type: 'application/pdf' }))
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'Invalid form payload' });
+    expect(hoisted.createClaimUploadIntentToken).not.toHaveBeenCalled();
+    expect(hoisted.upload).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes direct-upload extensions before storage upload', async () => {
+    hoisted.sanitizeClaimUploadExtension.mockReturnValueOnce('bin');
+
+    const response = await POST(
+      createEvidenceUploadRequest(
+        new File(['test'], 'evidence.pdf/..', { type: 'application/pdf' })
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(hoisted.upload).toHaveBeenCalledWith(
+      expect.stringMatching(/^pii\/tenants\/tenant-1\/claims\/claim-1\/[^/]+\.bin$/),
+      expect.any(Buffer),
+      expect.objectContaining({ contentType: 'application/pdf' })
+    );
+  });
+
+  it('fails upload intent configuration before storage upload', async () => {
+    hoisted.createClaimUploadIntentToken.mockImplementationOnce(() => {
+      throw new Error('missing secret');
+    });
+
+    const response = await POST(createEvidenceUploadRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({ error: 'Upload configuration error' });
+    expect(hoisted.upload).not.toHaveBeenCalled();
+    expect(hoisted.confirmAdminUpload).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/claims/evidence-upload/route.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.ts
@@ -3,6 +3,10 @@ import {
   resolveStorageUploadContentType,
   resolveUploadMimeType,
 } from '@/features/admin/claims/components/ops/file-upload-meta';
+import {
+  createClaimUploadIntentToken,
+  sanitizeClaimUploadExtension,
+} from '@/features/claims/upload/server/shared-upload';
 import { findAccessibleAdminUploadClaim } from '@/features/claims/upload/server/access';
 import { confirmUpload } from '@/features/member/claims/actions';
 import { LOCALES } from '@/i18n/locales';
@@ -25,6 +29,22 @@ const ADMIN_UPLOAD_ROLES = new Set([
 ]);
 const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 
+type UploadCategory = 'evidence' | 'legal';
+type EvidenceUploadForm = {
+  category: UploadCategory;
+  claimId: string;
+  file: File;
+};
+
+type ResponseResult<T> = { success: true; data: T } | { success: false; response: NextResponse };
+type ClaimAccess =
+  | { success: true; isAdminSurface: boolean }
+  | { success: false; status: 401 | 404 };
+
+function jsonError(error: string, status: number): NextResponse {
+  return NextResponse.json({ error }, { status });
+}
+
 function isAdminUploadRole(role: string | null | undefined): boolean {
   return role ? ADMIN_UPLOAD_ROLES.has(role) : false;
 }
@@ -36,7 +56,7 @@ async function validateClaimAccess(params: {
   tenantId: string;
   host: string;
   userId: string;
-}): Promise<{ success: true; isAdminSurface: boolean } | { success: false; status: 401 | 404 }> {
+}): Promise<ClaimAccess> {
   const { claimId, role, tenantId, host, userId } = params;
   const isAdminSurface = isAdminUploadRole(role) && resolveTenantFromHost(host) === tenantId;
 
@@ -66,15 +86,12 @@ async function validateClaimAccess(params: {
   return { success: true, isAdminSurface };
 }
 
-export async function POST(request: Request) {
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+async function parseEvidenceUploadForm(
+  request: Request
+): Promise<ResponseResult<EvidenceUploadForm>> {
   const formData = await request.formData().catch(() => null);
   if (!formData) {
-    return NextResponse.json({ error: 'Invalid form payload' }, { status: 400 });
+    return { success: false, response: jsonError('Invalid form payload', 400) };
   }
 
   const claimId = formData.get('claimId');
@@ -89,31 +106,166 @@ export async function POST(request: Request) {
     !LOCALES.includes(locale as (typeof LOCALES)[number]) ||
     !(file instanceof File)
   ) {
-    return NextResponse.json({ error: 'Invalid form payload' }, { status: 400 });
+    return { success: false, response: jsonError('Invalid form payload', 400) };
+  }
+
+  if (file.size <= 0) {
+    return { success: false, response: jsonError('Invalid form payload', 400) };
   }
 
   if (file.size > MAX_FILE_SIZE_BYTES) {
-    return NextResponse.json({ error: 'File too large (max 50MB)' }, { status: 413 });
+    return { success: false, response: jsonError('File too large (max 50MB)', 413) };
   }
 
-  let tenantId: string;
+  return { success: true, data: { category, claimId, file } };
+}
+
+function resolveTenantId(
+  session: NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>
+): ResponseResult<string> {
   try {
-    tenantId = ensureTenantId(session);
+    return { success: true, data: ensureTenantId(session) };
   } catch {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return { success: false, response: jsonError('Unauthorized', 401) };
   }
+}
 
-  let bucket: string;
+function resolveEvidenceBucket(): ResponseResult<string> {
   try {
-    bucket = resolveEvidenceBucketName();
+    return { success: true, data: resolveEvidenceBucketName() };
   } catch (error) {
     const message =
       error instanceof Error
         ? error.message
         : 'Invalid storage configuration for tenant evidence bucket';
-    return NextResponse.json({ error: message }, { status: 500 });
+    return { success: false, response: jsonError(message, 500) };
+  }
+}
+
+function createUploadIntent(params: {
+  bucket: string;
+  claimId: string;
+  file: File;
+  fileId: string;
+  resolvedMimeType: string;
+  storageContentType: string;
+  storagePath: string;
+  tenantId: string;
+  userId: string;
+}): ResponseResult<string> {
+  try {
+    return {
+      success: true,
+      data: createClaimUploadIntentToken({
+        actorId: params.userId,
+        bucket: params.bucket,
+        claimId: params.claimId,
+        fileId: params.fileId,
+        fileSize: params.file.size,
+        mimeType: params.resolvedMimeType,
+        storageContentType: params.storageContentType,
+        storagePath: params.storagePath,
+        tenantId: params.tenantId,
+      }),
+    };
+  } catch (error) {
+    console.error('[claims/evidence-upload] Upload intent configuration error', {
+      message: error instanceof Error ? error.message : 'Upload intent configuration error',
+      nodeEnv: process.env.NODE_ENV,
+      vercelEnv: process.env.VERCEL_ENV,
+    });
+    return { success: false, response: jsonError('Upload configuration error', 500) };
+  }
+}
+
+async function uploadEvidenceObject(params: {
+  bucket: string;
+  file: File;
+  storageContentType: string;
+  storagePath: string;
+}): Promise<NextResponse | null> {
+  const buffer = Buffer.from(await params.file.arrayBuffer());
+
+  const { error: uploadError } = await createAdminClient()
+    .storage.from(params.bucket)
+    .upload(params.storagePath, buffer, {
+      contentType: params.storageContentType,
+      upsert: true,
+    });
+
+  if (uploadError) {
+    return jsonError(uploadError.message || 'Failed to upload evidence', 500);
   }
 
+  return null;
+}
+
+async function confirmEvidenceUpload(params: {
+  bucket: string;
+  category: UploadCategory;
+  claimAccess: { isAdminSurface: boolean };
+  claimId: string;
+  file: File;
+  fileId: string;
+  resolvedMimeType: string;
+  storageContentType: string;
+  storagePath: string;
+  uploadIntentToken: string;
+}) {
+  const confirmation = {
+    claimId: params.claimId,
+    storagePath: params.storagePath,
+    originalName: params.file.name,
+    mimeType: params.resolvedMimeType,
+    fileSize: params.file.size,
+    fileId: params.fileId,
+    uploadIntentToken: params.uploadIntentToken,
+    storageContentType: params.storageContentType,
+    uploadedBucket: params.bucket,
+    category: params.category,
+  };
+
+  return params.claimAccess.isAdminSurface
+    ? confirmAdminUpload(confirmation)
+    : confirmUpload(confirmation);
+}
+
+function captureConfirmFailure(params: {
+  bucket: string;
+  category: UploadCategory;
+  claimId: string;
+  confirmError: string;
+  confirmStatus: number;
+  fileId: string;
+  role: string | null;
+  storagePath: string;
+  tenantId: string;
+  userId: string;
+}) {
+  Sentry.captureMessage('claim.evidence_upload.confirm_failed_after_storage_upload', {
+    level: 'warning',
+    extra: params,
+  });
+}
+
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session) {
+    return jsonError('Unauthorized', 401);
+  }
+
+  const form = await parseEvidenceUploadForm(request);
+  if (!form.success) return form.response;
+
+  const tenant = resolveTenantId(session);
+  if (!tenant.success) return tenant.response;
+
+  const evidenceBucket = resolveEvidenceBucket();
+  if (!evidenceBucket.success) return evidenceBucket.response;
+
+  const { category, claimId, file } = form.data;
+  const tenantId = tenant.data;
+  const bucket = evidenceBucket.data;
   const role = session.user.role ?? null;
   const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? '';
   const claimAccess = await validateClaimAccess({
@@ -126,72 +278,61 @@ export async function POST(request: Request) {
   });
 
   if (!claimAccess.success) {
-    return NextResponse.json(
-      { error: claimAccess.status === 404 ? 'Claim not found' : 'Unauthorized' },
-      { status: claimAccess.status }
+    return jsonError(
+      claimAccess.status === 404 ? 'Claim not found' : 'Unauthorized',
+      claimAccess.status
     );
   }
 
   const resolvedMimeType = resolveUploadMimeType(file);
   const storageContentType = resolveStorageUploadContentType(file);
-  const extension = file.name.split('.').pop() || 'bin';
   const fileId = randomUUID();
+  const extension = sanitizeClaimUploadExtension(file.name);
   const storagePath = `pii/tenants/${tenantId}/claims/${claimId}/${fileId}.${extension}`;
-  const buffer = Buffer.from(await file.arrayBuffer());
+  const uploadIntent = createUploadIntent({
+    bucket,
+    claimId,
+    file,
+    fileId,
+    resolvedMimeType,
+    storageContentType,
+    storagePath,
+    tenantId,
+    userId: session.user.id,
+  });
 
-  const { error: uploadError } = await createAdminClient()
-    .storage.from(bucket)
-    .upload(storagePath, buffer, {
-      contentType: storageContentType,
-      upsert: true,
-    });
+  if (!uploadIntent.success) return uploadIntent.response;
 
-  if (uploadError) {
-    return NextResponse.json(
-      { error: uploadError.message || 'Failed to upload evidence' },
-      { status: 500 }
-    );
-  }
+  const uploadError = await uploadEvidenceObject({ bucket, file, storageContentType, storagePath });
+  if (uploadError) return uploadError;
 
-  const confirmResult = claimAccess.isAdminSurface
-    ? await confirmAdminUpload({
-        claimId,
-        storagePath,
-        originalName: file.name,
-        mimeType: resolvedMimeType,
-        fileSize: file.size,
-        fileId,
-        uploadedBucket: bucket,
-        category,
-      })
-    : await confirmUpload({
-        claimId,
-        storagePath,
-        originalName: file.name,
-        mimeType: resolvedMimeType,
-        fileSize: file.size,
-        fileId,
-        uploadedBucket: bucket,
-        category,
-      });
+  const confirmResult = await confirmEvidenceUpload({
+    bucket,
+    category,
+    claimAccess,
+    claimId,
+    file,
+    fileId,
+    resolvedMimeType,
+    storageContentType,
+    storagePath,
+    uploadIntentToken: uploadIntent.data,
+  });
 
   if (!confirmResult.success) {
-    Sentry.captureMessage('claim.evidence_upload.confirm_failed_after_storage_upload', {
-      level: 'warning',
-      extra: {
-        claimId,
-        tenantId,
-        userId: session.user.id,
-        role,
-        fileId,
-        bucket,
-        storagePath,
-        category,
-        confirmStatus: confirmResult.status,
-        confirmError: confirmResult.error,
-      },
+    captureConfirmFailure({
+      bucket,
+      category,
+      claimId,
+      confirmError: confirmResult.error,
+      confirmStatus: confirmResult.status,
+      fileId,
+      role,
+      storagePath,
+      tenantId,
+      userId: session.user.id,
     });
-    return NextResponse.json({ error: confirmResult.error }, { status: confirmResult.status });
+    return jsonError(confirmResult.error, confirmResult.status);
   }
 
   return NextResponse.json({ success: true, fileId, storagePath });

--- a/apps/web/src/features/admin/claims/actions.test.ts
+++ b/apps/web/src/features/admin/claims/actions.test.ts
@@ -35,6 +35,7 @@ describe('admin claim action exports', () => {
       mimeType: 'application/pdf',
       fileSize: 42,
       fileId: 'file-1',
+      uploadIntentToken: 'upload-intent-token',
     };
 
     expect(uploadResult.status).toBe(401);

--- a/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
+++ b/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
@@ -10,6 +10,7 @@ const hoisted = vi.hoisted(() => ({
   revalidatePath: vi.fn(),
   createSignedUploadUrl: vi.fn(),
   persistClaimDocumentAndQueueWorkflows: vi.fn(),
+  validateConfirmedClaimUpload: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -31,6 +32,7 @@ vi.mock('@/features/claims/upload/server/shared-upload', () => ({
   createSignedUploadUrl: hoisted.createSignedUploadUrl,
   persistClaimDocumentAndQueueWorkflows: hoisted.persistClaimDocumentAndQueueWorkflows,
   revalidatePathForAllLocales: (path: string) => hoisted.revalidatePath(`/mk${path}`),
+  validateConfirmedClaimUpload: hoisted.validateConfirmedClaimUpload,
 }));
 
 import { confirmAdminUpload, generateAdminUploadUrl } from './evidence-upload';
@@ -59,9 +61,11 @@ describe('admin claim evidence upload actions', () => {
       bucket: 'claim-evidence',
       path: 'pii/tenants/tenant-1/claims/claim-1/file.pdf',
       token: 'upload-token',
+      intentToken: 'upload-intent-token',
       id: 'file-id',
     });
     hoisted.persistClaimDocumentAndQueueWorkflows.mockResolvedValue(undefined);
+    hoisted.validateConfirmedClaimUpload.mockResolvedValue({ success: true });
   });
 
   it('rejects upload URL issuance when the admin host tenant drifts', async () => {
@@ -133,6 +137,7 @@ describe('admin claim evidence upload actions', () => {
         mimeType: 'application/pdf',
         fileSize: 1024,
         fileId: 'file-id',
+        uploadIntentToken: 'upload-intent-token',
         uploadedBucket: 'claim-evidence',
       })
     ).resolves.toEqual({ success: false, error: 'Claim not found', status: 404 });
@@ -149,6 +154,7 @@ describe('admin claim evidence upload actions', () => {
         mimeType: 'application/pdf',
         fileSize: 1024,
         fileId: 'file-id',
+        uploadIntentToken: 'upload-intent-token',
         uploadedBucket: 'claim-evidence',
       })
     ).resolves.toEqual({ success: true });
@@ -156,5 +162,32 @@ describe('admin claim evidence upload actions', () => {
     expect(hoisted.revalidatePath).toHaveBeenCalledWith('/mk/admin/claims');
     expect(hoisted.revalidatePath).toHaveBeenCalledWith('/mk/admin/claims/claim-1');
     expect(hoisted.revalidatePath).toHaveBeenCalledWith('/mk/staff/claims/claim-1');
+  });
+
+  it('rejects forged upload metadata before persistence', async () => {
+    hoisted.validateConfirmedClaimUpload.mockResolvedValueOnce({
+      success: false,
+      error: 'Uploaded file metadata mismatch. Please retry upload.',
+      status: 409,
+    });
+
+    await expect(
+      confirmAdminUpload({
+        claimId: 'claim-1',
+        storagePath: 'pii/tenants/tenant-1/claims/claim-1/file.pdf',
+        originalName: 'evidence.pdf',
+        mimeType: 'application/pdf',
+        fileSize: 1024,
+        fileId: 'file-id',
+        uploadIntentToken: 'upload-intent-token',
+        uploadedBucket: 'claim-evidence',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: 'Uploaded file metadata mismatch. Please retry upload.',
+      status: 409,
+    });
+
+    expect(hoisted.persistClaimDocumentAndQueueWorkflows).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/admin/claims/actions/evidence-upload.ts
+++ b/apps/web/src/features/admin/claims/actions/evidence-upload.ts
@@ -5,6 +5,7 @@ import {
   createSignedUploadUrl,
   persistClaimDocumentAndQueueWorkflows,
   revalidatePathForAllLocales,
+  validateConfirmedClaimUpload,
 } from '@/features/claims/upload/server/shared-upload';
 import { auth } from '@/lib/auth';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
@@ -33,8 +34,16 @@ type UploadContext =
   | { success: false; error: string; status: 401 | 500 };
 
 export type GenerateAdminUploadUrlResult =
-  | { success: true; url: string; path: string; id: string; token: string; bucket: string }
-  | { success: false; error: string; status: 401 | 404 | 413 | 500 };
+  | {
+      success: true;
+      url: string;
+      path: string;
+      id: string;
+      token: string;
+      bucket: string;
+      intentToken: string;
+    }
+  | { success: false; error: string; status: 400 | 401 | 404 | 413 | 500 };
 
 export type ConfirmAdminUploadResult =
   | { success: true }
@@ -47,6 +56,8 @@ export type ConfirmAdminUploadParams = {
   mimeType: string;
   fileSize: number;
   fileId: string;
+  uploadIntentToken: string;
+  storageContentType?: string;
   uploadedBucket?: string;
   category?: 'evidence' | 'legal';
 };
@@ -98,7 +109,7 @@ function revalidateAdminEvidencePaths(claimId: string) {
 export async function generateAdminUploadUrl(
   claimId: string,
   fileName: string,
-  _contentType: string,
+  contentType: string,
   fileSize: number
 ): Promise<GenerateAdminUploadUrlResult> {
   const uploadContext = await resolveAdminUploadContext();
@@ -120,25 +131,30 @@ export async function generateAdminUploadUrl(
   }
 
   return createSignedUploadUrl({
+    actorId: uploadContext.session.user.id,
     bucket: resolvedBucket,
     claimId,
     fileName,
     fileSize,
     logPrefix: '[admin/claims]',
+    mimeType: contentType,
     tenantId,
   });
 }
 
-export async function confirmAdminUpload({
-  claimId,
-  storagePath,
-  originalName,
-  mimeType,
-  fileSize,
-  fileId,
-  uploadedBucket,
-  category = 'evidence',
-}: ConfirmAdminUploadParams): Promise<ConfirmAdminUploadResult> {
+export async function confirmAdminUpload(
+  params: ConfirmAdminUploadParams
+): Promise<ConfirmAdminUploadResult> {
+  const {
+    claimId,
+    storagePath,
+    originalName,
+    mimeType,
+    fileSize,
+    fileId,
+    uploadedBucket,
+    category = 'evidence',
+  } = params;
   const uploadContext = await resolveAdminUploadContext();
   if (!uploadContext.success) {
     return uploadContext;
@@ -164,6 +180,18 @@ export async function confirmAdminUpload({
         error: 'Upload bucket mismatch detected. Please retry upload.',
         status: 409,
       };
+    }
+
+    const validatedUpload = await validateConfirmedClaimUpload({
+      actorId: session.user.id,
+      bucket: resolvedBucket,
+      confirmation: params,
+      logPrefix: '[admin/claims] confirmAdminUpload',
+      tenantId,
+    });
+
+    if (!validatedUpload.success) {
+      return validatedUpload;
     }
 
     await persistClaimDocumentAndQueueWorkflows({

--- a/apps/web/src/features/claims/components/SharedEvidenceUploadDialog.tsx
+++ b/apps/web/src/features/claims/components/SharedEvidenceUploadDialog.tsx
@@ -35,6 +35,7 @@ type UploadUrlSuccess = {
   bucket: string;
   path: string;
   token: string;
+  intentToken: string;
   id: string;
 };
 
@@ -66,6 +67,8 @@ type ConfirmUploadFn = (params: {
   mimeType: string;
   fileSize: number;
   fileId: string;
+  uploadIntentToken: string;
+  storageContentType?: string;
   uploadedBucket: string;
   category: EvidenceCategory;
 }) => Promise<ConfirmUploadSuccess | ConfirmUploadFailure>;
@@ -202,6 +205,8 @@ export function SharedEvidenceUploadDialog({
       mimeType: resolvedMimeType,
       fileSize: selectedFile.size,
       fileId: uploadUrlResult.id,
+      uploadIntentToken: uploadUrlResult.intentToken,
+      storageContentType,
       uploadedBucket: uploadUrlResult.bucket,
       category: selectedCategory,
     });

--- a/apps/web/src/features/claims/components/shared-evidence-upload-dialog.test-helpers.tsx
+++ b/apps/web/src/features/claims/components/shared-evidence-upload-dialog.test-helpers.tsx
@@ -45,6 +45,7 @@ export function runSharedEvidenceUploadDialogTests({
         bucket: 'claim-evidence',
         path: 'pii/tenants/t1/claims/c1/file.pdf',
         token: 'signed-token',
+        intentToken: 'upload-intent-token',
         id: 'file-id',
       });
       uploadMocks.uploadToSignedUrl.mockResolvedValue({ error: null });
@@ -97,6 +98,8 @@ export function runSharedEvidenceUploadDialogTests({
           mimeType: 'application/pdf',
           fileSize: file.size,
           fileId: 'file-id',
+          uploadIntentToken: 'upload-intent-token',
+          storageContentType: 'application/pdf',
           uploadedBucket: 'claim-evidence',
           category: 'evidence',
         });

--- a/apps/web/src/features/claims/upload/server/shared-upload.ts
+++ b/apps/web/src/features/claims/upload/server/shared-upload.ts
@@ -6,11 +6,13 @@ import { LOCALES } from '@/i18n/locales';
 import { claimDocuments, db } from '@interdomestik/database';
 import { queueClaimDocumentAiWorkflows } from '@interdomestik/domain-claims/claims/ai-workflows';
 import { createClient } from '@supabase/supabase-js';
-import { randomUUID } from 'crypto';
+import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
 import { revalidatePath } from 'next/cache';
 
 const SIGNED_UPLOAD_MAX_ATTEMPTS = 3;
 const SIGNED_UPLOAD_RETRY_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 250;
+const CLAIM_UPLOAD_MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+const CLAIM_UPLOAD_INTENT_TTL_MS = 15 * 60 * 1000;
 const TRANSIENT_UPLOAD_ERROR_PATTERNS = [
   /fetch failed/i,
   /network/i,
@@ -27,8 +29,44 @@ const TRANSIENT_UPLOAD_ERROR_PATTERNS = [
 export type UploadCategory = 'evidence' | 'legal';
 
 export type SharedGenerateUploadUrlResult =
-  | { success: true; url: string; path: string; id: string; token: string; bucket: string }
-  | { success: false; error: string; status: 413 | 500 };
+  | {
+      success: true;
+      url: string;
+      path: string;
+      id: string;
+      token: string;
+      bucket: string;
+      intentToken: string;
+    }
+  | { success: false; error: string; status: 400 | 413 | 500 };
+
+type ClaimUploadIntentPayload = {
+  actorId: string;
+  bucket: string;
+  claimId: string;
+  expiresAt: number;
+  fileId: string;
+  fileSize: number;
+  mimeType: string;
+  storageContentType: string;
+  storagePath: string;
+  tenantId: string;
+  v: 1;
+};
+
+export type ConfirmedUploadValidationResult =
+  | { success: true }
+  | { success: false; error: string; status: 409 | 500 };
+
+export type ClaimUploadConfirmationInput = {
+  claimId: string;
+  fileId: string;
+  fileSize: number;
+  mimeType: string;
+  storageContentType?: string;
+  storagePath: string;
+  uploadIntentToken: string;
+};
 
 function shouldRetrySignedUpload(message: string): boolean {
   return TRANSIENT_UPLOAD_ERROR_PATTERNS.some(pattern => pattern.test(message));
@@ -46,32 +84,332 @@ export function revalidatePathForAllLocales(path: string) {
   }
 }
 
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+function base64UrlDecode(value: string): string {
+  return Buffer.from(value, 'base64url').toString('utf8');
+}
+
+function getClaimUploadIntentSecret(): string {
+  const secret = process.env.CLAIM_UPLOAD_INTENT_SECRET ?? process.env.BETTER_AUTH_SECRET;
+
+  if (!secret || secret.length < 24) {
+    throw new Error('CLAIM_UPLOAD_INTENT_SECRET or BETTER_AUTH_SECRET is required for uploads');
+  }
+
+  return secret;
+}
+
+function signUploadIntentPayload(encodedPayload: string): string {
+  return createHmac('sha256', getClaimUploadIntentSecret())
+    .update(encodedPayload)
+    .digest('base64url');
+}
+
+function safeCompare(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
+
+  return aBuffer.length === bBuffer.length && timingSafeEqual(aBuffer, bBuffer);
+}
+
+export function sanitizeClaimUploadExtension(fileName: string): string {
+  const ext =
+    fileName
+      .split('.')
+      .pop()
+      ?.toLowerCase()
+      .replaceAll(/[^a-z0-9]/g, '') || 'bin';
+  return ext.slice(0, 16) || 'bin';
+}
+
+function expectedUploadPath(params: {
+  claimId: string;
+  fileId: string;
+  storagePath: string;
+  tenantId: string;
+}): boolean {
+  const { claimId, fileId, storagePath, tenantId } = params;
+  const expectedPrefix = `pii/tenants/${tenantId}/claims/${claimId}/${fileId}.`;
+
+  return (
+    storagePath.startsWith(expectedPrefix) &&
+    !storagePath.includes('..') &&
+    storagePath.split('/').length === 6
+  );
+}
+
+export function createClaimUploadIntentToken(params: {
+  actorId: string;
+  bucket: string;
+  claimId: string;
+  fileId: string;
+  fileSize: number;
+  mimeType: string;
+  storageContentType?: string;
+  storagePath: string;
+  tenantId: string;
+}): string {
+  const payload: ClaimUploadIntentPayload = {
+    ...params,
+    expiresAt: Date.now() + CLAIM_UPLOAD_INTENT_TTL_MS,
+    storageContentType: params.storageContentType ?? params.mimeType,
+    v: 1,
+  };
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = signUploadIntentPayload(encodedPayload);
+
+  return `${encodedPayload}.${signature}`;
+}
+
+function verifyClaimUploadIntentToken(params: {
+  actorId: string;
+  bucket: string;
+  claimId: string;
+  fileId: string;
+  fileSize: number;
+  intentToken: string;
+  mimeType: string;
+  storageContentType?: string;
+  storagePath: string;
+  tenantId: string;
+}): ConfirmedUploadValidationResult {
+  const { intentToken, ...expected } = params;
+  const tokenParts = intentToken.split('.');
+
+  if (tokenParts.length !== 2) {
+    return {
+      success: false,
+      error: 'Upload confirmation expired. Please retry upload.',
+      status: 409,
+    };
+  }
+
+  const [encodedPayload, signature] = tokenParts;
+
+  const expectedSignature = signUploadIntentPayload(encodedPayload);
+  if (!safeCompare(signature, expectedSignature)) {
+    return {
+      success: false,
+      error: 'Upload confirmation expired. Please retry upload.',
+      status: 409,
+    };
+  }
+
+  let payload: ClaimUploadIntentPayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(encodedPayload)) as ClaimUploadIntentPayload;
+  } catch {
+    return {
+      success: false,
+      error: 'Upload confirmation expired. Please retry upload.',
+      status: 409,
+    };
+  }
+
+  if (
+    payload.v !== 1 ||
+    payload.expiresAt < Date.now() ||
+    payload.actorId !== expected.actorId ||
+    payload.bucket !== expected.bucket ||
+    payload.claimId !== expected.claimId ||
+    payload.fileId !== expected.fileId ||
+    payload.fileSize !== expected.fileSize ||
+    payload.mimeType !== expected.mimeType ||
+    payload.storageContentType !== (expected.storageContentType ?? expected.mimeType) ||
+    payload.storagePath !== expected.storagePath ||
+    payload.tenantId !== expected.tenantId
+  ) {
+    return {
+      success: false,
+      error: 'Upload confirmation expired. Please retry upload.',
+      status: 409,
+    };
+  }
+
+  return { success: true };
+}
+
+function getSupabaseStorageClient(logPrefix: string) {
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    console.error(`${logPrefix} missing Supabase configuration`);
+    return null;
+  }
+
+  return createClient(supabaseUrl, supabaseServiceKey);
+}
+
+function numberFromMetadata(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function stringFromMetadata(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function getObjectMetadataValue(metadata: Record<string, unknown>, keys: string[]): unknown {
+  for (const key of keys) {
+    if (metadata[key] !== undefined) return metadata[key];
+  }
+
+  return undefined;
+}
+
+async function validateStoredObject(params: {
+  bucket: string;
+  fileSize: number;
+  logPrefix: string;
+  mimeType: string;
+  storagePath: string;
+}): Promise<ConfirmedUploadValidationResult> {
+  const { bucket, fileSize, logPrefix, mimeType, storagePath } = params;
+  const lastSlashIndex = storagePath.lastIndexOf('/');
+  const folder = storagePath.slice(0, lastSlashIndex);
+  const fileName = storagePath.slice(lastSlashIndex + 1);
+  const supabase = getSupabaseStorageClient(logPrefix);
+
+  if (!supabase) {
+    return { success: false, error: 'Configuration error', status: 500 };
+  }
+
+  const { data, error } = await supabase.storage.from(bucket).list(folder, {
+    limit: 100,
+    search: fileName,
+  });
+
+  if (error) {
+    console.error(`${logPrefix} storage object verification failed`, {
+      bucket,
+      storagePath,
+      detail: error.message,
+    });
+    return { success: false, error: 'Failed to verify uploaded file', status: 500 };
+  }
+
+  const storedObject = data?.find(object => object.name === fileName);
+  if (!storedObject) {
+    return {
+      success: false,
+      error: 'Uploaded file was not found. Please retry upload.',
+      status: 409,
+    };
+  }
+
+  const metadata = (storedObject.metadata ?? {}) as Record<string, unknown>;
+  const storedSize = numberFromMetadata(
+    getObjectMetadataValue(metadata, ['size', 'contentLength', 'content_length'])
+  );
+  const storedMimeType = stringFromMetadata(
+    getObjectMetadataValue(metadata, ['mimetype', 'mimeType', 'contentType', 'content_type'])
+  );
+
+  if (storedSize !== fileSize || storedMimeType !== mimeType) {
+    return {
+      success: false,
+      error: 'Uploaded file metadata mismatch. Please retry upload.',
+      status: 409,
+    };
+  }
+
+  return { success: true };
+}
+
+export async function validateConfirmedClaimUpload(params: {
+  actorId: string;
+  bucket: string;
+  confirmation: ClaimUploadConfirmationInput;
+  logPrefix: string;
+  tenantId: string;
+}): Promise<ConfirmedUploadValidationResult> {
+  const { actorId, bucket, confirmation, logPrefix, tenantId } = params;
+  const {
+    claimId,
+    fileId,
+    fileSize,
+    mimeType,
+    storageContentType,
+    storagePath,
+    uploadIntentToken,
+  } = confirmation;
+
+  if (
+    !Number.isSafeInteger(fileSize) ||
+    fileSize <= 0 ||
+    fileSize > CLAIM_UPLOAD_MAX_FILE_SIZE_BYTES ||
+    !expectedUploadPath({ claimId, fileId, storagePath, tenantId })
+  ) {
+    return {
+      success: false,
+      error: 'Uploaded file metadata mismatch. Please retry upload.',
+      status: 409,
+    };
+  }
+
+  const intentResult = verifyClaimUploadIntentToken({
+    actorId,
+    bucket,
+    claimId,
+    fileId,
+    fileSize,
+    intentToken: uploadIntentToken,
+    mimeType,
+    storageContentType,
+    storagePath,
+    tenantId,
+  });
+
+  if (!intentResult.success) {
+    return intentResult;
+  }
+
+  return validateStoredObject({
+    bucket,
+    fileSize,
+    logPrefix,
+    mimeType: storageContentType ?? mimeType,
+    storagePath,
+  });
+}
+
 export async function createSignedUploadUrl(params: {
+  actorId: string;
   bucket: string;
   claimId: string;
   fileName: string;
   fileSize: number;
   logPrefix: string;
+  mimeType: string;
   tenantId: string;
 }): Promise<SharedGenerateUploadUrlResult> {
-  const { bucket, claimId, fileName, fileSize, logPrefix, tenantId } = params;
+  const { actorId, bucket, claimId, fileName, fileSize, logPrefix, mimeType, tenantId } = params;
 
-  if (fileSize > 50 * 1024 * 1024) {
+  if (!Number.isSafeInteger(fileSize) || fileSize <= 0) {
+    return { success: false, error: 'Invalid file size', status: 400 };
+  }
+
+  if (fileSize > CLAIM_UPLOAD_MAX_FILE_SIZE_BYTES) {
     return { success: false, error: 'File too large (max 50MB)', status: 413 };
   }
 
-  const ext = fileName.split('.').pop() || 'bin';
+  const ext = sanitizeClaimUploadExtension(fileName);
   const fileId = randomUUID();
   const path = `pii/tenants/${tenantId}/claims/${claimId}/${fileId}.${ext}`;
-  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const supabase = getSupabaseStorageClient(logPrefix);
 
-  if (!supabaseUrl || !supabaseServiceKey) {
-    console.error('Missing Supabase configuration');
+  if (!supabase) {
     return { success: false, error: 'Configuration error', status: 500 };
   }
-
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
   try {
     for (let attempt = 1; attempt <= SIGNED_UPLOAD_MAX_ATTEMPTS; attempt += 1) {
@@ -87,6 +425,16 @@ export async function createSignedUploadUrl(params: {
           id: fileId,
           token: data.token,
           bucket,
+          intentToken: createClaimUploadIntentToken({
+            actorId,
+            bucket,
+            claimId,
+            fileId,
+            fileSize,
+            mimeType,
+            storagePath: path,
+            tenantId,
+          }),
         };
       }
 

--- a/apps/web/src/features/member/claims/actions.test.ts
+++ b/apps/web/src/features/member/claims/actions.test.ts
@@ -11,6 +11,7 @@ const hoisted = vi.hoisted(() => {
     resolveEvidenceBucketName: vi.fn(),
     findClaimFirst: vi.fn(),
     createSignedUploadUrl: vi.fn(),
+    listStorageObjects: vi.fn(),
     storageFrom: vi.fn(),
     insertValues: vi.fn(),
     insert: vi.fn(),
@@ -88,7 +89,47 @@ vi.mock('next/cache', () => ({
   revalidatePath: hoisted.revalidatePath,
 }));
 
+import { createClaimUploadIntentToken } from '@/features/claims/upload/server/shared-upload';
 import { confirmUpload, generateUploadUrl } from './actions';
+
+function createUploadIntent(
+  overrides: Partial<{
+    actorId: string;
+    bucket: string;
+    claimId: string;
+    fileId: string;
+    fileSize: number;
+    mimeType: string;
+    storagePath: string;
+    tenantId: string;
+  }> = {}
+) {
+  return createClaimUploadIntentToken({
+    actorId: 'member-1',
+    bucket: 'claim-evidence',
+    claimId: 'claim-1',
+    fileId: 'uuid-1',
+    fileSize: 1024,
+    mimeType: 'application/pdf',
+    storagePath: 'pii/tenants/tenant-1/claims/claim-1/uuid-1.pdf',
+    tenantId: 'tenant-1',
+    ...overrides,
+  });
+}
+
+function createConfirmUploadParams(overrides: Partial<Parameters<typeof confirmUpload>[0]> = {}) {
+  return {
+    claimId: 'claim-1',
+    storagePath: 'pii/tenants/tenant-1/claims/claim-1/uuid-1.pdf',
+    originalName: 'evidence.pdf',
+    mimeType: 'application/pdf',
+    fileSize: 1024,
+    fileId: 'uuid-1',
+    uploadIntentToken: createUploadIntent(),
+    uploadedBucket: 'claim-evidence',
+    ...overrides,
+  };
+}
 
 describe('member claim upload actions', () => {
   beforeEach(() => {
@@ -103,9 +144,19 @@ describe('member claim upload actions', () => {
     hoisted.findClaimFirst.mockResolvedValue({ id: 'claim-1', userId: 'member-1' });
     hoisted.storageFrom.mockReturnValue({
       createSignedUploadUrl: hoisted.createSignedUploadUrl,
+      list: hoisted.listStorageObjects,
     });
     hoisted.createSignedUploadUrl.mockResolvedValue({
       data: { signedUrl: 'https://signed.example.com/upload', token: 'upload-token-1' },
+      error: null,
+    });
+    hoisted.listStorageObjects.mockResolvedValue({
+      data: [
+        {
+          name: 'uuid-1.pdf',
+          metadata: { size: 1024, mimetype: 'application/pdf' },
+        },
+      ],
       error: null,
     });
     hoisted.insert.mockReturnValue({
@@ -128,6 +179,7 @@ describe('member claim upload actions', () => {
 
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://supabase.example.com');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
+    vi.stubEnv('BETTER_AUTH_SECRET', 'upload-intent-test-secret-32-chars-minimum');
   });
 
   it('creates an upload URL for claims owned by the member', async () => {
@@ -140,6 +192,13 @@ describe('member claim upload actions', () => {
       })
     );
     expect(hoisted.createSignedUploadUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects invalid signed upload file sizes before storage URL creation', async () => {
+    const result = await generateUploadUrl('claim-1', 'evidence.pdf', 'application/pdf', 0);
+
+    expect(result).toEqual({ success: false, error: 'Invalid file size', status: 400 });
+    expect(hoisted.createSignedUploadUrl).not.toHaveBeenCalled();
   });
 
   it('retries transient signed upload URL failures before succeeding', async () => {
@@ -216,15 +275,7 @@ describe('member claim upload actions', () => {
   it('denies confirmUpload when claim is not owned by the member', async () => {
     hoisted.findClaimFirst.mockResolvedValue(null);
 
-    const result = await confirmUpload({
-      claimId: 'claim-1',
-      storagePath: 'pii/tenants/tenant-1/claims/claim-1/uuid-1.pdf',
-      originalName: 'evidence.pdf',
-      mimeType: 'application/pdf',
-      fileSize: 1024,
-      fileId: 'uuid-1',
-      uploadedBucket: 'claim-evidence',
-    });
+    const result = await confirmUpload(createConfirmUploadParams());
 
     expect(result).toEqual({ success: false, error: 'Claim not found', status: 404 });
     expect(hoisted.insert).not.toHaveBeenCalled();
@@ -238,17 +289,61 @@ describe('member claim upload actions', () => {
     });
   });
 
-  it('queues a legal-document ai run after confirming the upload metadata', async () => {
-    const result = await confirmUpload({
-      claimId: 'claim-1',
-      storagePath: 'pii/tenants/tenant-1/claims/claim-1/uuid-1.pdf',
-      originalName: 'demand-letter.pdf',
-      mimeType: 'application/pdf',
-      fileSize: 1024,
-      fileId: 'uuid-1',
-      uploadedBucket: 'claim-evidence',
-      category: 'legal',
+  it('rejects forged upload metadata before persisting the document', async () => {
+    const result = await confirmUpload(
+      createConfirmUploadParams({
+        storagePath: 'pii/tenants/tenant-1/claims/claim-1/uuid-2.pdf',
+        fileId: 'uuid-2',
+      })
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Upload confirmation expired. Please retry upload.',
+      status: 409,
     });
+    expect(hoisted.insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects upload intent tokens with extra segments before storage verification', async () => {
+    const result = await confirmUpload(
+      createConfirmUploadParams({ uploadIntentToken: `${createUploadIntent()}.extra` })
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Upload confirmation expired. Please retry upload.',
+      status: 409,
+    });
+    expect(hoisted.listStorageObjects).not.toHaveBeenCalled();
+    expect(hoisted.insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects confirmation when the uploaded object metadata does not match the intent', async () => {
+    hoisted.listStorageObjects.mockResolvedValueOnce({
+      data: [
+        {
+          name: 'uuid-1.pdf',
+          metadata: { size: 2048, mimetype: 'application/pdf' },
+        },
+      ],
+      error: null,
+    });
+
+    const result = await confirmUpload(createConfirmUploadParams());
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Uploaded file metadata mismatch. Please retry upload.',
+      status: 409,
+    });
+    expect(hoisted.insert).not.toHaveBeenCalled();
+  });
+
+  it('queues a legal-document ai run after confirming the upload metadata', async () => {
+    const result = await confirmUpload(
+      createConfirmUploadParams({ originalName: 'demand-letter.pdf', category: 'legal' })
+    );
 
     expect(result).toEqual({ success: true });
     expect(hoisted.transaction).toHaveBeenCalledTimes(2);
@@ -286,16 +381,7 @@ describe('member claim upload actions', () => {
   it('keeps the upload persisted when ai queueing fails after metadata is saved', async () => {
     hoisted.queueClaimDocumentAiWorkflows.mockRejectedValueOnce(new Error('ai queue unavailable'));
 
-    const result = await confirmUpload({
-      claimId: 'claim-1',
-      storagePath: 'pii/tenants/tenant-1/claims/claim-1/uuid-1.pdf',
-      originalName: 'evidence.pdf',
-      mimeType: 'application/pdf',
-      fileSize: 1024,
-      fileId: 'uuid-1',
-      uploadedBucket: 'claim-evidence',
-      category: 'evidence',
-    });
+    const result = await confirmUpload(createConfirmUploadParams({ category: 'evidence' }));
 
     expect(result).toEqual({ success: true });
     expect(hoisted.insert).toHaveBeenCalledWith('claim_documents');

--- a/apps/web/src/features/member/claims/actions.ts
+++ b/apps/web/src/features/member/claims/actions.ts
@@ -5,6 +5,7 @@ import {
   createSignedUploadUrl,
   persistClaimDocumentAndQueueWorkflows,
   revalidatePathForAllLocales,
+  validateConfirmedClaimUpload,
 } from '@/features/claims/upload/server/shared-upload';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
 import { claims, db } from '@interdomestik/database';
@@ -13,13 +14,21 @@ import { and, eq } from 'drizzle-orm';
 import { headers } from 'next/headers';
 
 export type GenerateUploadUrlResult =
-  | { success: true; url: string; path: string; id: string; token: string; bucket: string }
-  | { success: false; error: string; status: 401 | 404 | 413 | 500 };
+  | {
+      success: true;
+      url: string;
+      path: string;
+      id: string;
+      token: string;
+      bucket: string;
+      intentToken: string;
+    }
+  | { success: false; error: string; status: 400 | 401 | 404 | 413 | 500 };
 
 export async function generateUploadUrl(
   claimId: string,
   fileName: string,
-  _contentType: string,
+  contentType: string,
   fileSize: number
 ): Promise<GenerateUploadUrlResult> {
   const session = await auth.api.getSession({
@@ -58,11 +67,13 @@ export async function generateUploadUrl(
   }
 
   return createSignedUploadUrl({
+    actorId: session.user.id,
     bucket: evidenceBucket,
     claimId,
     fileName,
     fileSize,
     logPrefix: '[member/claims]',
+    mimeType: contentType,
     tenantId,
   });
 }
@@ -78,6 +89,8 @@ export type ConfirmUploadParams = {
   mimeType: string;
   fileSize: number;
   fileId: string;
+  uploadIntentToken: string;
+  storageContentType?: string;
   uploadedBucket?: string;
   category?: 'evidence' | 'legal';
 };
@@ -118,16 +131,17 @@ async function resolveConfirmUploadContext(): Promise<ConfirmUploadContext> {
   }
 }
 
-export async function confirmUpload({
-  claimId,
-  storagePath,
-  originalName,
-  mimeType,
-  fileSize,
-  fileId,
-  uploadedBucket,
-  category = 'evidence',
-}: ConfirmUploadParams): Promise<ConfirmUploadResult> {
+export async function confirmUpload(params: ConfirmUploadParams): Promise<ConfirmUploadResult> {
+  const {
+    claimId,
+    storagePath,
+    originalName,
+    mimeType,
+    fileSize,
+    fileId,
+    uploadedBucket,
+    category = 'evidence',
+  } = params;
   const uploadContext = await resolveConfirmUploadContext();
   if (!uploadContext.success) {
     return uploadContext;
@@ -158,6 +172,18 @@ export async function confirmUpload({
         error: 'Upload bucket mismatch detected. Please retry upload.',
         status: 409,
       };
+    }
+
+    const validatedUpload = await validateConfirmedClaimUpload({
+      actorId: session.user.id,
+      bucket: resolvedBucket,
+      confirmation: params,
+      logPrefix: '[member/claims] confirmUpload',
+      tenantId,
+    });
+
+    if (!validatedUpload.success) {
+      return validatedUpload;
     }
 
     await persistClaimDocumentAndQueueWorkflows({

--- a/packages/domain-activities/src/get-member.test.ts
+++ b/packages/domain-activities/src/get-member.test.ts
@@ -1,25 +1,48 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
   execute: vi.fn(),
+  findAssignment: vi.fn(),
+  findMember: vi.fn(),
   findMany: vi.fn(),
+  eq: vi.fn((...args: unknown[]) => ({ op: 'eq', left: args[0], right: args[1] })),
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  and: (...args: unknown[]) => mocks.and(...args),
   db: {
     execute: (...args: unknown[]) => mocks.execute(...args),
     query: {
+      agentClients: {
+        findFirst: (...args: unknown[]) => mocks.findAssignment(...args),
+      },
+      user: {
+        findFirst: (...args: unknown[]) => mocks.findMember(...args),
+      },
       memberActivities: {
         findMany: (...args: unknown[]) => mocks.findMany(...args),
       },
     },
   },
   // Minimal shape for query builder inputs
+  agentClients: {
+    id: 'agentClients.id',
+    tenantId: 'agentClients.tenantId',
+    agentId: 'agentClients.agentId',
+    memberId: 'agentClients.memberId',
+    status: 'agentClients.status',
+  },
   desc: (x: unknown) => x,
-  eq: (..._args: unknown[]) => ({}),
+  eq: (...args: unknown[]) => mocks.eq(...args),
   memberActivities: {
     memberId: 'memberActivities.memberId',
+    tenantId: 'memberActivities.tenantId',
     occurredAt: 'memberActivities.occurredAt',
+  },
+  user: {
+    id: 'user.id',
+    tenantId: 'user.tenantId',
   },
 }));
 
@@ -27,6 +50,12 @@ describe('getMemberActivitiesCore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    mocks.findMember.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      agentId: 'agent-1',
+    });
+    mocks.findAssignment.mockResolvedValue(null);
   });
 
   it('returns [] without querying when member_activities table is absent', async () => {
@@ -43,7 +72,7 @@ describe('getMemberActivitiesCore', () => {
     expect(mocks.findMany).not.toHaveBeenCalled();
   });
 
-  it('queries and returns activities when member_activities table exists', async () => {
+  it('queries tenant-scoped activities for the assigned agent', async () => {
     mocks.execute.mockResolvedValue([{ regclass: 'member_activities' }]);
     mocks.findMany.mockResolvedValue([{ id: 'a1' }]);
 
@@ -55,6 +84,128 @@ describe('getMemberActivitiesCore', () => {
     });
 
     expect(mocks.findMany).toHaveBeenCalled();
+    expect(mocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          op: 'and',
+          args: expect.arrayContaining([
+            expect.objectContaining({
+              op: 'eq',
+              left: 'memberActivities.memberId',
+              right: 'member-1',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: 'memberActivities.tenantId',
+              right: 'tenant-1',
+            }),
+          ]),
+        }),
+      })
+    );
     expect(result).toEqual([{ id: 'a1' }]);
+  });
+
+  it('denies unassigned agent reads before querying activities', async () => {
+    mocks.execute.mockResolvedValue([{ regclass: 'member_activities' }]);
+    mocks.findMember.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      agentId: 'agent-2',
+    });
+
+    const { getMemberActivitiesCore } = await import('./get-member');
+
+    await expect(
+      getMemberActivitiesCore({
+        session: { user: { id: 'agent-1', role: 'agent', tenantId: 'tenant-1' } },
+        memberId: 'member-1',
+      })
+    ).rejects.toThrow('Permission denied');
+
+    expect(mocks.findMany).not.toHaveBeenCalled();
+  });
+
+  it('allows active agent-client assignments when user.agentId is not mirrored', async () => {
+    mocks.execute.mockResolvedValue([{ regclass: 'member_activities' }]);
+    mocks.findMember.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      agentId: 'legacy-agent',
+    });
+    mocks.findAssignment.mockResolvedValue({
+      id: 'assignment-1',
+    });
+    mocks.findMany.mockResolvedValue([{ id: 'a1' }]);
+
+    const { getMemberActivitiesCore } = await import('./get-member');
+
+    const result = await getMemberActivitiesCore({
+      session: { user: { id: 'agent-1', role: 'agent', tenantId: 'tenant-1' } },
+      memberId: 'member-1',
+    });
+
+    expect(result).toEqual([{ id: 'a1' }]);
+    expect(mocks.findAssignment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          op: 'and',
+          args: expect.arrayContaining([
+            expect.objectContaining({
+              op: 'eq',
+              left: 'agentClients.tenantId',
+              right: 'tenant-1',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: 'agentClients.agentId',
+              right: 'agent-1',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: 'agentClients.memberId',
+              right: 'member-1',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: 'agentClients.status',
+              right: 'active',
+            }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('skips member lookup for self-service member reads', async () => {
+    mocks.execute.mockResolvedValue([{ regclass: 'member_activities' }]);
+    mocks.findMany.mockResolvedValue([{ id: 'a1' }]);
+
+    const { getMemberActivitiesCore } = await import('./get-member');
+
+    const result = await getMemberActivitiesCore({
+      session: { user: { id: 'member-1', role: 'member', tenantId: 'tenant-1' } },
+      memberId: 'member-1',
+    });
+
+    expect(result).toEqual([{ id: 'a1' }]);
+    expect(mocks.findMember).not.toHaveBeenCalled();
+    expect(mocks.findAssignment).not.toHaveBeenCalled();
+  });
+
+  it('denies cross-tenant reads before querying activities', async () => {
+    mocks.execute.mockResolvedValue([{ regclass: 'member_activities' }]);
+    mocks.findMember.mockResolvedValue(null);
+
+    const { getMemberActivitiesCore } = await import('./get-member');
+
+    await expect(
+      getMemberActivitiesCore({
+        session: { user: { id: 'agent-1', role: 'agent', tenantId: 'tenant-1' } },
+        memberId: 'member-1',
+      })
+    ).rejects.toThrow('Permission denied');
+
+    expect(mocks.findMany).not.toHaveBeenCalled();
   });
 });

--- a/packages/domain-activities/src/get-member.ts
+++ b/packages/domain-activities/src/get-member.ts
@@ -1,9 +1,12 @@
-import { db, desc, eq, memberActivities } from '@interdomestik/database';
+import { agentClients, and, db, desc, eq, memberActivities, user } from '@interdomestik/database';
 import { sql } from 'drizzle-orm';
 
 import type { ActivitySession } from './types';
 
 let memberActivitiesTableExists: Promise<boolean> | null = null;
+type TenantActivitySession = ActivitySession & {
+  user: ActivitySession['user'] & { tenantId: string };
+};
 
 async function hasMemberActivitiesTable(): Promise<boolean> {
   // Avoid triggering noisy production errors when a tenant DB is missing this optional table.
@@ -23,40 +26,113 @@ async function hasMemberActivitiesTable(): Promise<boolean> {
   return memberActivitiesTableExists;
 }
 
+function assertReadableSession(
+  session: ActivitySession | null,
+  memberId: string
+): asserts session is TenantActivitySession {
+  if (!session) {
+    throw new Error('Unauthorized');
+  }
+
+  if (!session.user.tenantId) {
+    throw new Error('Missing tenantId');
+  }
+
+  if (session.user.role === 'member' && session.user.id !== memberId) {
+    throw new Error('Permission denied');
+  }
+}
+
+async function findTenantMember(memberId: string, tenantId: string) {
+  return db.query.user.findFirst({
+    where: and(eq(user.id, memberId), eq(user.tenantId, tenantId)),
+    columns: {
+      id: true,
+      tenantId: true,
+      agentId: true,
+    },
+  });
+}
+
+async function findActiveAgentAssignment(params: {
+  agentId: string;
+  memberId: string;
+  tenantId: string;
+}) {
+  return db.query.agentClients.findFirst({
+    where: and(
+      eq(agentClients.tenantId, params.tenantId),
+      eq(agentClients.agentId, params.agentId),
+      eq(agentClients.memberId, params.memberId),
+      eq(agentClients.status, 'active')
+    ),
+    columns: {
+      id: true,
+    },
+  });
+}
+
+async function assertNonMemberReadAccess(session: TenantActivitySession, memberId: string) {
+  if (session.user.role === 'member') {
+    return;
+  }
+
+  const member = await findTenantMember(memberId, session.user.tenantId);
+  if (!member) {
+    throw new Error('Permission denied');
+  }
+
+  if (session.user.role !== 'agent' || member.agentId === session.user.id) {
+    return;
+  }
+
+  const assignment = await findActiveAgentAssignment({
+    agentId: session.user.id,
+    memberId,
+    tenantId: session.user.tenantId,
+  });
+
+  if (!assignment) {
+    throw new Error('Permission denied');
+  }
+}
+
+async function findMemberActivities(memberId: string, tenantId: string) {
+  return db.query.memberActivities.findMany({
+    where: and(eq(memberActivities.memberId, memberId), eq(memberActivities.tenantId, tenantId)),
+    orderBy: [desc(memberActivities.occurredAt)],
+    with: {
+      agent: {
+        columns: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+    },
+  });
+}
+
 export async function getMemberActivitiesCore(params: {
   session: ActivitySession | null;
   memberId: string;
 }) {
   const { session, memberId } = params;
 
-  if (!session) {
-    throw new Error('Unauthorized');
-  }
-
-  if (session.user.role === 'member' && session.user.id !== memberId) {
-    throw new Error('Permission denied');
-  }
+  assertReadableSession(session, memberId);
 
   try {
     if (!(await hasMemberActivitiesTable())) {
       return [];
     }
 
-    const activities = await db.query.memberActivities.findMany({
-      where: eq(memberActivities.memberId, memberId),
-      orderBy: [desc(memberActivities.occurredAt)],
-      with: {
-        agent: {
-          columns: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-      },
-    });
-    return activities;
+    await assertNonMemberReadAccess(session, memberId);
+    return findMemberActivities(memberId, session.user.tenantId);
   } catch (error) {
+    if (error instanceof Error && error.message === 'Permission denied') {
+      throw error;
+    }
+
     // Activities are non-critical for pilot flows; avoid polluting production error logs.
     console.warn('Failed to fetch activities:', error);
     return [];


### PR DESCRIPTION
## Summary
- Bind member/admin claim upload confirmation to a server-signed upload intent and verified storage object metadata.
- Sanitize direct-upload storage extensions and reject invalid zero-byte uploads before storage writes.
- Scope member activity reads by tenant and assignment, with member self-read constrained to the current user.

## Reviewer pool
- Security: no must-fix; fixed direct-upload raw extension issue.
- Architecture: no must-fix; moved intent signing before storage upload.
- QA: fixed zero-byte/unsafe-name pre-upload validation and agent assignment coverage.
- Performance: no must-fix; accepted storage-list metadata check for current Supabase adapter.
- Contracts: no findings.

## Verification
- pnpm --filter @interdomestik/web test:unit --run src/app/api/claims/evidence-upload/route.test.ts src/features/member/claims/actions.test.ts src/features/admin/claims/actions/evidence-upload.test.ts
- pnpm --filter @interdomestik/domain-activities test:unit --run src/get-member.test.ts
- pnpm --filter @interdomestik/web type-check
- pnpm --filter @interdomestik/domain-activities type-check
- pnpm --filter @interdomestik/web lint
- pnpm exec prettier --check <changed files>
- pnpm security:guard
- pnpm verify-slice -- --static
- pnpm verify-slice -- --required-gates

Required-gates run root: `/Users/arbenlila/development/interdomestik-crystal-home/tmp/multi-agent/verify-slice/verify-slice-20260424T193644Z-fe0766`