### PR TITLE
fix: restore member claim SLA status copy

### DIFF
--- a/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx
+++ b/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx
@@ -65,6 +65,16 @@ vi.mock('next-intl', () => ({
         return translations[key] || `claims-tracking.status.next_step.${key}`;
       };
     }
+    if (namespace === 'claims-tracking.tracking.sla') {
+      return (key: string) => {
+        const translations: Record<string, string> = {
+          title: 'SLA Status',
+          running: 'Response timer is running.',
+          incomplete: 'Waiting for your information before the SLA starts.',
+        };
+        return translations[key] || `claims-tracking.tracking.sla.${key}`;
+      };
+    }
     if (namespace === 'claims-tracking.tracking.assurance') {
       return (key: string) => {
         const translations: Record<string, string> = {
@@ -218,6 +228,11 @@ describe('MemberClaimDetailOpsPage', () => {
     });
 
     expect(screen.getByTestId('member-claim-trust-sla-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('member-claim-sla-status')).toBeInTheDocument();
+    expect(screen.getByText('SLA Status')).toBeInTheDocument();
+    expect(screen.getByTestId('member-claim-sla-status-phase')).toHaveTextContent(
+      'Waiting for your information before the SLA starts.'
+    );
     expect(screen.getByText('Handling assurance')).toBeInTheDocument();
     expect(screen.getByTestId('member-claim-trust-sla-state')).toHaveTextContent(
       'Waiting for your action'
@@ -244,6 +259,10 @@ describe('MemberClaimDetailOpsPage', () => {
 
     expect(screen.getByTestId('member-claim-trust-sla-state')).toHaveTextContent(
       'Response timer active'
+    );
+    expect(screen.getByText('SLA Status')).toBeInTheDocument();
+    expect(screen.getByTestId('member-claim-sla-status-phase')).toHaveTextContent(
+      'Response timer is running.'
     );
     expect(screen.getByTestId('member-claim-trust-sla-latest')).toBeInTheDocument();
     expect(screen.getByTestId('member-claim-trust-sla-body')).toHaveTextContent(
@@ -294,6 +313,7 @@ describe('MemberClaimDetailOpsPage', () => {
     });
 
     expect(screen.getByText('Matter allowance')).toBeInTheDocument();
+    expect(screen.queryByTestId('member-claim-sla-status')).not.toBeInTheDocument();
     expect(screen.getByText('Used this year')).toBeInTheDocument();
     expect(screen.getByText('Remaining this year')).toBeInTheDocument();
     expect(screen.getByText('Plan allowance')).toBeInTheDocument();

--- a/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.tsx
+++ b/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.tsx
@@ -82,6 +82,7 @@ export function MemberClaimDetailOpsPage({
   const t = useTranslations('claims');
   const tTrackingStatus = useTranslations('claims-tracking.status');
   const tTrackingNextStep = useTranslations('claims-tracking.status.next_step');
+  const tTrackingSla = useTranslations('claims-tracking.tracking.sla');
   const tAssurance = useTranslations('claims-tracking.tracking.assurance');
   const tClaimStatus = useTranslations('claims.status');
 
@@ -151,6 +152,7 @@ export function MemberClaimDetailOpsPage({
         claim.progressSummary.nextStepKey.replace('claims-tracking.status.next_step.', '')
       )
     : claim.progressSummary.nextStepKey;
+  const hasMemberSlaStatus = claim.slaPhase === 'incomplete' || claim.slaPhase === 'running';
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto p-4 md:p-8">
@@ -243,6 +245,19 @@ export function MemberClaimDetailOpsPage({
               </div>
             </CardContent>
           </Card>
+
+          {hasMemberSlaStatus ? (
+            <Card data-testid="member-claim-sla-status">
+              <CardHeader>
+                <CardTitle>{tTrackingSla('title')}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm font-medium" data-testid="member-claim-sla-status-phase">
+                  {tTrackingSla(claim.slaPhase)}
+                </p>
+              </CardContent>
+            </Card>
+          ) : null}
 
           <Card data-testid="member-claim-trust-sla-panel">
             <CardHeader>


### PR DESCRIPTION
## Summary
- Restore the member claim SLA status copy that P22-GO01 G09 expects for running and incomplete SLA phases.
- Hide the member SLA status panel for not_applicable claims so unchanged/non-SLA claim views stay clean.
- Add focused component assertions for running, incomplete, and not_applicable SLA states.

## Production failure addressed
P22-GO01 production release gate failed only G09:
- member_running missing: `SLA Status`, `Response timer is running.`
- member_incomplete missing: `SLA Status`, `Waiting for your information before the SLA starts.`

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx`
- `pnpm test:release-gate`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice`
- `pnpm verify-slice -- --required-gates`

Required-gates evidence: E2E gate completed with 110 passed, 4 skipped; `verify-slice` PASS.