### PR TITLE
P18 UX02: clarify member claim progress

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/claims/[id]/page.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/[id]/page.test.tsx
@@ -25,6 +25,13 @@ const hoisted = vi.hoisted(() => ({
     canShare: false,
     documents: [],
     timeline: [],
+    progressSummary: {
+      currentStatusLabelKey: 'claims-tracking.status.evaluation',
+      latestUpdateAt: new Date('2026-03-14T11:00:00.000Z'),
+      latestUpdateLabelKey: 'claims-tracking.status.evaluation',
+      latestUpdateNote: null,
+      nextStepKey: 'claims-tracking.status.next_step.evaluation',
+    },
     matterAllowance: null,
   })),
   memberClaimDetailOpsPageMock: vi.fn((props: unknown) => (

--- a/apps/web/src/app/[locale]/(app)/member/claims/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/[id]/page.tsx
@@ -48,6 +48,10 @@ export default async function ClaimDetailsPage({ params }: PageProps) {
       ...e,
       date: e.date.toISOString(),
     })),
+    progressSummary: {
+      ...claim.progressSummary,
+      latestUpdateAt: claim.progressSummary.latestUpdateAt.toISOString(),
+    },
   };
 
   return (

--- a/apps/web/src/features/claims/tracking/server/getMemberClaimDetail.test.ts
+++ b/apps/web/src/features/claims/tracking/server/getMemberClaimDetail.test.ts
@@ -243,6 +243,59 @@ describe('getMemberClaimDetail', () => {
     );
   });
 
