### PR TITLE
P23-PERF04 Member claims filter responsiveness

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -27,6 +27,7 @@ command = "npx"
 args = [
   "-y",
   "@playwright/mcp",
+  "--sandbox",
   "--user-data-dir",
   "/tmp/interdomestik-pilot-evidence/playwright-mcp-profile",
   "--output-dir",

--- a/apps/web/src/components/dashboard/claims/claims-filters.test.tsx
+++ b/apps/web/src/components/dashboard/claims/claims-filters.test.tsx
@@ -95,6 +95,18 @@ describe('ClaimsFilters', () => {
     expect(screen.getByTestId('member-claims-pending')).toHaveTextContent('Processing...');
   });
 
+  it('keeps a literal all search term instead of treating it as a status sentinel', () => {
+    render(<ClaimsFilters />);
+
+    fireEvent.change(screen.getByTestId('member-claims-search-input'), {
+      target: { value: 'all' },
+    });
+
+    expect(hoisted.push).toHaveBeenCalledWith('/member/claims?search=all', {
+      scroll: false,
+    });
+  });
+
   it('does not show pending feedback for a same-query search change', () => {
     hoisted.searchParams = new URLSearchParams('search=claim+42');
 

--- a/apps/web/src/components/dashboard/claims/claims-filters.test.tsx
+++ b/apps/web/src/components/dashboard/claims/claims-filters.test.tsx
@@ -1,17 +1,23 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ClaimsFilters } from './claims-filters';
 
+const hoisted = vi.hoisted(() => ({
+  push: vi.fn(),
+  searchParams: new URLSearchParams(),
+}));
+
 // Mock router
 vi.mock('@/i18n/routing', () => ({
+  usePathname: () => '/member/claims',
   useRouter: () => ({
-    push: vi.fn(),
+    push: hoisted.push,
   }),
 }));
 
 // Mock navigation
 vi.mock('next/navigation', () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => hoisted.searchParams,
 }));
 
 // Mock next-intl
