### PR TITLE
fix: harden agent crm mutation tenant contracts

### DIFF
--- a/apps/web/src/lib/actions/agent.core.ts
+++ b/apps/web/src/lib/actions/agent.core.ts
@@ -61,7 +61,14 @@ export async function updateLeadStatus(leadId: string, stage: string) {
     return { error: 'Unauthorized' };
   }
 
-  const result = await updateLeadStatusCore(session.user.id, leadId, stage);
+  let tenantId: string;
+  try {
+    tenantId = ensureTenantId(session);
+  } catch {
+    return { error: 'Missing tenantId' };
+  }
+
+  const result = await updateLeadStatusCore(session.user.id, tenantId, leadId, stage);
   if ('error' in result) {
     return result;
   }
@@ -78,7 +85,14 @@ export async function logActivity(leadId: string, type: string, summary: string)
     return { error: 'Unauthorized' };
   }
 
-  const result = await logActivityCore(session.user.id, leadId, type, summary);
+  let tenantId: string;
+  try {
+    tenantId = ensureTenantId(session);
+  } catch {
+    return { error: 'Missing tenantId' };
+  }
+
+  const result = await logActivityCore(session.user.id, tenantId, leadId, type, summary);
   if ('error' in result) {
     return result;
   }

--- a/apps/web/src/lib/actions/agent.test.ts
+++ b/apps/web/src/lib/actions/agent.test.ts
@@ -42,6 +42,29 @@ function createRowsFormData(rows: unknown[]) {
   return formData;
 }
 
+function scopedLeadPredicate(leadId = 'lead1', tenantId = 'tenant_mk', agentId = 'agent1') {
+  return expect.objectContaining({
+    op: 'and',
+    args: expect.arrayContaining([
+      expect.objectContaining({
+        op: 'eq',
+        left: expect.objectContaining({ name: 'id' }),
+        right: leadId,
+      }),
+      expect.objectContaining({
+        op: 'eq',
+        left: expect.objectContaining({ name: 'tenantId' }),
+        right: tenantId,
+      }),
+      expect.objectContaining({
+        op: 'eq',
+        left: expect.objectContaining({ name: 'agentId' }),
+        right: agentId,
+      }),
+    ]),
+  });
+}
+
 vi.mock('./agent/context', () => ({
   getAgentSession: vi.fn(),
 }));
@@ -176,50 +199,10 @@ describe('agent actions', () => {
         user: { id: 'agent1', role: 'agent', tenantId: 'tenant_mk' },
       });
       expect(db.query.crmLeads.findFirst).toHaveBeenCalledWith({
-        where: expect.objectContaining({
-          op: 'and',
-          args: expect.arrayContaining([
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'id' }),
-              right: 'lead1',
-            }),
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'tenantId' }),
-              right: 'tenant_mk',
-            }),
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'agentId' }),
-              right: 'agent1',
-            }),
-          ]),
-        }),
+        where: scopedLeadPredicate(),
       });
       expect(db.update).toHaveBeenCalled();
-      expect(dbMock.where).toHaveBeenCalledWith(
-        expect.objectContaining({
-          op: 'and',
-          args: expect.arrayContaining([
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'id' }),
-              right: 'lead1',
-            }),
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'tenantId' }),
-              right: 'tenant_mk',
-            }),
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'agentId' }),
-              right: 'agent1',
-            }),
-          ]),
-        })
-      );
+      expect(dbMock.where).toHaveBeenCalledWith(scopedLeadPredicate());
     });
 
     it('should fail if not owner', async () => {
@@ -262,26 +245,7 @@ describe('agent actions', () => {
         user: { id: 'agent1', role: 'agent', tenantId: 'tenant_mk' },
       });
       expect(db.query.crmLeads.findFirst).toHaveBeenCalledWith({
-        where: expect.objectContaining({
-          op: 'and',
-          args: expect.arrayContaining([
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'id' }),
-              right: 'lead1',
-            }),
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'tenantId' }),
-              right: 'tenant_mk',
-            }),
-            expect.objectContaining({
-              op: 'eq',
-              left: expect.objectContaining({ name: 'agentId' }),
-              right: 'agent1',
-            }),
-          ]),
-        }),
+        where: scopedLeadPredicate(),
       });
       expect(db.insert).toHaveBeenCalled();
       expect(dbMock.values).toHaveBeenCalledWith(

--- a/apps/web/src/lib/actions/agent.test.ts
+++ b/apps/web/src/lib/actions/agent.test.ts
@@ -1,4 +1,5 @@
 import { db } from '@interdomestik/database/db';
+import { ensureTenantId } from '@interdomestik/shared-auth';
 import { redirect } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createLead, logActivity, registerMember, updateLeadStatus } from './agent';
