### PR TITLE
docs: add fast tools agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,3 +417,34 @@ pnpm --filter @interdomestik/web test:unit --run src/components/auth/login-form.
 # E2E test
 pnpm --filter @interdomestik/web test:e2e:chromium -- --grep "login form"
 ```
+
+<!-- FAST-TOOLS PROMPT v1 | codex-mastery | watermark:do-not-alter -->
+
+## CRITICAL: Use ripgrep, not grep
+
+NEVER use grep for project-wide searches (slow, ignores .gitignore). ALWAYS use rg.
+
+- `rg "pattern"` — search content
+- `rg --files | rg "name"` — find files
+- `rg -t python "def"` — language filters
+
+## File finding
+
+- Prefer `fd` (or `fdfind` on Debian/Ubuntu). Respects .gitignore.
+
+## JSON
+
+- Use `jq` for parsing and transformations.
+
+## Install Guidance
+
+- macOS: `brew install ripgrep fd jq`
+- Debian/Ubuntu: `sudo apt update && sudo apt install -y ripgrep fd-find jq` (alias `fd=fdfind`)
+
+## Agent Instructions
+
+- Replace commands: grep→rg, find→rg --files/fd, ls -R→rg --files, cat|grep→rg pattern file
+- Cap reads at 250 lines; prefer `rg -n -A 3 -B 3` for context
+- Use `jq` for JSON instead of regex
+
+<!-- END FAST-TOOLS PROMPT v1 | codex-mastery -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,3 +448,5 @@ NEVER use grep for project-wide searches (slow, ignores .gitignore). ALWAYS use 
 - Use `jq` for JSON instead of regex
 
 <!-- END FAST-TOOLS PROMPT v1 | codex-mastery -->
+
+Note: The fast-tools guidance above applies to the `grep` shell command / CLI for repository searches. It does not prohibit tool-specific flags such as Playwright's `--grep`.


### PR DESCRIPTION
## Summary
- append the fast-tools agent guidance block to AGENTS.md
- instruct future agents to prefer rg, fd, and jq for repo work

## Verification
- git diff --check
- pnpm docs:verify