### PR TITLE
P23-PERF01: Add portal navigation feedback

### DIFF
--- a/apps/web/e2e/gate/golden-gate.spec.ts
+++ b/apps/web/e2e/gate/golden-gate.spec.ts
@@ -194,7 +194,7 @@ test.describe('Golden Gate: Critical Path', () => {
       await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'branches-screen' });
 
       // 1. Verify at least one branch card is present
-      const cards = page.locator('[data-testid^="branch-card-"]');
+      const cards = page.getByTestId('branches-screen').locator('[data-testid^="branch-card-"]');
       await expect(cards.first()).toBeVisible();
       expect(await cards.count()).toBeGreaterThan(0);
 
@@ -247,7 +247,10 @@ test.describe('Golden Gate: Critical Path', () => {
       await gotoApp(page, routes.adminBranches(testInfo), testInfo, { marker: 'branches-screen' });
 
       // Find the KS-A branch card
-      const ksBranchACard = page.getByTestId('branch-card-KS-A');
+      const ksBranchACard = page
+        .getByTestId('branches-screen')
+        .getByTestId('branch-card-KS-A')
+        .first();
       await expect(ksBranchACard).toBeVisible();
       await expect(ksBranchACard).toContainText(/Urgjent|Urgent/i);
     });

--- a/apps/web/e2e/gate/internal-notes-isolation.spec.ts
+++ b/apps/web/e2e/gate/internal-notes-isolation.spec.ts
@@ -33,7 +33,8 @@ test.describe('Internal Notes Isolation', () => {
         marker: 'ops-timeline',
       });
 
