### PR TITLE
fix: make document download filenames header safe

### DIFF
--- a/apps/web/src/app/api/documents/[id]/download/_core.ts
+++ b/apps/web/src/app/api/documents/[id]/download/_core.ts
@@ -4,7 +4,11 @@ import { db } from '@/lib/db.server';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { createAdminClient } from '@interdomestik/database';
 
-import { downloadStorageFileCore, getDocumentAccessCore, safeFilename } from '../../_core';
+import {
+  buildContentDispositionHeader,
+  downloadStorageFileCore,
+  getDocumentAccessCore,
+} from '../../_core';
 
 const storageService = {
   createSignedUrl: async (_bucket: string, _path: string, _expiresIn: number) => ({}),
@@ -121,8 +125,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     return Response.json({ error: 'Failed to download document' }, { status: 500 });
   }
 
-  const filename = safeFilename(access.document.name || 'document');
-  const encoded = encodeURIComponent(filename);
+  const filename = access.document.name || 'document';
 
   const body = 'stream' in file.data ? file.data.stream() : file.data;
 
@@ -130,7 +133,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     status: 200,
     headers: {
       'Content-Type': access.document.fileType || 'application/octet-stream',
-      'Content-Disposition': `${disposition}; filename="${filename}"; filename*=UTF-8''${encoded}`,
+      'Content-Disposition': buildContentDispositionHeader({ disposition, filename }),
       'Cache-Control': 'private, no-store',
     },
   });

--- a/apps/web/src/app/api/documents/[id]/download/route.test.ts
+++ b/apps/web/src/app/api/documents/[id]/download/route.test.ts
@@ -227,4 +227,35 @@ describe('GET /api/documents/[id]/download', () => {
       })
     );
   });
+
+  it('streams files with non-ASCII names without creating invalid response headers', async () => {
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'user-1', role: 'user', tenantId: 'tenant_mk' },
+    });
+    mockSelectChain.where.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        doc: {
+          id: 'doc-1',
+          claimId: 'claim-1',
+          bucket: 'bucket',
+          filePath: 'path/file.pdf',
+          uploadedBy: 'someone-else',
+          name: 'IHÇK SHKURT 2026.pdf',
+          fileType: 'application/pdf',
+          fileSize: 123,
+        },
+        claimOwnerId: 'user-1',
+      },
+    ]);
+
+    const request = new Request(
+      'http://localhost:3000/api/documents/doc-1/download?disposition=inline'
+    );
+    const response = await GET(request, { params: Promise.resolve({ id: 'doc-1' }) });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Disposition')).toBe(
+      'inline; filename="IHCK SHKURT 2026.pdf"; filename*=UTF-8\'\'IHC%CC%A7K%20SHKURT%202026.pdf'
+    );
+  });
 });

