### PR TITLE
fix(web): improve admin claims filter responsiveness

### DIFF
--- a/apps/web/e2e/gate/matter-allowance-visibility.spec.ts
+++ b/apps/web/e2e/gate/matter-allowance-visibility.spec.ts
@@ -14,22 +14,36 @@ test.describe('Matter allowance visibility', () => {
       marker: 'member-claim-matter-allowance',
     });
 
-    await expect(memberPage.getByTestId('member-claim-matter-allowance')).toBeVisible();
-    await expect(memberPage.getByTestId('member-claim-matter-allowance-used')).toHaveText('0');
-    await expect(memberPage.getByTestId('member-claim-matter-allowance-remaining')).toHaveText('2');
-    await expect(memberPage.getByTestId('member-claim-matter-allowance-total')).toHaveText('2');
+    const memberMatterAllowance = memberPage
+      .locator('[data-testid="member-claim-matter-allowance"]:visible')
+      .last();
+    await expect(memberMatterAllowance).toBeVisible();
+    await expect(
+      memberMatterAllowance.getByTestId('member-claim-matter-allowance-used')
+    ).toHaveText('0');
+    await expect(
+      memberMatterAllowance.getByTestId('member-claim-matter-allowance-remaining')
+    ).toHaveText('2');
+    await expect(
+      memberMatterAllowance.getByTestId('member-claim-matter-allowance-total')
+    ).toHaveText('2');
 
     await gotoApp(staffPage, routes.staffClaimDetail(claimId, testInfo), testInfo, {
       marker: 'staff-claim-detail-matter-allowance',
     });
 
-    await expect(staffPage.getByTestId('staff-claim-detail-matter-allowance')).toBeVisible();
-    await expect(staffPage.getByTestId('staff-claim-detail-matter-allowance-used')).toHaveText('0');
-    await expect(staffPage.getByTestId('staff-claim-detail-matter-allowance-remaining')).toHaveText(
-      '2'
-    );
-    await expect(staffPage.getByTestId('staff-claim-detail-matter-allowance-total')).toHaveText(
-      '2'
-    );
+    const staffMatterAllowance = staffPage
+      .locator('[data-testid="staff-claim-detail-matter-allowance"]:visible')
+      .last();
+    await expect(staffMatterAllowance).toBeVisible();
+    await expect(
+      staffMatterAllowance.getByTestId('staff-claim-detail-matter-allowance-used')
+    ).toHaveText('0');
+    await expect(
+      staffMatterAllowance.getByTestId('staff-claim-detail-matter-allowance-remaining')
+    ).toHaveText('2');
+    await expect(
+      staffMatterAllowance.getByTestId('staff-claim-detail-matter-allowance-total')
+    ).toHaveText('2');
   });
 });

--- a/apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts
+++ b/apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts
@@ -181,7 +181,9 @@ test.describe('P21-QA01 v1.0.0 live surface revalidation', () => {
     await expect(page.getByTestId('dashboard-page-ready')).toBeVisible();
 
     await gotoApp(page, routes.agent(testInfo), testInfo, { marker: 'agent-members-ready' });
-    await page.getByTestId('agent-support-link').click();
+    const agentMembersReady = page.locator('[data-testid="agent-members-ready"]:visible').last();
+    await expect(agentMembersReady).toBeVisible();
+    await agentMembersReady.getByTestId('agent-support-link').click();
     await expect(page).toHaveURL(new RegExp(`${routes.agentCrm(testInfo)}$`));
     await expect(page.getByTestId('dashboard-page-ready')).toBeVisible();
   });

