### PR TITLE
fix: harden push subscription tenant contract

### DIFF
--- a/apps/web/src/app/api/settings/push/_core.ts
+++ b/apps/web/src/app/api/settings/push/_core.ts
@@ -20,11 +20,71 @@ type Audit = {
   metadata?: Record<string, unknown>;
 };
 
+type CoreResult = {
+  status: 200 | 400 | 409;
+  body: { success?: true; error?: string };
+  audit?: Audit;
+};
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' && error !== null && (error as { code?: unknown }).code === '23505'
+  );
+}
+
+function isOwnedSubscription(
+  subscription: { tenantId: string; userId: string },
+  tenantId: string,
+  userId: string
+): boolean {
+  return subscription.tenantId === tenantId && subscription.userId === userId;
+}
+
+async function findPushSubscriptionByEndpoint(endpoint: string) {
+  const [existing] = await db
+    .select()
+    .from(pushSubscriptions)
+    .where(eq(pushSubscriptions.endpoint, endpoint))
+    .limit(1);
+
+  return existing;
+}
+
+async function updatePushSubscription(args: {
+  endpoint: string;
+  tenantId: string;
+  userId: string;
+  p256dh: string;
+  authKey: string;
+  userAgent?: string;
+}) {
+  const { endpoint, tenantId, userId, p256dh, authKey, userAgent } = args;
+
+  await db
+    .update(pushSubscriptions)
+    .set({
+      tenantId,
+      userId,
+      endpoint,
+      p256dh,
+      auth: authKey,
+      userAgent,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(pushSubscriptions.endpoint, endpoint),
+        eq(pushSubscriptions.tenantId, tenantId),
+        eq(pushSubscriptions.userId, userId)
+      )
+    );
+}
+
 export async function upsertPushSubscriptionCore(args: {
   userId: string;
   tenantId?: string | null;
   body: PushSubscriptionBody;
-}): Promise<{ status: 200 | 400; body: { success?: true; error?: string }; audit?: Audit }> {
+}): Promise<CoreResult> {
   const { userId, tenantId, body } = args;
   if (!tenantId) {
     return { status: 400, body: { error: 'Missing tenantId' } };
@@ -40,43 +100,53 @@ export async function upsertPushSubscriptionCore(args: {
   const { endpoint, keys, userAgent } = validation.data;
   const { p256dh, auth: authKey } = keys;
 
-  const [existing] = await db
-    .select()
-    .from(pushSubscriptions)
-    .where(eq(pushSubscriptions.endpoint, endpoint))
-    .limit(1);
+  const existing = await findPushSubscriptionByEndpoint(endpoint);
 
   if (existing) {
-    await db
-      .update(pushSubscriptions)
-      .set({
+    if (!isOwnedSubscription(existing, resolvedTenantId, userId)) {
+      return { status: 409, body: { error: 'Push subscription endpoint already registered' } };
+    }
+
+    await updatePushSubscription({
+      endpoint,
+      tenantId: resolvedTenantId,
+      userId,
+      p256dh,
+      authKey,
+      userAgent,
+    });
+  } else {
+    try {
+      await db.insert(pushSubscriptions).values({
+        id: nanoid(),
         tenantId: resolvedTenantId,
         userId,
         endpoint,
         p256dh,
         auth: authKey,
         userAgent,
+        createdAt: new Date(),
         updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(pushSubscriptions.endpoint, endpoint),
-          eq(pushSubscriptions.tenantId, resolvedTenantId),
-          eq(pushSubscriptions.userId, userId)
-        )
-      );
-  } else {
-    await db.insert(pushSubscriptions).values({
-      id: nanoid(),
-      tenantId: resolvedTenantId,
-      userId,
-      endpoint,
-      p256dh,
-      auth: authKey,
-      userAgent,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+      });
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
+
+      const racedExisting = await findPushSubscriptionByEndpoint(endpoint);
+      if (!racedExisting || !isOwnedSubscription(racedExisting, resolvedTenantId, userId)) {
+        return { status: 409, body: { error: 'Push subscription endpoint already registered' } };
+      }
+
+      await updatePushSubscription({
+        endpoint,
+        tenantId: resolvedTenantId,
+        userId,
+        p256dh,
+        authKey,
+        userAgent,
+      });
+    }
   }
 
   return {

--- a/apps/web/src/app/api/settings/push/_core.ts
+++ b/apps/web/src/app/api/settings/push/_core.ts
@@ -26,6 +26,12 @@ type CoreResult = {
   audit?: Audit;
 };
 
+const PUSH_ENDPOINT_CONFLICT_ERROR = 'Push subscription endpoint already registered';
+
+function pushEndpointConflict(): CoreResult {
+  return { status: 409, body: { error: PUSH_ENDPOINT_CONFLICT_ERROR } };
+}
+
 function isUniqueViolation(error: unknown): boolean {
   return (
     typeof error === 'object' && error !== null && (error as { code?: unknown }).code === '23505'
@@ -99,22 +105,23 @@ export async function upsertPushSubscriptionCore(args: {
 
   const { endpoint, keys, userAgent } = validation.data;
   const { p256dh, auth: authKey } = keys;
+  const updateArgs = {
+    endpoint,
+    tenantId: resolvedTenantId,
+    userId,
+    p256dh,
+    authKey,
+    userAgent,
+  };
 
   const existing = await findPushSubscriptionByEndpoint(endpoint);
 
   if (existing) {
     if (!isOwnedSubscription(existing, resolvedTenantId, userId)) {
-      return { status: 409, body: { error: 'Push subscription endpoint already registered' } };
+      return pushEndpointConflict();
     }
 
-    await updatePushSubscription({
-      endpoint,
-      tenantId: resolvedTenantId,
-      userId,
-      p256dh,
-      authKey,
-      userAgent,
-    });
+    await updatePushSubscription(updateArgs);
   } else {
     try {
       await db.insert(pushSubscriptions).values({
@@ -135,17 +142,10 @@ export async function upsertPushSubscriptionCore(args: {
 
       const racedExisting = await findPushSubscriptionByEndpoint(endpoint);
       if (!racedExisting || !isOwnedSubscription(racedExisting, resolvedTenantId, userId)) {
-        return { status: 409, body: { error: 'Push subscription endpoint already registered' } };
+        return pushEndpointConflict();
       }
 
-      await updatePushSubscription({
-        endpoint,
-        tenantId: resolvedTenantId,
-        userId,
-        p256dh,
-        authKey,
-        userAgent,
-      });
+      await updatePushSubscription(updateArgs);
     }
   }
 

--- a/apps/web/src/app/api/settings/push/_core.ts
+++ b/apps/web/src/app/api/settings/push/_core.ts
@@ -20,15 +20,22 @@ type Audit = {
   metadata?: Record<string, unknown>;
 };
 
-type CoreResult = {
-  status: 200 | 400 | 409;
-  body: { success?: true; error?: string };
+type CoreSuccessResult = {
+  status: 200;
+  body: { success: true };
   audit?: Audit;
 };
 
+type CoreErrorResult = {
+  status: 400 | 409;
+  body: { error: string };
+};
+
+type CoreResult = CoreSuccessResult | CoreErrorResult;
+
 const PUSH_ENDPOINT_CONFLICT_ERROR = 'Push subscription endpoint already registered';
 
-function pushEndpointConflict(): CoreResult {
+function pushEndpointConflict(): CoreErrorResult {
   return { status: 409, body: { error: PUSH_ENDPOINT_CONFLICT_ERROR } };
 }
 

--- a/apps/web/src/app/api/settings/push/route.test.ts
+++ b/apps/web/src/app/api/settings/push/route.test.ts
@@ -80,6 +80,11 @@ const validPushBody = {
   userAgent: 'UA',
 };
 
+const validDeleteBody = { endpoint: validPushBody.endpoint };
+const sameEndpointOwner = { tenantId: 'tenant_mk', userId: 'user-123' };
+const endpointConflict = { error: 'Push subscription endpoint already registered' };
+const uniqueViolation = Object.assign(new Error('duplicate key'), { code: '23505' });
+
 function authenticatedSession(tenantId: string | null = 'tenant_mk') {
   return { user: { id: 'user-123', tenantId } };
 }
@@ -91,11 +96,56 @@ function postRequest(body: unknown = validPushBody): Request {
   });
 }
 
-function deleteRequest(body: unknown = { endpoint: validPushBody.endpoint }): Request {
+function deleteRequest(body: unknown = validDeleteBody): Request {
   return new Request('http://localhost:3000/api/settings/push', {
     method: 'DELETE',
     body: typeof body === 'string' ? body : JSON.stringify(body),
   });
+}
+
+function subscriptionFor(owner = sameEndpointOwner) {
+  return {
+    id: 'sub-1',
+    endpoint: validPushBody.endpoint,
+    ...owner,
+  };
+}
+
+async function expectJsonResponse(
+  response: Response,
+  status: number,
+  body: Record<string, unknown>
+) {
+  expect(response.status).toBe(status);
+  expect(await response.json()).toEqual(body);
+}
+
+function expectNoPushWriteOrAudit() {
+  expect(mockInsertChain.values).not.toHaveBeenCalled();
+  expect(mockUpdateChain.set).not.toHaveBeenCalled();
+  expect(hoistedMocks.logAuditEvent).not.toHaveBeenCalled();
+}
+
+function expectValidPushUpdate() {
+  expect(mockUpdateChain.set).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ...sameEndpointOwner,
+      endpoint: validPushBody.endpoint,
+      p256dh: 'p256',
+      auth: 'auth',
+      userAgent: 'UA',
+      updatedAt: expect.any(Date),
+    })
+  );
+}
+
+function mockExistingSubscription(owner = sameEndpointOwner) {
+  mockSelectChain.limit.mockResolvedValue([subscriptionFor(owner)]);
+}
+
+function mockRacedInsertSubscription(owner = sameEndpointOwner) {
+  mockSelectChain.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([subscriptionFor(owner)]);
+  mockInsertChain.values.mockRejectedValueOnce(uniqueViolation);
 }
 
 describe('POST /api/settings/push', () => {
@@ -113,44 +163,31 @@ describe('POST /api/settings/push', () => {
     hoistedMocks.getSession.mockResolvedValue(null);
 
     const response = await POST(postRequest());
-    const data = await response.json();
-
-    expect(response.status).toBe(401);
-    expect(data).toEqual({ error: 'Unauthorized' });
+    await expectJsonResponse(response, 401, { error: 'Unauthorized' });
   });
 
   it('returns 401 when tenant identity is missing', async () => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession(null));
 
     const response = await POST(postRequest());
-    const data = await response.json();
 
-    expect(response.status).toBe(401);
-    expect(data).toEqual({ error: 'Missing tenant identity' });
+    await expectJsonResponse(response, 401, { error: 'Missing tenant identity' });
     expect(mockSelectChain.from).not.toHaveBeenCalled();
-    expect(mockInsertChain.values).not.toHaveBeenCalled();
-    expect(mockUpdateChain.set).not.toHaveBeenCalled();
-    expect(hoistedMocks.logAuditEvent).not.toHaveBeenCalled();
+    expectNoPushWriteOrAudit();
   });
 
   it('returns 400 on invalid JSON', async () => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
     const response = await POST(postRequest('invalid json'));
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toEqual({ error: 'Invalid JSON' });
+    await expectJsonResponse(response, 400, { error: 'Invalid JSON' });
   });
 
   it('returns 400 on missing fields', async () => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
     const response = await POST(postRequest({ endpoint: '' }));
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toEqual({ error: 'Invalid subscription data' });
+    await expectJsonResponse(response, 400, { error: 'Invalid subscription data' });
   });
 
   it('creates a new subscription when none exists', async () => {
@@ -158,15 +195,12 @@ describe('POST /api/settings/push', () => {
     mockSelectChain.limit.mockResolvedValue([]);
 
     const response = await POST(postRequest());
-    const data = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(data).toEqual({ success: true });
+    await expectJsonResponse(response, 200, { success: true });
     expect(mockInsertChain.values).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'test-id-123',
-        tenantId: 'tenant_mk',
-        userId: 'user-123',
+        ...sameEndpointOwner,
         endpoint: validPushBody.endpoint,
         p256dh: 'p256',
         auth: 'auth',
@@ -177,31 +211,11 @@ describe('POST /api/settings/push', () => {
 
   it('updates subscription when it exists', async () => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
-    mockSelectChain.limit.mockResolvedValue([
-      {
-        id: 'sub-1',
-        endpoint: validPushBody.endpoint,
-        tenantId: 'tenant_mk',
-        userId: 'user-123',
-      },
-    ]);
+    mockExistingSubscription();
 
     const response = await POST(postRequest());
-    const data = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(data).toEqual({ success: true });
-    expect(mockUpdateChain.set).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tenantId: 'tenant_mk',
-        userId: 'user-123',
-        endpoint: validPushBody.endpoint,
-        p256dh: 'p256',
-        auth: 'auth',
-        userAgent: 'UA',
-        updatedAt: expect.any(Date),
-      })
-    );
+    await expectJsonResponse(response, 200, { success: true });
+    expectValidPushUpdate();
   });
 
   it.each([
@@ -209,42 +223,21 @@ describe('POST /api/settings/push', () => {
     ['the same user in another tenant', { tenantId: 'tenant_other', userId: 'user-123' }],
   ])('returns 409 when the endpoint belongs to %s', async (_caseName, owner) => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
-    mockSelectChain.limit.mockResolvedValue([
-      {
-        id: 'sub-1',
-        endpoint: validPushBody.endpoint,
-        ...owner,
-      },
-    ]);
+    mockExistingSubscription(owner);
 
     const response = await POST(postRequest());
-    const data = await response.json();
 
-    expect(response.status).toBe(409);
-    expect(data).toEqual({ error: 'Push subscription endpoint already registered' });
-    expect(mockUpdateChain.set).not.toHaveBeenCalled();
-    expect(mockInsertChain.values).not.toHaveBeenCalled();
-    expect(hoistedMocks.logAuditEvent).not.toHaveBeenCalled();
+    await expectJsonResponse(response, 409, endpointConflict);
+    expectNoPushWriteOrAudit();
   });
 
   it('returns 409 when a raced insert finds another endpoint owner', async () => {
-    const uniqueViolation = Object.assign(new Error('duplicate key'), { code: '23505' });
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
-    mockSelectChain.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([
-      {
-        id: 'sub-1',
-        endpoint: validPushBody.endpoint,
-        tenantId: 'tenant_other',
-        userId: 'other-user',
-      },
-    ]);
-    mockInsertChain.values.mockRejectedValueOnce(uniqueViolation);
+    mockRacedInsertSubscription({ tenantId: 'tenant_other', userId: 'other-user' });
 
     const response = await POST(postRequest());
-    const data = await response.json();
 
-    expect(response.status).toBe(409);
-    expect(data).toEqual({ error: 'Push subscription endpoint already registered' });
+    await expectJsonResponse(response, 409, endpointConflict);
     expect(mockInsertChain.values).toHaveBeenCalledTimes(1);
     expect(mockSelectChain.limit).toHaveBeenCalledTimes(2);
     expect(mockUpdateChain.set).not.toHaveBeenCalled();
@@ -252,35 +245,13 @@ describe('POST /api/settings/push', () => {
   });
 
   it('updates when a raced insert finds the same endpoint owner', async () => {
-    const uniqueViolation = Object.assign(new Error('duplicate key'), { code: '23505' });
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
-    mockSelectChain.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([
-      {
-        id: 'sub-1',
-        endpoint: validPushBody.endpoint,
-        tenantId: 'tenant_mk',
-        userId: 'user-123',
-      },
-    ]);
-    mockInsertChain.values.mockRejectedValueOnce(uniqueViolation);
+    mockRacedInsertSubscription();
 
     const response = await POST(postRequest());
-    const data = await response.json();
-
-    expect(response.status).toBe(200);
-    expect(data).toEqual({ success: true });
+    await expectJsonResponse(response, 200, { success: true });
     expect(mockInsertChain.values).toHaveBeenCalledTimes(1);
-    expect(mockUpdateChain.set).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tenantId: 'tenant_mk',
-        userId: 'user-123',
-        endpoint: validPushBody.endpoint,
-        p256dh: 'p256',
-        auth: 'auth',
-        userAgent: 'UA',
-        updatedAt: expect.any(Date),
-      })
-    );
+    expectValidPushUpdate();
   });
 });
 
@@ -294,20 +265,15 @@ describe('DELETE /api/settings/push', () => {
     hoistedMocks.getSession.mockResolvedValue(null);
 
     const response = await DELETE(deleteRequest());
-    const data = await response.json();
-
-    expect(response.status).toBe(401);
-    expect(data).toEqual({ error: 'Unauthorized' });
+    await expectJsonResponse(response, 401, { error: 'Unauthorized' });
   });
 
   it('returns 401 when tenant identity is missing', async () => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession(null));
 
     const response = await DELETE(deleteRequest());
-    const data = await response.json();
 
-    expect(response.status).toBe(401);
-    expect(data).toEqual({ error: 'Missing tenant identity' });
+    await expectJsonResponse(response, 401, { error: 'Missing tenant identity' });
     expect(mockDeleteChain.where).not.toHaveBeenCalled();
     expect(hoistedMocks.logAuditEvent).not.toHaveBeenCalled();
   });
@@ -316,36 +282,28 @@ describe('DELETE /api/settings/push', () => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
     const response = await DELETE(deleteRequest('invalid json'));
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toEqual({ error: 'Invalid JSON' });
+    await expectJsonResponse(response, 400, { error: 'Invalid JSON' });
   });
 
   it('returns 400 when endpoint is missing', async () => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
     const response = await DELETE(deleteRequest({}));
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data).toEqual({ error: 'Invalid subscription' });
+    await expectJsonResponse(response, 400, { error: 'Invalid subscription' });
   });
 
   it('deletes subscription by endpoint', async () => {
     hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
     const response = await DELETE(deleteRequest());
-    const data = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(data).toEqual({ success: true });
+    await expectJsonResponse(response, 200, { success: true });
     expect(mockDeleteChain.where).toHaveBeenCalledWith({
       type: 'and',
       conditions: [
         { type: 'eq', field: 'endpoint', value: validPushBody.endpoint },
-        { type: 'eq', field: 'tenant_id', value: 'tenant_mk' },
-        { type: 'eq', field: 'user_id', value: 'user-123' },
+        { type: 'eq', field: 'tenant_id', value: sameEndpointOwner.tenantId },
+        { type: 'eq', field: 'user_id', value: sameEndpointOwner.userId },
       ],
     });
   });

--- a/apps/web/src/app/api/settings/push/route.test.ts
+++ b/apps/web/src/app/api/settings/push/route.test.ts
@@ -4,6 +4,9 @@ import { DELETE, POST } from './route';
 const hoistedMocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   headers: vi.fn(),
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+  eq: vi.fn((field: unknown, value: unknown) => ({ type: 'eq', field, value })),
+  and: vi.fn((...conditions: unknown[]) => ({ type: 'and', conditions })),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -15,7 +18,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@/lib/audit', () => ({
-  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+  logAuditEvent: hoistedMocks.logAuditEvent,
 }));
 
 vi.mock('@/lib/rate-limit', () => ({
@@ -59,8 +62,8 @@ vi.mock('@interdomestik/database/schema', () => ({
 }));
 
 vi.mock('drizzle-orm', () => ({
-  eq: vi.fn(),
-  and: vi.fn(),
+  eq: hoistedMocks.eq,
+  and: hoistedMocks.and,
 }));
 
 vi.mock('nanoid', () => ({
@@ -70,6 +73,30 @@ vi.mock('nanoid', () => ({
 vi.mock('next/headers', () => ({
   headers: hoistedMocks.headers,
 }));
+
+const validPushBody = {
+  endpoint: 'https://example.com/ep',
+  keys: { p256dh: 'p256', auth: 'auth' },
+  userAgent: 'UA',
+};
+
+function authenticatedSession(tenantId: string | null = 'tenant_mk') {
+  return { user: { id: 'user-123', tenantId } };
+}
+
+function postRequest(body: unknown = validPushBody): Request {
+  return new Request('http://localhost:3000/api/settings/push', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+function deleteRequest(body: unknown = { endpoint: validPushBody.endpoint }): Request {
+  return new Request('http://localhost:3000/api/settings/push', {
+    method: 'DELETE',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
 
 describe('POST /api/settings/push', () => {
   beforeEach(() => {
@@ -85,30 +112,31 @@ describe('POST /api/settings/push', () => {
   it('returns 401 if user is not authenticated', async () => {
     hoistedMocks.getSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'POST',
-      body: JSON.stringify({
-        endpoint: 'https://example.com/ep',
-        keys: { p256dh: 'p', auth: 'a' },
-      }),
-    });
-
-    const response = await POST(request);
+    const response = await POST(postRequest());
     const data = await response.json();
 
     expect(response.status).toBe(401);
     expect(data).toEqual({ error: 'Unauthorized' });
   });
 
+  it('returns 401 when tenant identity is missing', async () => {
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession(null));
+
+    const response = await POST(postRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toEqual({ error: 'Missing tenant identity' });
+    expect(mockSelectChain.from).not.toHaveBeenCalled();
+    expect(mockInsertChain.values).not.toHaveBeenCalled();
+    expect(mockUpdateChain.set).not.toHaveBeenCalled();
+    expect(hoistedMocks.logAuditEvent).not.toHaveBeenCalled();
+  });
+
   it('returns 400 on invalid JSON', async () => {
-    hoistedMocks.getSession.mockResolvedValue({ user: { id: 'user-123', tenantId: 'tenant_mk' } });
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'POST',
-      body: 'invalid json',
-    });
-
-    const response = await POST(request);
+    const response = await POST(postRequest('invalid json'));
     const data = await response.json();
 
     expect(response.status).toBe(400);
@@ -116,14 +144,9 @@ describe('POST /api/settings/push', () => {
   });
 
   it('returns 400 on missing fields', async () => {
-    hoistedMocks.getSession.mockResolvedValue({ user: { id: 'user-123', tenantId: 'tenant_mk' } });
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'POST',
-      body: JSON.stringify({ endpoint: '' }),
-    });
-
-    const response = await POST(request);
+    const response = await POST(postRequest({ endpoint: '' }));
     const data = await response.json();
 
     expect(response.status).toBe(400);
@@ -131,21 +154,10 @@ describe('POST /api/settings/push', () => {
   });
 
   it('creates a new subscription when none exists', async () => {
-    hoistedMocks.getSession.mockResolvedValue({ user: { id: 'user-123', tenantId: 'tenant_mk' } });
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
     mockSelectChain.limit.mockResolvedValue([]);
 
-    const body = {
-      endpoint: 'https://example.com/ep',
-      keys: { p256dh: 'p256', auth: 'auth' },
-      userAgent: 'UA',
-    };
-
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'POST',
-      body: JSON.stringify(body),
-    });
-
-    const response = await POST(request);
+    const response = await POST(postRequest());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -155,7 +167,7 @@ describe('POST /api/settings/push', () => {
         id: 'test-id-123',
         tenantId: 'tenant_mk',
         userId: 'user-123',
-        endpoint: body.endpoint,
+        endpoint: validPushBody.endpoint,
         p256dh: 'p256',
         auth: 'auth',
         userAgent: 'UA',
@@ -164,21 +176,17 @@ describe('POST /api/settings/push', () => {
   });
 
   it('updates subscription when it exists', async () => {
-    hoistedMocks.getSession.mockResolvedValue({ user: { id: 'user-123', tenantId: 'tenant_mk' } });
-    mockSelectChain.limit.mockResolvedValue([{ id: 'sub-1', endpoint: 'https://example.com/ep' }]);
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
+    mockSelectChain.limit.mockResolvedValue([
+      {
+        id: 'sub-1',
+        endpoint: validPushBody.endpoint,
+        tenantId: 'tenant_mk',
+        userId: 'user-123',
+      },
+    ]);
 
-    const body = {
-      endpoint: 'https://example.com/ep',
-      keys: { p256dh: 'p256', auth: 'auth' },
-      userAgent: 'UA',
-    };
-
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'POST',
-      body: JSON.stringify(body),
-    });
-
-    const response = await POST(request);
+    const response = await POST(postRequest());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -187,7 +195,86 @@ describe('POST /api/settings/push', () => {
       expect.objectContaining({
         tenantId: 'tenant_mk',
         userId: 'user-123',
-        endpoint: body.endpoint,
+        endpoint: validPushBody.endpoint,
+        p256dh: 'p256',
+        auth: 'auth',
+        userAgent: 'UA',
+        updatedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it.each([
+    ['another user in the same tenant', { tenantId: 'tenant_mk', userId: 'other-user' }],
+    ['the same user in another tenant', { tenantId: 'tenant_other', userId: 'user-123' }],
+  ])('returns 409 when the endpoint belongs to %s', async (_caseName, owner) => {
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
+    mockSelectChain.limit.mockResolvedValue([
+      {
+        id: 'sub-1',
+        endpoint: validPushBody.endpoint,
+        ...owner,
+      },
+    ]);
+
+    const response = await POST(postRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data).toEqual({ error: 'Push subscription endpoint already registered' });
+    expect(mockUpdateChain.set).not.toHaveBeenCalled();
+    expect(mockInsertChain.values).not.toHaveBeenCalled();
+    expect(hoistedMocks.logAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when a raced insert finds another endpoint owner', async () => {
+    const uniqueViolation = Object.assign(new Error('duplicate key'), { code: '23505' });
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
+    mockSelectChain.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: 'sub-1',
+        endpoint: validPushBody.endpoint,
+        tenantId: 'tenant_other',
+        userId: 'other-user',
+      },
+    ]);
+    mockInsertChain.values.mockRejectedValueOnce(uniqueViolation);
+
+    const response = await POST(postRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data).toEqual({ error: 'Push subscription endpoint already registered' });
+    expect(mockInsertChain.values).toHaveBeenCalledTimes(1);
+    expect(mockSelectChain.limit).toHaveBeenCalledTimes(2);
+    expect(mockUpdateChain.set).not.toHaveBeenCalled();
+    expect(hoistedMocks.logAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('updates when a raced insert finds the same endpoint owner', async () => {
+    const uniqueViolation = Object.assign(new Error('duplicate key'), { code: '23505' });
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
+    mockSelectChain.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: 'sub-1',
+        endpoint: validPushBody.endpoint,
+        tenantId: 'tenant_mk',
+        userId: 'user-123',
+      },
+    ]);
+    mockInsertChain.values.mockRejectedValueOnce(uniqueViolation);
+
+    const response = await POST(postRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true });
+    expect(mockInsertChain.values).toHaveBeenCalledTimes(1);
+    expect(mockUpdateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant_mk',
+        userId: 'user-123',
+        endpoint: validPushBody.endpoint,
         p256dh: 'p256',
         auth: 'auth',
         userAgent: 'UA',
@@ -206,27 +293,29 @@ describe('DELETE /api/settings/push', () => {
   it('returns 401 if user is not authenticated', async () => {
     hoistedMocks.getSession.mockResolvedValue(null);
 
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'DELETE',
-      body: JSON.stringify({ endpoint: 'https://example.com/ep' }),
-    });
-
-    const response = await DELETE(request);
+    const response = await DELETE(deleteRequest());
     const data = await response.json();
 
     expect(response.status).toBe(401);
     expect(data).toEqual({ error: 'Unauthorized' });
   });
 
+  it('returns 401 when tenant identity is missing', async () => {
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession(null));
+
+    const response = await DELETE(deleteRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toEqual({ error: 'Missing tenant identity' });
+    expect(mockDeleteChain.where).not.toHaveBeenCalled();
+    expect(hoistedMocks.logAuditEvent).not.toHaveBeenCalled();
+  });
+
   it('returns 400 on invalid JSON', async () => {
-    hoistedMocks.getSession.mockResolvedValue({ user: { id: 'user-123', tenantId: 'tenant_mk' } });
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'DELETE',
-      body: 'invalid json',
-    });
-
-    const response = await DELETE(request);
+    const response = await DELETE(deleteRequest('invalid json'));
     const data = await response.json();
 
     expect(response.status).toBe(400);
@@ -234,14 +323,9 @@ describe('DELETE /api/settings/push', () => {
   });
 
   it('returns 400 when endpoint is missing', async () => {
-    hoistedMocks.getSession.mockResolvedValue({ user: { id: 'user-123', tenantId: 'tenant_mk' } });
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'DELETE',
-      body: JSON.stringify({}),
-    });
-
-    const response = await DELETE(request);
+    const response = await DELETE(deleteRequest({}));
     const data = await response.json();
 
     expect(response.status).toBe(400);
@@ -249,18 +333,20 @@ describe('DELETE /api/settings/push', () => {
   });
 
   it('deletes subscription by endpoint', async () => {
-    hoistedMocks.getSession.mockResolvedValue({ user: { id: 'user-123', tenantId: 'tenant_mk' } });
+    hoistedMocks.getSession.mockResolvedValue(authenticatedSession());
 
-    const request = new Request('http://localhost:3000/api/settings/push', {
-      method: 'DELETE',
-      body: JSON.stringify({ endpoint: 'https://example.com/ep' }),
-    });
-
-    const response = await DELETE(request);
+    const response = await DELETE(deleteRequest());
     const data = await response.json();
 
     expect(response.status).toBe(200);
     expect(data).toEqual({ success: true });
-    expect(mockDeleteChain.where).toHaveBeenCalled();
+    expect(mockDeleteChain.where).toHaveBeenCalledWith({
+      type: 'and',
+      conditions: [
+        { type: 'eq', field: 'endpoint', value: validPushBody.endpoint },
+        { type: 'eq', field: 'tenant_id', value: 'tenant_mk' },
+        { type: 'eq', field: 'user_id', value: 'user-123' },
+      ],
+    });
   });
 });

--- a/apps/web/src/app/api/settings/push/route.ts
+++ b/apps/web/src/app/api/settings/push/route.ts
@@ -1,3 +1,4 @@
+import { resolveTenantBoundary } from '@/app/api/tenant-boundary';
 import { logAuditEvent } from '@/lib/audit';
 import { auth } from '@/lib/auth';
 import { enforceRateLimit } from '@/lib/rate-limit';
@@ -26,6 +27,11 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const tenant = resolveTenantBoundary(session);
+    if (!tenant.success) {
+      return tenant.response;
+    }
+
     let body: PushSubscriptionBody;
     try {
       body = await request.json();
@@ -35,7 +41,7 @@ export async function POST(request: Request) {
 
     const result = await upsertPushSubscriptionCore({
       userId: session.user.id,
-      tenantId: (session.user as { tenantId?: string | null }).tenantId,
+      tenantId: tenant.tenantId,
       body,
     });
     if (result.status !== 200) {
@@ -76,6 +82,11 @@ export async function DELETE(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const tenant = resolveTenantBoundary(session);
+    if (!tenant.success) {
+      return tenant.response;
+    }
+
     let body: { endpoint?: string };
     try {
       body = await request.json();
@@ -87,7 +98,7 @@ export async function DELETE(request: Request) {
 
     const result = await deletePushSubscriptionCore({
       userId: session.user.id,
-      tenantId: (session.user as { tenantId?: string | null }).tenantId,
+      tenantId: tenant.tenantId,
       endpoint: endpoint ?? '',
     });
     if (result.status !== 200) {


### PR DESCRIPTION
## Summary
- Resolve push POST/DELETE tenant identity at the route boundary with the shared tenant contract helper.
- Return explicit 409 for cross-user or cross-tenant push endpoint ownership collisions, including raced unique constraint collisions.
- Add focused route tests for missing tenant identity, endpoint collisions, raced collisions, same-owner update compatibility, and scoped delete predicates.

## Verification
- pnpm --filter @interdomestik/web test:unit --run src/app/api/settings/push/route.test.ts
- git diff --check
- pnpm --filter @interdomestik/web type-check
- pnpm verify-slice -- --static
- Pre-PR reviewer pool: security, architecture, QA, performance, contracts; fixed QA and security must-fix findings
- pnpm verify-slice -- --required-gates

## Notes
- apps/web/src/proxy.ts untouched.
- No route, auth, tenancy, or portal architecture refactor.