### PR TITLE
fix: harden tenant-boundary api contracts

### DIFF
--- a/apps/web/src/app/api/ai/reviews/[id]/route.test.ts
+++ b/apps/web/src/app/api/ai/reviews/[id]/route.test.ts
@@ -23,6 +23,14 @@ vi.mock('./_core', () => ({
   submitAiReview: hoisted.submitAiReview,
 }));
 
+function approveReviewRequest(): Request {
+  return new Request('http://localhost:3000/api/ai/reviews/run-1', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ action: 'approve' }),
+  });
+}
+
 describe('POST /api/ai/reviews/[id]', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -32,15 +40,26 @@ describe('POST /api/ai/reviews/[id]', () => {
   it('returns 401 when unauthenticated', async () => {
     hoisted.getSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost:3000/api/ai/reviews/run-1', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'approve' }),
+    const response = await POST(approveReviewRequest(), {
+      params: Promise.resolve({ id: 'run-1' }),
     });
-    const response = await POST(request, { params: Promise.resolve({ id: 'run-1' }) });
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when the session is missing tenant identity', async () => {
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'staff-1', role: 'staff', tenantId: undefined },
+    });
+
+    const response = await POST(approveReviewRequest(), {
+      params: Promise.resolve({ id: 'run-1' }),
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Missing tenant identity' });
+    expect(hoisted.submitAiReview).not.toHaveBeenCalled();
   });
 
   it('returns 403 when caller is not privileged', async () => {
@@ -48,12 +67,9 @@ describe('POST /api/ai/reviews/[id]', () => {
       user: { id: 'member-1', role: 'member', tenantId: 'tenant-1' },
     });
 
-    const request = new Request('http://localhost:3000/api/ai/reviews/run-1', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'approve' }),
+    const response = await POST(approveReviewRequest(), {
+      params: Promise.resolve({ id: 'run-1' }),
     });
-    const response = await POST(request, { params: Promise.resolve({ id: 'run-1' }) });
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
@@ -120,12 +136,9 @@ describe('POST /api/ai/reviews/[id]', () => {
       })
     );
 
-    const request = new Request('http://localhost:3000/api/ai/reviews/run-1', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'approve' }),
+    const response = await POST(approveReviewRequest(), {
+      params: Promise.resolve({ id: 'run-1' }),
     });
-    const response = await POST(request, { params: Promise.resolve({ id: 'run-1' }) });
 
     expect(response.status).toBe(429);
     await expect(response.json()).resolves.toEqual({ error: 'Too many requests' });

--- a/apps/web/src/app/api/ai/reviews/[id]/route.ts
+++ b/apps/web/src/app/api/ai/reviews/[id]/route.ts
@@ -1,3 +1,4 @@
+import { resolveTenantBoundary } from '@/app/api/tenant-boundary';
 import { auth } from '@/lib/auth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { isStaffOrHigher } from '@interdomestik/shared-auth';
@@ -26,8 +27,13 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
 
   const session = await auth.api.getSession({ headers: request.headers });
 
-  if (!session) {
+  if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const tenant = resolveTenantBoundary(session);
+  if (!tenant.success) {
+    return tenant.response;
   }
 
   if (!isPrivilegedRole(session.user.role)) {
@@ -46,7 +52,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   const { id } = await params;
   const result = await submitAiReview({
     runId: id,
-    tenantId: session.user.tenantId,
+    tenantId: tenant.tenantId,
     reviewerId: session.user.id,
     reviewerRole: session.user.role,
     action: body.action,

--- a/apps/web/src/app/api/ai/runs/[id]/route.test.ts
+++ b/apps/web/src/app/api/ai/runs/[id]/route.test.ts
@@ -23,6 +23,10 @@ vi.mock('@interdomestik/domain-ai', () => ({
   getAiRun: hoisted.getAiRun,
 }));
 
+function runRequest(): Request {
+  return new Request('http://localhost:3000/api/ai/runs/run-1');
+}
+
 describe('GET /api/ai/runs/[id]', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -32,11 +36,22 @@ describe('GET /api/ai/runs/[id]', () => {
   it('returns 401 when unauthenticated', async () => {
     hoisted.getSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost:3000/api/ai/runs/run-1');
-    const response = await GET(request, { params: Promise.resolve({ id: 'run-1' }) });
+    const response = await GET(runRequest(), { params: Promise.resolve({ id: 'run-1' }) });
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when the session is missing tenant identity', async () => {
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'member-1', role: 'member', tenantId: null },
+    });
+
+    const response = await GET(runRequest(), { params: Promise.resolve({ id: 'run-1' }) });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Missing tenant identity' });
+    expect(hoisted.getAiRun).not.toHaveBeenCalled();
   });
 
   it('returns 403 when a member requests another users run', async () => {
@@ -62,8 +77,7 @@ describe('GET /api/ai/runs/[id]', () => {
       completedAt: null,
     });
 
-    const request = new Request('http://localhost:3000/api/ai/runs/run-1');
-    const response = await GET(request, { params: Promise.resolve({ id: 'run-1' }) });
+    const response = await GET(runRequest(), { params: Promise.resolve({ id: 'run-1' }) });
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
@@ -95,8 +109,7 @@ describe('GET /api/ai/runs/[id]', () => {
       completedAt: '2026-03-08T12:02:00.000Z',
     });
 
-    const request = new Request('http://localhost:3000/api/ai/runs/run-1');
-    const response = await GET(request, { params: Promise.resolve({ id: 'run-1' }) });
+    const response = await GET(runRequest(), { params: Promise.resolve({ id: 'run-1' }) });
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -126,8 +139,7 @@ describe('GET /api/ai/runs/[id]', () => {
       })
     );
 
-    const request = new Request('http://localhost:3000/api/ai/runs/run-1');
-    const response = await GET(request, { params: Promise.resolve({ id: 'run-1' }) });
+    const response = await GET(runRequest(), { params: Promise.resolve({ id: 'run-1' }) });
 
     expect(response.status).toBe(429);
     await expect(response.json()).resolves.toEqual({ error: 'Too many requests' });

--- a/apps/web/src/app/api/ai/runs/[id]/route.ts
+++ b/apps/web/src/app/api/ai/runs/[id]/route.ts
@@ -1,3 +1,4 @@
+import { resolveTenantBoundary } from '@/app/api/tenant-boundary';
 import { auth } from '@/lib/auth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { getAiRun } from '@interdomestik/domain-ai';
@@ -20,13 +21,18 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 
   const session = await auth.api.getSession({ headers: request.headers });
 
-  if (!session) {
+  if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const tenant = resolveTenantBoundary(session);
+  if (!tenant.success) {
+    return tenant.response;
   }
 
   const { id } = await params;
   const run = await getAiRun({
-    tenantId: session.user.tenantId,
+    tenantId: tenant.tenantId,
     runId: id,
   });
 

--- a/apps/web/src/app/api/settings/notifications/route.test.ts
+++ b/apps/web/src/app/api/settings/notifications/route.test.ts
@@ -75,6 +75,32 @@ vi.mock('next/headers', () => ({
   headers: hoistedMocks.headers,
 }));
 
+const samplePreferences = {
+  emailClaimUpdates: true,
+  emailMarketing: false,
+  emailNewsletter: true,
+  pushClaimUpdates: true,
+  pushMessages: true,
+  inAppAll: true,
+};
+
+function notificationPostRequest(body = samplePreferences): Request {
+  return new Request('http://localhost:3000/api/settings/notifications', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function expectMissingTenantIdentity(response: Response): Promise<void> {
+  const data = await response.json();
+
+  expect(response.status).toBe(401);
+  expect(data).toEqual({ error: 'Missing tenant identity' });
+  expect(mockSelectChain.from).not.toHaveBeenCalled();
+  expect(mockInsertChain.values).not.toHaveBeenCalled();
+  expect(mockUpdateChain.set).not.toHaveBeenCalled();
+}
+
 describe('GET /api/settings/notifications', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -92,6 +118,15 @@ describe('GET /api/settings/notifications', () => {
 
     expect(response.status).toBe(401);
     expect(data).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('should return 401 if the session is missing tenant identity', async () => {
+    hoistedMocks.getSession.mockResolvedValue({
+      user: { id: 'user-123', tenantId: null },
+    });
+
+    const request = new Request('http://localhost:3000/api/settings/notifications');
+    await expectMissingTenantIdentity(await GET(request));
   });
 
   it('should return default preferences if none exist', async () => {
@@ -178,23 +213,19 @@ describe('POST /api/settings/notifications', () => {
   it('should return 401 if user is not authenticated', async () => {
     hoistedMocks.getSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost:3000/api/settings/notifications', {
-      method: 'POST',
-      body: JSON.stringify({
-        emailClaimUpdates: true,
-        emailMarketing: false,
-        emailNewsletter: true,
-        pushClaimUpdates: true,
-        pushMessages: true,
-        inAppAll: true,
-      }),
-    });
-
-    const response = await POST(request);
+    const response = await POST(notificationPostRequest());
     const data = await response.json();
 
     expect(response.status).toBe(401);
     expect(data).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('should return 401 if the session is missing tenant identity', async () => {
+    hoistedMocks.getSession.mockResolvedValue({
+      user: { id: 'user-123', tenantId: undefined },
+    });
+
+    await expectMissingTenantIdentity(await POST(notificationPostRequest()));
   });
 
   it('should create new preferences if none exist', async () => {

--- a/apps/web/src/app/api/settings/notifications/route.ts
+++ b/apps/web/src/app/api/settings/notifications/route.ts
@@ -1,3 +1,4 @@
+import { resolveTenantBoundary } from '@/app/api/tenant-boundary';
 import { auth } from '@/lib/auth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { NextResponse } from 'next/server';
@@ -25,9 +26,14 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const tenant = resolveTenantBoundary(session);
+    if (!tenant.success) {
+      return tenant.response;
+    }
+
     const preferences = await getNotificationPreferencesCore({
       userId: session.user.id,
-      tenantId: session.user.tenantId,
+      tenantId: tenant.tenantId,
     });
     return NextResponse.json(preferences);
   } catch (error) {
@@ -53,6 +59,11 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const tenant = resolveTenantBoundary(session);
+    if (!tenant.success) {
+      return tenant.response;
+    }
+
     let body: NotificationPreferences;
 
     try {
@@ -63,7 +74,7 @@ export async function POST(request: Request) {
 
     await upsertNotificationPreferencesCore({
       userId: session.user.id,
-      tenantId: session.user.tenantId,
+      tenantId: tenant.tenantId,
       preferences: body,
     });
 

--- a/apps/web/src/app/api/tenant-boundary.ts
+++ b/apps/web/src/app/api/tenant-boundary.ts
@@ -1,0 +1,17 @@
+import { ensureTenantId, type SessionWithTenant } from '@interdomestik/shared-auth';
+import { NextResponse } from 'next/server';
+
+type TenantBoundaryResult =
+  | { success: true; tenantId: string }
+  | { success: false; response: NextResponse<{ error: string }> };
+
+export function resolveTenantBoundary(session: SessionWithTenant): TenantBoundaryResult {
+  try {
+    return { success: true, tenantId: ensureTenantId(session) };
+  } catch {
+    return {
+      success: false,
+      response: NextResponse.json({ error: 'Missing tenant identity' }, { status: 401 }),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Normalize AI run, AI review, and notification settings API handlers to resolve tenant identity at the route boundary.
- Return explicit `{ "error": "Missing tenant identity" }` 401 responses for authenticated sessions without tenant identity before downstream core logic runs.
- Add focused negative route tests covering missing tenant identity for the targeted APIs.

## Scope Notes
- `apps/web/src/proxy.ts` was not touched.
- Canonical routes, portal structure, auth architecture, routing, and tenancy architecture were not refactored.
- `apps/web/src/app/api/settings/push/route.ts` was inspected only; no push endpoint changes were made.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/api/ai/runs/[id]/route.test.ts' 'src/app/api/ai/reviews/[id]/route.test.ts' src/app/api/settings/notifications/route.test.ts`\n- `git diff --check`\n- `pnpm pr:verify:hosts`\n- `pnpm security:guard`\n- `pnpm verify-slice -- --static`\n  - run root: `tmp/multi-agent/verify-slice/verify-slice-20260425T115710Z-497b89`\n  - selected reviewers: security, architect, QA, performance, contracts\n  - reviewer pool: no must-fix findings; all READY FOR PR\n- `pnpm verify-slice -- --required-gates`\n  - run root: `tmp/multi-agent/verify-slice/verify-slice-20260425T120005Z-fb463e`\n  - final standalone E2E gate: 101 passed, 3 skipped\n