@@ -7,6 +8,11 @@ import { getAgentSession } from './agent/context';
 const IMPORT_AGENT_SESSION = {
   user: { id: 'agent1', name: 'Agent', role: 'agent', tenantId: 'tenant_mk', branchId: 'b1' },
 } as const;
+
+const dbMock = db as unknown as {
+  where: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+};
 
 function makeCredential(label: string) {
   return ['member', label, 'access'].join('-');
@@ -48,6 +54,16 @@ vi.mock('./agent/import-members.core', () => ({
   importMembersCore: vi.fn(),
 }));
 
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: vi.fn((session: { user?: { tenantId?: string | null } } | null) => {
+    const tenantId = session?.user?.tenantId;
+    if (!tenantId) {
+      throw new Error('Missing tenantId');
+    }
+    return tenantId;
+  }),
+}));
+
 vi.mock('@interdomestik/database/db', () => ({
   db: {
     insert: vi.fn().mockReturnThis(),
@@ -66,6 +82,11 @@ vi.mock('@interdomestik/database/db', () => ({
 vi.mock('@interdomestik/database/schema', () => ({
   crmLeads: { id: { name: 'id' }, agentId: { name: 'agentId' }, tenantId: { name: 'tenantId' } },
   crmActivities: { id: { name: 'id' }, tenantId: { name: 'tenantId' } },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
 }));
 
 vi.mock('next/cache', () => ({
@@ -141,45 +162,146 @@ describe('agent actions', () => {
   describe('updateLeadStatus', () => {
     it('should update status if owned by agent', async () => {
       (getAgentSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-        user: { id: 'agent1', role: 'agent' },
+        user: { id: 'agent1', role: 'agent', tenantId: 'tenant_mk' },
       });
       (db.query.crmLeads.findFirst as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'lead1',
         agentId: 'agent1',
+        tenantId: 'tenant_mk',
       });
 
       const result = await updateLeadStatus('lead1', 'contacted');
       expect(result).toEqual({ success: true });
+      expect(ensureTenantId).toHaveBeenCalledWith({
+        user: { id: 'agent1', role: 'agent', tenantId: 'tenant_mk' },
+      });
+      expect(db.query.crmLeads.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          op: 'and',
+          args: expect.arrayContaining([
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'id' }),
+              right: 'lead1',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'tenantId' }),
+              right: 'tenant_mk',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'agentId' }),
+              right: 'agent1',
+            }),
+          ]),
+        }),
+      });
       expect(db.update).toHaveBeenCalled();
+      expect(dbMock.where).toHaveBeenCalledWith(
+        expect.objectContaining({
+          op: 'and',
+          args: expect.arrayContaining([
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'id' }),
+              right: 'lead1',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'tenantId' }),
+              right: 'tenant_mk',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'agentId' }),
+              right: 'agent1',
+            }),
+          ]),
+        })
+      );
     });
 
     it('should fail if not owner', async () => {
       (getAgentSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-        user: { id: 'agent1', role: 'agent' },
+        user: { id: 'agent1', role: 'agent', tenantId: 'tenant_mk' },
       });
-      (db.query.crmLeads.findFirst as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-        id: 'lead1',
-        agentId: 'agent2',
-      });
+      (db.query.crmLeads.findFirst as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
       const result = await updateLeadStatus('lead1', 'contacted');
       expect(result).toEqual({ error: 'Not found' });
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('should reject missing tenant identity before updating status', async () => {
+      (getAgentSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        user: { id: 'agent1', role: 'agent', tenantId: null },
+      });
+
+      const result = await updateLeadStatus('lead1', 'contacted');
+      expect(result).toEqual({ error: 'Missing tenantId' });
+      expect(db.query.crmLeads.findFirst).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
     });
   });
 
   describe('logActivity', () => {
     it('should log activity', async () => {
       (getAgentSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-        user: { id: 'agent1', role: 'agent' },
+        user: { id: 'agent1', role: 'agent', tenantId: 'tenant_mk' },
       });
       (db.query.crmLeads.findFirst as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: 'lead1',
         agentId: 'agent1',
+        tenantId: 'tenant_mk',
       });
 
       const result = await logActivity('lead1', 'call', 'Called user');
       expect(result).toEqual({ success: true });
+      expect(ensureTenantId).toHaveBeenCalledWith({
+        user: { id: 'agent1', role: 'agent', tenantId: 'tenant_mk' },
+      });
+      expect(db.query.crmLeads.findFirst).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          op: 'and',
+          args: expect.arrayContaining([
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'id' }),
+              right: 'lead1',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'tenantId' }),
+              right: 'tenant_mk',
+            }),
+            expect.objectContaining({
+              op: 'eq',
+              left: expect.objectContaining({ name: 'agentId' }),
+              right: 'agent1',
+            }),
+          ]),
+        }),
+      });
       expect(db.insert).toHaveBeenCalled();