+  it('derives member progress summary from the latest public timeline event', async () => {
+    const latestUpdate = new Date('2026-04-15T12:30:00.000Z');
+
+    hoisted.claimFindFirst.mockResolvedValueOnce({
+      id: 'claim_progress',
+      title: 'Delayed flight',
+      status: 'evaluation',
+      createdAt: new Date('2026-04-14T09:00:00.000Z'),
+      updatedAt: latestUpdate,
+      description: 'Compensation review',
+      claimAmount: 250,
+      currency: 'EUR',
+      documents: [],
+    });
+    hoisted.timelineRows.mockResolvedValueOnce([
+      {
+        id: 'history_latest',
+        createdAt: latestUpdate,
+        fromStatus: 'verification',
+        toStatus: 'evaluation',
+        note: 'We reviewed the boarding pass and moved the case to evaluation.',
+        isPublic: true,
+      },
+      {
+        id: 'history_previous',
+        createdAt: new Date('2026-04-14T09:00:00.000Z'),
+        fromStatus: null,
+        toStatus: 'submitted',
+        note: 'Claim received.',
+        isPublic: true,
+      },
+    ]);
+
+    const result = await getMemberClaimDetail(
+      {
+        user: {
+          id: 'member-1',
+          role: 'member',
+          tenantId: 'tenant-1',
+        },
+      },
+      'claim_progress'
+    );
+
+    expect(result?.progressSummary).toEqual({
+      currentStatusLabelKey: 'claims-tracking.status.evaluation',
+      latestUpdateAt: latestUpdate,
+      latestUpdateLabelKey: 'claims-tracking.status.evaluation',
+      latestUpdateNote: 'We reviewed the boarding pass and moved the case to evaluation.',
+      nextStepKey: 'claims-tracking.status.next_step.evaluation',
+    });
+  });
+
   it('maps annual matter allowance visibility onto the member claim detail dto', async () => {
     hoisted.claimFindFirst.mockResolvedValueOnce({
       id: 'claim_2',

--- a/apps/web/src/features/claims/tracking/server/getMemberClaimDetail.ts
+++ b/apps/web/src/features/claims/tracking/server/getMemberClaimDetail.ts
@@ -16,7 +16,12 @@ import {
 import * as Sentry from '@sentry/nextjs';
 import { and, desc, eq } from 'drizzle-orm';
 import 'server-only';
-import type { ClaimTimelineEvent, ClaimTrackingDetailDto, ClaimTrackingDocument } from '../types';
+import type {
+  ClaimProgressSummaryDto,
+  ClaimTimelineEvent,
+  ClaimTrackingDetailDto,
+  ClaimTrackingDocument,
+} from '../types';
 import { buildClaimVisibilityWhere } from '../utils';
 
 function buildFallbackTimelineEvent(args: {
@@ -32,6 +37,22 @@ function buildFallbackTimelineEvent(args: {
     labelKey: `claims-tracking.status.${args.status}`,
     note: null,
     isPublic: true,
+  };
+}
+
+function buildProgressSummary(args: {
+  status: ClaimStatus;
+  timeline: ClaimTimelineEvent[];
+}): ClaimProgressSummaryDto {
+  const currentStatusLabelKey = `claims-tracking.status.${args.status}`;
+  const latestUpdate = args.timeline[0];
+
+  return {
+    currentStatusLabelKey,
+    latestUpdateAt: latestUpdate?.date ?? new Date(),
+    latestUpdateLabelKey: latestUpdate?.labelKey ?? currentStatusLabelKey,
+    latestUpdateNote: latestUpdate?.note ?? null,
+    nextStepKey: `claims-tracking.status.next_step.${args.status}`,
   };
 }
 
@@ -185,6 +206,10 @@ export async function getMemberClaimDetail(
         documents,
         timeline,
         canShare: true, // TODO: Logic for enabling share button
+        progressSummary: buildProgressSummary({
+          status: claimStatus,
+          timeline,
+        }),
         matterAllowance,
         recoveryDecision,
       };

--- a/apps/web/src/features/claims/tracking/server/getMemberClaimDetail.ts
+++ b/apps/web/src/features/claims/tracking/server/getMemberClaimDetail.ts
@@ -47,11 +47,15 @@ function buildProgressSummary(args: {
   const currentStatusLabelKey = `claims-tracking.status.${args.status}`;
   const latestUpdate = args.timeline[0];
 
+  if (!latestUpdate) {
+    throw new Error('buildProgressSummary requires a non-empty timeline');
+  }
+
   return {
     currentStatusLabelKey,
-    latestUpdateAt: latestUpdate?.date ?? new Date(),
-    latestUpdateLabelKey: latestUpdate?.labelKey ?? currentStatusLabelKey,
-    latestUpdateNote: latestUpdate?.note ?? null,
+    latestUpdateAt: latestUpdate.date,
+    latestUpdateLabelKey: latestUpdate.labelKey,
+    latestUpdateNote: latestUpdate.note,
     nextStepKey: `claims-tracking.status.next_step.${args.status}`,
   };
 }

--- a/apps/web/src/features/claims/tracking/types.ts
+++ b/apps/web/src/features/claims/tracking/types.ts
@@ -15,6 +15,14 @@ export interface ClaimRecoveryDecisionDto {
   description: string | null;
 }
 
+export interface ClaimProgressSummaryDto {
+  currentStatusLabelKey: string;
+  latestUpdateAt: Date;
+  latestUpdateLabelKey: string;
+  latestUpdateNote: string | null;
+  nextStepKey: string;
+}
+
 export interface ClaimTrackingDetailDto {
   id: string;
   publicId?: string; // For public link if exists
@@ -34,6 +42,7 @@ export interface ClaimTrackingDetailDto {
 
   // Context
   canShare: boolean; // If allowed to generate public link
+  progressSummary: ClaimProgressSummaryDto;
   matterAllowance?: ClaimMatterAllowanceDto | null;
   recoveryDecision?: ClaimRecoveryDecisionDto | null;
 }

--- a/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx
+++ b/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx
@@ -46,7 +46,17 @@ vi.mock('next-intl', () => ({
     if (namespace === 'claims-tracking.status') {
       return (key: string) => {
         if (key === 'evaluation') return 'Evaluation';
+        if (key === 'verification') return 'Verification';
         return `claims-tracking.status.${key}`;
+      };
+    }
+    if (namespace === 'claims-tracking.status.next_step') {
+      return (key: string) => {
+        const translations: Record<string, string> = {
+          evaluation: 'Our experts are evaluating the damages and liability.',
+          verification: 'We are verifying the provided documents and evidence.',
+        };
+        return translations[key] || `claims-tracking.status.next_step.${key}`;
       };
     }
     if (namespace === 'claims-tracking.tracking.sla') {
@@ -74,6 +84,10 @@ vi.mock('next-intl', () => ({
           'timeline.empty': 'No updates yet',
           'claimsPro.actions.uploadEvidence': 'Upload evidence',
           'claimsPro.actions.sendMessage': 'Send message',
+          'detail.progress.title': 'Progress summary',
+          'detail.progress.currentState': 'Current state',
+          'detail.progress.latestUpdate': 'Latest update',
+          'detail.progress.nextAction': 'Expected next action',
           'table.amount': 'Amount',
         };
 
@@ -121,6 +135,13 @@ function buildClaim(now: Date, overrides: Partial<TestClaim> = {}): TestClaim {
     canShare: false,
     documents: [],
     timeline: [],
+    progressSummary: {
+      currentStatusLabelKey: 'claims-tracking.status.evaluation',
+      latestUpdateAt: now,
+      latestUpdateLabelKey: 'claims-tracking.status.evaluation',
+      latestUpdateNote: null,
+      nextStepKey: 'claims-tracking.status.next_step.evaluation',
+    },
     ...overrides,
   };
 }
@@ -168,6 +189,30 @@ describe('MemberClaimDetailOpsPage', () => {
     expect(
       screen.getByText('Waiting for your information before the SLA starts.')
     ).toBeInTheDocument();
+  });
+
+  it('shows current state, latest public update, and expected next action', () => {
+    renderPage({
+      progressSummary: {
+        currentStatusLabelKey: 'claims-tracking.status.verification',
+        latestUpdateAt: '2026-04-15T12:30:00.000Z',
+        latestUpdateLabelKey: 'claims-tracking.status.evaluation',
+        latestUpdateNote: 'We reviewed your boarding pass and moved the case forward.',
+        nextStepKey: 'claims-tracking.status.next_step.evaluation',
+      },
+    });
+
+    expect(screen.getByTestId('member-claim-progress-summary')).toBeInTheDocument();
+    expect(screen.getByText('Progress summary')).toBeInTheDocument();
+    expect(screen.getByText('Current state')).toBeInTheDocument();
+    expect(screen.getByTestId('member-claim-current-state')).toHaveTextContent('Verification');
+    expect(screen.getByTestId('member-claim-latest-update')).toHaveTextContent('Evaluation');
+    expect(screen.getByTestId('member-claim-latest-update-note')).toHaveTextContent(
+      'We reviewed your boarding pass and moved the case forward.'
+    );
+    expect(screen.getByTestId('member-claim-expected-next-action')).toHaveTextContent(
+      'Our experts are evaluating the damages and liability.'
+    );
   });
 
   it('shows annual matter usage and remaining allowance when the snapshot is available', () => {

--- a/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.tsx
+++ b/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ops/adapters/claims';
 import type {
   ClaimMatterAllowanceDto,
+  ClaimProgressSummaryDto,
   ClaimRecoveryDecisionDto,
   ClaimTrackingDetailDto,
   ClaimTrackingDocument,
@@ -38,14 +39,25 @@ type SerializedClaimMatterAllowance = Omit<ClaimMatterAllowanceDto, 'windowStart
 
 type SerializedClaimRecoveryDecision = ClaimRecoveryDecisionDto;
 
+type SerializedClaimProgressSummary = Omit<ClaimProgressSummaryDto, 'latestUpdateAt'> & {
+  latestUpdateAt: ClaimProgressSummaryDto['latestUpdateAt'] | string;
+};
+
 type MemberClaimDetailOpsClaim = Omit<
   ClaimTrackingDetailDto,
-  'createdAt' | 'updatedAt' | 'documents' | 'timeline' | 'matterAllowance' | 'recoveryDecision'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'documents'
+  | 'timeline'
+  | 'matterAllowance'
+  | 'recoveryDecision'
+  | 'progressSummary'
 > & {
   createdAt: ClaimTrackingDetailDto['createdAt'] | string;
   updatedAt: ClaimTrackingDetailDto['updatedAt'] | string | null;
   documents: SerializedClaimTrackingDocument[];
   timeline: SerializedClaimTimelineEvent[];
+  progressSummary: SerializedClaimProgressSummary;
   matterAllowance?: SerializedClaimMatterAllowance | null;
   recoveryDecision?: SerializedClaimRecoveryDecision | null;
 };
@@ -68,17 +80,24 @@ export function MemberClaimDetailOpsPage({
   const locale = useLocale();
   const t = useTranslations('claims');
   const tTrackingStatus = useTranslations('claims-tracking.status');
+  const tTrackingNextStep = useTranslations('claims-tracking.status.next_step');
   const tSla = useTranslations('claims-tracking.tracking.sla');
   const tClaimStatus = useTranslations('claims.status');
+
+  const translateTrackingStatus = (labelKey: string) => {
+    if (!labelKey.startsWith('claims-tracking.status.')) {
+      return labelKey;
+    }
+
+    return tTrackingStatus(labelKey.replace('claims-tracking.status.', ''));
+  };
 
   // Transform events and translate titles
   const opsEvents = toOpsTimelineEvents(claim.timeline).map(e => ({
     ...e,
     // claim.timeline labelKey is a fully qualified key (e.g. "claims-tracking.status.evaluation").
     // Translating it within the "claims" namespace causes missing-message errors in production.
-    title: e.title.startsWith('claims-tracking.status.')
-      ? tTrackingStatus(e.title.replace('claims-tracking.status.', ''))
-      : e.title,
+    title: translateTrackingStatus(e.title),
   }));
 
   const opsDocuments = toOpsDocuments(claim.documents);
@@ -112,6 +131,18 @@ export function MemberClaimDetailOpsPage({
   const uploadAction = secondary.find(action => action.id === 'upload');
   const secondaryActions = secondary.filter(action => action.id !== 'upload').map(mapAction);
   const showSlaCard = claim.slaPhase === 'incomplete' || claim.slaPhase === 'running';
+  const latestUpdateDate = formatPilotDateTime(
+    claim.progressSummary.latestUpdateAt,
+    locale,
+    String(claim.progressSummary.latestUpdateAt)
+  );
+  const nextStepLabel = claim.progressSummary.nextStepKey.startsWith(
+    'claims-tracking.status.next_step.'
+  )
+    ? tTrackingNextStep(
+        claim.progressSummary.nextStepKey.replace('claims-tracking.status.next_step.', '')
+      )
+    : claim.progressSummary.nextStepKey;
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto p-4 md:p-8">
@@ -157,6 +188,54 @@ export function MemberClaimDetailOpsPage({
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Main Content */}
         <div className="lg:col-span-2 space-y-6">
+          <Card data-testid="member-claim-progress-summary">
+            <CardHeader>
+              <CardTitle>{t('detail.progress.title')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 md:grid-cols-3">
+                <div>
+                  <span className="text-xs uppercase text-muted-foreground">
+                    {t('detail.progress.currentState')}
+                  </span>
+                  <p className="mt-1 font-semibold" data-testid="member-claim-current-state">
+                    {translateTrackingStatus(claim.progressSummary.currentStatusLabelKey)}
+                  </p>
+                </div>
+                <div>
+                  <span className="text-xs uppercase text-muted-foreground">
+                    {t('detail.progress.latestUpdate')}
+                  </span>
+                  <p className="mt-1 font-semibold" data-testid="member-claim-latest-update">
+                    {translateTrackingStatus(claim.progressSummary.latestUpdateLabelKey)}
+                  </p>
+                  <p
+                    className="mt-1 text-xs text-muted-foreground"
+                    data-testid="member-claim-latest-update-date"
+                  >
+                    {latestUpdateDate}
+                  </p>
+                  {claim.progressSummary.latestUpdateNote ? (
+                    <p className="mt-2 text-sm" data-testid="member-claim-latest-update-note">
+                      {claim.progressSummary.latestUpdateNote}
+                    </p>
+                  ) : null}
+                </div>
+                <div>
+                  <span className="text-xs uppercase text-muted-foreground">
+                    {t('detail.progress.nextAction')}
+                  </span>
+                  <p
+                    className="mt-1 text-sm leading-6"
+                    data-testid="member-claim-expected-next-action"
+                  >
+                    {nextStepLabel}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
           {showSlaCard ? (
             <Card>
               <CardHeader>

--- a/apps/web/src/messages/en/claims.json
+++ b/apps/web/src/messages/en/claims.json
@@ -165,6 +165,12 @@
       "evidence": "Attached Evidence",
       "documentsEmpty": "No documents uploaded yet",
       "viewDocument": "View",
+      "progress": {
+        "title": "Progress summary",
+        "currentState": "Current state",
+        "latestUpdate": "Latest update",
+        "nextAction": "Expected next action"
+      },
       "matterAllowance": {
         "title": "Matter allowance",
         "used": "Used this year",

--- a/apps/web/src/messages/mk/claims.json
+++ b/apps/web/src/messages/mk/claims.json
@@ -165,6 +165,12 @@
       "evidence": "Приложени докази",
       "documentsEmpty": "Сè уште нема прикачени документи",
       "viewDocument": "Отвори",
+      "progress": {
+        "title": "Преглед на напредокот",
+        "currentState": "Тековна состојба",
+        "latestUpdate": "Последно ажурирање",
+        "nextAction": "Очекуван следен чекор"
+      },
       "matterAllowance": {
         "title": "Квота за случаи",
         "used": "Искористено оваа година",

--- a/apps/web/src/messages/sq/claims.json
+++ b/apps/web/src/messages/sq/claims.json
@@ -165,6 +165,12 @@
       "evidence": "Dëshmi të bashkëngjitura",
       "documentsEmpty": "Ende nuk ka dokumente të ngarkuara",
       "viewDocument": "Shiko",
+      "progress": {
+        "title": "Përmbledhje e progresit",
+        "currentState": "Gjendja aktuale",
+        "latestUpdate": "Përditësimi i fundit",
+        "nextAction": "Hapi i pritshëm vijues"
+      },
       "matterAllowance": {
         "title": "Kuota e rasteve",
         "used": "Përdorur këtë vit",

--- a/apps/web/src/messages/sr/claims.json
+++ b/apps/web/src/messages/sr/claims.json
@@ -165,6 +165,12 @@
       "evidence": "Priloženi Dokazi",
       "documentsEmpty": "Još nema otpremljenih dokumenata",
       "viewDocument": "Otvori",
+      "progress": {
+        "title": "Pregled napretka",
+        "currentState": "Trenutno stanje",
+        "latestUpdate": "Poslednje ažuriranje",
+        "nextAction": "Očekivani sledeći korak"
+      },
       "matterAllowance": {
         "title": "Kvota predmeta",
         "used": "Iskorišćeno ove godine",


### PR DESCRIPTION
## Summary
- add a derived member claim progress summary DTO from the existing member-scoped claim detail read model
- render current state, latest member-visible update, and expected next action on the canonical member claim detail page
- add focused negative/contract coverage for summary derivation and rendering, with localized labels in en/sq/mk/sr

## Scope constraints
- untouched: apps/web/src/proxy.ts
- no route rename, auth/routing/tenancy redesign, schema change, portal restructuring, or Stripe work
- progress summary uses the existing member claim detail boundary and public timeline data already scoped by member/tenant access

## Verification
- Focused unit tests: pnpm --filter @interdomestik/web test:unit --run src/features/claims/tracking/server/getMemberClaimDetail.test.ts src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx 'src/app/[locale]/(app)/member/claims/[id]/page.test.tsx' (3 files, 15 tests passed)
- Deterministic local gates: git diff --check; pnpm --filter @interdomestik/web lint; pnpm --filter @interdomestik/web type-check; pnpm plan:status; pnpm plan:audit; pnpm track:audit; pnpm docs:verify
- Static verifier: pnpm verify-slice -- --static PASS, run_root=/Users/arbenlila/development/interdomestik-crystal-home/tmp/multi-agent/verify-slice/verify-slice-20260426T092437Z-40ab64
- Pre-PR reviewer pool: security, architecture, QA/contracts reviewers reported no must-fix findings
- Required gates: pnpm verify-slice -- --required-gates PASS, run_root=/Users/arbenlila/development/interdomestik-crystal-home/tmp/multi-agent/verify-slice/verify-slice-20260426T092735Z-468a7a