### PR TITLE
fix: expose register commercial promise markers

### DIFF
--- a/apps/web/e2e/gate/subscription-contract.spec.ts
+++ b/apps/web/e2e/gate/subscription-contract.spec.ts
@@ -61,8 +61,10 @@ test.describe('Subscription Contract Verification', () => {
     const billingSignal = page.getByTestId('pricing-page');
     await expect(billingSignal).toHaveAttribute('data-billing-test-mode', '1');
 
-    // Click CTA
-    await page.getByTestId('plan-cta-standard').click();
+    // Wait for session hydration so the CTA click is not swallowed while disabled.
+    const standardCta = page.getByTestId('plan-cta-standard');
+    await expect(standardCta).toBeEnabled();
+    await standardCta.click();
 
     // In Billing Test Mode, it should redirect to success
     await expect(page).toHaveURL(/.*\/member\/membership\/success\?test=true/, {

--- a/apps/web/src/app/[locale]/(auth)/register/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/_core.entry.test.tsx
@@ -32,10 +32,10 @@ describe('RegisterPage redirect', () => {
         params: Promise.resolve({ locale: 'en' }),
         searchParams: Promise.resolve({}),
       })
-    ).rejects.toThrow('redirect:/en/pricing');
+    ).rejects.toThrow('redirect:/en/pricing?entry=register');
 
     expect(hoisted.setRequestLocaleMock).toHaveBeenCalledWith('en');
-    expect(hoisted.redirectMock).toHaveBeenCalledWith('/en/pricing');
+    expect(hoisted.redirectMock).toHaveBeenCalledWith('/en/pricing?entry=register');
     expect(hoisted.registerFormMock).not.toHaveBeenCalled();
   });
 
@@ -49,10 +49,10 @@ describe('RegisterPage redirect', () => {
         params: Promise.resolve({ locale: 'mk' }),
         searchParams: Promise.resolve({ tenantId: 'tenant_mk', plan: 'standard' }),
       })
-    ).rejects.toThrow('redirect:/mk/pricing?plan=standard&tenantId=tenant_mk');
+    ).rejects.toThrow('redirect:/mk/pricing?plan=standard&entry=register&tenantId=tenant_mk');
 
     expect(hoisted.redirectMock).toHaveBeenCalledWith(
-      '/mk/pricing?plan=standard&tenantId=tenant_mk'
+      '/mk/pricing?plan=standard&entry=register&tenantId=tenant_mk'
     );
   });
 });

--- a/apps/web/src/app/[locale]/(auth)/register/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(auth)/register/_core.entry.tsx
@@ -15,6 +15,7 @@ export default async function RegisterPage({ params, searchParams }: Props) {
     resolvedSearchParams?.plan ?? null
   ).split('?');
   const destination = new URLSearchParams(pricingQuery);