+      expect(dbMock.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: 'tenant_mk',
+          leadId: 'lead1',
+          agentId: 'agent1',
+        })
+      );
+    });
+
+    it('should reject missing tenant identity before logging activity', async () => {
+      (getAgentSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        user: { id: 'agent1', role: 'agent', tenantId: undefined },
+      });
+
+      const result = await logActivity('lead1', 'call', 'Called user');
+      expect(result).toEqual({ error: 'Missing tenantId' });
+      expect(db.query.crmLeads.findFirst).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/lib/actions/agent/log-activity.core.ts
+++ b/apps/web/src/lib/actions/agent/log-activity.core.ts
@@ -1,25 +1,30 @@
 import { db } from '@interdomestik/database/db';
 import { crmActivities, crmLeads } from '@interdomestik/database/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
 export async function logActivityCore(
   agentId: string,
+  tenantId: string,
   leadId: string,
   type: string,
   summary: string
 ) {
   const lead = await db.query.crmLeads.findFirst({
-    where: eq(crmLeads.id, leadId),
+    where: and(
+      eq(crmLeads.id, leadId),
+      eq(crmLeads.tenantId, tenantId),
+      eq(crmLeads.agentId, agentId)
+    ),
   });
 
-  if (lead?.agentId !== agentId) {
+  if (!lead) {
     return { error: 'Not found' as const };
   }
 
   await db.insert(crmActivities).values({
     id: nanoid(),
-    tenantId: lead.tenantId,
+    tenantId,
     leadId,
     agentId,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/web/src/lib/actions/agent/update-lead-status.core.ts
+++ b/apps/web/src/lib/actions/agent/update-lead-status.core.ts
@@ -1,14 +1,25 @@
 import { db } from '@interdomestik/database/db';
 import { crmLeads } from '@interdomestik/database/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { isLeadStage } from './schemas';
 
-export async function updateLeadStatusCore(agentId: string, leadId: string, stage: string) {
+export async function updateLeadStatusCore(
+  agentId: string,
+  tenantId: string,
+  leadId: string,
+  stage: string
+) {
+  const leadWhere = and(
+    eq(crmLeads.id, leadId),
+    eq(crmLeads.tenantId, tenantId),
+    eq(crmLeads.agentId, agentId)
+  );
+
   const lead = await db.query.crmLeads.findFirst({
-    where: eq(crmLeads.id, leadId),
+    where: leadWhere,
   });
 
-  if (lead?.agentId !== agentId) {
+  if (!lead) {
     return { error: 'Not found' as const };
   }
 
@@ -16,6 +27,6 @@ export async function updateLeadStatusCore(agentId: string, leadId: string, stag
     return { error: 'Invalid stage' as const };
   }
 
-  await db.update(crmLeads).set({ stage, updatedAt: new Date() }).where(eq(crmLeads.id, leadId));
+  await db.update(crmLeads).set({ stage, updatedAt: new Date() }).where(leadWhere);
   return { success: true as const };
 }


### PR DESCRIPTION
## Summary
- Enforce tenant identity at the legacy agent CRM mutation action boundary for `updateLeadStatus` and `logActivity`.
- Scope lead reads and status writes by `tenantId + agentId + leadId` in the mutation cores.
- Add focused tests for missing tenant identity and scoped CRM mutation predicates.

## Scope guardrails
- `apps/web/src/proxy.ts` untouched.
- No route, auth, tenancy architecture, schema, UI, or Stripe changes.
- Authorized happy paths remain behavior-compatible.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/lib/actions/agent.test.ts` ✅ 12 tests passed
- `pnpm --filter @interdomestik/web type-check` ✅
- `git diff --check` ✅
- `pnpm --filter @interdomestik/web lint` ✅ existing warning debt only
- `pnpm security:guard` ✅
- `pnpm pr:verify:hosts` ✅
- `pnpm verify-slice -- --static` ✅ run root: `tmp/multi-agent/verify-slice/verify-slice-20260426T212416Z-9985de`
- Pre-PR reviewer pool ✅ security, architecture, and QA reviewers reported no must-fix findings
- `pnpm verify-slice -- --required-gates` ✅ run root: `tmp/multi-agent/verify-slice/verify-slice-20260426T212659Z-219321`