--- a/apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts
+++ b/apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts
@@ -168,7 +168,11 @@ test.describe('P21-QA01 v1.0.0 live surface revalidation', () => {
 
     await page.getByTestId('agent-member-dashboard-cta').first().click();
     await expect(page).toHaveURL(new RegExp(`${routes.member(testInfo)}$`));
-    await expect(page.getByTestId('member-dashboard-ready')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="member-dashboard-ready"]:visible').first()
+    ).toBeVisible({
+      timeout: 15000,
+    });
 
     const memberStartClaimCta = page.getByTestId('member-start-claim-cta').first();
     await expect(memberStartClaimCta).toBeVisible();

--- a/apps/web/src/components/admin/claims/claims-filters.test.tsx
+++ b/apps/web/src/components/admin/claims/claims-filters.test.tsx
@@ -137,6 +137,18 @@ describe('AdminClaimsFilters', () => {
     expect(input).toHaveValue('query');
   });
 
+  it('does not show pending feedback when search would keep the same url', () => {
+    vi.mocked(useSearchParams).mockReturnValue(createMockParams('search=query&view=list'));
+    render(<AdminClaimsFilters />);
+
+    const input = screen.getByPlaceholderText('Search...');
+    fireEvent.change(input, { target: { value: 'query' } });
+
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('admin-claims-pending')).not.toBeInTheDocument();
+    expect(screen.getByTestId('admin-claims-filter-region')).toHaveAttribute('aria-busy', 'false');
+  });
+
   it('routes status tabs through the pending contract and keeps the active tab inert', () => {
     vi.mocked(useSearchParams).mockReturnValue(createMockParams('status=active'));
     render(<AdminClaimsFilters />);

--- a/apps/web/src/components/admin/claims/claims-filters.test.tsx
+++ b/apps/web/src/components/admin/claims/claims-filters.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps, PropsWithChildren } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AdminClaimsFilters } from './claims-filters';
 
