### PR TITLE
feat: migrate active AI defaults to GPT-5.5

### DIFF
--- a/apps/web/src/app/api/policies/analyze/_services.test.ts
+++ b/apps/web/src/app/api/policies/analyze/_services.test.ts
@@ -185,8 +185,8 @@ describe('queuePolicyAnalysisService', () => {
         entityType: 'policy',
         entityId: 'policy-1',
         requestedBy: 'user-1',
-        model: 'gpt-5.4',
-        modelSnapshot: 'gpt-5.4',
+        model: 'gpt-5.5',
+        modelSnapshot: 'gpt-5.5',
         promptVersion: 'policy_extract_v1',
         requestJson: {
           fileName: 'file.pdf',

--- a/apps/web/src/app/api/policies/analyze/_services.ts
+++ b/apps/web/src/app/api/policies/analyze/_services.ts
@@ -170,8 +170,8 @@ export async function queuePolicyAnalysisService(
       entityType: 'policy',
       entityId: policyId,
       requestedBy: data.userId,
-      model: 'gpt-5.4',
-      modelSnapshot: 'gpt-5.4',
+      model: 'gpt-5.5',
+      modelSnapshot: 'gpt-5.5',
       promptVersion: 'policy_extract_v1',
       inputHash: buildPolicyInputHash(data),
       requestJson: {

--- a/packages/domain-ai/src/models.ts
+++ b/packages/domain-ai/src/models.ts
@@ -1,8 +1,8 @@
 import type { AiModel, AiModelProfile, AiWorkflow } from './types';
 
 export const AI_MODEL_PROFILES = {
-  'gpt-5.4': {
-    model: 'gpt-5.4',
+  'gpt-5.5': {
+    model: 'gpt-5.5',
     tier: 'advanced',
     defaultFor: ['policy_extract', 'legal_doc_extract'],
     useCase: 'Ambiguous extraction and reviewed document reasoning.',
@@ -36,9 +36,9 @@ export const AI_MODEL_PROFILES = {
 } as const satisfies Record<AiModel, AiModelProfile>;
 
 export const DEFAULT_MODEL_BY_WORKFLOW = {
-  policy_extract: 'gpt-5.4',
+  policy_extract: 'gpt-5.5',
   claim_intake_extract: 'gpt-5-mini',
-  legal_doc_extract: 'gpt-5.4',
+  legal_doc_extract: 'gpt-5.5',
   claim_summary: 'gpt-5-mini',
 } as const satisfies Record<AiWorkflow, AiModel>;
 

--- a/packages/domain-ai/src/types.ts
+++ b/packages/domain-ai/src/types.ts
@@ -7,7 +7,7 @@ export const AI_WORKFLOWS = [
 
 export type AiWorkflow = (typeof AI_WORKFLOWS)[number];
 
-export const AI_MODELS = ['gpt-5.4', 'gpt-5-mini', 'gpt-5-nano', 'gpt-5.4-pro'] as const;
+export const AI_MODELS = ['gpt-5.5', 'gpt-5-mini', 'gpt-5-nano', 'gpt-5.4-pro'] as const;
 
 export type AiModel = (typeof AI_MODELS)[number];
 

--- a/packages/domain-claims/src/claims/ai-workflows.test.ts
+++ b/packages/domain-claims/src/claims/ai-workflows.test.ts
@@ -8,7 +8,7 @@ const hoisted = vi.hoisted(() => {
 
   return {
     getDefaultModelForWorkflow: vi.fn((workflow: string) =>
-      workflow === 'legal_doc_extract' ? 'gpt-5.4' : 'gpt-5-mini'
+      workflow === 'legal_doc_extract' ? 'gpt-5.5' : 'gpt-5-mini'
     ),
     nanoid: vi.fn().mockReturnValueOnce('run-1').mockReturnValueOnce('run-2'),
     txInsert,
@@ -138,7 +138,7 @@ describe('queueClaimDocumentAiWorkflows', () => {
           id: 'run-2',
           workflow: 'legal_doc_extract',
           documentId: 'legacy-doc-2',
-          model: 'gpt-5.4',
+          model: 'gpt-5.5',
           promptVersion: 'legal_doc_extract_v1',
           requestJson: expect.objectContaining({
             category: 'legal',


### PR DESCRIPTION
## Summary
- Updates the active advanced AI model profile/defaults from `gpt-5.4` to `gpt-5.5`.
- Persists `gpt-5.5` for queued policy extraction runs.
- Updates directly coupled policy and claim AI workflow assertions.

## Scope
- Leaves `gpt-5-mini`, `gpt-5-nano`, historical docs, eval datasets, and manual `gpt-5.4-pro` escalation paths unchanged.
- No routing/auth/tenant/proxy changes.

## Test Plan
- [x] `pnpm pr:verify`
- [x] `pnpm security:guard` (covered by `pr:verify` prerequisites and separately verified before final run)
- [x] E2E PR gate via `pnpm pr:verify` (`e2e:gate:pr:fast`)

## Notes
- Local full verification was run with Node 24.15.0 to match repo `.nvmrc`.
