### PR TITLE
P17-PR05: Harden verification API tenant boundary

### DIFF
--- a/apps/web/src/app/api/verification/[id]/route.test.ts
+++ b/apps/web/src/app/api/verification/[id]/route.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from './route';
+
+const hoisted = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getVerificationRequestDetails: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: hoisted.getSession,
+    },
+  },
+}));
+
+vi.mock('@/features/admin/verification/server/verification.core', () => ({
+  getVerificationRequestDetails: hoisted.getVerificationRequestDetails,
+}));
+
+function verificationRequest(): Request {
+  return new Request('http://localhost:3000/api/verification/payment-attempt-1');
+}
+
+function routeParams(id = 'payment-attempt-1') {
+  return { params: Promise.resolve({ id }) };
+}
+
+function session(user: {
+  id?: string;
+  role?: string;
+  tenantId?: string | null;
+  branchId?: string | null;
+}) {
+  return {
+    user: {
+      id: 'staff-1',
+      role: 'staff',
+      tenantId: 'tenant-1',
+      branchId: 'branch-1',
+      ...user,
+    },
+  };
+}
+
+async function expectJson(response: Response, status: number, body: Record<string, unknown>) {
+  expect(response.status).toBe(status);
+  await expect(response.json()).resolves.toEqual(body);
+}
+
+describe('GET /api/verification/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    hoisted.getSession.mockResolvedValue(null);
+
+    const response = await GET(verificationRequest(), routeParams());
+
+    await expectJson(response, 401, { error: 'Unauthorized' });
+    expect(hoisted.getVerificationRequestDetails).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when the session has no user payload', async () => {
+    hoisted.getSession.mockResolvedValue({});
+
+    const response = await GET(verificationRequest(), routeParams());
+
+    await expectJson(response, 401, { error: 'Unauthorized' });
+    expect(hoisted.getVerificationRequestDetails).not.toHaveBeenCalled();
+  });
+
+  it.each([null, undefined, ''])(
+    'returns 401 when tenant identity is missing or malformed (%s)',
+    async tenantId => {
+      hoisted.getSession.mockResolvedValue(session({ tenantId }));
+
+      const response = await GET(verificationRequest(), routeParams());
+
+      await expectJson(response, 401, { error: 'Missing tenant identity' });
+      expect(hoisted.getVerificationRequestDetails).not.toHaveBeenCalled();
+    }
+  );
+
+  it('returns 403 for roles outside the verification API contract', async () => {
+    hoisted.getSession.mockResolvedValue(
+      session({ id: 'member-1', role: 'member', tenantId: 'tenant-1', branchId: null })
+    );
+
+    const response = await GET(verificationRequest(), routeParams());
+
+    await expectJson(response, 403, { error: 'Forbidden' });
+    expect(hoisted.getVerificationRequestDetails).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when scoped verification details are not found', async () => {
+    hoisted.getSession.mockResolvedValue(session({}));
+    hoisted.getVerificationRequestDetails.mockResolvedValue(null);
+
+    const response = await GET(verificationRequest(), routeParams());
+
+    await expectJson(response, 404, { error: 'Not found' });
+    expect(hoisted.getVerificationRequestDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        userId: 'staff-1',
+        userRole: 'staff',
+        scope: expect.objectContaining({ branchId: 'branch-1' }),
+      }),
+      'payment-attempt-1'
+    );
+  });
+
+  it('returns scoped verification details for an authorized staff session', async () => {
+    hoisted.getSession.mockResolvedValue(session({}));
+    hoisted.getVerificationRequestDetails.mockResolvedValue({
+      id: 'payment-attempt-1',
+      status: 'pending',
+    });
+
+    const response = await GET(verificationRequest(), routeParams());
+
+    await expectJson(response, 200, { id: 'payment-attempt-1', status: 'pending' });
+    expect(hoisted.getVerificationRequestDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        userId: 'staff-1',
+        userRole: 'staff',
+        scope: expect.objectContaining({ branchId: 'branch-1' }),
+      }),
+      'payment-attempt-1'
+    );
+  });
+});

--- a/apps/web/src/app/api/verification/[id]/route.ts
+++ b/apps/web/src/app/api/verification/[id]/route.ts
@@ -1,7 +1,7 @@
 import { getVerificationRequestDetails } from '@/features/admin/verification/server/verification.core';
+import { resolveTenantBoundary } from '@/app/api/tenant-boundary';
 import { auth } from '@/lib/auth';
 import { NextResponse } from 'next/server';
-import { resolveTenantBoundary } from '../../tenant-boundary';
 import { getVerificationApiCore } from './_core';
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {

--- a/apps/web/src/app/api/verification/[id]/route.ts
+++ b/apps/web/src/app/api/verification/[id]/route.ts
@@ -1,14 +1,20 @@
 import { getVerificationRequestDetails } from '@/features/admin/verification/server/verification.core';
 import { auth } from '@/lib/auth';
 import { NextResponse } from 'next/server';
+import { resolveTenantBoundary } from '../../tenant-boundary';
 import { getVerificationApiCore } from './_core';
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const session = await auth.api.getSession({ headers: request.headers });
 
-  if (!session) {
+  if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const tenant = resolveTenantBoundary(session);
+  if (!tenant.success) {
+    return tenant.response;
   }
 
   const result = await getVerificationApiCore(
@@ -17,7 +23,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       user: {
         id: session.user.id,
         role: session.user.role,
-        tenantId: session.user.tenantId,
+        tenantId: tenant.tenantId,
         branchId: session.user.branchId,
       },
     },


### PR DESCRIPTION
## Summary
- Resolve the verification API tenant identity at the route boundary with the existing tenant-boundary helper.
- Preserve the route's unauthorized contract for missing session/user payloads before tenant checks.
- Add focused route-level negative and happy-path tests for unauthenticated, missing/malformed tenant identity, forbidden role, scoped not-found, and authorized success cases.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/api/verification/[id]/route.test.ts' 'src/app/api/verification/[id]/_core.test.ts'`
- `git diff --check`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm security:guard`
- `pnpm pr:verify:hosts`
- `pnpm verify-slice -- --static`
- Pre-PR reviewer pool: security no findings, QA no findings, contracts must-fix addressed (`!session?.user` guard + test)
- `pnpm verify-slice -- --required-gates`

## Constraints
- `apps/web/src/proxy.ts` untouched.
- No canonical route changes.
- No auth/routing/tenancy architecture refactor.
- No README, AGENTS.md, or architecture docs changes.