@@ -19,6 +25,7 @@ vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => {
     const translations: Record<string, string> = {
       all: 'All',
+      processing: 'Processing...',
       search: 'Search',
       draft: 'Draft',
       submitted: 'Submitted',
@@ -35,18 +42,14 @@ vi.mock('next-intl', () => ({
 
 // Mock UI components
 vi.mock('@interdomestik/ui', () => ({
-  Badge: ({
-    children,
-    ...props
-  }: React.HTMLAttributes<HTMLSpanElement> & { children: React.ReactNode; variant?: string }) => (
-    <span {...props}>{children}</span>
-  ),
+  badgeVariants: () => 'badge',
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
 }));
 
 describe('ClaimsFilters', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.searchParams = new URLSearchParams();
   });
 
   it('renders search input', () => {
@@ -76,5 +79,63 @@ describe('ClaimsFilters', () => {
       /All|Draft|Submitted|Verification|Evaluation|Negotiation|Court|Resolved|Rejected/
     );
     expect(badges.length).toBe(9);
+  });
+
+  it('shows pending feedback and updates the url when search changes', () => {
+    render(<ClaimsFilters />);
+
+    fireEvent.change(screen.getByTestId('member-claims-search-input'), {
+      target: { value: 'claim 42' },
+    });
+
+    expect(hoisted.push).toHaveBeenCalledWith('/member/claims?search=claim+42', {
+      scroll: false,
+    });
+    expect(screen.getByTestId('member-claims-filter-region')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByTestId('member-claims-pending')).toHaveTextContent('Processing...');
+  });
+
+  it('does not show pending feedback for a same-query search change', () => {
+    hoisted.searchParams = new URLSearchParams('search=claim+42');
+
+    render(<ClaimsFilters />);
+
+    fireEvent.change(screen.getByTestId('member-claims-search-input'), {
+      target: { value: 'claim 42' },
+    });
+
+    expect(hoisted.push).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('member-claims-pending')).not.toBeInTheDocument();
+    expect(screen.getByTestId('member-claims-filter-region')).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('keeps the active status filter inert and starts pending feedback for a new status', () => {
+    hoisted.searchParams = new URLSearchParams('status=submitted&search=claim');
+
+    render(<ClaimsFilters />);
+
+    const activeStatus = screen.getByTestId('member-claims-status-filter-submitted');
+    expect(activeStatus).toBeDisabled();
+    fireEvent.click(activeStatus);
+    expect(hoisted.push).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('member-claims-status-filter-draft'));
+
+    expect(hoisted.push).toHaveBeenCalledWith('/member/claims?status=draft&search=claim', {
+      scroll: false,
+    });
+    expect(screen.getByTestId('member-claims-pending')).toHaveTextContent('Processing...');
+  });
+
+  it('blocks overlapping filter navigation while a status update is pending', () => {
+    render(<ClaimsFilters />);
+
+    fireEvent.click(screen.getByTestId('member-claims-status-filter-draft'));
+    fireEvent.click(screen.getByTestId('member-claims-status-filter-submitted'));
+
+    expect(hoisted.push).toHaveBeenCalledTimes(1);
+    expect(hoisted.push).toHaveBeenCalledWith('/member/claims?status=draft', {
+      scroll: false,
+    });
   });
 });

--- a/apps/web/src/components/dashboard/claims/claims-filters.tsx
+++ b/apps/web/src/components/dashboard/claims/claims-filters.tsx
@@ -46,11 +46,14 @@ function buildMemberClaimsUrl(
   params.delete('page');
 
   Object.entries(updates).forEach(([key, value]) => {
-    if (value && value !== 'all') {
-      params.set(key, value);
-    } else {
+    const shouldDelete = value === null || value === '' || (key === 'status' && value === 'all');
+
+    if (shouldDelete) {
       params.delete(key);
+      return;
     }
+
+    params.set(key, value);
   });
 
   const query = params.toString();

--- a/apps/web/src/components/dashboard/claims/claims-filters.tsx
+++ b/apps/web/src/components/dashboard/claims/claims-filters.tsx
@@ -7,11 +7,35 @@ import { badgeVariants, Input } from '@interdomestik/ui';
 import { Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import { useCallback, useEffect, useReducer, useRef, useTransition } from 'react';
 
 const PENDING_FEEDBACK_TIMEOUT_MS = 10_000;
 
 type PendingKind = 'filter' | 'search';
+
+type FilterUiState = {
+  pendingKind: PendingKind | null;
+  searchValue: string;
+};
+
+type FilterUiAction =
+  | { type: 'pending-changed'; pendingKind: PendingKind | null }
+  | { type: 'search-edited'; searchValue: string };
+
+function filterUiReducer(state: FilterUiState, action: FilterUiAction): FilterUiState {
+  switch (action.type) {
+    case 'pending-changed':
+      if (state.pendingKind === action.pendingKind) {
+        return state;
+      }
+      return { ...state, pendingKind: action.pendingKind };
+    case 'search-edited':
+      if (state.searchValue === action.searchValue) {
+        return state;
+      }
+      return { ...state, searchValue: action.searchValue };
+  }
+}
 
 function buildMemberClaimsUrl(
   currentParams: URLSearchParams,
@@ -44,19 +68,22 @@ export function ClaimsFilters() {
   const currentSearch = searchParams.get('search') || '';
   const currentParamsString = searchParams.toString();
 
-  const [pendingKind, setPendingKind] = useState<PendingKind | null>(null);
+  const [filterUi, dispatchFilterUi] = useReducer(filterUiReducer, {
+    pendingKind: null,
+    searchValue: currentSearch,
+  });
   const pendingKindRef = useRef<PendingKind | null>(null);
-  const [searchValue, setSearchValue] = useState(currentSearch);
   const [isTransitionPending, startTransition] = useTransition();
+  const { pendingKind, searchValue } = filterUi;
   const isNavigationPending = Boolean(pendingKind || isTransitionPending);
 
   const updatePendingKind = useCallback((nextPendingKind: PendingKind | null) => {
     pendingKindRef.current = nextPendingKind;
-    setPendingKind(nextPendingKind);
+    dispatchFilterUi({ type: 'pending-changed', pendingKind: nextPendingKind });
   }, []);
 
   useEffect(() => {
-    setSearchValue(currentSearch);
+    dispatchFilterUi({ type: 'search-edited', searchValue: currentSearch });
   }, [currentSearch]);
 
   useEffect(() => {
@@ -100,7 +127,7 @@ export function ClaimsFilters() {
   };
 
   const handleSearch = (value: string) => {
-    setSearchValue(value);
+    dispatchFilterUi({ type: 'search-edited', searchValue: value });
 
     if (pendingKindRef.current === 'filter') {
       return;

--- a/apps/web/src/components/dashboard/claims/claims-filters.tsx
+++ b/apps/web/src/components/dashboard/claims/claims-filters.tsx
@@ -1,20 +1,79 @@
 'use client';
 
-import { useRouter } from '@/i18n/routing';
+import { cn } from '@/lib/utils';
+import { usePathname, useRouter } from '@/i18n/routing';
 import { CLAIM_STATUSES } from '@interdomestik/database/constants';
-import { Badge, Input } from '@interdomestik/ui';
+import { badgeVariants, Input } from '@interdomestik/ui';
 import { Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+
+const PENDING_FEEDBACK_TIMEOUT_MS = 10_000;
+
+type PendingKind = 'filter' | 'search';
+
+function buildMemberClaimsUrl(
+  currentParams: URLSearchParams,
+  updates: Record<string, string | null>
+): string {
+  const params = new URLSearchParams(currentParams.toString());
+
+  params.delete('page');
+
+  Object.entries(updates).forEach(([key, value]) => {
+    if (value && value !== 'all') {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+  });
+
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
 
 export function ClaimsFilters() {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const tCommon = useTranslations('common');
   const tStatus = useTranslations('claims.status');
 
   const currentStatus = searchParams.get('status') || 'all';
   const currentSearch = searchParams.get('search') || '';
+  const currentParamsString = searchParams.toString();
+
+  const [pendingKind, setPendingKind] = useState<PendingKind | null>(null);
+  const pendingKindRef = useRef<PendingKind | null>(null);
+  const [searchValue, setSearchValue] = useState(currentSearch);
+  const [isTransitionPending, startTransition] = useTransition();
+  const isNavigationPending = Boolean(pendingKind || isTransitionPending);
+
+  const updatePendingKind = useCallback((nextPendingKind: PendingKind | null) => {
+    pendingKindRef.current = nextPendingKind;
+    setPendingKind(nextPendingKind);
+  }, []);
+
+  useEffect(() => {
+    setSearchValue(currentSearch);
+  }, [currentSearch]);
+
+  useEffect(() => {
+    updatePendingKind(null);
+  }, [currentParamsString, updatePendingKind]);
+
+  useEffect(() => {
+    if (!pendingKind) {
+      return undefined;
+    }
+
+    const timeout = globalThis.setTimeout(
+      () => updatePendingKind(null),
+      PENDING_FEEDBACK_TIMEOUT_MS
+    );
+    return () => globalThis.clearTimeout(timeout);
+  }, [pendingKind, updatePendingKind]);
 
   const statusOptions = [
     { value: 'all', label: tCommon('all') },
@@ -22,53 +81,96 @@ export function ClaimsFilters() {
   ];
 
   const handleStatusChange = (status: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('page');
-    if (status === 'all') {
-      params.delete('status');
-    } else {
-      params.set('status', status);
+    if (pendingKindRef.current || currentStatus === status) {
+      return;
     }
-    router.push(`?${params.toString()}`);
+
+    const nextUrl = buildMemberClaimsUrl(searchParams, { status });
+    const currentUrl = currentParamsString ? `?${currentParamsString}` : '';
+
+    if (nextUrl === currentUrl) {
+      return;
+    }
+
+    updatePendingKind('filter');
+
+    startTransition(() => {
+      router.push(`${pathname}${nextUrl}`, { scroll: false });
+    });
   };
 
   const handleSearch = (value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('page');
-    if (value) {
-      params.set('search', value);
-    } else {
-      params.delete('search');
+    setSearchValue(value);
+
+    if (pendingKindRef.current === 'filter') {
+      return;
     }
-    router.push(`?${params.toString()}`);
+
+    const nextUrl = buildMemberClaimsUrl(searchParams, { search: value || null });
+    const currentUrl = currentParamsString ? `?${currentParamsString}` : '';
+
+    if (nextUrl === currentUrl) {
+      return;
+    }
+
+    updatePendingKind('search');
+
+    startTransition(() => {
+      router.push(`${pathname}${nextUrl}`, { scroll: false });
+    });
   };
 
   return (
-    <div className="space-y-4">
+    <div
+      className="space-y-4"
+      data-testid="member-claims-filter-region"
+      aria-busy={isNavigationPending ? 'true' : 'false'}
+    >
       {/* Search */}
       <div className="relative">
         <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
         <Input
           placeholder={`${tCommon('search')}...`}
           className="pl-9"
-          defaultValue={currentSearch}
+          data-testid="member-claims-search-input"
+          disabled={pendingKind === 'filter'}
+          value={searchValue}
           onChange={e => handleSearch(e.target.value)}
         />
       </div>
+
+      {pendingKind ? (
+        <div
+          data-testid="member-claims-pending"
+          role="status"
+          aria-live="polite"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          {tCommon('processing')}
+        </div>
+      ) : null}
 
       {/* Status Filter */}
       <div className="flex flex-wrap gap-2">
         {statusOptions.map(option => {
           const isActive = currentStatus === option.value;
+          const isInert = isNavigationPending || isActive;
           return (
-            <Badge
+            <button
               key={option.value}
-              variant={isActive ? 'default' : 'outline'}
-              className="cursor-pointer hover:bg-primary/10 transition-colors"
+              type="button"
+              aria-pressed={isActive}
+              aria-disabled={isInert}
+              disabled={isInert}
+              data-testid={`member-claims-status-filter-${option.value}`}
+              className={cn(
+                badgeVariants({ variant: isActive ? 'default' : 'outline' }),
+                'cursor-pointer hover:bg-primary/10 transition-colors disabled:pointer-events-none disabled:cursor-default disabled:opacity-70'
+              )}
               onClick={() => handleStatusChange(option.value)}
             >
               {option.label}
-            </Badge>
+            </button>
           );
         })}
       </div>

--- a/apps/web/src/components/dashboard/claims/member-claims-table.test.tsx
+++ b/apps/web/src/components/dashboard/claims/member-claims-table.test.tsx
@@ -1,6 +1,12 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { AnchorHTMLAttributes } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemberClaimsTable } from './member-claims-table';
+
+const hoisted = vi.hoisted(() => ({
+  push: vi.fn(),
+  searchParams: new URLSearchParams(),
+}));
 
 // Mock react-query
 vi.mock('@tanstack/react-query', () => ({
@@ -12,7 +18,7 @@ const mockUseQuery = vi.mocked(useQuery);
 
 // Mock search params
 vi.mock('next/navigation', () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => hoisted.searchParams,
 }));
 
 // Mock next-intl
@@ -34,6 +40,7 @@ vi.mock('next-intl', () => ({
       claim: 'claim',
       claimsPlural: 'claims',
       loading: 'Loading...',
+      processing: 'Processing...',
       'errors.generic': 'An error occurred',
       tryAgain: 'Try Again',
       previous: 'Previous',
@@ -48,9 +55,24 @@ vi.mock('next-intl', () => ({
 
 // Mock routing
 vi.mock('@/i18n/routing', () => ({
-  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
+  Link: ({
+    children,
+    href,
+    prefetch: _prefetch,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+    prefetch?: boolean;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
   ),
+  usePathname: () => '/member/claims',
+  useRouter: () => ({
+    push: hoisted.push,
+  }),
 }));
 
 // Mock ClaimStatusBadge
@@ -89,6 +111,7 @@ const mockClaims = [
 describe('MemberClaimsTable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.searchParams = new URLSearchParams();
   });
 
   it('renders loading state', () => {
@@ -178,5 +201,48 @@ describe('MemberClaimsTable', () => {
       expect(screen.getByText('Flight Delay')).toBeInTheDocument();
       expect(screen.getByText('Lufthansa')).toBeInTheDocument();
     });
+  });
+
+  it('shows deterministic pending feedback when pagination changes page', async () => {
+    mockUseQuery.mockReturnValue({
+      data: { claims: mockClaims, totalPages: 3 },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useQuery>);
+
+    render(<MemberClaimsTable />);
+
+    fireEvent.click(screen.getByTestId('member-claims-page-next'));
+
+    expect(hoisted.push).toHaveBeenCalledWith('/member/claims?page=2', { scroll: false });
+    expect(screen.getByTestId('member-claims-table-region')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByTestId('member-claims-pagination-pending')).toHaveTextContent(
+      'Processing...'
+    );
+  });
+
+  it('keeps current and pending pagination controls inert', async () => {
+    hoisted.searchParams = new URLSearchParams('page=2&search=claim');
+    mockUseQuery.mockReturnValue({
+      data: { claims: mockClaims, totalPages: 3 },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useQuery>);
+
+    render(<MemberClaimsTable />);
+
+    fireEvent.click(screen.getByTestId('member-claims-page-next'));
+    fireEvent.click(screen.getByTestId('member-claims-page-previous'));
+
+    expect(hoisted.push).toHaveBeenCalledTimes(1);
+    expect(hoisted.push).toHaveBeenCalledWith('/member/claims?page=3&search=claim', {
+      scroll: false,
+    });
+    expect(screen.getByTestId('member-claims-page-previous')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
   });
 });

--- a/apps/web/src/components/dashboard/claims/member-claims-table.tsx
+++ b/apps/web/src/components/dashboard/claims/member-claims-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ClaimStatusBadge } from '@/components/dashboard/claims/claim-status-badge';
-import { Link } from '@/i18n/routing';
+import { Link, usePathname, useRouter } from '@/i18n/routing';
 import { fetchClaims } from '@/lib/api/claims';
 import { formatPilotDate } from '@/lib/utils/date';
 import {
@@ -19,11 +19,20 @@ import { useQuery } from '@tanstack/react-query';
 import { FileText, Plus } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
+import type { MouseEvent } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 
 const PER_PAGE = 10;
+const PENDING_FEEDBACK_TIMEOUT_MS = 10_000;
+
+function isPrimaryNavigationClick(event: MouseEvent<HTMLAnchorElement>) {
+  return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+}
 
 export function MemberClaimsTable() {
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
   const locale = useLocale();
   const t = useTranslations('claims');
   const tCategory = useTranslations('claims.category');
@@ -32,6 +41,23 @@ export function MemberClaimsTable() {
   const statusFilter = searchParams.get('status') || undefined;
   const searchQuery = searchParams.get('search') || undefined;
   const page = Math.max(1, Number(searchParams.get('page') || 1));
+  const currentParamsString = searchParams.toString();
+  const [pendingPage, setPendingPage] = useState<number | null>(null);
+  const [isTransitionPending, startTransition] = useTransition();
+  const isPageNavigationPending = pendingPage !== null || isTransitionPending;
+
+  useEffect(() => {
+    setPendingPage(null);
+  }, [currentParamsString]);
+
+  useEffect(() => {
+    if (pendingPage === null) {
+      return undefined;
+    }
+
+    const timeout = globalThis.setTimeout(() => setPendingPage(null), PENDING_FEEDBACK_TIMEOUT_MS);
+    return () => globalThis.clearTimeout(timeout);
+  }, [pendingPage]);
 
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['claims', 'member', { statusFilter, searchQuery, page }],
@@ -55,6 +81,35 @@ export function MemberClaimsTable() {
     }
     const queryString = query.toString();
     return queryString ? `?${queryString}` : '';
+  };
+
+  const startPageNavigation = (event: MouseEvent<HTMLAnchorElement>, targetPage: number) => {
+    const totalPages = data?.totalPages ?? 1;
+    const isPageInert =
+      isPageNavigationPending || targetPage === page || targetPage < 1 || targetPage > totalPages;
+
+    if ((isPageInert || event.defaultPrevented) && isPrimaryNavigationClick(event)) {
+      event.preventDefault();
+      return;
+    }
+
+    if (!isPrimaryNavigationClick(event)) {
+      return;
+    }
+
+    const nextUrl = buildPageLink(targetPage);
+    const currentUrl = currentParamsString ? `?${currentParamsString}` : '';
+
+    if (nextUrl === currentUrl) {
+      event.preventDefault();
+      return;
+    }
+
+    event.preventDefault();
+    setPendingPage(targetPage);
+    startTransition(() => {
+      router.push(`${pathname}${nextUrl}`, { scroll: false });
+    });
   };
 
   const formatCategory = (category: string | null | undefined) => {
@@ -113,7 +168,11 @@ export function MemberClaimsTable() {
   }
 
   return (
-    <div className="space-y-4">
+    <div
+      className="space-y-4"
+      data-testid="member-claims-table-region"
+      aria-busy={isPageNavigationPending ? 'true' : 'false'}
+    >
       <div className="rounded-md border">
         <Table>
           <TableHeader>
@@ -172,18 +231,58 @@ export function MemberClaimsTable() {
         </p>
         {data.totalPages > 1 && (
           <div className="flex items-center gap-2">
-            <Button asChild variant="outline" size="sm" disabled={page <= 1}>
-              <Link href={buildPageLink(page - 1)}>{tCommon('previous')}</Link>
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              disabled={isPageNavigationPending || page <= 1}
+            >
+              <Link
+                href={buildPageLink(page - 1)}
+                aria-disabled={isPageNavigationPending || page <= 1 ? 'true' : undefined}
+                data-testid="member-claims-page-previous"
+                onClick={event => startPageNavigation(event, page - 1)}
+                prefetch={false}
+                tabIndex={isPageNavigationPending || page <= 1 ? -1 : undefined}
+              >
+                {tCommon('previous')}
+              </Link>
             </Button>
             <span className="text-sm text-muted-foreground">
               {tCommon('pagination.pageOf', { page, total: data.totalPages })}
             </span>
-            <Button asChild variant="outline" size="sm" disabled={page >= data.totalPages}>
-              <Link href={buildPageLink(page + 1)}>{tCommon('next')}</Link>
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              disabled={isPageNavigationPending || page >= data.totalPages}
+            >
+              <Link
+                href={buildPageLink(page + 1)}
+                aria-disabled={
+                  isPageNavigationPending || page >= data.totalPages ? 'true' : undefined
+                }
+                data-testid="member-claims-page-next"
+                onClick={event => startPageNavigation(event, page + 1)}
+                prefetch={false}
+                tabIndex={isPageNavigationPending || page >= data.totalPages ? -1 : undefined}
+              >
+                {tCommon('next')}
+              </Link>
             </Button>
           </div>
         )}
       </div>
+      {pendingPage !== null ? (
+        <div
+          data-testid="member-claims-pagination-pending"
+          role="status"
+          aria-live="polite"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          {tCommon('processing')}
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds deterministic pending feedback for `/member/claims` search and status filter transitions.
- Makes active and in-flight member claim filters/pagination controls inert to prevent overlapping navigations.
- Keeps query semantics and canonical `/member/claims` routing intact, and enables Playwright MCP sandbox mode to avoid the local browser `--no-sandbox` warning.

## Verification
- [x] Real-site browser pass on `http://ks.127.0.0.1.nip.io:3000/sq/member/claims`
  - login as seeded KS member
  - search URL update and filtered results
  - status filter URL update and active-state inertness
  - pagination with temporary local fixture rows, then fixture cleanup confirmed
  - mobile viewport `390x844`
- [x] `pnpm --filter @interdomestik/web test:unit --run src/components/dashboard/claims/claims-filters.test.tsx src/components/dashboard/claims/member-claims-table.test.tsx`
- [x] `pnpm verify-slice -- --static`
- [x] `pnpm verify-slice -- --required-gates`

## Notes
- No changes to `apps/web/src/proxy.ts`.
- No routing, auth, tenancy, schema, Stripe, or architecture refactors.
