### PR TITLE
feat(ai): align workflows with gpt-5.5

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -10,7 +10,7 @@ max_threads = 5
 max_depth = 1
 
 [profiles.prepr]
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 approval_policy = "never"
 sandbox_mode = "workspace-write"

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .github/codex/prompts/review.md
-          model: gpt-5.4
+          model: gpt-5.5
           effort: high
           output-file: codex-output.md
           safety-strategy: drop-sudo

--- a/apps/web/src/app/api/policies/analyze/_services.test.ts
+++ b/apps/web/src/app/api/policies/analyze/_services.test.ts
@@ -193,6 +193,7 @@ describe('queuePolicyAnalysisService', () => {
           fileSize: 2048,
           fileUrl: 'pii/tenants/tenant-1/policies/user-1/file.pdf',
           mimeType: 'application/pdf',
+          promptCacheKey: 'interdomestik:policy_extract:gpt-5.5:policy_extract_v1',
         },
         reviewStatus: 'pending',
         createdAt: expect.any(Date),

--- a/apps/web/src/app/api/policies/analyze/_services.ts
+++ b/apps/web/src/app/api/policies/analyze/_services.ts
@@ -9,10 +9,13 @@ import { db } from '@/lib/db.server';
 import { inngest } from '@/lib/inngest/client';
 import { createAdminClient } from '@interdomestik/database';
 import { aiRuns, documentExtractions, documents, policies } from '@interdomestik/database/schema';
+import { getResponsesWorkflowConfig } from '@interdomestik/domain-ai/models';
 import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
 const POLICIES_BUCKET = process.env.NEXT_PUBLIC_SUPABASE_POLICY_BUCKET || 'policies';
+const POLICY_EXTRACT_WORKFLOW = 'policy_extract' as const;
+const POLICY_EXTRACT_CONFIG = getResponsesWorkflowConfig(POLICY_EXTRACT_WORKFLOW);
 
 function buildPolicyInputHash(args: {
   fileUrl: string;
@@ -164,21 +167,22 @@ export async function queuePolicyAnalysisService(
     await tx.insert(aiRuns).values({
       id: runId,
       tenantId: data.tenantId,
-      workflow: 'policy_extract',
+      workflow: POLICY_EXTRACT_WORKFLOW,
       status: 'queued',
       documentId,
       entityType: 'policy',
       entityId: policyId,
       requestedBy: data.userId,
-      model: 'gpt-5.5',
-      modelSnapshot: 'gpt-5.5',
-      promptVersion: 'policy_extract_v1',
+      model: POLICY_EXTRACT_CONFIG.model,
+      modelSnapshot: POLICY_EXTRACT_CONFIG.model,
+      promptVersion: POLICY_EXTRACT_CONFIG.promptVersion,
       inputHash: buildPolicyInputHash(data),
       requestJson: {
         fileUrl: data.fileUrl,
         fileName: data.fileName,
         mimeType: data.mimeType,
         fileSize: data.fileSize,
+        promptCacheKey: POLICY_EXTRACT_CONFIG.promptCacheKey,
       },
       reviewStatus: 'pending',
       createdAt: now,
@@ -254,7 +258,7 @@ export async function processPolicyAnalysisRunService(args: {
     .where(
       and(
         eq(aiRuns.id, runId),
-        eq(aiRuns.workflow, 'policy_extract'),
+        eq(aiRuns.workflow, POLICY_EXTRACT_WORKFLOW),
         eq(aiRuns.entityType, 'policy')
       )
     );
@@ -344,8 +348,8 @@ export async function processPolicyAnalysisRunService(args: {
           documentId,
           entityType: 'policy',
           entityId: policyId,
-          workflow: 'policy_extract',
-          schemaVersion: 'policy_extract_v1',
+          workflow: POLICY_EXTRACT_WORKFLOW,
+          schemaVersion: POLICY_EXTRACT_CONFIG.promptVersion,
           extractedJson: analysis,
           warnings: [],
           sourceRunId: runId,

--- a/packages/domain-ai/src/models.test.ts
+++ b/packages/domain-ai/src/models.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AI_MODEL_PROFILES,
+  DEFAULT_MODEL_BY_WORKFLOW,
+  DEFAULT_PROMPT_VERSION_BY_WORKFLOW,
+  getDefaultModelForWorkflow,
+  getDefaultPromptVersionForWorkflow,
+  getPromptCacheKeyForWorkflow,
+  getReasoningEffortForLevel,
+  getResponsesModelConfig,
+  getResponsesWorkflowConfig,
+} from './models';
+import { AI_MODELS, AI_WORKFLOWS } from './types';
+
+const sortStrings = (values: readonly string[]): string[] =>
+  [...values].sort((left, right) => left.localeCompare(right));
+
+describe('AI model profiles', () => {
+  it('has a default model for every workflow', () => {
+    expect(sortStrings(Object.keys(DEFAULT_MODEL_BY_WORKFLOW))).toEqual(sortStrings(AI_WORKFLOWS));
+  });
+
+  it('has a prompt version for every workflow', () => {
+    expect(sortStrings(Object.keys(DEFAULT_PROMPT_VERSION_BY_WORKFLOW))).toEqual(
+      sortStrings(AI_WORKFLOWS)
+    );
+  });
+
+  it('has a profile for every supported model', () => {
+    expect(sortStrings(Object.keys(AI_MODEL_PROFILES))).toEqual(sortStrings(AI_MODELS));
+  });
+
+  it('keeps workflow defaults aligned with model profile defaultFor declarations', () => {
+    for (const workflow of AI_WORKFLOWS) {
+      const model = getDefaultModelForWorkflow(workflow);
+
+      expect(AI_MODEL_PROFILES[model].defaultFor).toContain(workflow);
+    }
+  });
+
+  it('returns canonical prompt versions for workflow provenance', () => {
+    expect(getDefaultPromptVersionForWorkflow('policy_extract')).toBe('policy_extract_v1');
+    expect(getDefaultPromptVersionForWorkflow('claim_intake_extract')).toBe(
+      'claim_intake_extract_v1'
+    );
+    expect(getDefaultPromptVersionForWorkflow('legal_doc_extract')).toBe('legal_doc_extract_v1');
+    expect(getDefaultPromptVersionForWorkflow('claim_summary')).toBe('claim_summary_v1');
+  });
+});
+
+describe('Responses model config', () => {
+  it('maps profile reasoning levels to Responses API reasoning efforts', () => {
+    expect(getReasoningEffortForLevel('light')).toBe('low');
+    expect(getReasoningEffortForLevel('balanced')).toBe('medium');
+    expect(getReasoningEffortForLevel('deep')).toBe('high');
+  });
+
+  it('builds a Responses-ready config from the profile', () => {
+    expect(getResponsesModelConfig('gpt-5.5')).toEqual({
+      model: 'gpt-5.5',
+      reasoning: {
+        effort: 'high',
+      },
+      text: {
+        verbosity: 'low',
+      },
+      maxOutputTokens: 4_000,
+    });
+  });
+
+  it('builds a Responses-ready workflow config with a stable prompt cache key', () => {
+    expect(getPromptCacheKeyForWorkflow('policy_extract')).toBe(
+      'interdomestik:policy_extract:gpt-5.5:policy_extract_v1'
+    );
+    expect(getResponsesWorkflowConfig('policy_extract')).toEqual({
+      workflow: 'policy_extract',
+      model: 'gpt-5.5',
+      promptVersion: 'policy_extract_v1',
+      promptCacheKey: 'interdomestik:policy_extract:gpt-5.5:policy_extract_v1',
+      reasoning: {
+        effort: 'high',
+      },
+      text: {
+        verbosity: 'low',
+      },
+      maxOutputTokens: 4_000,
+    });
+  });
+});

--- a/packages/domain-ai/src/models.ts
+++ b/packages/domain-ai/src/models.ts
@@ -1,4 +1,16 @@
-import type { AiModel, AiModelProfile, AiWorkflow } from './types';
+import type {
+  AiModel,
+  AiModelProfile,
+  AiReasoningEffort,
+  AiReasoningLevel,
+  AiResponsesModelConfig,
+  AiResponsesWorkflowConfig,
+  AiWorkflow,
+} from './types';
+import { CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION } from './schemas/claim-intake-extract';
+import { CLAIM_SUMMARY_SCHEMA_VERSION } from './schemas/claim-summary';
+import { LEGAL_DOC_EXTRACT_SCHEMA_VERSION } from './schemas/legal-doc-extract';
+import { POLICY_EXTRACT_SCHEMA_VERSION } from './schemas/policy-extract';
 
 export const AI_MODEL_PROFILES = {
   'gpt-5.5': {
@@ -7,6 +19,7 @@ export const AI_MODEL_PROFILES = {
     defaultFor: ['policy_extract', 'legal_doc_extract'],
     useCase: 'Ambiguous extraction and reviewed document reasoning.',
     reasoningLevel: 'deep',
+    textVerbosity: 'low',
     maxOutputTokens: 4_000,
   },
   'gpt-5-mini': {
@@ -15,6 +28,7 @@ export const AI_MODEL_PROFILES = {
     defaultFor: ['claim_intake_extract', 'claim_summary'],
     useCase: 'Stable extraction and operational summaries.',
     reasoningLevel: 'balanced',
+    textVerbosity: 'low',
     maxOutputTokens: 2_000,
   },
   'gpt-5-nano': {
@@ -23,6 +37,7 @@ export const AI_MODEL_PROFILES = {
     defaultFor: [],
     useCase: 'Routing, classification, and cheap control-plane decisions.',
     reasoningLevel: 'light',
+    textVerbosity: 'low',
     maxOutputTokens: 512,
   },
   'gpt-5.4-pro': {
@@ -31,6 +46,7 @@ export const AI_MODEL_PROFILES = {
     defaultFor: [],
     useCase: 'Manual escalation paths only, never the default.',
     reasoningLevel: 'deep',
+    textVerbosity: 'medium',
     maxOutputTokens: 8_000,
   },
 } as const satisfies Record<AiModel, AiModelProfile>;
@@ -42,10 +58,60 @@ export const DEFAULT_MODEL_BY_WORKFLOW = {
   claim_summary: 'gpt-5-mini',
 } as const satisfies Record<AiWorkflow, AiModel>;
 
+export const DEFAULT_PROMPT_VERSION_BY_WORKFLOW = {
+  policy_extract: POLICY_EXTRACT_SCHEMA_VERSION,
+  claim_intake_extract: CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION,
+  legal_doc_extract: LEGAL_DOC_EXTRACT_SCHEMA_VERSION,
+  claim_summary: CLAIM_SUMMARY_SCHEMA_VERSION,
+} as const satisfies Record<AiWorkflow, string>;
+
 export function getAiModelProfile(model: AiModel): AiModelProfile {
   return AI_MODEL_PROFILES[model];
 }
 
 export function getDefaultModelForWorkflow(workflow: AiWorkflow): AiModel {
   return DEFAULT_MODEL_BY_WORKFLOW[workflow];
+}
+
+export function getDefaultPromptVersionForWorkflow(workflow: AiWorkflow): string {
+  return DEFAULT_PROMPT_VERSION_BY_WORKFLOW[workflow];
+}
+
+export function getReasoningEffortForLevel(level: AiReasoningLevel): AiReasoningEffort {
+  if (level === 'light') return 'low';
+  if (level === 'balanced') return 'medium';
+  return 'high';
+}
+
+export function getResponsesModelConfig(model: AiModel): AiResponsesModelConfig {
+  const profile = getAiModelProfile(model);
+
+  return {
+    model: profile.model,
+    reasoning: {
+      effort: getReasoningEffortForLevel(profile.reasoningLevel),
+    },
+    text: {
+      verbosity: profile.textVerbosity,
+    },
+    maxOutputTokens: profile.maxOutputTokens,
+  };
+}
+
+export function getPromptCacheKeyForWorkflow(workflow: AiWorkflow): string {
+  const model = getDefaultModelForWorkflow(workflow);
+  const promptVersion = getDefaultPromptVersionForWorkflow(workflow);
+
+  return `interdomestik:${workflow}:${model}:${promptVersion}`;
+}
+
+export function getResponsesWorkflowConfig(workflow: AiWorkflow): AiResponsesWorkflowConfig {
+  const model = getDefaultModelForWorkflow(workflow);
+
+  return {
+    workflow,
+    promptVersion: getDefaultPromptVersionForWorkflow(workflow),
+    promptCacheKey: getPromptCacheKeyForWorkflow(workflow),
+    ...getResponsesModelConfig(model),
+  };
 }

--- a/packages/domain-ai/src/types.ts
+++ b/packages/domain-ai/src/types.ts
@@ -14,6 +14,8 @@ export type AiModel = (typeof AI_MODELS)[number];
 export type AiModelTier = 'routing' | 'standard' | 'advanced' | 'escalation';
 
 export type AiReasoningLevel = 'light' | 'balanced' | 'deep';
+export type AiReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type AiTextVerbosity = 'low' | 'medium' | 'high';
 
 export interface AiModelProfile {
   model: AiModel;
@@ -21,5 +23,23 @@ export interface AiModelProfile {
   defaultFor: readonly AiWorkflow[];
   useCase: string;
   reasoningLevel: AiReasoningLevel;
+  textVerbosity: AiTextVerbosity;
   maxOutputTokens: number;
+}
+
+export interface AiResponsesModelConfig {
+  model: AiModel;
+  reasoning: {
+    effort: AiReasoningEffort;
+  };
+  text: {
+    verbosity: AiTextVerbosity;
+  };
+  maxOutputTokens: number;
+}
+
+export interface AiResponsesWorkflowConfig extends AiResponsesModelConfig {
+  workflow: AiWorkflow;
+  promptVersion: string;
+  promptCacheKey: string;
 }

--- a/packages/domain-claims/src/claims/ai-workflows.test.ts
+++ b/packages/domain-claims/src/claims/ai-workflows.test.ts
@@ -7,20 +7,25 @@ const hoisted = vi.hoisted(() => {
   }));
 
   return {
-    getResponsesWorkflowConfig: vi.fn((workflow: string) => ({
-      workflow,
-      model: workflow === 'legal_doc_extract' ? 'gpt-5.5' : 'gpt-5-mini',
-      promptVersion:
-        workflow === 'legal_doc_extract' ? 'legal_doc_extract_v1' : 'claim_intake_extract_v1',
-      promptCacheKey: `interdomestik:${workflow}`,
-      reasoning: {
-        effort: workflow === 'legal_doc_extract' ? 'high' : 'medium',
-      },
-      text: {
-        verbosity: 'low',
-      },
-      maxOutputTokens: workflow === 'legal_doc_extract' ? 4_000 : 2_000,
-    })),
+    getResponsesWorkflowConfig: vi.fn((workflow: string) => {
+      const model = workflow === 'legal_doc_extract' ? 'gpt-5.5' : 'gpt-5-mini';
+      const promptVersion =
+        workflow === 'legal_doc_extract' ? 'legal_doc_extract_v1' : 'claim_intake_extract_v1';
+
+      return {
+        workflow,
+        model,
+        promptVersion,
+        promptCacheKey: `interdomestik:${workflow}:${model}:${promptVersion}`,
+        reasoning: {
+          effort: workflow === 'legal_doc_extract' ? 'high' : 'medium',
+        },
+        text: {
+          verbosity: 'low',
+        },
+        maxOutputTokens: workflow === 'legal_doc_extract' ? 4_000 : 2_000,
+      };
+    }),
     nanoid: vi.fn().mockReturnValueOnce('run-1').mockReturnValueOnce('run-2'),
     txInsert,
     txInsertValues,
@@ -140,7 +145,8 @@ describe('queueClaimDocumentAiWorkflows', () => {
           requestJson: expect.objectContaining({
             category: 'evidence',
             bucket: 'claim-evidence',
-            promptCacheKey: 'interdomestik:claim_intake_extract',
+            promptCacheKey:
+              'interdomestik:claim_intake_extract:gpt-5-mini:claim_intake_extract_v1',
             claimSnapshot: expect.objectContaining({
               incidentDate: '2026-02-15',
             }),
@@ -154,7 +160,7 @@ describe('queueClaimDocumentAiWorkflows', () => {
           promptVersion: 'legal_doc_extract_v1',
           requestJson: expect.objectContaining({
             category: 'legal',
-            promptCacheKey: 'interdomestik:legal_doc_extract',
+            promptCacheKey: 'interdomestik:legal_doc_extract:gpt-5.5:legal_doc_extract_v1',
           }),
         }),
       ])

--- a/packages/domain-claims/src/claims/ai-workflows.test.ts
+++ b/packages/domain-claims/src/claims/ai-workflows.test.ts
@@ -7,9 +7,20 @@ const hoisted = vi.hoisted(() => {
   }));
 
   return {
-    getDefaultModelForWorkflow: vi.fn((workflow: string) =>
-      workflow === 'legal_doc_extract' ? 'gpt-5.5' : 'gpt-5-mini'
-    ),
+    getResponsesWorkflowConfig: vi.fn((workflow: string) => ({
+      workflow,
+      model: workflow === 'legal_doc_extract' ? 'gpt-5.5' : 'gpt-5-mini',
+      promptVersion:
+        workflow === 'legal_doc_extract' ? 'legal_doc_extract_v1' : 'claim_intake_extract_v1',
+      promptCacheKey: `interdomestik:${workflow}`,
+      reasoning: {
+        effort: workflow === 'legal_doc_extract' ? 'high' : 'medium',
+      },
+      text: {
+        verbosity: 'low',
+      },
+      maxOutputTokens: workflow === 'legal_doc_extract' ? 4_000 : 2_000,
+    })),
     nanoid: vi.fn().mockReturnValueOnce('run-1').mockReturnValueOnce('run-2'),
     txInsert,
     txInsertValues,
@@ -22,7 +33,7 @@ vi.mock('@interdomestik/database', () => ({
 }));
 
 vi.mock('@interdomestik/domain-ai/models', () => ({
-  getDefaultModelForWorkflow: hoisted.getDefaultModelForWorkflow,
+  getResponsesWorkflowConfig: hoisted.getResponsesWorkflowConfig,
 }));
 
 vi.mock('nanoid', () => ({
@@ -129,6 +140,7 @@ describe('queueClaimDocumentAiWorkflows', () => {
           requestJson: expect.objectContaining({
             category: 'evidence',
             bucket: 'claim-evidence',
+            promptCacheKey: 'interdomestik:claim_intake_extract',
             claimSnapshot: expect.objectContaining({
               incidentDate: '2026-02-15',
             }),
@@ -142,6 +154,7 @@ describe('queueClaimDocumentAiWorkflows', () => {
           promptVersion: 'legal_doc_extract_v1',
           requestJson: expect.objectContaining({
             category: 'legal',
+            promptCacheKey: 'interdomestik:legal_doc_extract',
           }),
         }),
       ])

--- a/packages/domain-claims/src/claims/ai-workflows.ts
+++ b/packages/domain-claims/src/claims/ai-workflows.ts
@@ -1,11 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import { aiRuns, documents } from '@interdomestik/database';
-import {
-  CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION,
-  LEGAL_DOC_EXTRACT_SCHEMA_VERSION,
-} from '@interdomestik/domain-ai';
-import { getDefaultModelForWorkflow } from '@interdomestik/domain-ai/models';
+import { getResponsesWorkflowConfig } from '@interdomestik/domain-ai/models';
 import { nanoid } from 'nanoid';
 
 export type ClaimAiWorkflow = 'claim_intake_extract' | 'legal_doc_extract';
@@ -53,12 +49,6 @@ function resolveWorkflow(category: ClaimAiDocumentCategory): ClaimAiWorkflow {
   return category === 'legal' ? 'legal_doc_extract' : 'claim_intake_extract';
 }
 
-function resolvePromptVersion(workflow: ClaimAiWorkflow) {
-  return workflow === 'legal_doc_extract'
-    ? LEGAL_DOC_EXTRACT_SCHEMA_VERSION
-    : CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION;
-}
-
 function buildInputHash(args: {
   workflow: ClaimAiWorkflow;
   claimId: string;
@@ -88,7 +78,7 @@ export async function queueClaimDocumentAiWorkflows(args: {
     const workflow = resolveWorkflow(category);
     const documentId = file.documentId ?? nanoid();
     const runId = nanoid();
-    const model = getDefaultModelForWorkflow(workflow);
+    const config = getResponsesWorkflowConfig(workflow);
 
     return {
       runId,
@@ -96,8 +86,9 @@ export async function queueClaimDocumentAiWorkflows(args: {
       claimId: args.claimId,
       documentId,
       category,
-      model,
-      promptVersion: resolvePromptVersion(workflow),
+      model: config.model,
+      promptVersion: config.promptVersion,
+      promptCacheKey: config.promptCacheKey,
       file,
       inputHash: buildInputHash({
         workflow,
@@ -151,6 +142,7 @@ export async function queueClaimDocumentAiWorkflows(args: {
         storagePath: queuedRun.file.path,
         bucket: queuedRun.file.bucket,
         category: queuedRun.category,
+        promptCacheKey: queuedRun.promptCacheKey,
         claimSnapshot: args.claimSnapshot ?? null,
       },
       reviewStatus: 'pending',

--- a/scripts/ci/codex-contracts.test.mjs
+++ b/scripts/ci/codex-contracts.test.mjs
@@ -92,6 +92,8 @@ test('Codex PR review workflow uses the official action with a repo-owned review
   assert.match(workflow, /Skipping Codex review because OPENAI_API_KEY is not configured/);
   assert.match(workflow, /uses:\s*openai\/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031/);
   assert.match(workflow, /prompt-file:\s*\.github\/codex\/prompts\/review\.md/);
+  assert.match(workflow, /model:\s*gpt-5\.5/);
+  assert.match(workflow, /effort:\s*high/);
   assert.match(workflow, /safety-strategy:\s*drop-sudo/);
   assert.match(workflow, /sandbox:\s*workspace-write/);
 


### PR DESCRIPTION
## Summary
- switch Codex review workflow to GPT-5.5 with high effort
- centralize Responses workflow config for AI model, reasoning effort, verbosity, prompt versions, and prompt cache keys
- wire policy analysis and claims AI workflows through the centralized config
- add contract/unit coverage for the GPT-5.5 defaults

## Verification
- node --test scripts/ci/codex-contracts.test.mjs
- pnpm test:ci:contracts
- pnpm security:guard
- pnpm e2e:gate
- pnpm pr:verify