--- a/apps/web/src/app/api/documents/[id]/download/route.test.ts
+++ b/apps/web/src/app/api/documents/[id]/download/route.test.ts
@@ -201,45 +201,6 @@ describe('GET /api/documents/[id]/download', () => {
           bucket: 'bucket',
           filePath: 'path/file.pdf',
           uploadedBy: 'someone-else',
-          name: 'file.pdf',
-          fileType: 'application/pdf',
-          fileSize: 123,
-        },
-        claimOwnerId: 'user-1',
-      },
-    ]);
-
-    const request = new Request(
-      'http://localhost:3000/api/documents/doc-1/download?disposition=inline'
-    );
-    const response = await GET(request, { params: Promise.resolve({ id: 'doc-1' }) });
-
-    expect(response.status).toBe(200);
-    const contentDisposition = response.headers.get('Content-Disposition');
-    expect(contentDisposition).toContain('inline');
-
-    expect(hoisted.logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tenantId: 'tenant_mk',
-        action: 'document.view',
-        entityType: 'claim_document',
-        entityId: 'doc-1',
-      })
-    );
-  });
-
-  it('streams files with non-ASCII names without creating invalid response headers', async () => {
-    hoisted.getSession.mockResolvedValue({
-      user: { id: 'user-1', role: 'user', tenantId: 'tenant_mk' },
-    });
-    mockSelectChain.where.mockResolvedValueOnce([]).mockResolvedValueOnce([
-      {
-        doc: {
-          id: 'doc-1',
-          claimId: 'claim-1',
-          bucket: 'bucket',
-          filePath: 'path/file.pdf',
-          uploadedBy: 'someone-else',
           name: 'IHÇK SHKURT 2026.pdf',
           fileType: 'application/pdf',
           fileSize: 123,
@@ -254,8 +215,18 @@ describe('GET /api/documents/[id]/download', () => {
     const response = await GET(request, { params: Promise.resolve({ id: 'doc-1' }) });
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Disposition')).toBe(
+    const contentDisposition = response.headers.get('Content-Disposition');
+    expect(contentDisposition).toBe(
       'inline; filename="IHCK SHKURT 2026.pdf"; filename*=UTF-8\'\'IHC%CC%A7K%20SHKURT%202026.pdf'
+    );
+
+    expect(hoisted.logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant_mk',
+        action: 'document.view',
+        entityType: 'claim_document',
+        entityId: 'doc-1',
+      })
     );
   });
 });

--- a/apps/web/src/app/api/documents/[id]/download/route.ts
+++ b/apps/web/src/app/api/documents/[id]/download/route.ts
@@ -6,7 +6,11 @@ import { enforceRateLimit } from '@/lib/rate-limit';
 import { createAdminClient } from '@interdomestik/database';
 import * as Sentry from '@sentry/nextjs';
 import { NextResponse } from 'next/server';
-import { downloadStorageFileCore, getDocumentAccessCore, safeFilename } from '../../_core';
+import {
+  buildContentDispositionHeader,
+  downloadStorageFileCore,
+  getDocumentAccessCore,
+} from '../../_core';
 
 // Service Adapter
 const storageService = {
@@ -117,8 +121,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     return NextResponse.json({ error: 'Failed to download document' }, { status: 500 });
   }
 
-  const filename = safeFilename(access.document.name || 'document');
-  const encoded = encodeURIComponent(filename);
+  const filename = access.document.name || 'document';
 
   let body: BodyInit;
   if (typeof (file.data as any)?.stream === 'function') {
@@ -134,7 +137,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     status: 200,
     headers: {
       'Content-Type': access.document.fileType || 'application/octet-stream',
-      'Content-Disposition': `${disposition}; filename="${filename}"; filename*=UTF-8''${encoded}`,
+      'Content-Disposition': buildContentDispositionHeader({ disposition, filename }),
       'Cache-Control': 'private, no-store',
     },
   });

--- a/apps/web/src/app/api/documents/_core.test.ts
+++ b/apps/web/src/app/api/documents/_core.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { DocumentAccessDeps, getDocumentAccessCore } from './_core';
+import {
+  buildContentDispositionHeader,
+  DocumentAccessDeps,
+  getDocumentAccessCore,
+  safeFilename,
+} from './_core';
 
 const mockDb = { select: vi.fn() } as any;
 const mockStorage = { createSignedUrl: vi.fn(), download: vi.fn() };
@@ -76,6 +81,17 @@ async function execAccess(
 
 describe('getDocumentAccessCore Hardening', () => {
   beforeEach(() => vi.clearAllMocks());
+
+  describe('content disposition filename safety', () => {
+    it('uses a byte-safe fallback filename while preserving UTF-8 filename metadata', () => {
+      const filename = 'IHÇK SHKURT 2026.pdf';
+
+      expect(safeFilename(filename)).toBe('IHCK SHKURT 2026.pdf');
+      expect(buildContentDispositionHeader({ disposition: 'inline', filename })).toBe(
+        'inline; filename="IHCK SHKURT 2026.pdf"; filename*=UTF-8\'\'IHC%CC%A7K%20SHKURT%202026.pdf'
+      );
+    });
+  });
 
   describe('Polymorphic Documents', () => {
     it('allows access to own profile document', async () => {

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -96,7 +96,36 @@ function hasScopedClaimReadAccess(args: {
 }
 
 export function safeFilename(value: string) {
-  return value.split('\r').join('_').split('\n').join('_').split('"').join('_');
+  const normalized = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+  const ascii = normalized
+    .split('\r')
+    .join('_')
+    .split('\n')
+    .join('_')
+    .split('"')
+    .join('_')
+    .split('\\')
+    .join('_')
+    .replace(/[^\x20-\x7E]/g, '_')
+    .trim();
+
+  return ascii || 'document';
+}
+
+export function encodeContentDispositionFilename(value: string) {
+  return encodeURIComponent(value)
+    .replace(/['()]/g, character => `%${character.charCodeAt(0).toString(16).toUpperCase()}`)
+    .replace(/\*/g, '%2A');
+}
+
+export function buildContentDispositionHeader(args: {
+  disposition: 'inline' | 'attachment';
+  filename: string;
+}) {
+  const fallbackFilename = safeFilename(args.filename || 'document');
+  const encodedFilename = encodeContentDispositionFilename(args.filename || 'document');
+
+  return `${args.disposition}; filename="${fallbackFilename}"; filename*=UTF-8''${encodedFilename}`;
 }
 
 function getFinalDisposition(disposition?: 'inline' | 'attachment'): 'inline' | 'attachment' {

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -96,26 +96,22 @@ function hasScopedClaimReadAccess(args: {
 }
 
 export function safeFilename(value: string) {
-  const normalized = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
-  const ascii = normalized
-    .split('\r')
-    .join('_')
-    .split('\n')
-    .join('_')
-    .split('"')
-    .join('_')
-    .split('\\')
-    .join('_')
-    .replace(/[^\x20-\x7E]/g, '_')
+  const ascii = value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\r\n"\\]|[^\x20-\x7E]/g, '_')
     .trim();
 
   return ascii || 'document';
 }
 
+const RFC_5987_EXTRA_CHARS = /['()*]/g;
+
 export function encodeContentDispositionFilename(value: string) {
-  return encodeURIComponent(value)
-    .replace(/['()]/g, character => `%${character.charCodeAt(0).toString(16).toUpperCase()}`)
-    .replace(/\*/g, '%2A');
+  return encodeURIComponent(value).replace(
+    RFC_5987_EXTRA_CHARS,
+    character => `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+  );
 }
 
 export function buildContentDispositionHeader(args: {


### PR DESCRIPTION
## Summary
- Fix document download/view responses for filenames containing non-ASCII combining characters.
- Keep `filename=` ASCII/ByteString-safe while preserving the original UTF-8 filename in `filename*=`.
- Add regression coverage using the failing `IHÇK SHKURT 2026.pdf` filename shape.

## Production Evidence
- `ks.interdomestik.com` document metadata exists for `hnyyunITmjKyDO43X0xrD` on tenant `tenant_ks`.
- Supabase Storage object exists and downloads successfully.
- Local reproduction confirmed `new Response()` throws when `Content-Disposition` contains the raw combining character.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/api/documents/[id]/download/route.test.ts' 'src/app/api/documents/_core.test.ts'`\n- `pnpm verify-slice -- --static`\n