### PR TITLE
fix: tenant-scope agent dashboard crm kpis

### DIFF
--- a/apps/web/src/app/[locale]/(agent)/agent/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/_core.test.ts
@@ -1,71 +1,178 @@
-import { claims, memberLeads } from '@interdomestik/database/schema';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getAgentDashboardLiteCore, getAgentDashboardV2StatsCore } from './_core';
 
-describe('getAgentDashboardLiteCore', () => {
+vi.mock('@interdomestik/database/schema', () => ({
+  agentCommissions: {
+    tenantId: 'agentCommissions.tenantId',
+    agentId: 'agentCommissions.agentId',
+    status: 'agentCommissions.status',
+    amount: 'agentCommissions.amount',
+  },
+  claims: {
+    agentId: 'claims.agentId',
+    status: 'claims.status',
+  },
+  crmDeals: {
+    tenantId: 'crmDeals.tenantId',
+    agentId: 'crmDeals.agentId',
+    stage: 'crmDeals.stage',
+  },
+  crmLeads: {
+    tenantId: 'crmLeads.tenantId',
+    agentId: 'crmLeads.agentId',
+    stage: 'crmLeads.stage',
+  },
+  memberLeads: {
+    agentId: 'memberLeads.agentId',
+    status: 'memberLeads.status',
+  },
+  subscriptions: {
+    tenantId: 'subscriptions.tenantId',
+    referredByAgentId: 'subscriptions.referredByAgentId',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  count: vi.fn(() => ({ kind: 'count' })),
+  eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
+  inArray: vi.fn((col: unknown, vals: unknown) => ({ inArray: [col, vals] })),
+  not: vi.fn((arg: unknown) => ({ not: arg })),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: { strings, values } }),
+}));
+
+import {
+  agentCommissions,
+  claims,
+  crmDeals,
+  crmLeads,
+  memberLeads,
+  subscriptions,
+} from '@interdomestik/database/schema';
+
+import {
+  getAgentDashboardLiteCore,
+  getAgentDashboardV2StatsCore,
+  type AgentDashboardServices,
+} from './_core';
+
+describe('agent dashboard core', () => {
   const mockDb = {
     select: vi.fn().mockReturnThis(),
     from: vi.fn().mockReturnThis(),
     where: vi.fn(),
   };
 
-  const services = { db: mockDb as any };
+  const services: AgentDashboardServices = { db: mockDb };
 
   beforeEach(() => {
-    mockDb.select.mockClear();
-    mockDb.from.mockClear();
-    mockDb.where.mockReset();
+    vi.clearAllMocks();
+    mockDb.select.mockReturnThis();
+    mockDb.from.mockReturnThis();
   });
 
-  it('calculates counts correctly for an agent', async () => {
-    // Mock leads count
-    mockDb.where.mockResolvedValueOnce([{ count: 5 }]);
-    // Mock claims count
-    mockDb.where.mockResolvedValueOnce([{ count: 3 }]);
+  describe('getAgentDashboardLiteCore', () => {
+    it('calculates counts correctly for an agent', async () => {
+      mockDb.where.mockResolvedValueOnce([{ count: 5 }]).mockResolvedValueOnce([{ count: 3 }]);
 
-    const result = await getAgentDashboardLiteCore({ agentId: 'agent-1' }, services);
+      const result = await getAgentDashboardLiteCore({ agentId: 'agent-1' }, services);
 
-    expect(result.newLeadsCount).toBe(5);
-    expect(result.activeClaimsCount).toBe(3);
-    expect(result.followUpsCount).toBe(0);
-
-    // Verify lead query
-    expect(mockDb.from).toHaveBeenCalledWith(memberLeads);
-    // Verify claim query
-    expect(mockDb.from).toHaveBeenCalledWith(claims);
-  });
-
-  it('handles empty results', async () => {
-    mockDb.where.mockResolvedValueOnce([]);
-    mockDb.where.mockResolvedValueOnce([]);
-
-    const result = await getAgentDashboardLiteCore({ agentId: 'agent-1' }, services);
-
-    expect(result.newLeadsCount).toBe(0);
-    expect(result.activeClaimsCount).toBe(0);
-  });
-
-  it('maps v2 KPI aggregates to numeric DTO fields', async () => {
-    mockDb.where
-      .mockResolvedValueOnce([{ count: '4' }])
-      .mockResolvedValueOnce([{ count: '6' }])
-      .mockResolvedValueOnce([{ count: '2' }])
-      .mockResolvedValueOnce([{ total: '42.75' }])
-      .mockResolvedValueOnce([{ count: '9' }]);
-
-    const stats = await getAgentDashboardV2StatsCore({ agentId: 'agent-1' }, services);
-
-    expect(stats).toEqual({
-      newLeads: 4,
-      contactedLeads: 6,
-      wonDeals: 2,
-      totalPaidCommission: 42.75,
-      clientCount: 9,
+      expect(result.newLeadsCount).toBe(5);
+      expect(result.activeClaimsCount).toBe(3);
+      expect(result.followUpsCount).toBe(0);
+      expect(mockDb.from).toHaveBeenCalledWith(memberLeads);
+      expect(mockDb.from).toHaveBeenCalledWith(claims);
     });
-    expect(typeof stats.newLeads).toBe('number');
-    expect(typeof stats.contactedLeads).toBe('number');
-    expect(typeof stats.wonDeals).toBe('number');
-    expect(typeof stats.totalPaidCommission).toBe('number');
-    expect(typeof stats.clientCount).toBe('number');
+
+    it('handles empty results', async () => {
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await getAgentDashboardLiteCore({ agentId: 'agent-1' }, services);
+
+      expect(result.newLeadsCount).toBe(0);
+      expect(result.activeClaimsCount).toBe(0);
+    });
+  });
+
+  describe('getAgentDashboardV2StatsCore', () => {
+    it('maps v2 KPI aggregates to numeric DTO fields', async () => {
+      mockDb.where
+        .mockResolvedValueOnce([{ count: '4' }])
+        .mockResolvedValueOnce([{ count: '6' }])
+        .mockResolvedValueOnce([{ count: '2' }])
+        .mockResolvedValueOnce([{ total: '42.75' }])
+        .mockResolvedValueOnce([{ count: '9' }]);
+
+      const stats = await getAgentDashboardV2StatsCore(
+        { agentId: 'agent-1', tenantId: 'tenant-1' },
+        services
+      );
+
+      expect(stats).toEqual({
+        newLeads: 4,
+        contactedLeads: 6,
+        wonDeals: 2,
+        totalPaidCommission: 42.75,
+        clientCount: 9,
+      });
+      expect(typeof stats.newLeads).toBe('number');
+      expect(typeof stats.contactedLeads).toBe('number');
+      expect(typeof stats.wonDeals).toBe('number');
+      expect(typeof stats.totalPaidCommission).toBe('number');
+      expect(typeof stats.clientCount).toBe('number');
+    });
+
+    it('filters every tenant-bearing v2 KPI read by tenant and agent or referrer', async () => {
+      mockDb.where
+        .mockResolvedValueOnce([{ count: 1 }])
+        .mockResolvedValueOnce([{ count: 2 }])
+        .mockResolvedValueOnce([{ count: 3 }])
+        .mockResolvedValueOnce([{ total: '4.50' }])
+        .mockResolvedValueOnce([{ count: 5 }]);
+
+      await getAgentDashboardV2StatsCore({ agentId: 'agent-1', tenantId: 'tenant-1' }, services);
+
+      expect(mockDb.from.mock.calls).toEqual([
+        [crmLeads],
+        [crmLeads],
+        [crmDeals],
+        [agentCommissions],
+        [subscriptions],
+      ]);
+
+      expect(mockDb.where.mock.calls[0]?.[0]).toEqual({
+        and: [
+          { eq: ['crmLeads.tenantId', 'tenant-1'] },
+          { eq: ['crmLeads.agentId', 'agent-1'] },
+          { eq: ['crmLeads.stage', 'new'] },
+        ],
+      });
+      expect(mockDb.where.mock.calls[1]?.[0]).toEqual({
+        and: [
+          { eq: ['crmLeads.tenantId', 'tenant-1'] },
+          { eq: ['crmLeads.agentId', 'agent-1'] },
+          { eq: ['crmLeads.stage', 'contacted'] },
+        ],
+      });
+      expect(mockDb.where.mock.calls[2]?.[0]).toEqual({
+        and: [
+          { eq: ['crmDeals.tenantId', 'tenant-1'] },
+          { eq: ['crmDeals.agentId', 'agent-1'] },
+          { eq: ['crmDeals.stage', 'closed_won'] },
+        ],
+      });
+      expect(mockDb.where.mock.calls[3]?.[0]).toEqual({
+        and: [
+          { eq: ['agentCommissions.tenantId', 'tenant-1'] },
+          { eq: ['agentCommissions.agentId', 'agent-1'] },
+          { eq: ['agentCommissions.status', 'paid'] },
+        ],
+      });
+      expect(mockDb.where.mock.calls[4]?.[0]).toEqual({
+        and: [
+          { eq: ['subscriptions.tenantId', 'tenant-1'] },
+          { eq: ['subscriptions.referredByAgentId', 'agent-1'] },
+        ],
+      });
+    });
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/_core.ts
@@ -46,10 +46,10 @@ export async function getAgentDashboardLiteCore(
  * V2: Logic for the Pro/V2 Agent Dashboard (using CRM schema).
  */
 export async function getAgentDashboardV2StatsCore(
-  params: { agentId: string },
+  params: { agentId: string; tenantId: string },
   services: AgentDashboardServices
 ) {
-  const { agentId } = params;
+  const { agentId, tenantId } = params;
   const { db } = services;
 
   const STAGE_NEW: LeadStage = 'new';
@@ -58,27 +58,51 @@ export async function getAgentDashboardV2StatsCore(
   const [newLeads] = await db
     .select({ count: count() })
     .from(crmLeads)
-    .where(and(eq(crmLeads.agentId, agentId), eq(crmLeads.stage, STAGE_NEW)));
+    .where(
+      and(
+        eq(crmLeads.tenantId, tenantId),
+        eq(crmLeads.agentId, agentId),
+        eq(crmLeads.stage, STAGE_NEW)
+      )
+    );
 
   const [contactedLeads] = await db
     .select({ count: count() })
     .from(crmLeads)
-    .where(and(eq(crmLeads.agentId, agentId), eq(crmLeads.stage, STAGE_CONTACTED)));
+    .where(
+      and(
+        eq(crmLeads.tenantId, tenantId),
+        eq(crmLeads.agentId, agentId),
+        eq(crmLeads.stage, STAGE_CONTACTED)
+      )
+    );
 
   const [wonDeals] = await db
     .select({ count: count() })
     .from(crmDeals)
-    .where(and(eq(crmDeals.agentId, agentId), eq(crmDeals.stage, 'closed_won')));
+    .where(
+      and(
+        eq(crmDeals.tenantId, tenantId),
+        eq(crmDeals.agentId, agentId),
+        eq(crmDeals.stage, 'closed_won')
+      )
+    );
 
   const [totalCommission] = await db
     .select({ total: sql<number>`COALESCE(sum(${agentCommissions.amount}), 0)` })
     .from(agentCommissions)
-    .where(and(eq(agentCommissions.agentId, agentId), eq(agentCommissions.status, 'paid')));
+    .where(
+      and(
+        eq(agentCommissions.tenantId, tenantId),
+        eq(agentCommissions.agentId, agentId),
+        eq(agentCommissions.status, 'paid')
+      )
+    );
 
   const [clientCount] = await db
     .select({ count: count() })
     .from(subscriptions)
-    .where(eq(subscriptions.referredByAgentId, agentId));
+    .where(and(eq(subscriptions.tenantId, tenantId), eq(subscriptions.referredByAgentId, agentId)));
 
   return {
     newLeads: Number(newLeads?.count ?? 0),

--- a/apps/web/src/features/agent/dashboard/components/AgentDashboardV2Page.test.tsx
+++ b/apps/web/src/features/agent/dashboard/components/AgentDashboardV2Page.test.tsx
@@ -1,0 +1,179 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  branchFindFirstMock: vi.fn(),
+  ensureTenantIdMock: vi.fn(() => 'tenant-1'),
+  getMyCommissionSummaryMock: vi.fn(),
+  getSessionMock: vi.fn(),
+  getTranslationsMock: vi.fn(async () => (key: string) => key),
+  headersMock: vi.fn(async () => new Headers()),
+  redirectMock: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+  setRequestLocaleMock: vi.fn(),
+  statsCoreMock: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  headers: hoisted.headersMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: hoisted.redirectMock,
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: hoisted.getTranslationsMock,
+  setRequestLocale: hoisted.setRequestLocaleMock,
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: hoisted.getSessionMock,
+    },
+  },
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: hoisted.ensureTenantIdMock,
+}));
+
+vi.mock('@interdomestik/database/db', () => ({
+  db: {
+    query: {
+      branches: {
+        findFirst: hoisted.branchFindFirstMock,
+      },
+    },
+  },
+}));
+
+vi.mock('@/app/[locale]/(agent)/agent/_core', () => ({
+  getAgentDashboardV2StatsCore: hoisted.statsCoreMock,
+}));
+
+vi.mock('@/actions/commissions', () => ({
+  getMyCommissionSummary: hoisted.getMyCommissionSummaryMock,
+}));
+
+vi.mock('@/components/agent/agent-verified-id', () => ({
+  AgentVerifiedID: () => null,
+}));
+
+vi.mock('@/components/agent/leaderboard-card', () => ({
+  LeaderboardCard: () => null,
+}));
+
+vi.mock('@/components/agent/pipeline-chart', () => ({
+  PipelineChart: () => null,
+}));
+
+vi.mock('@/components/agent/referral-link-card', () => ({
+  ReferralLinkCard: () => null,
+}));
+
+vi.mock('@/components/dashboard/matte-anchor-card', () => ({
+  MatteAnchorCard: () => null,
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('@/lib/localize-seeded-branch-name', () => ({
+  localizeSeededBranchName: (name: string) => name,
+}));
+
+vi.mock('@interdomestik/ui', () => {
+  const passthrough = ({ children }: { children?: ReactNode }) => children ?? null;
+  return {
+    Button: passthrough,
+    Card: passthrough,
+    CardContent: passthrough,
+    CardDescription: passthrough,
+    CardHeader: passthrough,
+    CardTitle: passthrough,
+  };
+});
+
+import { AgentDashboardV2Page } from './AgentDashboardV2Page';
+
+describe('AgentDashboardV2Page tenant boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.ensureTenantIdMock.mockReturnValue('tenant-1');
+    hoisted.getSessionMock.mockResolvedValue({
+      user: {
+        id: 'agent-1',
+        tenantId: 'tenant-1',
+        branchId: 'branch-1',
+        name: 'Agent One',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    });
+    hoisted.statsCoreMock.mockResolvedValue({
+      newLeads: 1,
+      contactedLeads: 2,
+      wonDeals: 3,
+      totalPaidCommission: 4,
+      clientCount: 5,
+    });
+    hoisted.branchFindFirstMock.mockResolvedValue({ name: 'Prishtina' });
+    hoisted.getMyCommissionSummaryMock.mockResolvedValue({
+      success: true,
+      data: {
+        totalPaid: 0,
+        totalPending: 0,
+        totalApproved: 0,
+      },
+    });
+  });
+
+  it('rejects missing tenant identity before loading dashboard stats', async () => {
+    const session = {
+      user: {
+        id: 'agent-1',
+        tenantId: null,
+        branchId: null,
+        name: 'Agent One',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    };
+    hoisted.getSessionMock.mockResolvedValue(session);
+    hoisted.ensureTenantIdMock.mockImplementationOnce(() => {
+      throw new Error('Session missing tenantId. Data integrity issue.');
+    });
+
+    await expect(AgentDashboardV2Page({ locale: 'en', tier: 'pro' })).rejects.toThrow(
+      'Session missing tenantId. Data integrity issue.'
+    );
+
+    expect(hoisted.ensureTenantIdMock).toHaveBeenCalledWith(session);
+    expect(hoisted.statsCoreMock).not.toHaveBeenCalled();
+    expect(hoisted.branchFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it('passes tenant identity into the v2 stats core on the authorized path', async () => {
+    await AgentDashboardV2Page({ locale: 'en', tier: 'pro' });
+
+    expect(hoisted.statsCoreMock).toHaveBeenCalledWith(
+      { agentId: 'agent-1', tenantId: 'tenant-1' },
+      expect.objectContaining({ db: expect.any(Object) })
+    );
+    const branchLookup = hoisted.branchFindFirstMock.mock.calls[0]?.[0];
+    const andMock = vi.fn((...args: unknown[]) => ({ and: args }));
+    const eqMock = vi.fn((field: unknown, value: unknown) => ({ eq: [field, value] }));
+
+    expect(branchLookup.columns).toEqual({ name: true });
+    expect(
+      branchLookup.where(
+        { id: 'branches.id', tenantId: 'branches.tenantId' },
+        { and: andMock, eq: eqMock }
+      )
+    ).toEqual({
+      and: [{ eq: ['branches.id', 'branch-1'] }, { eq: ['branches.tenantId', 'tenant-1'] }],
+    });
+  });
+});

--- a/apps/web/src/features/agent/dashboard/components/AgentDashboardV2Page.tsx
+++ b/apps/web/src/features/agent/dashboard/components/AgentDashboardV2Page.tsx
@@ -9,6 +9,7 @@ import { Link } from '@/i18n/routing';
 import { auth } from '@/lib/auth';
 import { localizeSeededBranchName } from '@/lib/localize-seeded-branch-name';
 import { db } from '@interdomestik/database/db';
+import { ensureTenantId } from '@interdomestik/shared-auth';
 import {
   Button,
   Card,
@@ -42,12 +43,14 @@ export async function AgentDashboardV2Page({
   }
 
   const agentId = session.user.id;
+  const tenantId = ensureTenantId(session);
 
   const [stats, branch] = await Promise.all([
-    getAgentDashboardV2StatsCore({ agentId }, { db }),
+    getAgentDashboardV2StatsCore({ agentId, tenantId }, { db }),
     session.user.branchId
       ? db.query.branches.findFirst({
-          where: (fields, { eq }) => eq(fields.id, session.user.branchId!),
+          where: (fields, { and, eq }) =>
+            and(eq(fields.id, session.user.branchId!), eq(fields.tenantId, tenantId)),
           columns: { name: true },
         })
       : null,

--- a/apps/web/src/features/agent/dashboard/components/AgentDashboardV2Page.tsx
+++ b/apps/web/src/features/agent/dashboard/components/AgentDashboardV2Page.tsx
@@ -50,7 +50,7 @@ export async function AgentDashboardV2Page({
     session.user.branchId
       ? db.query.branches.findFirst({
           where: (fields, { and, eq }) =>
-            and(eq(fields.id, session.user.branchId!), eq(fields.tenantId, tenantId)),
+            and(eq(fields.id, session.user.branchId), eq(fields.tenantId, tenantId)),
           columns: { name: true },
         })
       : null,


### PR DESCRIPTION
## Summary
- require tenant identity at the agent dashboard V2 boundary before CRM KPI reads
- pass tenantId into `getAgentDashboardV2StatsCore` and tenant-scope CRM lead, deal, commission, subscription, and branch reads
- add focused unit coverage for missing tenant identity, tenant-scoped KPI predicates, and tenant-scoped branch lookup

## Verification
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(agent)/agent/_core.test.ts' 'src/features/agent/dashboard/components/AgentDashboardV2Page.test.tsx'`\n- `pnpm pr:verify:hosts`\n- `pnpm security:guard`\n- `pnpm verify-slice -- --static`\n- pre-PR reviewer pool: architecture READY, QA procedural must-fix addressed by staging/committing new test, security must-fix addressed by tenant-scoping branch lookup\n- `pnpm verify-slice -- --required-gates`