-      await expect(memberPage.getByTestId('ops-timeline')).toBeVisible({
+      const ready = memberPage.getByTestId('dashboard-page-ready').first();
+      await expect(ready.getByTestId('ops-timeline')).toBeVisible({
         timeout: 10_000,
       });
       await expect(memberPage.getByText(internalHistoryNote)).toHaveCount(0);

--- a/apps/web/e2e/gate/member-documents-upload-entry.spec.ts
+++ b/apps/web/e2e/gate/member-documents-upload-entry.spec.ts
@@ -8,10 +8,23 @@ test.describe('Member Documents Upload Entry', () => {
     await gotoApp(page, '/member/documents', testInfo, { marker: 'member-documents-page-ready' });
 
     const claimCards = page.locator('[data-testid^="member-documents-claim-"]');
+    const emptyState = page.getByTestId('member-documents-create-claim');
+
+    await expect
+      .poll(
+        async () => {
+          const cardCount = await claimCards.count();
+          if (cardCount > 0) return true;
+          return emptyState.isVisible();
+        },
+        { timeout: 10000 }
+      )
+      .toBe(true);
+
     const cardCount = await claimCards.count();
 
     if (cardCount === 0) {
-      await expect(page.getByTestId('member-documents-create-claim')).toBeVisible();
+      await expect(emptyState).toBeVisible();
       return;
     }
 

--- a/apps/web/e2e/gate/seed-contract.spec.ts
+++ b/apps/web/e2e/gate/seed-contract.spec.ts
@@ -1,8 +1,13 @@
+import type { Page } from '@playwright/test';
+
 import { expect, test } from '../fixtures/auth.fixture';
 import { routes } from '../routes';
 import { gotoApp } from '../utils/navigation';
 
 test.describe('Seed Contract Verification', () => {
+  const branchCard = (page: Page, code: string) =>
+    page.getByTestId('branches-screen').getByTestId(`branch-card-${code}`);
+
   test('Tenant KS has required branch codes', async ({ adminPage: page }, testInfo) => {
     if (!testInfo.project.name.includes('ks')) {
       testInfo.annotations.push({
@@ -16,7 +21,7 @@ test.describe('Seed Contract Verification', () => {
 
     const requiredBranches = ['KS-A', 'KS-B', 'KS-C'];
     for (const code of requiredBranches) {
-      await expect(page.getByTestId(`branch-card-${code}`)).toBeVisible();
+      await expect(branchCard(page, code).first()).toBeVisible();
     }
   });
 
@@ -33,7 +38,7 @@ test.describe('Seed Contract Verification', () => {
 
     const requiredBranches = ['MK-A', 'MK-B', 'MK-E'];
     for (const code of requiredBranches) {
-      await expect(page.getByTestId(`branch-card-${code}`)).toBeVisible();
+      await expect(branchCard(page, code).first()).toBeVisible();
     }
   });
 
@@ -50,7 +55,7 @@ test.describe('Seed Contract Verification', () => {
 
     const mkBranches = ['MK-A', 'MK-B', 'MK-E'];
     for (const code of mkBranches) {
-      await expect(page.getByTestId(`branch-card-${code}`)).not.toBeVisible();
+      await expect(branchCard(page, code)).toHaveCount(0);
     }
   });
 
@@ -67,7 +72,7 @@ test.describe('Seed Contract Verification', () => {
 
     const ksBranches = ['KS-A', 'KS-B', 'KS-C'];
     for (const code of ksBranches) {
-      await expect(page.getByTestId(`branch-card-${code}`)).not.toBeVisible();
+      await expect(branchCard(page, code)).toHaveCount(0);
     }
   });
 });

--- a/apps/web/e2e/navigation-feedback.spec.ts
+++ b/apps/web/e2e/navigation-feedback.spec.ts
@@ -1,0 +1,88 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from './fixtures/auth.fixture';
+import { routes } from './routes';
+import { gotoApp } from './utils/navigation';
+
+async function delayRouteTransition(page: Page, pathSuffix: string) {
+  let delayedFirstMatch = false;
+
+  await page.route(
+    requestUrl => {
+      const url = new URL(requestUrl.toString());
+      return url.pathname.endsWith(pathSuffix);
+    },
+    async route => {
+      if (delayedFirstMatch) {
+        await route.continue();
+        return;
+      }
+
+      delayedFirstMatch = true;
+      await new Promise(resolve => setTimeout(resolve, 500));
+      await route.continue();
+    }
+  );
+}
+
+async function expectNavigationFeedbackForSidebarLink({
+  page,
+  linkHrefSuffix,
+  targetPathSuffix,
+  rootTestId,
+}: {
+  page: Page;
+  linkHrefSuffix: string;
+  targetPathSuffix: string;
+  rootTestId?: string;
+}) {
+  await delayRouteTransition(page, targetPathSuffix);
+
+  const progress = page.getByTestId('portal-navigation-progress');
+  const root = rootTestId ? page.getByTestId(rootTestId) : page.locator('body');
+  const link = root.locator(`a[href$="${linkHrefSuffix}"]`).first();
+  await expect(link).toBeVisible();
+
+  const click = link.click();
+  try {
+    await expect(progress).toBeVisible({ timeout: 2_000 });
+    await click;
+
+    await expect(page).toHaveURL(new RegExp(`${targetPathSuffix}(?:[?#].*)?$`));
+    await expect(page.getByTestId('dashboard-page-ready')).toBeVisible();
+    await expect(progress).toHaveCount(0, { timeout: 10_000 });
+  } finally {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  }
+}
+
+test.describe('Portal navigation feedback', () => {
+  test('member sidebar links show and clear navigation feedback', async ({
+    authenticatedPage: page,
+  }, testInfo) => {
+    await gotoApp(page, routes.member(testInfo), testInfo, {
+      marker: 'member-dashboard-ready',
+    });
+
+    await expectNavigationFeedbackForSidebarLink({
+      page,
+      linkHrefSuffix: '/member/claims',
+      targetPathSuffix: '/member/claims',
+    });
+  });
+
+  test('admin sidebar links show and clear navigation feedback', async ({
+    adminPage: page,
+  }, testInfo) => {
+    await gotoApp(page, routes.admin(testInfo), testInfo, {
+      marker: 'admin-page-ready',
+    });
+
+    await expectNavigationFeedbackForSidebarLink({
+      page,
+      linkHrefSuffix: '/admin/claims',
+      targetPathSuffix: '/admin/claims',
+      rootTestId: 'admin-sidebar',
+    });
+  });
+});

--- a/apps/web/e2e/support/admin-tenant-classification.ts
+++ b/apps/web/e2e/support/admin-tenant-classification.ts
@@ -119,6 +119,10 @@ async function ensureCookieBannerDismissed(page: Page): Promise<void> {
   await expect(banner).toHaveCount(0);
 }
 
+function dashboardReady(page: Page) {
+  return page.getByTestId('dashboard-page-ready').first();
+}
+
 async function expectTenantClassificationPersisted(params: {
   page: Page;
   memberId: string;
@@ -146,7 +150,7 @@ async function expectTenantClassificationPersisted(params: {
     });
 
   await page.reload({ waitUntil: 'domcontentloaded' });
-  await expect(page.getByTestId('tenant-classification-confirmed')).toBeVisible({
+  await expect(dashboardReady(page).getByTestId('tenant-classification-confirmed')).toBeVisible({
     timeout: 15_000,
   });
 }
@@ -164,9 +168,10 @@ export async function confirmCurrentTenantClassification(params: {
   await gotoApp(page, detailPath, testInfo, { marker: 'body' });
   await ensureCookieBannerDismissed(page);
 
-  await expect(page.getByTestId('tenant-classification-controls')).toBeVisible();
-  await expect(page.getByTestId('tenant-classification-confirm')).toBeVisible();
-  await page.getByTestId('tenant-classification-confirm').click();
+  const ready = dashboardReady(page);
+  await expect(ready.getByTestId('tenant-classification-controls')).toBeVisible();
+  await expect(ready.getByTestId('tenant-classification-confirm')).toBeVisible();
+  await ready.getByTestId('tenant-classification-confirm').click();
   await expectTenantClassificationPersisted({ page, memberId, expectedTenantId });
 }
 
@@ -190,12 +195,13 @@ export async function reassignTenantClassification(params: {
     await ensureCookieBannerDismissed(page);
   }
 
-  await expect(page.getByTestId('tenant-classification-controls')).toBeVisible();
-  await expect(page.getByTestId('tenant-classification-reassign')).toBeVisible();
+  const ready = dashboardReady(page);
+  await expect(ready.getByTestId('tenant-classification-controls')).toBeVisible();
+  await expect(ready.getByTestId('tenant-classification-reassign')).toBeVisible();
 
-  await page.selectOption('[data-testid="tenant-classification-reassign-select"]', nextTenantId);
-  await page.getByTestId('tenant-classification-reassign').scrollIntoViewIfNeeded();
-  await page.getByTestId('tenant-classification-reassign').click({ force: true });
+  await ready.getByTestId('tenant-classification-reassign-select').selectOption(nextTenantId);
+  await ready.getByTestId('tenant-classification-reassign').scrollIntoViewIfNeeded();
+  await ready.getByTestId('tenant-classification-reassign').click({ force: true });
   await expect
     .poll(() => new URL(page.url()).searchParams.get('tenantId'), {
       timeout: 15_000,

--- a/apps/web/src/app/[locale]/(app)/member/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/_core.entry.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@/components/shell/session', () => ({
   requireSessionOrRedirect: hoisted.requireSessionOrRedirectMock,
 }));
 
+vi.mock('@/components/shell/navigation-feedback', () => ({
+  NavigationFeedback: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 vi.mock('@/i18n/messages', () => ({
   APP_NAMESPACES: [],
   pickMessages: hoisted.pickMessagesMock,

--- a/apps/web/src/app/[locale]/(app)/member/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/_core.entry.tsx
@@ -2,6 +2,7 @@ import { DashboardHeader } from '@/components/dashboard/dashboard-header';
 import { DashboardSidebar } from '@/components/dashboard/dashboard-sidebar';
 import { LegacyBanner } from '@/components/dashboard/legacy-banner';
 import { toClientShellUser } from '@/components/shell/client-shell-user';
+import { NavigationFeedback } from '@/components/shell/navigation-feedback';
 import { getSessionSafe, requireSessionOrRedirect } from '@/components/shell/session';
 import { APP_NAMESPACES, pickMessages } from '@/i18n/messages';
 import { getCanonicalRouteForRole } from '@/lib/canonical-routes';
@@ -47,18 +48,20 @@ export default async function DashboardLayout({
 
   return (
     <NextIntlClientProvider messages={messages} locale={locale}>
-      <div data-testid="dashboard-page-ready">
-        <SidebarProvider defaultOpen={true}>
-          <DashboardSidebar user={shellUser} adminAccess={false} />
-          <SidebarInset className="bg-mesh flex flex-col min-h-screen">
-            <DashboardHeader user={shellUser} adminAccess={false} />
-            <div className="px-6 pt-4 md:px-8">
-              <LegacyBanner role={shellUser.role} />
-            </div>
-            <main className="flex-1 p-6 md:p-8 pt-6">{children}</main>
-          </SidebarInset>
-        </SidebarProvider>
-      </div>
+      <NavigationFeedback>
+        <div data-testid="dashboard-page-ready">
+          <SidebarProvider defaultOpen={true}>
+            <DashboardSidebar user={shellUser} adminAccess={false} />
+            <SidebarInset className="bg-mesh flex flex-col min-h-screen">
+              <DashboardHeader user={shellUser} adminAccess={false} />
+              <div className="px-6 pt-4 md:px-8">
+                <LegacyBanner role={shellUser.role} />
+              </div>
+              <main className="flex-1 p-6 md:p-8 pt-6">{children}</main>
+            </SidebarInset>
+          </SidebarProvider>
+        </div>
+      </NavigationFeedback>
     </NextIntlClientProvider>
   );
 }

--- a/apps/web/src/app/[locale]/(app)/member/loading.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/loading.tsx
@@ -1,0 +1,5 @@
+import { MemberDashboardSkeleton } from '@/components/dashboard/member-dashboard-skeleton';
+
+export default function MemberPortalLoading() {
+  return <MemberDashboardSkeleton />;
+}

--- a/apps/web/src/app/[locale]/admin/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/admin/_core.entry.test.tsx
@@ -47,7 +47,12 @@ vi.mock('@/components/shell/authenticated-shell', () => ({
     children: ReactNode;
     locale: string;
     messages: Record<string, unknown>;
+    enableNavigationFeedback?: boolean;
   }) => children,
+}));
+
+vi.mock('@/components/shell/navigation-feedback', () => ({
+  NavigationFeedback: ({ children }: { children: ReactNode }) => children,
 }));
 
 vi.mock('@/components/admin/admin-sidebar', () => ({

--- a/apps/web/src/app/[locale]/admin/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/admin/_core.entry.tsx
@@ -4,6 +4,7 @@ import { AdminTenantSelector } from '@/components/admin/admin-tenant-selector';
 import { LegacyBanner } from '@/components/dashboard/legacy-banner';
 import { PortalSurfaceIndicator } from '@/components/dashboard/portal-surface-indicator';
 import { AuthenticatedShell } from '@/components/shell/authenticated-shell';
+import { NavigationFeedback } from '@/components/shell/navigation-feedback';
 import { getSessionSafe, requireSessionOrRedirect } from '@/components/shell/session';
 import { ADMIN_NAMESPACES, BASE_NAMESPACES, pickMessages } from '@/i18n/messages';
 import { requireEffectivePortalAccessOrNotFound } from '@/server/auth/effective-portal-access';
@@ -66,51 +67,53 @@ export default async function AdminLayout({
   }
 
   return (
-    <AuthenticatedShell locale={locale} messages={messages}>
-      <SidebarProvider defaultOpen={true}>
-        <AdminSidebar
-          user={{
-            name: sessionNonNull.user.name || 'Admin',
-            email: sessionNonNull.user.email,
-            role: sessionNonNull.user.role,
-          }}
-        />
-        <SidebarInset className="bg-mesh flex flex-col min-h-screen">
-          <header className="flex h-16 shrink-0 items-center gap-2 border-b bg-background/80 backdrop-blur-md sticky top-0 z-30 px-6 transition-all">
-            <div className="flex items-center gap-2">
-              <SidebarTrigger
-                className="-ml-1"
-                title={tNav('toggleSidebar')}
-                aria-label={tNav('toggleSidebar')}
-              />
-              <Separator orientation="vertical" className="mr-2 h-4" />
-            </div>
-            <div className="flex-1 flex items-center justify-between">
-              <h1 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-                {tSidebar('title')}
-              </h1>
-              <div className="flex items-center gap-3">
-                <PortalSurfaceIndicator role={role} />
-                {isSuperAdmin ? (
-                  <div className="flex items-center gap-2">
-                    <AdminTenantSelector
-                      tenants={tenantOptions}
-                      defaultTenantId={sessionNonNull.user.tenantId}
-                    />
-                  </div>
-                ) : null}
+    <AuthenticatedShell locale={locale} messages={messages} enableNavigationFeedback={false}>
+      <NavigationFeedback>
+        <SidebarProvider defaultOpen={true}>
+          <AdminSidebar
+            user={{
+              name: sessionNonNull.user.name || 'Admin',
+              email: sessionNonNull.user.email,
+              role: sessionNonNull.user.role,
+            }}
+          />
+          <SidebarInset className="bg-mesh flex flex-col min-h-screen">
+            <header className="flex h-16 shrink-0 items-center gap-2 border-b bg-background/80 backdrop-blur-md sticky top-0 z-30 px-6 transition-all">
+              <div className="flex items-center gap-2">
+                <SidebarTrigger
+                  className="-ml-1"
+                  title={tNav('toggleSidebar')}
+                  aria-label={tNav('toggleSidebar')}
+                />
+                <Separator orientation="vertical" className="mr-2 h-4" />
               </div>
+              <div className="flex-1 flex items-center justify-between">
+                <h1 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                  {tSidebar('title')}
+                </h1>
+                <div className="flex items-center gap-3">
+                  <PortalSurfaceIndicator role={role} />
+                  {isSuperAdmin ? (
+                    <div className="flex items-center gap-2">
+                      <AdminTenantSelector
+                        tenants={tenantOptions}
+                        defaultTenantId={sessionNonNull.user.tenantId}
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            </header>
+            <div className="px-6 pt-4 md:px-8">
+              <LegacyBanner role={role} />
             </div>
-          </header>
-          <div className="px-6 pt-4 md:px-8">
-            <LegacyBanner role={role} />
-          </div>
-          {/* SidebarInset renders as <main>, so use <div> here to avoid nested landmarks */}
-          <div className="flex-1 overflow-y-auto p-6 md:p-8">
-            <div className="container mx-auto">{children}</div>
-          </div>
-        </SidebarInset>
-      </SidebarProvider>
+            {/* SidebarInset renders as <main>, so use <div> here to avoid nested landmarks */}
+            <div className="flex-1 overflow-y-auto p-6 md:p-8">
+              <div className="container mx-auto">{children}</div>
+            </div>
+          </SidebarInset>
+        </SidebarProvider>
+      </NavigationFeedback>
     </AuthenticatedShell>
   );
 }

--- a/apps/web/src/app/[locale]/admin/loading.tsx
+++ b/apps/web/src/app/[locale]/admin/loading.tsx
@@ -1,0 +1,5 @@
+import { SkeletonDashboard } from '@/components/ui/skeleton-loader';
+
+export default function AdminPortalLoading() {
+  return <SkeletonDashboard />;
+}

--- a/apps/web/src/components/shell/authenticated-shell.tsx
+++ b/apps/web/src/components/shell/authenticated-shell.tsx
@@ -2,27 +2,42 @@ import type { ReactElement, ReactNode } from 'react';
 
 import { NextIntlClientProvider } from 'next-intl';
 
+import { NavigationFeedback } from './navigation-feedback';
+
 type AuthenticatedShellProps = {
   locale: string;
   messages: Record<string, unknown>;
   children: ReactNode;
+  enableNavigationFeedback?: boolean;
 };
 
 /**
- * Shared infra-only shell:
+ * Shared portal shell:
  * - NextIntl provider
  * - E2E readiness marker (must remain stable)
- * - NO UI opinions (sidebar/header/content handled by portal wrappers)
+ * - optional shared navigation feedback for portal route transitions
+ * - no portal chrome opinions (sidebar/header/content handled by portal wrappers)
  */
 export function AuthenticatedShell({
   locale,
   messages,
   children,
+  enableNavigationFeedback = true,
 }: AuthenticatedShellProps): ReactElement {
-  return (
-    <NextIntlClientProvider messages={messages} locale={locale}>
+  const readyContent = (
+    <>
       {/* E2E contract: ensureAuthenticated waits for dashboard-page-ready across all portals */}
       <div data-testid="dashboard-page-ready">{children}</div>
+    </>
+  );
+
+  return (
+    <NextIntlClientProvider messages={messages} locale={locale}>
+      {enableNavigationFeedback ? (
+        <NavigationFeedback>{readyContent}</NavigationFeedback>
+      ) : (
+        readyContent
+      )}
     </NextIntlClientProvider>
   );
 }

--- a/apps/web/src/components/shell/navigation-feedback.test.tsx
+++ b/apps/web/src/components/shell/navigation-feedback.test.tsx
@@ -1,0 +1,168 @@
+/* eslint-disable @next/next/no-html-link-for-pages */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NavigationFeedback } from './navigation-feedback';
+
+const routeState = vi.hoisted(() => ({
+  pathname: '/sq/member',
+  search: '',
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  usePathname: () => routeState.pathname,
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(routeState.search),
+}));
+
+describe('NavigationFeedback', () => {
+  beforeEach(() => {
+    routeState.pathname = '/sq/member';
+    routeState.search = '';
+    window.history.pushState({}, '', '/sq/member');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not show a pending indicator before navigation starts', () => {
+    render(
+      <NavigationFeedback>
+        <a href="/sq/member/claims">Claims</a>
+      </NavigationFeedback>
+    );
+
+    expect(screen.queryByTestId('portal-navigation-progress')).not.toBeInTheDocument();
+  });
+
+  it('shows a pending indicator for normal internal link navigation', () => {
+    render(
+      <NavigationFeedback>
+        <a href="/sq/member/claims">Claims</a>
+      </NavigationFeedback>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Claims' }));
+
+    expect(screen.getByTestId('portal-navigation-progress')).toBeInTheDocument();
+  });
+
+  it('ignores links that do not trigger app navigation', () => {
+    render(
+      <NavigationFeedback>
+        <a href="https://external.test">External</a>
+        <a download href="/sq/member/report.pdf">
+          Download
+        </a>
+        <a href="/sq/member#quota">Same page</a>
+      </NavigationFeedback>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'External' }));
+    fireEvent.click(screen.getByRole('link', { name: 'Download' }));
+    fireEvent.click(screen.getByRole('link', { name: 'Same page' }));
+
+    expect(screen.queryByTestId('portal-navigation-progress')).not.toBeInTheDocument();
+  });
+
+  it('ignores internal navigation cancelled by the link handler', () => {
+    render(
+      <NavigationFeedback>
+        <a
+          data-navigation-feedback="ignore"
+          href="/sq/member/claims"
+          onClick={event => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+        >
+          Cancelled
+        </a>
+      </NavigationFeedback>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Cancelled' }));
+
+    expect(screen.queryByTestId('portal-navigation-progress')).not.toBeInTheDocument();
+  });
+
+  it('clears the pending indicator when internal navigation is cancelled after capture', () => {
+    vi.useFakeTimers();
+    render(
+      <NavigationFeedback>
+        <a
+          href="/sq/member/claims"
+          onClick={event => {
+            event.preventDefault();
+          }}
+        >
+          Cancelled
+        </a>
+      </NavigationFeedback>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Cancelled' }));
+    expect(screen.getByTestId('portal-navigation-progress')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2_499);
+    });
+
+    expect(screen.queryByTestId('portal-navigation-progress')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(screen.queryByTestId('portal-navigation-progress')).not.toBeInTheDocument();
+  });
+
+  it('clears the pending indicator when the route changes', () => {
+    vi.useFakeTimers();
+    const { rerender } = render(
+      <NavigationFeedback>
+        <a href="/sq/member/claims">Claims</a>
+      </NavigationFeedback>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Claims' }));
+    expect(screen.getByTestId('portal-navigation-progress')).toBeInTheDocument();
+
+    routeState.pathname = '/sq/member/claims';
+    window.history.pushState({}, '', '/sq/member/claims');
+    rerender(
+      <NavigationFeedback>
+        <a href="/sq/member">Overview</a>
+      </NavigationFeedback>
+    );
+
+    expect(screen.getByTestId('portal-navigation-progress')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.queryByTestId('portal-navigation-progress')).not.toBeInTheDocument();
+  });
+
+  it('clears the pending indicator after the fallback timeout', () => {
+    vi.useFakeTimers();
+    render(
+      <NavigationFeedback>
+        <a href="/sq/member/claims">Claims</a>
+      </NavigationFeedback>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Claims' }));
+    expect(screen.getByTestId('portal-navigation-progress')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.queryByTestId('portal-navigation-progress')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shell/navigation-feedback.tsx
+++ b/apps/web/src/components/shell/navigation-feedback.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import type { MouseEvent, ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { usePathname } from '@/i18n/routing';
+
+const NAVIGATION_FEEDBACK_TIMEOUT_MS = 10_000;
+const CANCELLED_NAVIGATION_CLEAR_MS = 2_500;
+const MIN_VISIBLE_NAVIGATION_FEEDBACK_MS = 200;
+const NAVIGATION_FEEDBACK_IGNORE_SELECTOR = '[data-navigation-feedback="ignore"]';
+
+function getClickedAnchor(target: EventTarget | null): HTMLAnchorElement | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+
+  return target.closest('a[href]');
+}
+
+function isPrimaryNavigationClick(event: MouseEvent<HTMLElement>): boolean {
+  return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+}
+
+function shouldTrackAnchor(anchor: HTMLAnchorElement, currentUrl: URL): boolean {
+  if (anchor.target && anchor.target !== '_self') {
+    return false;
+  }
+
+  if (anchor.hasAttribute('download')) {
+    return false;
+  }
+
+  if (anchor.closest(NAVIGATION_FEEDBACK_IGNORE_SELECTOR)) {
+    return false;
+  }
+
+  const href = anchor.getAttribute('href');
+  if (!href || href.startsWith('#')) {
+    return false;
+  }
+
+  const nextUrl = new URL(anchor.href, currentUrl);
+  if (nextUrl.origin !== currentUrl.origin) {
+    return false;
+  }
+
+  return nextUrl.pathname !== currentUrl.pathname || nextUrl.search !== currentUrl.search;
+}
+
+export function NavigationFeedback({ children }: Readonly<{ children: ReactNode }>): ReactNode {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = useMemo(() => searchParams.toString(), [searchParams]);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancellationCheckRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const routeClearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastRouteKeyRef = useRef<string | null>(null);
+  const pendingStartedAtRef = useRef<number>(0);
+  const [isPending, setIsPending] = useState(false);
+
+  function clearPendingTimer() {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }
+
+  function clearCancellationCheck() {
+    if (cancellationCheckRef.current) {
+      clearTimeout(cancellationCheckRef.current);
+      cancellationCheckRef.current = null;
+    }
+  }
+
+  function clearRouteClearTimer() {
+    if (routeClearRef.current) {
+      clearTimeout(routeClearRef.current);
+      routeClearRef.current = null;
+    }
+  }
+
+  function clearNavigationTimers() {
+    clearPendingTimer();
+    clearCancellationCheck();
+    clearRouteClearTimer();
+  }
+
+  useEffect(() => {
+    const routeKey = `${pathname}?${search}`;
+    const previousRouteKey = lastRouteKeyRef.current;
+    lastRouteKeyRef.current = routeKey;
+
+    if (previousRouteKey === null || previousRouteKey === routeKey) {
+      return clearNavigationTimers;
+    }
+
+    clearNavigationTimers();
+
+    const elapsedMs = Date.now() - pendingStartedAtRef.current;
+    const remainingVisibleMs = Math.max(0, MIN_VISIBLE_NAVIGATION_FEEDBACK_MS - elapsedMs);
+
+    if (remainingVisibleMs === 0) {
+      setIsPending(false);
+      return clearNavigationTimers;
+    }
+
+    routeClearRef.current = setTimeout(() => {
+      setIsPending(false);
+      routeClearRef.current = null;
+    }, remainingVisibleMs);
+
+    return clearNavigationTimers;
+  }, [pathname, search]);
+
+  function handleClick(event: MouseEvent<HTMLDivElement>) {
+    if (!isPrimaryNavigationClick(event)) {
+      return;
+    }
+
+    const anchor = getClickedAnchor(event.target);
+    if (!anchor || !shouldTrackAnchor(anchor, new URL(window.location.href))) {
+      return;
+    }
+
+    const startingHref = window.location.href;
+    const nativeEvent = event.nativeEvent;
+
+    clearNavigationTimers();
+    pendingStartedAtRef.current = Date.now();
+    setIsPending(true);
+    timeoutRef.current = setTimeout(() => {
+      setIsPending(false);
+      timeoutRef.current = null;
+    }, NAVIGATION_FEEDBACK_TIMEOUT_MS);
+
+    cancellationCheckRef.current = setTimeout(() => {
+      if (!event.defaultPrevented && !nativeEvent.defaultPrevented) {
+        cancellationCheckRef.current = null;
+        return;
+      }
+
+      cancellationCheckRef.current = setTimeout(() => {
+        cancellationCheckRef.current = null;
+
+        if (window.location.href !== startingHref) {
+          return;
+        }
+
+        setIsPending(false);
+        clearPendingTimer();
+      }, CANCELLED_NAVIGATION_CLEAR_MS);
+    }, 0);
+  }
+
+  return (
+    <div onClickCapture={handleClick}>
+      {isPending ? (
+        <div
+          aria-label="Loading page"
+          aria-live="polite"
+          className="fixed inset-x-0 top-0 z-[100] h-1 bg-primary/15"
+          data-testid="portal-navigation-progress"
+          role="status"
+        >
+          <div className="h-full w-1/3 animate-pulse rounded-r-full bg-primary shadow-[0_0_16px_rgba(14,116,144,0.45)]" />
+          <span className="sr-only">Loading page</span>
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared portal navigation feedback with an immediate top progress indicator for internal portal transitions
- wire member/admin portal shells and add member/admin loading skeletons
- add unit/E2E coverage for real member/admin sidebar navigation feedback and harden timing-sensitive gate assertions exposed by this slice

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/components/shell/navigation-feedback.test.tsx 'src/app/[locale]/(app)/member/_core.entry.test.tsx' 'src/app/[locale]/admin/_core.entry.test.tsx'`
- `NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web build:ci`
- `E2E_DATABASE_URL=... E2E_DATABASE_URL_RLS=... NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web exec playwright test e2e/navigation-feedback.spec.ts --project=ks-sq --workers=1 --max-failures=1 --trace=retain-on-failure --reporter=line`
- `pnpm verify-slice -- --static` (`tmp/multi-agent/verify-slice/verify-slice-20260428T134205Z-1d51ee`)
- `pnpm verify-slice -- --required-gates` (`tmp/multi-agent/verify-slice/verify-slice-20260428T133040Z-38f2cb`)