@@ -25,6 +26,8 @@ vi.mock('next-intl', () => ({
       'filters.origin_label': 'Origin',
       'filters.origin_all': 'All origins',
       'filters.origin_diaspora': 'Diaspora / Green Card',
+      'filters.pending_filter': 'Updating filters...',
+      'filters.pending_search': 'Updating search...',
     };
 
     return adminClaimsKeys[key] ?? key;
@@ -33,13 +36,20 @@ vi.mock('next-intl', () => ({
 
 // Mock UI components
 vi.mock('@interdomestik/ui', () => ({
-  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
-  Input: (props: any) => <input {...props} />,
+  Button: ({
+    children,
+    ...props
+  }: PropsWithChildren<ComponentProps<'button'> & { asChild?: boolean }>) => (
+    <button {...props}>{children}</button>
+  ),
+  Badge: ({ children, ...props }: PropsWithChildren<ComponentProps<'span'>>) => (
+    <span {...props}>{children}</span>
+  ),
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
   // GlassCard is just a div in test
 }));
 vi.mock('@/components/ui/glass-card', () => ({
-  GlassCard: ({ children }: any) => <div>{children}</div>,
+  GlassCard: ({ children }: PropsWithChildren) => <div>{children}</div>,
 }));
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -47,13 +57,14 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 describe('AdminClaimsFilters', () => {
   const mockRouter = { replace: vi.fn() };
   // Helper to create mocked params
-  const createMockParams = (qs = '') => new URLSearchParams(qs);
+  const createMockParams = (qs = '') =>
+    new URLSearchParams(qs) as unknown as ReturnType<typeof useSearchParams>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useRouter as any).mockReturnValue(mockRouter);
-    (usePathname as any).mockReturnValue('/admin/claims');
-    (useSearchParams as any).mockReturnValue(createMockParams());
+    vi.mocked(useRouter).mockReturnValue(mockRouter as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(usePathname).mockReturnValue('/admin/claims');
+    vi.mocked(useSearchParams).mockReturnValue(createMockParams());
   });
 
   it('renders search input', () => {
@@ -83,7 +94,7 @@ describe('AdminClaimsFilters', () => {
   });
 
   it('removes status param when clicking All', () => {
-    (useSearchParams as any).mockReturnValue(createMockParams('status=active'));
+    vi.mocked(useSearchParams).mockReturnValue(createMockParams('status=active'));
     render(<AdminClaimsFilters />);
 
     const statusAllTab = screen.getByTestId('claims-tab-all');
@@ -99,5 +110,64 @@ describe('AdminClaimsFilters', () => {
     expect(mockRouter.replace).toHaveBeenCalledWith(expect.stringContaining('search=query'), {
       scroll: false,
     });
+  });
+
+  it('shows deterministic pending feedback when search updates the url', () => {
+    render(<AdminClaimsFilters />);
+
+    const input = screen.getByPlaceholderText('Search...');
+    fireEvent.change(input, { target: { value: 'query' } });
+
+    expect(screen.getByTestId('admin-claims-filter-region')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByTestId('admin-claims-pending')).toHaveTextContent('Updating search...');
+    expect(input).toHaveValue('query');
+  });
+
+  it('keeps replacing the latest search query while search feedback is pending', () => {
+    render(<AdminClaimsFilters />);
+
+    const input = screen.getByPlaceholderText('Search...');
+    fireEvent.change(input, { target: { value: 'q' } });
+    fireEvent.change(input, { target: { value: 'query' } });
+
+    expect(mockRouter.replace).toHaveBeenCalledTimes(2);
+    expect(mockRouter.replace).toHaveBeenLastCalledWith('/admin/claims?search=query&view=list', {
+      scroll: false,
+    });
+    expect(input).toHaveValue('query');
+  });
+
+  it('routes status tabs through the pending contract and keeps the active tab inert', () => {
+    vi.mocked(useSearchParams).mockReturnValue(createMockParams('status=active'));
+    render(<AdminClaimsFilters />);
+
+    fireEvent.click(screen.getByTestId('claims-tab-active'));
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('claims-tab-draft'));
+    expect(mockRouter.replace).toHaveBeenCalledWith('/admin/claims?status=draft&view=list', {
+      scroll: false,
+    });
+    expect(screen.getByTestId('admin-claims-pending')).toHaveTextContent('Updating filters...');
+  });
+
+  it('blocks overlapping filter navigation while a filter update is pending', () => {
+    render(<AdminClaimsFilters />);
+
+    fireEvent.click(screen.getByTestId('assigned-filter-unassigned'));
+    fireEvent.click(screen.getByTestId('diaspora-filter-diaspora'));
+
+    expect(mockRouter.replace).toHaveBeenCalledTimes(1);
+    expect(mockRouter.replace).toHaveBeenCalledWith('/admin/claims?assigned=unassigned&view=list', {
+      scroll: false,
+    });
+  });
+
+  it('makes search inert while a filter update is pending', () => {
+    render(<AdminClaimsFilters />);
+
+    fireEvent.click(screen.getByTestId('assigned-filter-unassigned'));
+
+    expect(screen.getByPlaceholderText('Search...')).toBeDisabled();
   });
 });

--- a/apps/web/src/components/admin/claims/claims-filters.tsx
+++ b/apps/web/src/components/admin/claims/claims-filters.tsx
@@ -46,15 +46,15 @@ export function AdminClaimsFilters() {
   const currentDiasporaOrigin = parseAdminDiasporaOriginFilter(searchParams.get('diaspora'));
   const currentParamsString = searchParams.toString();
 
-  const [pendingKind, setPendingKindState] = useState<PendingKind | null>(null);
+  const [pendingKind, setPendingKind] = useState<PendingKind | null>(null);
   const pendingKindRef = useRef<PendingKind | null>(null);
   const [searchValue, setSearchValue] = useState(currentSearch);
   const [isTransitionPending, startTransition] = useTransition();
   const isNavigationPending = Boolean(pendingKind || isTransitionPending);
 
-  const setPendingKind = useCallback((nextPendingKind: PendingKind | null) => {
+  const updatePendingKind = useCallback((nextPendingKind: PendingKind | null) => {
     pendingKindRef.current = nextPendingKind;
-    setPendingKindState(nextPendingKind);
+    setPendingKind(nextPendingKind);
   }, []);
 
   useEffect(() => {
@@ -62,17 +62,20 @@ export function AdminClaimsFilters() {
   }, [currentSearch]);
 
   useEffect(() => {
-    setPendingKind(null);
-  }, [currentParamsString, setPendingKind]);
+    updatePendingKind(null);
+  }, [currentParamsString, updatePendingKind]);
 
   useEffect(() => {
     if (!pendingKind) {
       return undefined;
     }
 
-    const timeout = globalThis.setTimeout(() => setPendingKind(null), PENDING_FEEDBACK_TIMEOUT_MS);
+    const timeout = globalThis.setTimeout(
+      () => updatePendingKind(null),
+      PENDING_FEEDBACK_TIMEOUT_MS
+    );
     return () => globalThis.clearTimeout(timeout);
-  }, [pendingKind, setPendingKind]);
+  }, [pendingKind, updatePendingKind]);
 
   // V2 Status Tabs
   const statusOptions = [
@@ -101,7 +104,7 @@ export function AdminClaimsFilters() {
       return;
     }
 
-    setPendingKind(nextPendingKind);
+    updatePendingKind(nextPendingKind);
 
     startTransition(() => {
       router.replace(`${pathname}${buildClaimsListUrl(searchParams, updates)}`, { scroll: false });
@@ -122,7 +125,7 @@ export function AdminClaimsFilters() {
       return;
     }
 
-    setPendingKind('search');
+    updatePendingKind('search');
 
     startTransition(() => {
       router.replace(`${pathname}${nextUrl}`, {

--- a/apps/web/src/components/admin/claims/claims-filters.tsx
+++ b/apps/web/src/components/admin/claims/claims-filters.tsx
@@ -49,7 +49,8 @@ export function AdminClaimsFilters() {
   const [pendingKind, setPendingKindState] = useState<PendingKind | null>(null);
   const pendingKindRef = useRef<PendingKind | null>(null);
   const [searchValue, setSearchValue] = useState(currentSearch);
-  const [, startTransition] = useTransition();
+  const [isTransitionPending, startTransition] = useTransition();
+  const isNavigationPending = Boolean(pendingKind || isTransitionPending);
 
   const setPendingKind = useCallback((nextPendingKind: PendingKind | null) => {
     pendingKindRef.current = nextPendingKind;
@@ -69,8 +70,8 @@ export function AdminClaimsFilters() {
       return undefined;
     }
 
-    const timeout = window.setTimeout(() => setPendingKind(null), PENDING_FEEDBACK_TIMEOUT_MS);
-    return () => window.clearTimeout(timeout);
+    const timeout = globalThis.setTimeout(() => setPendingKind(null), PENDING_FEEDBACK_TIMEOUT_MS);
+    return () => globalThis.clearTimeout(timeout);
   }, [pendingKind, setPendingKind]);
 
   // V2 Status Tabs
@@ -133,7 +134,7 @@ export function AdminClaimsFilters() {
   return (
     <div
       data-testid="admin-claims-filter-region"
-      aria-busy={pendingKind ? 'true' : 'false'}
+      aria-busy={isNavigationPending ? 'true' : 'false'}
       className="space-y-2"
     >
       {/* Audit Contract Satisfaction: Hidden aliases for legacy static analysis */}
@@ -175,14 +176,14 @@ export function AdminClaimsFilters() {
         onSearchChange={updateSearch}
         searchPlaceholder={`${tCommon('search')}...`}
         searchInputTestId="claims-search-input"
-        isPending={Boolean(pendingKind)}
+        isPending={isNavigationPending}
         searchDisabled={pendingKind === 'filter'}
         rightActions={
           <div className="flex flex-wrap items-center gap-3">
             <div className="flex bg-black/20 p-1 rounded-lg border border-white/5">
               {assignmentOptions.map(option => {
                 const isActive = currentAssignment === option.value;
-                const isInert = Boolean(pendingKind) || isActive;
+                const isInert = isNavigationPending || isActive;
                 return (
                   <button
                     key={option.value}
@@ -211,7 +212,7 @@ export function AdminClaimsFilters() {
             >
               {diasporaOptions.map(option => {
                 const isActive = currentDiasporaOrigin === option.value;
-                const isInert = Boolean(pendingKind) || isActive;
+                const isInert = isNavigationPending || isActive;
                 return (
                   <button
                     key={option.value}

--- a/apps/web/src/components/admin/claims/claims-filters.tsx
+++ b/apps/web/src/components/admin/claims/claims-filters.tsx
@@ -2,9 +2,14 @@
 
 import { useTranslations } from 'next-intl';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
 
 import { OpsFiltersBar } from '@/components/ops';
 import { parseAdminDiasporaOriginFilter } from '@/features/admin/claims/lib/diaspora-origin-filter';
+
+const PENDING_FEEDBACK_TIMEOUT_MS = 10_000;
+
+type PendingKind = 'filter' | 'search';
 
 function buildClaimsListUrl(
   currentParams: URLSearchParams,
@@ -39,6 +44,34 @@ export function AdminClaimsFilters() {
   const currentStatus = searchParams.get('status') || 'all';
   const currentAssignment = searchParams.get('assigned') || 'all';
   const currentDiasporaOrigin = parseAdminDiasporaOriginFilter(searchParams.get('diaspora'));
+  const currentParamsString = searchParams.toString();
+
+  const [pendingKind, setPendingKindState] = useState<PendingKind | null>(null);
+  const pendingKindRef = useRef<PendingKind | null>(null);
+  const [searchValue, setSearchValue] = useState(currentSearch);
+  const [, startTransition] = useTransition();
+
+  const setPendingKind = useCallback((nextPendingKind: PendingKind | null) => {
+    pendingKindRef.current = nextPendingKind;
+    setPendingKindState(nextPendingKind);
+  }, []);
+
+  useEffect(() => {
+    setSearchValue(currentSearch);
+  }, [currentSearch]);
+
+  useEffect(() => {
+    setPendingKind(null);
+  }, [currentParamsString, setPendingKind]);
+
+  useEffect(() => {
+    if (!pendingKind) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => setPendingKind(null), PENDING_FEEDBACK_TIMEOUT_MS);
+    return () => window.clearTimeout(timeout);
+  }, [pendingKind, setPendingKind]);
 
   // V2 Status Tabs
   const statusOptions = [
@@ -62,12 +95,40 @@ export function AdminClaimsFilters() {
     return buildClaimsListUrl(searchParams, updates);
   };
 
-  const updateFilters = (updates: Record<string, string | null>) => {
-    router.replace(`${pathname}${buildClaimsListUrl(searchParams, updates)}`, { scroll: false });
+  const updateFilters = (updates: Record<string, string | null>, nextPendingKind: PendingKind) => {
+    if (pendingKindRef.current) {
+      return;
+    }
+
+    setPendingKind(nextPendingKind);
+
+    startTransition(() => {
+      router.replace(`${pathname}${buildClaimsListUrl(searchParams, updates)}`, { scroll: false });
+    });
+  };
+
+  const updateSearch = (query: string) => {
+    setSearchValue(query);
+
+    if (pendingKindRef.current === 'filter') {
+      return;
+    }
+
+    setPendingKind('search');
+
+    startTransition(() => {
+      router.replace(`${pathname}${buildClaimsListUrl(searchParams, { search: query || null })}`, {
+        scroll: false,
+      });
+    });
   };
 
   return (
-    <div>
+    <div
+      data-testid="admin-claims-filter-region"
+      aria-busy={pendingKind ? 'true' : 'false'}
+      className="space-y-2"
+    >
       {/* Audit Contract Satisfaction: Hidden aliases for legacy static analysis */}
       <div
         data-testid="admin-claims-filters"
@@ -81,6 +142,19 @@ export function AdminClaimsFilters() {
         ))}
       </div>
 
+      {pendingKind ? (
+        <div
+          data-testid="admin-claims-pending"
+          role="status"
+          aria-live="polite"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          {pendingKind === 'search'
+            ? tAdmin('filters.pending_search')
+            : tAdmin('filters.pending_filter')}
+        </div>
+      ) : null}
+
       <OpsFiltersBar
         tabs={statusOptions.map(option => ({
           id: option.value,
@@ -89,22 +163,27 @@ export function AdminClaimsFilters() {
           href: buildHref({ status: option.value }),
         }))}
         activeTab={currentStatus}
-        onTabChange={tabId => updateFilters({ status: tabId })}
-        searchQuery={currentSearch}
-        onSearchChange={query => updateFilters({ search: query || null })}
+        onTabChange={tabId => updateFilters({ status: tabId }, 'filter')}
+        searchQuery={searchValue}
+        onSearchChange={updateSearch}
         searchPlaceholder={`${tCommon('search')}...`}
         searchInputTestId="claims-search-input"
+        isPending={Boolean(pendingKind)}
+        searchDisabled={pendingKind === 'filter'}
         rightActions={
           <div className="flex flex-wrap items-center gap-3">
             <div className="flex bg-black/20 p-1 rounded-lg border border-white/5">
               {assignmentOptions.map(option => {
                 const isActive = currentAssignment === option.value;
+                const isInert = Boolean(pendingKind) || isActive;
                 return (
                   <button
                     key={option.value}
-                    onClick={() => updateFilters({ assigned: option.value })}
+                    onClick={() => updateFilters({ assigned: option.value }, 'filter')}
                     type="button"
                     aria-pressed={isActive}
+                    aria-disabled={isInert}
+                    disabled={isInert}
                     data-state={isActive ? 'on' : 'off'}
                     data-testid={`assigned-filter-${option.value}`}
                     className={[
@@ -125,12 +204,15 @@ export function AdminClaimsFilters() {
             >
               {diasporaOptions.map(option => {
                 const isActive = currentDiasporaOrigin === option.value;
+                const isInert = Boolean(pendingKind) || isActive;
                 return (
                   <button
                     key={option.value}
-                    onClick={() => updateFilters({ diaspora: option.value })}
+                    onClick={() => updateFilters({ diaspora: option.value }, 'filter')}
                     type="button"
                     aria-pressed={isActive}
+                    aria-disabled={isInert}
+                    disabled={isInert}
                     data-state={isActive ? 'on' : 'off'}
                     data-testid={`diaspora-filter-${option.value}`}
                     className={[

--- a/apps/web/src/components/admin/claims/claims-filters.tsx
+++ b/apps/web/src/components/admin/claims/claims-filters.tsx
@@ -114,10 +114,17 @@ export function AdminClaimsFilters() {
       return;
     }
 
+    const nextUrl = buildClaimsListUrl(searchParams, { search: query || null });
+    const currentUrl = currentParamsString ? `?${currentParamsString}` : '';
+
+    if (nextUrl === currentUrl) {
+      return;
+    }
+
     setPendingKind('search');
 
     startTransition(() => {
-      router.replace(`${pathname}${buildClaimsListUrl(searchParams, { search: query || null })}`, {
+      router.replace(`${pathname}${nextUrl}`, {
         scroll: false,
       });
     });

--- a/apps/web/src/components/ops/OpsFiltersBar.test.tsx
+++ b/apps/web/src/components/ops/OpsFiltersBar.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps, PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { OpsFiltersBar } from './OpsFiltersBar';
+
+vi.mock('@interdomestik/ui', () => ({
+  Button: ({
+    children,
+    asChild: _asChild,
+    ...props
+  }: PropsWithChildren<ComponentProps<'button'> & { asChild?: boolean }>) => (
+    <button {...props}>{children}</button>
+  ),
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
+}));
+
+describe('OpsFiltersBar', () => {
+  const tabs = [
+    { id: 'all', label: 'All' },
+    { id: 'active', label: 'Active' },
+  ];
+
+  it('keeps the active non-link tab inert', () => {
+    const onTabChange = vi.fn();
+
+    render(
+      <OpsFiltersBar
+        tabs={tabs}
+        activeTab="all"
+        onTabChange={onTabChange}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Search..."
+      />
+    );
+
+    const allTab = screen.getByTestId('ops-tab-all');
+    expect(allTab).toBeDisabled();
+
+    fireEvent.click(allTab);
+    expect(onTabChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps inactive non-link tabs clickable when not pending', () => {
+    const onTabChange = vi.fn();
+
+    render(
+      <OpsFiltersBar
+        tabs={tabs}
+        activeTab="all"
+        onTabChange={onTabChange}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Search..."
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ops-tab-active'));
+    expect(onTabChange).toHaveBeenCalledWith('active');
+  });
+});

--- a/apps/web/src/components/ops/OpsFiltersBar.tsx
+++ b/apps/web/src/components/ops/OpsFiltersBar.tsx
@@ -3,7 +3,7 @@
 import { Button, Input } from '@interdomestik/ui';
 import { Search } from 'lucide-react';
 import Link from 'next/link';
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { OPS_TEST_IDS } from './testids';
 
 export type OpsFilterTab = {
@@ -24,6 +24,12 @@ interface OpsFiltersBarProps {
   searchInputTestId?: string;
   rightActions?: ReactNode;
   className?: string;
+  isPending?: boolean;
+  searchDisabled?: boolean;
+}
+
+function isPrimaryNavigationClick(event: MouseEvent<HTMLElement>) {
+  return event.button === 0 && !event.metaKey && !event.altKey && !event.ctrlKey && !event.shiftKey;
 }
 
 export function OpsFiltersBar({
@@ -36,6 +42,8 @@ export function OpsFiltersBar({
   searchInputTestId,
   rightActions,
   className,
+  isPending = false,
+  searchDisabled = false,
 }: Readonly<OpsFiltersBarProps>) {
   const containerClasses = [
     'flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 p-4 rounded-lg border border-white/5 bg-card/30 backdrop-blur-sm',
@@ -47,12 +55,14 @@ export function OpsFiltersBar({
   return (
     <div className={containerClasses} data-testid={OPS_TEST_IDS.FILTERS.BAR}>
       <div className="flex gap-2">
-        {tabs.map(tab =>
-          tab.href ? (
+        {tabs.map(tab => {
+          const isActive = tab.id === activeTab;
+
+          return tab.href ? (
             <Button
               key={tab.id}
               asChild
-              variant={tab.id === activeTab ? 'default' : 'outline'}
+              variant={isActive ? 'default' : 'outline'}
               size="sm"
               className="gap-2"
             >
@@ -61,6 +71,21 @@ export function OpsFiltersBar({
                 scroll={false}
                 prefetch={false}
                 data-testid={tab.testId ?? OPS_TEST_IDS.FILTERS.TAB(tab.id)}
+                aria-disabled={isPending || isActive || undefined}
+                tabIndex={isPending || isActive ? -1 : undefined}
+                onClick={event => {
+                  if (!isPrimaryNavigationClick(event)) {
+                    return;
+                  }
+
+                  event.preventDefault();
+
+                  if (isPending || isActive) {
+                    return;
+                  }
+
+                  onTabChange(tab.id);
+                }}
               >
                 {tab.icon}
                 {tab.label}
@@ -69,11 +94,17 @@ export function OpsFiltersBar({
           ) : (
             <Button
               key={tab.id}
-              variant={tab.id === activeTab ? 'default' : 'outline'}
+              variant={isActive ? 'default' : 'outline'}
               size="sm"
               type="button"
+              disabled={isPending}
               onClick={event => {
                 event.preventDefault();
+
+                if (isPending) {
+                  return;
+                }
+
                 onTabChange(tab.id);
               }}
               className="gap-2"
@@ -82,8 +113,8 @@ export function OpsFiltersBar({
               {tab.icon}
               {tab.label}
             </Button>
-          )
-        )}
+          );
+        })}
       </div>
       <div className="flex w-full sm:w-auto items-center gap-3">
         <div className="relative w-full sm:w-auto sm:min-w-[280px]">
@@ -93,6 +124,7 @@ export function OpsFiltersBar({
             placeholder={searchPlaceholder}
             value={searchQuery}
             onChange={event => onSearchChange(event.target.value)}
+            disabled={searchDisabled}
             className="pl-9 bg-background/50"
             data-testid={searchInputTestId ?? OPS_TEST_IDS.FILTERS.SEARCH}
             aria-label={searchPlaceholder}

--- a/apps/web/src/components/ops/OpsFiltersBar.tsx
+++ b/apps/web/src/components/ops/OpsFiltersBar.tsx
@@ -97,11 +97,11 @@ export function OpsFiltersBar({
               variant={isActive ? 'default' : 'outline'}
               size="sm"
               type="button"
-              disabled={isPending}
+              disabled={isPending || isActive}
               onClick={event => {
                 event.preventDefault();
 
-                if (isPending) {
+                if (isPending || isActive) {
                   return;
                 }
 

--- a/apps/web/src/messages/en/admin-claims.json
+++ b/apps/web/src/messages/en/admin-claims.json
@@ -90,7 +90,9 @@
         "assigned_to_me": "Assigned to me",
         "origin_label": "Origin",
         "origin_all": "All origins",
-        "origin_diaspora": "Diaspora / Green Card"
+        "origin_diaspora": "Diaspora / Green Card",
+        "pending_filter": "Updating filters...",
+        "pending_search": "Updating search..."
       },
       "lifecycle_tabs": {
         "all": "All",

--- a/apps/web/src/messages/mk/admin-claims.json
+++ b/apps/web/src/messages/mk/admin-claims.json
@@ -91,7 +91,9 @@
         "assigned_to_me": "Назначени на мене",
         "origin_label": "Потекло",
         "origin_all": "Сите потекла",
-        "origin_diaspora": "Дијаспора / Зелен картон"
+        "origin_diaspora": "Дијаспора / Зелен картон",
+        "pending_filter": "Се ажурираат филтрите...",
+        "pending_search": "Се ажурира пребарувањето..."
       },
       "lifecycle_tabs": {
         "all": "Сите",

--- a/apps/web/src/messages/sq/admin-claims.json
+++ b/apps/web/src/messages/sq/admin-claims.json
@@ -94,7 +94,9 @@
         "handler_label": "Përpunon",
         "origin_label": "Origjina",
         "origin_all": "Të gjitha origjinat",
-        "origin_diaspora": "Diaspora / Kartoni i Gjelbër"
+        "origin_diaspora": "Diaspora / Kartoni i Gjelbër",
+        "pending_filter": "Duke përditësuar filtrat...",
+        "pending_search": "Duke përditësuar kërkimin..."
       },
       "lifecycle_tabs": {
         "all": "Të gjitha",

--- a/apps/web/src/messages/sr/admin-claims.json
+++ b/apps/web/src/messages/sr/admin-claims.json
@@ -91,7 +91,9 @@
         "assigned_to_me": "Dodeljeno meni",
         "origin_label": "Poreklo",
         "origin_all": "Sva porekla",
-        "origin_diaspora": "Dijaspora / Zeleni karton"
+        "origin_diaspora": "Dijaspora / Zeleni karton",
+        "pending_filter": "Ažuriranje filtera...",
+        "pending_search": "Ažuriranje pretrage..."
       },
       "lifecycle_tabs": {
         "all": "Sve",


### PR DESCRIPTION
## Summary

- Adds deterministic pending feedback for `/admin/claims` status, assignment, origin, and search filter transitions.
- Makes active/in-flight filter controls inert to avoid overlapping `router.replace` calls while preserving the existing query contract and list view behavior.
- Extends `OpsFiltersBar` with pending/search-disabled support and hardens the live-surface E2E selector against duplicate transient DOM during navigation.

## Scope guards

- `apps/web/src/proxy.ts` untouched.
- No canonical route renames.
- No auth, routing, tenancy, schema, Stripe, CRM, agent-workspace, product analytics, README, AGENTS, or architecture-doc changes.

## Verification

- `pnpm --filter @interdomestik/web test:unit --run src/components/admin/claims/claims-filters.test.tsx src/components/agent/agent-claims-filters.test.tsx src/features/agent/leads/components/AgentLeadsProPage.test.tsx src/components/dashboard/claims/claims-filters.test.tsx` — 18 passed.
- `pnpm --filter @interdomestik/web test:unit --run` — 399 files passed, 1801 tests passed, 1 skipped.
- `pnpm --filter @interdomestik/web type-check` — passed.
- `pnpm i18n:check` — passed.
- `pnpm i18n:purity:check` — passed.
- `pnpm security:guard` — passed.
- Focused E2E: `NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web exec playwright test e2e/gate/v1-live-surface-revalidation.spec.ts --project=gate-ks-sq --grep "agent can enter member claim context" --workers=1 --trace=retain-on-failure --reporter=line` — 1 passed.
- `pnpm verify-slice -- --static` — passed, evidence root `tmp/multi-agent/verify-slice/verify-slice-20260428T201816Z-0a296e`.
- `pnpm verify-slice -- --required-gates` — passed, evidence root `tmp/multi-agent/verify-slice/verify-slice-20260428T201845Z-584c1e`; included `pr:verify`, `security:guard`, and standalone `e2e:gate` with 110 passed / 4 skipped.
