### PR TITLE
P19-CRM01 agent CRM tenant read contracts

### DIFF
--- a/apps/web/src/app/[locale]/(agent)/agent/crm/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/_core.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   dbSelect: vi.fn(),
@@ -11,9 +11,18 @@ vi.mock('@interdomestik/database/db', () => ({
 }));
 
 vi.mock('@interdomestik/database/schema', () => ({
-  crmLeads: { agentId: 'crmLeads.agentId', stage: 'crmLeads.stage' },
-  crmDeals: { agentId: 'crmDeals.agentId', stage: 'crmDeals.stage' },
+  crmLeads: {
+    tenantId: 'crmLeads.tenantId',
+    agentId: 'crmLeads.agentId',
+    stage: 'crmLeads.stage',
+  },
+  crmDeals: {
+    tenantId: 'crmDeals.tenantId',
+    agentId: 'crmDeals.agentId',
+    stage: 'crmDeals.stage',
+  },
   agentCommissions: {
+    tenantId: 'agentCommissions.tenantId',
     agentId: 'agentCommissions.agentId',
     status: 'agentCommissions.status',
     amount: 'agentCommissions.amount',
@@ -37,6 +46,10 @@ function createSelectChain(result: unknown) {
 }
 
 describe('getAgentCrmStatsCore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('returns numeric defaults when aggregates are null', async () => {
     hoisted.dbSelect
       .mockReturnValueOnce(createSelectChain([{ count: 0 }]))
@@ -44,7 +57,7 @@ describe('getAgentCrmStatsCore', () => {
       .mockReturnValueOnce(createSelectChain([{ count: 0 }]))
       .mockReturnValueOnce(createSelectChain([{ total: null }]));
 
-    const stats = await getAgentCrmStatsCore({ agentId: 'agent-1' });
+    const stats = await getAgentCrmStatsCore({ agentId: 'agent-1', tenantId: 'tenant-1' });
 
     expect(stats).toEqual({
       newLeadsCount: 0,
@@ -61,7 +74,7 @@ describe('getAgentCrmStatsCore', () => {
       .mockReturnValueOnce(createSelectChain([{ count: '2' }]))
       .mockReturnValueOnce(createSelectChain([{ total: '123.45' }]));
 
-    const stats = await getAgentCrmStatsCore({ agentId: 'agent-1' });
+    const stats = await getAgentCrmStatsCore({ agentId: 'agent-1', tenantId: 'tenant-1' });
 
     expect(stats).toEqual({
       newLeadsCount: 3,
@@ -73,5 +86,48 @@ describe('getAgentCrmStatsCore', () => {
     expect(typeof stats.contactedLeadsCount).toBe('number');
     expect(typeof stats.closedWonDealsCount).toBe('number');
     expect(typeof stats.paidCommissionTotal).toBe('number');
+  });
+
+  it('filters every tenant-bearing CRM aggregate by tenant and agent', async () => {
+    const chains = [
+      createSelectChain([{ count: 1 }]),
+      createSelectChain([{ count: 2 }]),
+      createSelectChain([{ count: 3 }]),
+      createSelectChain([{ total: '4.50' }]),
+    ];
+    for (const chain of chains) {
+      hoisted.dbSelect.mockReturnValueOnce(chain);
+    }
+
+    await getAgentCrmStatsCore({ agentId: 'agent-1', tenantId: 'tenant-1' });
+
+    expect(chains[0].where).toHaveBeenCalledWith({
+      and: [
+        { eq: ['crmLeads.tenantId', 'tenant-1'] },
+        { eq: ['crmLeads.agentId', 'agent-1'] },
+        { eq: ['crmLeads.stage', 'new'] },
+      ],
+    });
+    expect(chains[1].where).toHaveBeenCalledWith({
+      and: [
+        { eq: ['crmLeads.tenantId', 'tenant-1'] },
+        { eq: ['crmLeads.agentId', 'agent-1'] },
+        { eq: ['crmLeads.stage', 'contacted'] },
+      ],
+    });
+    expect(chains[2].where).toHaveBeenCalledWith({
+      and: [
+        { eq: ['crmDeals.tenantId', 'tenant-1'] },
+        { eq: ['crmDeals.agentId', 'agent-1'] },
+        { eq: ['crmDeals.stage', 'closed_won'] },
+      ],
+    });
+    expect(chains[3].where).toHaveBeenCalledWith({
+      and: [
+        { eq: ['agentCommissions.tenantId', 'tenant-1'] },
+        { eq: ['agentCommissions.agentId', 'agent-1'] },
+        { eq: ['agentCommissions.status', 'paid'] },
+      ],
+    });
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/crm/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/_core.test.ts
@@ -32,16 +32,28 @@ vi.mock('@interdomestik/database/schema', () => ({
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ and: args })),
   eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
+  inArray: vi.fn((col: unknown, vals: unknown) => ({ inArray: [col, vals] })),
   count: vi.fn(() => ({ kind: 'count' })),
   sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: { strings, values } }),
 }));
 
 import { getAgentCrmStatsCore } from './_core';
 
+/** Terminal at .where() – for crmDeals and agentCommissions queries */
 function createSelectChain(result: unknown) {
   return {
     from: vi.fn().mockReturnThis(),
     where: vi.fn().mockResolvedValue(result),
+  };
+}
+
+/** Terminal at .groupBy() – for the combined crmLeads count query */
+function createGroupByChain(result: unknown) {
+  const afterWhere = { groupBy: vi.fn().mockResolvedValue(result) };
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnValue(afterWhere),
+    afterWhere,
   };
 }
 
@@ -52,8 +64,7 @@ describe('getAgentCrmStatsCore', () => {
 
   it('returns numeric defaults when aggregates are null', async () => {
     hoisted.dbSelect
-      .mockReturnValueOnce(createSelectChain([{ count: 0 }]))
-      .mockReturnValueOnce(createSelectChain([{ count: 0 }]))
+      .mockReturnValueOnce(createGroupByChain([]))
       .mockReturnValueOnce(createSelectChain([{ count: 0 }]))
       .mockReturnValueOnce(createSelectChain([{ total: null }]));
 
@@ -69,8 +80,12 @@ describe('getAgentCrmStatsCore', () => {
 
   it('maps counts and totals to a stable numeric DTO', async () => {
     hoisted.dbSelect
-      .mockReturnValueOnce(createSelectChain([{ count: '3' }]))
-      .mockReturnValueOnce(createSelectChain([{ count: '7' }]))
+      .mockReturnValueOnce(
+        createGroupByChain([
+          { stage: 'new', count: '3' },
+          { stage: 'contacted', count: '7' },
+        ])
+      )
       .mockReturnValueOnce(createSelectChain([{ count: '2' }]))
       .mockReturnValueOnce(createSelectChain([{ total: '123.45' }]));
 
@@ -89,40 +104,41 @@ describe('getAgentCrmStatsCore', () => {
   });
 
   it('filters every tenant-bearing CRM aggregate by tenant and agent', async () => {
-    const chains = [
-      createSelectChain([{ count: 1 }]),
-      createSelectChain([{ count: 2 }]),
-      createSelectChain([{ count: 3 }]),
-      createSelectChain([{ total: '4.50' }]),
-    ];
-    for (const chain of chains) {
-      hoisted.dbSelect.mockReturnValueOnce(chain);
-    }
+    const leadChain = createGroupByChain([
+      { stage: 'new', count: 1 },
+      { stage: 'contacted', count: 2 },
+    ]);
+    const dealsChain = createSelectChain([{ count: 3 }]);
+    const commissionChain = createSelectChain([{ total: '4.50' }]);
+
+    hoisted.dbSelect
+      .mockReturnValueOnce(leadChain)
+      .mockReturnValueOnce(dealsChain)
+      .mockReturnValueOnce(commissionChain);
 
     await getAgentCrmStatsCore({ agentId: 'agent-1', tenantId: 'tenant-1' });
 
-    expect(chains[0].where).toHaveBeenCalledWith({
+    // crmLeads: combined new+contacted query uses inArray and groupBy
+    expect(leadChain.where).toHaveBeenCalledWith({
       and: [
         { eq: ['crmLeads.tenantId', 'tenant-1'] },
         { eq: ['crmLeads.agentId', 'agent-1'] },
-        { eq: ['crmLeads.stage', 'new'] },
+        { inArray: ['crmLeads.stage', ['new', 'contacted']] },
       ],
     });
-    expect(chains[1].where).toHaveBeenCalledWith({
-      and: [
-        { eq: ['crmLeads.tenantId', 'tenant-1'] },
-        { eq: ['crmLeads.agentId', 'agent-1'] },
-        { eq: ['crmLeads.stage', 'contacted'] },
-      ],
-    });
-    expect(chains[2].where).toHaveBeenCalledWith({
+    expect(leadChain.afterWhere.groupBy).toHaveBeenCalledWith('crmLeads.stage');
+
+    // crmDeals: unchanged single-stage filter
+    expect(dealsChain.where).toHaveBeenCalledWith({
       and: [
         { eq: ['crmDeals.tenantId', 'tenant-1'] },
         { eq: ['crmDeals.agentId', 'agent-1'] },
         { eq: ['crmDeals.stage', 'closed_won'] },
       ],
     });
-    expect(chains[3].where).toHaveBeenCalledWith({
+
+    // agentCommissions: unchanged
+    expect(commissionChain.where).toHaveBeenCalledWith({
       and: [
         { eq: ['agentCommissions.tenantId', 'tenant-1'] },
         { eq: ['agentCommissions.agentId', 'agent-1'] },

--- a/apps/web/src/app/[locale]/(agent)/agent/crm/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/_core.ts
@@ -1,7 +1,7 @@
 import { type LeadStage } from '@interdomestik/database/constants';
 import { db } from '@interdomestik/database/db';
 import { agentCommissions, crmDeals, crmLeads } from '@interdomestik/database/schema';
-import { and, count, eq, sql } from 'drizzle-orm';
+import { and, count, eq, inArray, sql } from 'drizzle-orm';
 
 export type AgentCrmStats = {
   newLeadsCount: number;
@@ -16,30 +16,18 @@ export async function getAgentCrmStatsCore(args: {
 }): Promise<AgentCrmStats> {
   const { agentId, tenantId } = args;
 
-  const STAGE_NEW: LeadStage = 'new';
-  const STAGE_CONTACTED: LeadStage = 'contacted';
-
-  const [[newLeads], [contactedLeads], [wonDeals], [totalCommission]] = await Promise.all([
+  const [leadCounts, [wonDeals], [totalCommission]] = await Promise.all([
     db
-      .select({ count: count() })
+      .select({ stage: crmLeads.stage, count: count() })
       .from(crmLeads)
       .where(
         and(
           eq(crmLeads.tenantId, tenantId),
           eq(crmLeads.agentId, agentId),
-          eq(crmLeads.stage, STAGE_NEW)
+          inArray(crmLeads.stage, ['new', 'contacted'] as LeadStage[])
         )
-      ),
-    db
-      .select({ count: count() })
-      .from(crmLeads)
-      .where(
-        and(
-          eq(crmLeads.tenantId, tenantId),
-          eq(crmLeads.agentId, agentId),
-          eq(crmLeads.stage, STAGE_CONTACTED)
-        )
-      ),
+      )
+      .groupBy(crmLeads.stage),
     db
       .select({ count: count() })
       .from(crmDeals)
@@ -63,8 +51,8 @@ export async function getAgentCrmStatsCore(args: {
   ]);
 
   return {
-    newLeadsCount: Number(newLeads?.count ?? 0),
-    contactedLeadsCount: Number(contactedLeads?.count ?? 0),
+    newLeadsCount: Number(leadCounts.find(r => r.stage === 'new')?.count ?? 0),
+    contactedLeadsCount: Number(leadCounts.find(r => r.stage === 'contacted')?.count ?? 0),
     closedWonDealsCount: Number(wonDeals?.count ?? 0),
     paidCommissionTotal: Number(totalCommission?.total ?? 0),
   };

--- a/apps/web/src/app/[locale]/(agent)/agent/crm/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/_core.ts
@@ -10,8 +10,11 @@ export type AgentCrmStats = {
   paidCommissionTotal: number;
 };
 
-export async function getAgentCrmStatsCore(args: { agentId: string }): Promise<AgentCrmStats> {
-  const { agentId } = args;
+export async function getAgentCrmStatsCore(args: {
+  agentId: string;
+  tenantId: string;
+}): Promise<AgentCrmStats> {
+  const { agentId, tenantId } = args;
 
   const STAGE_NEW: LeadStage = 'new';
   const STAGE_CONTACTED: LeadStage = 'contacted';
@@ -20,19 +23,43 @@ export async function getAgentCrmStatsCore(args: { agentId: string }): Promise<A
     db
       .select({ count: count() })
       .from(crmLeads)
-      .where(and(eq(crmLeads.agentId, agentId), eq(crmLeads.stage, STAGE_NEW))),
+      .where(
+        and(
+          eq(crmLeads.tenantId, tenantId),
+          eq(crmLeads.agentId, agentId),
+          eq(crmLeads.stage, STAGE_NEW)
+        )
+      ),
     db
       .select({ count: count() })
       .from(crmLeads)
-      .where(and(eq(crmLeads.agentId, agentId), eq(crmLeads.stage, STAGE_CONTACTED))),
+      .where(
+        and(
+          eq(crmLeads.tenantId, tenantId),
+          eq(crmLeads.agentId, agentId),
+          eq(crmLeads.stage, STAGE_CONTACTED)
+        )
+      ),
     db
       .select({ count: count() })
       .from(crmDeals)
-      .where(and(eq(crmDeals.agentId, agentId), eq(crmDeals.stage, 'closed_won'))),
+      .where(
+        and(
+          eq(crmDeals.tenantId, tenantId),
+          eq(crmDeals.agentId, agentId),
+          eq(crmDeals.stage, 'closed_won')
+        )
+      ),
     db
       .select({ total: sql<number>`sum(${agentCommissions.amount})` })
       .from(agentCommissions)
-      .where(and(eq(agentCommissions.agentId, agentId), eq(agentCommissions.status, 'paid'))),
+      .where(
+        and(
+          eq(agentCommissions.tenantId, tenantId),
+          eq(agentCommissions.agentId, agentId),
+          eq(agentCommissions.status, 'paid')
+        )
+      ),
   ]);
 
   return {

--- a/apps/web/src/app/[locale]/(agent)/agent/crm/page.test.tsx
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/page.test.tsx
@@ -10,6 +10,9 @@ const hoisted = vi.hoisted(() => ({
   ),
   getTranslationsMock: vi.fn(async () => (key: string) => key),
   setRequestLocaleMock: vi.fn(),
+  getFormatterMock: vi.fn(async () => ({
+    number: vi.fn((val: number) => String(val)),
+  })),
   ensureTenantIdMock: vi.fn(() => 'tenant-1'),
   getAgentCrmStatsCoreMock: vi.fn(),
 }));
@@ -25,6 +28,7 @@ vi.mock('next/navigation', () => ({
 vi.mock('next-intl/server', () => ({
   getTranslations: hoisted.getTranslationsMock,
   setRequestLocale: hoisted.setRequestLocaleMock,
+  getFormatter: hoisted.getFormatterMock,
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/[locale]/(agent)/agent/crm/page.test.tsx
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/page.test.tsx
@@ -1,13 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   headersMock: vi.fn(async () => new Headers()),
   redirectMock: vi.fn((url: string) => {
     throw new Error(`redirect:${url}`);
   }),
-  getSessionMock: vi.fn(async () => null),
+  getSessionMock: vi.fn<() => Promise<{ user: { id: string; tenantId: string | null } } | null>>(
+    async () => null
+  ),
   getTranslationsMock: vi.fn(async () => (key: string) => key),
   setRequestLocaleMock: vi.fn(),
+  ensureTenantIdMock: vi.fn(() => 'tenant-1'),
   getAgentCrmStatsCoreMock: vi.fn(),
 }));
 
@@ -32,6 +35,10 @@ vi.mock('@/lib/auth', () => ({
   },
 }));
 
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: hoisted.ensureTenantIdMock,
+}));
+
 vi.mock('./_core', () => ({
   getAgentCrmStatsCore: hoisted.getAgentCrmStatsCoreMock,
 }));
@@ -47,11 +54,55 @@ vi.mock('@/components/agent/pipeline-chart', () => ({
 import CRMPage from './page';
 
 describe('CRMPage auth redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSessionMock.mockResolvedValue(null);
+    hoisted.ensureTenantIdMock.mockReturnValue('tenant-1');
+    hoisted.getAgentCrmStatsCoreMock.mockResolvedValue({
+      newLeadsCount: 0,
+      contactedLeadsCount: 0,
+      closedWonDealsCount: 0,
+      paidCommissionTotal: 0,
+    });
+  });
+
   it('redirects unauthenticated users to the locale login path', async () => {
     await expect(
       CRMPage({
         params: Promise.resolve({ locale: 'en' }),
       })
     ).rejects.toThrow('redirect:/en/login');
+  });
+
+  it('rejects a session with missing tenant identity before loading CRM stats', async () => {
+    const session = { user: { id: 'agent-1', tenantId: null } };
+    hoisted.getSessionMock.mockResolvedValue(session);
+    hoisted.ensureTenantIdMock.mockImplementationOnce(() => {
+      throw new Error('Session missing tenantId. Data integrity issue.');
+    });
+
+    await expect(
+      CRMPage({
+        params: Promise.resolve({ locale: 'en' }),
+      })
+    ).rejects.toThrow('Session missing tenantId. Data integrity issue.');
+
+    expect(hoisted.ensureTenantIdMock).toHaveBeenCalledWith(session);
+    expect(hoisted.getAgentCrmStatsCoreMock).not.toHaveBeenCalled();
+  });
+
+  it('passes tenant identity into the CRM stats core on the authorized path', async () => {
+    hoisted.getSessionMock.mockResolvedValue({
+      user: { id: 'agent-1', tenantId: 'tenant-1' },
+    });
+
+    await CRMPage({
+      params: Promise.resolve({ locale: 'en' }),
+    });
+
+    expect(hoisted.getAgentCrmStatsCoreMock).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      tenantId: 'tenant-1',
+    });
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/crm/page.tsx
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/page.tsx
@@ -2,7 +2,7 @@ import { LeaderboardCard } from '@/components/agent/leaderboard-card';
 import { PipelineChart } from '@/components/agent/pipeline-chart';
 import { auth } from '@/lib/auth'; // server-side auth
 import { ensureTenantId } from '@interdomestik/shared-auth';
-import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
@@ -14,6 +14,7 @@ export default async function CRMPage({
   const { locale } = await params;
   setRequestLocale(locale);
   const t = await getTranslations('agent');
+  const format = await getFormatter();
   const session = await auth.api.getSession({
     headers: await headers(),
   });
@@ -48,7 +49,9 @@ export default async function CRMPage({
         </div>
         <div className="p-6 bg-white rounded-lg border shadow-sm">
           <div className="text-sm font-medium text-muted-foreground">{t('commissions.title')}</div>
-          <div className="text-2xl font-bold">€ {stats.paidCommissionTotal.toFixed(2)}</div>
+          <div className="text-2xl font-bold">
+            {format.number(stats.paidCommissionTotal, { style: 'currency', currency: 'EUR' })}
+          </div>
         </div>
       </div>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">

--- a/apps/web/src/app/[locale]/(agent)/agent/crm/page.tsx
+++ b/apps/web/src/app/[locale]/(agent)/agent/crm/page.tsx
@@ -1,6 +1,7 @@
 import { LeaderboardCard } from '@/components/agent/leaderboard-card';
 import { PipelineChart } from '@/components/agent/pipeline-chart';
 import { auth } from '@/lib/auth'; // server-side auth
+import { ensureTenantId } from '@interdomestik/shared-auth';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
@@ -22,8 +23,9 @@ export default async function CRMPage({
   }
 
   const agentId = session.user.id;
+  const tenantId = ensureTenantId(session);
 
-  const stats = await getAgentCrmStatsCore({ agentId });
+  const stats = await getAgentCrmStatsCore({ agentId, tenantId });
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   findLeadFirst: vi.fn(),
@@ -17,15 +17,18 @@ vi.mock('@interdomestik/database/db', () => ({
 }));
 
 vi.mock('drizzle-orm', () => ({
-  and: vi.fn(),
-  eq: vi.fn(),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
 }));
 
 vi.mock('@interdomestik/database/schema', () => ({
   crmLeads: {
     id: 'crmLeads.id',
+    tenantId: 'crmLeads.tenantId',
+    agentId: 'crmLeads.agentId',
   },
   crmDeals: {
+    tenantId: 'crmDeals.tenantId',
     leadId: 'crmDeals.leadId',
     agentId: 'crmDeals.agentId',
     $inferSelect: {} as unknown,
@@ -35,18 +38,31 @@ vi.mock('@interdomestik/database/schema', () => ({
 import { getAgentLeadDetailsCore } from './_core';
 
 describe('getAgentLeadDetailsCore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('returns not_found when lead missing', async () => {
     hoisted.findLeadFirst.mockResolvedValueOnce(null);
 
-    const result = await getAgentLeadDetailsCore({ leadId: 'l1', viewerAgentId: 'a1' });
+    const result = await getAgentLeadDetailsCore({
+      leadId: 'l1',
+      tenantId: 'tenant-1',
+      viewerAgentId: 'a1',
+    });
     expect(result).toEqual({ kind: 'not_found' });
   });
 
-  it('redirects when lead owned by other agent', async () => {
-    hoisted.findLeadFirst.mockResolvedValueOnce({ id: 'l1', agentId: 'other' });
+  it('returns not_found when lead is not owned by viewer agent', async () => {
+    hoisted.findLeadFirst.mockResolvedValueOnce(null);
 
-    const result = await getAgentLeadDetailsCore({ leadId: 'l1', viewerAgentId: 'a1' });
-    expect(result).toEqual({ kind: 'redirect', href: '/agent/leads' });
+    const result = await getAgentLeadDetailsCore({
+      leadId: 'l1',
+      tenantId: 'tenant-1',
+      viewerAgentId: 'a1',
+    });
+    expect(result).toEqual({ kind: 'not_found' });
+    expect(hoisted.dbSelect).not.toHaveBeenCalled();
   });
 
   it('returns ok when agent owns lead', async () => {
@@ -57,11 +73,46 @@ describe('getAgentLeadDetailsCore', () => {
       }),
     });
 
-    const result = await getAgentLeadDetailsCore({ leadId: 'l1', viewerAgentId: 'a1' });
+    const result = await getAgentLeadDetailsCore({
+      leadId: 'l1',
+      tenantId: 'tenant-1',
+      viewerAgentId: 'a1',
+    });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {
       expect(result.lead).toEqual({ id: 'l1', agentId: 'a1' });
       expect(result.deals).toEqual([]);
     }
+  });
+
+  it('filters lead and deal reads by tenant and viewer agent', async () => {
+    hoisted.findLeadFirst.mockResolvedValueOnce({ id: 'l1', agentId: 'a1' });
+    const where = vi.fn().mockResolvedValue([]);
+    hoisted.dbSelect.mockReturnValueOnce({
+      from: vi.fn(() => ({ where })),
+    });
+
+    await getAgentLeadDetailsCore({
+      leadId: 'l1',
+      tenantId: 'tenant-1',
+      viewerAgentId: 'a1',
+    });
+
+    expect(hoisted.findLeadFirst).toHaveBeenCalledWith({
+      where: {
+        and: [
+          { eq: ['crmLeads.id', 'l1'] },
+          { eq: ['crmLeads.tenantId', 'tenant-1'] },
+          { eq: ['crmLeads.agentId', 'a1'] },
+        ],
+      },
+    });
+    expect(where).toHaveBeenCalledWith({
+      and: [
+        { eq: ['crmDeals.tenantId', 'tenant-1'] },
+        { eq: ['crmDeals.leadId', 'l1'] },
+        { eq: ['crmDeals.agentId', 'a1'] },
+      ],
+    });
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts
@@ -16,6 +16,12 @@ vi.mock('@interdomestik/database/db', () => ({
   },
 }));
 
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: vi.fn((tenantId: unknown, col: unknown, conds?: unknown) => ({
+    withTenant: [tenantId, col, conds],
+  })),
+}));
+
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ and: args })),
   eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
@@ -53,7 +59,7 @@ describe('getAgentLeadDetailsCore', () => {
     expect(result).toEqual({ kind: 'not_found' });
   });
 
-  it('returns not_found when lead is not owned by viewer agent', async () => {
+  it('returns not_found when no lead matches the tenant and viewer agent scope', async () => {
     hoisted.findLeadFirst.mockResolvedValueOnce(null);
 
     const result = await getAgentLeadDetailsCore({
@@ -100,18 +106,18 @@ describe('getAgentLeadDetailsCore', () => {
 
     expect(hoisted.findLeadFirst).toHaveBeenCalledWith({
       where: {
-        and: [
-          { eq: ['crmLeads.id', 'l1'] },
-          { eq: ['crmLeads.tenantId', 'tenant-1'] },
-          { eq: ['crmLeads.agentId', 'a1'] },
+        withTenant: [
+          'tenant-1',
+          'crmLeads.tenantId',
+          { and: [{ eq: ['crmLeads.id', 'l1'] }, { eq: ['crmLeads.agentId', 'a1'] }] },
         ],
       },
     });
     expect(where).toHaveBeenCalledWith({
-      and: [
-        { eq: ['crmDeals.tenantId', 'tenant-1'] },
-        { eq: ['crmDeals.leadId', 'l1'] },
-        { eq: ['crmDeals.agentId', 'a1'] },
+      withTenant: [
+        'tenant-1',
+        'crmDeals.tenantId',
+        { and: [{ eq: ['crmDeals.leadId', 'l1'] }, { eq: ['crmDeals.agentId', 'a1'] }] },
       ],
     });
   });

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.ts
@@ -1,5 +1,6 @@
 import { db } from '@interdomestik/database/db';
 import { crmDeals, crmLeads } from '@interdomestik/database/schema';
+import { withTenant } from '@interdomestik/database/tenant-security';
 import { and, eq } from 'drizzle-orm';
 
 export type AgentLeadDetails = Awaited<ReturnType<typeof db.query.crmLeads.findFirst>>;
@@ -8,8 +9,7 @@ export type AgentLeadDealRow = typeof crmDeals.$inferSelect;
 
 export type AgentLeadDetailsResult =
   | { kind: 'ok'; lead: NonNullable<AgentLeadDetails>; deals: AgentLeadDealRow[] }
-  | { kind: 'not_found' }
-  | { kind: 'redirect'; href: string };
+  | { kind: 'not_found' };
 
 export async function getAgentLeadDetailsCore(args: {
   leadId: string;
@@ -17,10 +17,10 @@ export async function getAgentLeadDetailsCore(args: {
   viewerAgentId: string;
 }): Promise<AgentLeadDetailsResult> {
   const lead = await db.query.crmLeads.findFirst({
-    where: and(
-      eq(crmLeads.id, args.leadId),
-      eq(crmLeads.tenantId, args.tenantId),
-      eq(crmLeads.agentId, args.viewerAgentId)
+    where: withTenant(
+      args.tenantId,
+      crmLeads.tenantId,
+      and(eq(crmLeads.id, args.leadId), eq(crmLeads.agentId, args.viewerAgentId))
     ),
   });
 
@@ -30,10 +30,10 @@ export async function getAgentLeadDetailsCore(args: {
     .select()
     .from(crmDeals)
     .where(
-      and(
-        eq(crmDeals.tenantId, args.tenantId),
-        eq(crmDeals.leadId, args.leadId),
-        eq(crmDeals.agentId, args.viewerAgentId)
+      withTenant(
+        args.tenantId,
+        crmDeals.tenantId,
+        and(eq(crmDeals.leadId, args.leadId), eq(crmDeals.agentId, args.viewerAgentId))
       )
     );
 

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.ts
@@ -13,22 +13,29 @@ export type AgentLeadDetailsResult =
 
 export async function getAgentLeadDetailsCore(args: {
   leadId: string;
+  tenantId: string;
   viewerAgentId: string;
 }): Promise<AgentLeadDetailsResult> {
   const lead = await db.query.crmLeads.findFirst({
-    where: eq(crmLeads.id, args.leadId),
+    where: and(
+      eq(crmLeads.id, args.leadId),
+      eq(crmLeads.tenantId, args.tenantId),
+      eq(crmLeads.agentId, args.viewerAgentId)
+    ),
   });
 
   if (!lead) return { kind: 'not_found' };
 
-  if (lead.agentId !== args.viewerAgentId) {
-    return { kind: 'redirect', href: '/agent/leads' };
-  }
-
   const deals = await db
     .select()
     .from(crmDeals)
-    .where(and(eq(crmDeals.leadId, args.leadId), eq(crmDeals.agentId, args.viewerAgentId)));
+    .where(
+      and(
+        eq(crmDeals.tenantId, args.tenantId),
+        eq(crmDeals.leadId, args.leadId),
+        eq(crmDeals.agentId, args.viewerAgentId)
+      )
+    );
 
   return { kind: 'ok', lead, deals };
 }

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
@@ -113,14 +113,14 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
     expect(hoisted.getLeadActivitiesMock).toHaveBeenCalledWith('lead-1');
   });
 
-  it('does not load activities when the lead detail core redirects', async () => {
+  it('does not load activities when the lead detail core returns not_found', async () => {
     hoisted.getAgentLeadDetailsCoreMock.mockResolvedValueOnce({
-      kind: 'redirect',
-      href: '/agent/leads',
+      kind: 'not_found',
     });
 
-    await expect(AgentLeadDetailV2Page({ id: 'lead-1' })).rejects.toThrow('redirect:/agent/leads');
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1' })).rejects.toThrow('not-found');
 
+    expect(hoisted.notFoundMock).toHaveBeenCalled();
     expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  headersMock: vi.fn(async () => new Headers()),
+  redirectMock: vi.fn((href: string) => {
+    throw new Error(`redirect:${href}`);
+  }),
+  notFoundMock: vi.fn(() => {
+    throw new Error('not-found');
+  }),
+  getTranslationsMock: vi.fn(async () => (key: string) => key),
+  getSessionMock: vi.fn(),
+  ensureTenantIdMock: vi.fn(() => 'tenant-1'),
+  getAgentLeadDetailsCoreMock: vi.fn(),
+  getLeadActivitiesMock: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  headers: hoisted.headersMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: hoisted.notFoundMock,
+  redirect: hoisted.redirectMock,
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: hoisted.getTranslationsMock,
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: hoisted.getSessionMock,
+    },
+  },
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: hoisted.ensureTenantIdMock,
+}));
+
+vi.mock('@/actions/activities', () => ({
+  getLeadActivities: hoisted.getLeadActivitiesMock,
+}));
+
+vi.mock('@/app/[locale]/(agent)/agent/leads/[id]/_core', () => ({
+  getAgentLeadDetailsCore: hoisted.getAgentLeadDetailsCoreMock,
+}));
+
+vi.mock('@/components/crm/activity-feed', () => ({
+  ActivityFeed: () => null,
+}));
+
+vi.mock('@/components/crm/log-activity-dialog', () => ({
+  LogActivityDialog: () => null,
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('@interdomestik/ui', () => ({
+  Button: ({ children }: { children: ReactNode }) => children,
+  Card: ({ children }: { children: ReactNode }) => children,
+  CardContent: ({ children }: { children: ReactNode }) => children,
+  CardHeader: ({ children }: { children: ReactNode }) => children,
+  CardTitle: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { AgentLeadDetailV2Page } from './AgentLeadDetailV2Page';
+
+describe('AgentLeadDetailV2Page tenant contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSessionMock.mockResolvedValue({
+      user: { id: 'agent-1', tenantId: 'tenant-1' },
+    });
+    hoisted.ensureTenantIdMock.mockReturnValue('tenant-1');
+    hoisted.getAgentLeadDetailsCoreMock.mockResolvedValue({
+      kind: 'ok',
+      lead: { id: 'lead-1', agentId: 'agent-1', fullName: 'Lead', stage: 'new' },
+      deals: [],
+    });
+    hoisted.getLeadActivitiesMock.mockResolvedValue([]);
+  });
+
+  it('rejects a session with missing tenant identity before loading lead details', async () => {
+    const session = { user: { id: 'agent-1', tenantId: null } };
+    hoisted.getSessionMock.mockResolvedValue(session);
+    hoisted.ensureTenantIdMock.mockImplementationOnce(() => {
+      throw new Error('Session missing tenantId. Data integrity issue.');
+    });
+
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1' })).rejects.toThrow(
+      'Session missing tenantId. Data integrity issue.'
+    );
+
+    expect(hoisted.ensureTenantIdMock).toHaveBeenCalledWith(session);
+    expect(hoisted.getAgentLeadDetailsCoreMock).not.toHaveBeenCalled();
+    expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('passes tenant identity into the lead detail core before loading activities', async () => {
+    await AgentLeadDetailV2Page({ id: 'lead-1' });
+
+    expect(hoisted.getAgentLeadDetailsCoreMock).toHaveBeenCalledWith({
+      leadId: 'lead-1',
+      tenantId: 'tenant-1',
+      viewerAgentId: 'agent-1',
+    });
+    expect(hoisted.getLeadActivitiesMock).toHaveBeenCalledWith('lead-1');
+  });
+
+  it('does not load activities when the lead detail core redirects', async () => {
+    hoisted.getAgentLeadDetailsCoreMock.mockResolvedValueOnce({
+      kind: 'redirect',
+      href: '/agent/leads',
+    });
+
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1' })).rejects.toThrow('redirect:/agent/leads');
+
+    expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
@@ -4,6 +4,7 @@ import { LogActivityDialog } from '@/components/crm/log-activity-dialog';
 import { Link } from '@/i18n/routing';
 import { auth } from '@/lib/auth';
 import { Button, Card, CardContent, CardHeader, CardTitle } from '@interdomestik/ui';
+import { ensureTenantId } from '@interdomestik/shared-auth';
 import { getTranslations } from 'next-intl/server';
 import { headers } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
@@ -19,13 +20,18 @@ export async function AgentLeadDetailV2Page({ id }: { id: string }) {
     redirect('/auth/login');
   }
 
-  const [leadResult, activities] = await Promise.all([
-    getAgentLeadDetailsCore({ leadId: id, viewerAgentId: session.user.id }),
-    getLeadActivities(id),
-  ]);
+  const tenantId = ensureTenantId(session);
+
+  const leadResult = await getAgentLeadDetailsCore({
+    leadId: id,
+    tenantId,
+    viewerAgentId: session.user.id,
+  });
 
   if (leadResult.kind === 'not_found') notFound();
   if (leadResult.kind === 'redirect') redirect(leadResult.href);
+
+  const activities = await getLeadActivities(id);
 
   const lead = leadResult.lead;
   const deals = leadResult.deals;

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
@@ -29,7 +29,6 @@ export async function AgentLeadDetailV2Page({ id }: { id: string }) {
   });
 
   if (leadResult.kind === 'not_found') notFound();
-  if (leadResult.kind === 'redirect') redirect(leadResult.href);
 
   const activities = await getLeadActivities(id);
 


### PR DESCRIPTION
## Summary
- Require tenant identity at the agent CRM page boundary and pass tenantId into CRM aggregate reads.
- Scope CRM aggregate lead/deal/commission reads by tenant and agent.
- Scope agent lead detail reads by tenant and viewer agent before loading deals or activities.
- Add focused negative/query-contract tests for missing tenant identity and tenant-bound reads.

## Verification
- pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(agent)/agent/crm/page.test.tsx' 'src/app/[locale]/(agent)/agent/crm/_core.test.ts' 'src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts' 'src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx'
- pnpm pr:verify:hosts
- pnpm security:guard
- pnpm verify-slice -- --static
- pnpm verify-slice -- --required-gates (PASS; run_root tmp/multi-agent/verify-slice/verify-slice-20260426T162846Z-8d7d36; full e2e gate 101 passed / 3 skipped)

## Reviewer pool
- Security reviewer: no must-fix; ownership-bound lead read suggestion applied.
- Architecture reviewer: no must-fix.
- QA reviewer: no must-fix.

## Scope notes
- apps/web/src/proxy.ts untouched.
- No route renames, auth/routing/tenancy redesign, schema changes, or Stripe changes.