+  destination.set('entry', 'register');
 
   if (resolvedSearchParams?.tenantId) {
     destination.set('tenantId', resolvedSearchParams.tenantId);

--- a/apps/web/src/app/[locale]/(site)/pricing/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/_core.entry.test.tsx
@@ -88,6 +88,9 @@ describe('PricingPage server shell', () => {
       rowKey: 'coverageMatrix.rows.vehicle.title',
       sectionTestId: 'pricing-coverage-matrix',
     });
+    expect(screen.queryByTestId('register-success-fee-calculator')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('register-billing-terms')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('register-coverage-matrix')).not.toBeInTheDocument();
     expect(screen.getByTestId('pricing-commercial-disclaimers')).toBeInTheDocument();
     expectSuccessFeeCalculator({ sectionTestId: 'pricing-success-fee-calculator' });
     expectCommercialTerms({ sectionTestId: 'pricing-billing-terms' });
@@ -108,6 +111,26 @@ describe('PricingPage server shell', () => {
     });
     expect(hoisted.headersMock).not.toHaveBeenCalled();
     expect(hoisted.getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('exposes register commercial promise markers when reached from the register entry', async () => {
+    const tree = await PricingPage({
+      params: Promise.resolve({ locale: 'sq' }),
+      searchParams: Promise.resolve({ entry: 'register' }),
+    });
+
+    render(tree);
+
+    expectSuccessFeeCalculator({ sectionTestId: 'pricing-success-fee-calculator' });
+    expectCommercialTerms({ sectionTestId: 'pricing-billing-terms' });
+    expectCoverageMatrix({
+      columnKey: 'coverageMatrix.columns.included',
+      rowKey: 'coverageMatrix.rows.vehicle.title',
+      sectionTestId: 'pricing-coverage-matrix',
+    });
+    expect(screen.getByTestId('register-success-fee-calculator')).toBeVisible();
+    expect(screen.getByTestId('register-billing-terms')).toBeVisible();
+    expect(screen.getByTestId('register-coverage-matrix')).toBeVisible();
   });
 
   it('keeps rendering the pricing shell during local sandbox builds when checkout config is unavailable', async () => {

--- a/apps/web/src/app/[locale]/(site)/pricing/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(site)/pricing/_core.entry.tsx
@@ -20,6 +20,7 @@ import { PricingPageRuntime } from './pricing-page-runtime';
 
 type PricingPageProps = Readonly<{
   params: Promise<{ locale: string }>;
+  searchParams?: Promise<{ entry?: string }>;
 }>;
 
 export async function generateMetadata({ params }: PricingPageProps): Promise<Metadata> {
@@ -31,8 +32,10 @@ export async function generateMetadata({ params }: PricingPageProps): Promise<Me
   };
 }
 
-export default async function PricingPage({ params }: PricingPageProps) {
+export default async function PricingPage({ params, searchParams }: PricingPageProps) {
   const { locale } = await params;
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const isRegisterEntry = resolvedSearchParams?.entry === 'register';
   const [t, coverageMatrix, commercialTerms] = await Promise.all([
     getTranslations({ locale, namespace: 'pricing' }),
     getTranslations({ locale, namespace: 'coverageMatrix' }),
@@ -100,19 +103,27 @@ export default async function PricingPage({ params }: PricingPageProps) {
       />
 
       <div className="mt-16">
-        <SuccessFeeCalculator
-          {...buildSuccessFeeCalculatorProps(t, 'pricing-success-fee-calculator', locale)}
-        />
+        <div data-testid={isRegisterEntry ? 'register-success-fee-calculator' : undefined}>
+          <SuccessFeeCalculator
+            {...buildSuccessFeeCalculatorProps(t, 'pricing-success-fee-calculator', locale)}
+          />
+        </div>
       </div>
 
       <div className="mt-16">
-        <CommercialBillingTerms
-          {...buildCommercialTermsProps(commercialTerms, 'pricing-billing-terms')}
-        />
+        <div data-testid={isRegisterEntry ? 'register-billing-terms' : undefined}>
+          <CommercialBillingTerms
+            {...buildCommercialTermsProps(commercialTerms, 'pricing-billing-terms')}
+          />
+        </div>
       </div>
 
       <div className="mt-16">
-        <CoverageMatrix {...buildCoverageMatrixProps(coverageMatrix, 'pricing-coverage-matrix')} />
+        <div data-testid={isRegisterEntry ? 'register-coverage-matrix' : undefined}>
+          <CoverageMatrix
+            {...buildCoverageMatrixProps(coverageMatrix, 'pricing-coverage-matrix')}
+          />
+        </div>
       </div>
 
       <div className="mt-16">


### PR DESCRIPTION
## Summary
- keep /register redirecting to pricing while tagging the entry as register
- expose register-specific commercial promise markers on the existing pricing commercial sections only for register entry traffic
- stabilize the logged-in subscription gate by waiting for session-hydrated CTA enablement before clicking

## Verification
- pnpm --filter @interdomestik/web test:unit --run "src/app/[locale]/(auth)/register/_core.entry.test.tsx" "src/app/[locale]/(site)/pricing/_core.entry.test.tsx"
- pnpm exec prettier --check 'apps/web/src/app/[locale]/(auth)/register/_core.entry.tsx' 'apps/web/src/app/[locale]/(auth)/register/_core.entry.test.tsx' 'apps/web/src/app/[locale]/(site)/pricing/_core.entry.tsx' 'apps/web/src/app/[locale]/(site)/pricing/_core.entry.test.tsx' apps/web/e2e/gate/subscription-contract.spec.ts
- pnpm --filter @interdomestik/web type-check
- pnpm --filter @interdomestik/web lint
- pnpm test:release-gate
- git diff --check
- pnpm verify-slice -- --static
- NEXT_PUBLIC_BILLING_TEST_MODE=1 PW_FAST_GATES=1 pnpm --filter @interdomestik/web exec playwright test e2e/gate/subscription-contract.spec.ts --project=gate-ks-sq --workers=1 --max-failures=1 --trace=retain-on-failure --reporter=line
- pnpm verify-slice -- --required-gates

## Notes
- No changes to apps/web/src/proxy.ts.
- No route renames or billing provider changes.
- verify-slice required gates passed with run_root tmp/multi-agent/verify-slice/verify-slice-20260427T131047Z-44ec99.
