### PR TITLE
fix: improve admin users filter responsiveness

### DIFF
--- a/apps/web/src/app/[locale]/admin/users/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/admin/users/_core.entry.test.tsx
@@ -26,18 +26,16 @@ vi.mock('@/components/admin/add-agent-dialog', () => ({
   },
 }));
 
+vi.mock('@/components/admin/admin-users-role-tabs', () => ({
+  AdminUsersRoleTabs: () => <div data-testid="admin-users-role-tabs" />,
+}));
+
 vi.mock('@/components/admin/users-filters', () => ({
   UsersFilters: () => <div data-testid="users-filters" />,
 }));
 
 vi.mock('@/components/admin/users-sections', () => ({
   UsersSections: () => <div data-testid="users-sections" />,
-}));
-
-vi.mock('@/i18n/routing', () => ({
-  Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
-  ),
 }));
 
 vi.mock('@interdomestik/ui/components/button', () => ({

--- a/apps/web/src/app/[locale]/admin/users/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/admin/users/_core.entry.tsx
@@ -1,11 +1,10 @@
 import { listBranches } from '@/actions/admin-rbac.core';
 import { getAgents, getUsers } from '@/actions/admin-users';
 import { AddAgentDialog } from '@/components/admin/add-agent-dialog';
+import { AdminUsersRoleTabs } from '@/components/admin/admin-users-role-tabs';
 import { isPromotableToAgentRole } from '@/components/admin/promotable-roles';
 import { UsersFilters } from '@/components/admin/users-filters';
 import { UsersSections } from '@/components/admin/users-sections';
-import { Link } from '@/i18n/routing';
-import { Button } from '@interdomestik/ui/components/button';
 import { getTranslations } from 'next-intl/server';
 
 import { notFound } from 'next/navigation';
@@ -95,15 +94,6 @@ export default async function AdminUsersPage({ searchParams }: Props) {
   // Filter users eligible for promotion (exclude existing agents/admin roles).
   const eligibleUsers = promotableUsers.filter(u => isPromotableToAgentRole(u.role));
 
-  const roleOptions = [
-    { value: 'user', label: tFilters('roles.user') },
-    { value: 'agent', label: tFilters('roles.agent') },
-    {
-      value: 'admin,staff',
-      label: `${tFilters('roles.staff')} / ${tFilters('roles.admin')}`,
-    },
-  ];
-
   const buildRoleHref = (role: string) => {
     const nextParams = new URLSearchParams();
     for (const [key, value] of Object.entries(params)) {
@@ -129,38 +119,29 @@ export default async function AdminUsersPage({ searchParams }: Props) {
     return query ? `/admin/users?${query}` : '/admin/users';
   };
 
+  const roleOptions = [
+    { value: 'user', label: tFilters('roles.user'), href: buildRoleHref('user') },
+    { value: 'agent', label: tFilters('roles.agent'), href: buildRoleHref('agent') },
+    {
+      value: 'admin,staff',
+      label: `${tFilters('roles.staff')} / ${tFilters('roles.admin')}`,
+      href: buildRoleHref('admin,staff'),
+    },
+  ];
+
   return (
-    <div className="space-y-6" data-testid="admin-users-page">
-      <div className="flex items-center justify-between">
+    <div
+      className="w-full max-w-[calc(100vw-3rem)] min-w-0 space-y-6 sm:max-w-full"
+      data-testid="admin-users-page"
+    >
+      <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">{t('title')}</h1>
           <p className="text-muted-foreground">{t('description')}</p>
         </div>
         <AddAgentDialog users={eligibleUsers} branches={branches} />
       </div>
-      <div className="flex flex-wrap items-center gap-3">
-        <div className="inline-flex items-center rounded-lg bg-muted/60 p-1">
-          {roleOptions.map(option => {
-            const isActive = selectedRole === option.value;
-            return (
-              <Button
-                key={option.value}
-                asChild={!isActive}
-                disabled={isActive}
-                size="sm"
-                variant={isActive ? 'default' : 'ghost'}
-                className="rounded-md"
-              >
-                {isActive ? (
-                  option.label
-                ) : (
-                  <Link href={buildRoleHref(option.value)}>{option.label}</Link>
-                )}
-              </Button>
-            );
-          })}
-        </div>
-      </div>
+      <AdminUsersRoleTabs selectedRole={selectedRole} options={roleOptions} />
       <UsersFilters hideRole hideAssignment={selectedRole !== 'user'} />
       <UsersSections users={users} agents={agents} />
     </div>

--- a/apps/web/src/components/admin/admin-users-role-tabs.test.tsx
+++ b/apps/web/src/components/admin/admin-users-role-tabs.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AdminUsersRoleTabs } from './admin-users-role-tabs';
+
+const { searchParamsMock, pathnameMock } = vi.hoisted(() => ({
+  searchParamsMock: vi.fn(() => new URLSearchParams()),
+  pathnameMock: vi.fn(() => '/admin/users'),
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  usePathname: () => pathnameMock(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => searchParamsMock(),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      processing: 'Processing...',
+    };
+    return translations[key] || key;
+  },
+}));
+
+vi.mock('@interdomestik/ui/components/button', () => ({
+  Button: ({
+    asChild,
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    children: React.ReactNode;
+  }) => {
+    if (asChild) return <>{children}</>;
+    return <button {...props}>{children}</button>;
+  },
+}));
+
+const options = [
+  { value: 'user', label: 'Members', href: '/admin/users?tenantId=tenant_ks' },
+  { value: 'agent', label: 'Agents', href: '/admin/users?tenantId=tenant_ks&role=agent' },
+  {
+    value: 'admin,staff',
+    label: 'Staff / Admins',
+    href: '/admin/users?tenantId=tenant_ks&role=admin%2Cstaff',
+  },
+];
+
+describe('AdminUsersRoleTabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pathnameMock.mockReturnValue('/admin/users');
+    searchParamsMock.mockReturnValue(new URLSearchParams('tenantId=tenant_ks'));
+  });
+
+  it('keeps the active role tab inert', () => {
+    render(<AdminUsersRoleTabs selectedRole="user" options={options} />);
+
+    expect(screen.getByRole('button', { name: 'Members' })).toBeDisabled();
+    expect(screen.getByRole('link', { name: 'Agents' })).toHaveAttribute(
+      'href',
+      '/admin/users?tenantId=tenant_ks&role=agent'
+    );
+  });
+
+  it('shows pending feedback and makes inactive role links inert after a transition starts', () => {
+    const sameDocumentOptions = options.map(option => ({ ...option, href: `#${option.value}` }));
+    render(<AdminUsersRoleTabs selectedRole="user" options={sameDocumentOptions} />);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }));
+
+    expect(screen.getByTestId('admin-users-role-tabs')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByTestId('admin-users-role-tabs-pending')).toHaveTextContent('Processing...');
+    expect(screen.getByRole('link', { name: 'Agents' })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('link', { name: 'Staff / Admins' })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+});

--- a/apps/web/src/components/admin/admin-users-role-tabs.tsx
+++ b/apps/web/src/components/admin/admin-users-role-tabs.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Link, usePathname } from '@/i18n/routing';
+import { cn } from '@/lib/utils';
+import { Button } from '@interdomestik/ui/components/button';
+import { useTranslations } from 'next-intl';
+import { useSearchParams } from 'next/navigation';
+import { useAdminUsersPendingValue } from './use-admin-users-pending-value';
+
+export type AdminUsersRoleTabOption = {
+  readonly value: string;
+  readonly label: string;
+  readonly href: string;
+};
+
+type AdminUsersRoleTabsProps = {
+  readonly selectedRole: string;
+  readonly options: readonly AdminUsersRoleTabOption[];
+};
+
+export function AdminUsersRoleTabs({ selectedRole, options }: AdminUsersRoleTabsProps) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tCommon = useTranslations('common');
+  const currentParamsString = searchParams.toString();
+  const {
+    hasPendingValue: isPending,
+    pendingValue: pendingHref,
+    pendingValueRef: pendingHrefRef,
+    updatePendingValue: updatePendingHref,
+  } = useAdminUsersPendingValue<string>(`${pathname}?${currentParamsString}`);
+
+  return (
+    <div
+      className="w-full min-w-0 space-y-2"
+      data-testid="admin-users-role-tabs"
+      aria-busy={isPending ? 'true' : 'false'}
+    >
+      <div className="inline-flex max-w-full flex-wrap items-center gap-1 rounded-lg bg-muted/60 p-1">
+        {options.map(option => {
+          const isActive = selectedRole === option.value;
+          const isInert = isActive || isPending;
+
+          return (
+            <Button
+              key={option.value}
+              asChild={!isActive}
+              disabled={isActive}
+              size="sm"
+              variant={isActive ? 'default' : 'ghost'}
+              className={cn('rounded-md', isInert && !isActive && 'pointer-events-none opacity-70')}
+            >
+              {isActive ? (
+                option.label
+              ) : (
+                <Link
+                  href={option.href}
+                  aria-disabled={isInert ? 'true' : undefined}
+                  data-testid={`admin-users-role-tab-${option.value}`}
+                  tabIndex={isInert ? -1 : undefined}
+                  onClick={event => {
+                    if (pendingHrefRef.current || isActive) {
+                      event.preventDefault();
+                      return;
+                    }
+                    updatePendingHref(option.href);
+                  }}
+                >
+                  {option.label}
+                </Link>
+              )}
+            </Button>
+          );
+        })}
+      </div>
+
+      {pendingHref ? (
+        <div
+          data-testid="admin-users-role-tabs-pending"
+          role="status"
+          aria-live="polite"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          {tCommon('processing')}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/use-admin-users-pending-value.ts
+++ b/apps/web/src/components/admin/use-admin-users-pending-value.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const PENDING_FEEDBACK_TIMEOUT_MS = 10_000;
+
+export function useAdminUsersPendingValue<TPendingValue extends string>(resetSignature: string) {
+  const [pendingValue, setPendingValue] = useState<TPendingValue | null>(null);
+  const pendingValueRef = useRef<TPendingValue | null>(null);
+
+  const updatePendingValue = useCallback((nextPendingValue: TPendingValue | null) => {
+    pendingValueRef.current = nextPendingValue;
+    setPendingValue(nextPendingValue);
+  }, []);
+
+  useEffect(() => {
+    updatePendingValue(null);
+  }, [resetSignature, updatePendingValue]);
+
+  useEffect(() => {
+    if (!pendingValue) {
+      return undefined;
+    }
+
+    const timeout = globalThis.setTimeout(
+      () => updatePendingValue(null),
+      PENDING_FEEDBACK_TIMEOUT_MS
+    );
+    return () => globalThis.clearTimeout(timeout);
+  }, [pendingValue, updatePendingValue]);
+
+  return {
+    hasPendingValue: Boolean(pendingValue),
+    pendingValue,
+    pendingValueRef,
+    updatePendingValue,
+  };
+}

--- a/apps/web/src/components/admin/users-filters.test.tsx
+++ b/apps/web/src/components/admin/users-filters.test.tsx
@@ -1,17 +1,24 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { UsersFilters } from './users-filters';
 
+const { pushMock, searchParamsMock, pathnameMock } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  searchParamsMock: vi.fn(() => new URLSearchParams()),
+  pathnameMock: vi.fn(() => '/admin/users'),
+}));
+
 // Mock router
 vi.mock('@/i18n/routing', () => ({
+  usePathname: () => pathnameMock(),
   useRouter: () => ({
-    push: vi.fn(),
+    push: pushMock,
   }),
 }));
 
 // Mock navigation
 vi.mock('next/navigation', () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchParamsMock(),
 }));
 
 // Mock next-intl
@@ -30,6 +37,7 @@ vi.mock('next-intl', () => ({
       'assignments.unassigned': 'Company-owned',
       'labels.role': 'Role',
       'labels.assignment': 'Assignment',
+      processing: 'Processing...',
     };
     return translations[key] || key;
   },
@@ -37,18 +45,15 @@ vi.mock('next-intl', () => ({
 
 // Mock UI components
 vi.mock('@interdomestik/ui', () => ({
-  Badge: ({
-    children,
-    ...props
-  }: React.HTMLAttributes<HTMLSpanElement> & { children: React.ReactNode; variant?: string }) => (
-    <span {...props}>{children}</span>
-  ),
+  badgeVariants: () => 'badge',
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
 }));
 
 describe('UsersFilters', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    pathnameMock.mockReturnValue('/admin/users');
+    searchParamsMock.mockReturnValue(new URLSearchParams());
   });
 
   it('renders search input', () => {
@@ -79,5 +84,66 @@ describe('UsersFilters', () => {
 
     expect(screen.getByText('Role')).toBeInTheDocument();
     expect(screen.getByText('Assignment')).toBeInTheDocument();
+  });
+
+  it('shows pending feedback and makes controls inert during assignment filter navigation', () => {
+    render(<UsersFilters />);
+
+    fireEvent.click(screen.getByTestId('admin-users-assignment-filter-assigned'));
+
+    expect(pushMock).toHaveBeenCalledWith('/admin/users?assignment=assigned', { scroll: false });
+    expect(screen.getByTestId('admin-users-filter-region')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByTestId('admin-users-filters-pending')).toHaveTextContent('Processing...');
+    expect(screen.getByTestId('admin-users-search-input')).toBeDisabled();
+    expect(screen.getByTestId('admin-users-assignment-filter-unassigned')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('admin-users-assignment-filter-unassigned'));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps active filters inert and avoids redundant same-query navigation', () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams('assignment=assigned&search=john&page=2'));
+
+    render(<UsersFilters />);
+
+    expect(screen.getByTestId('admin-users-assignment-filter-assigned')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('admin-users-assignment-filter-assigned'));
+    fireEvent.change(screen.getByTestId('admin-users-search-input'), {
+      target: { value: 'john' },
+    });
+
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('resets pagination and preserves query context for search navigation', () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams('tenantId=tenant_ks&page=3'));
+
+    render(<UsersFilters hideRole hideAssignment />);
+
+    fireEvent.change(screen.getByTestId('admin-users-search-input'), {
+      target: { value: 'ada' },
+    });
+
+    expect(pushMock).toHaveBeenCalledWith('/admin/users?tenantId=tenant_ks&search=ada', {
+      scroll: false,
+    });
+  });
+
+  it('preserves the literal search term all while treating filter all as a sentinel', () => {
+    searchParamsMock.mockReturnValue(
+      new URLSearchParams('tenantId=tenant_ks&assignment=assigned&page=2')
+    );
+
+    render(<UsersFilters hideRole />);
+
+    fireEvent.change(screen.getByTestId('admin-users-search-input'), {
+      target: { value: 'all' },
+    });
+
+    expect(pushMock).toHaveBeenCalledWith(
+      '/admin/users?tenantId=tenant_ks&assignment=assigned&search=all',
+      { scroll: false }
+    );
   });
 });

--- a/apps/web/src/components/admin/users-filters.tsx
+++ b/apps/web/src/components/admin/users-filters.tsx
@@ -1,11 +1,93 @@
 'use client';
 
 import { GlassCard } from '@/components/ui/glass-card';
-import { useRouter } from '@/i18n/routing';
-import { Badge, Input } from '@interdomestik/ui';
+import { usePathname, useRouter } from '@/i18n/routing';
+import { cn } from '@/lib/utils';
+import { badgeVariants, Input } from '@interdomestik/ui';
 import { Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
+import { useEffect, useState, useTransition } from 'react';
+import { useAdminUsersPendingValue } from './use-admin-users-pending-value';
+
+type PendingKind = 'search' | 'role' | 'assignment';
+
+type FilterOption = {
+  label: string;
+  value: string;
+};
+
+function buildAdminUsersUrl(
+  currentParams: URLSearchParams,
+  updates: Record<string, string | null>
+): string {
+  const params = new URLSearchParams(currentParams.toString());
+  params.delete('page');
+
+  Object.entries(updates).forEach(([key, value]) => {
+    const isAllFilterSentinel = (key === 'role' || key === 'assignment') && value === 'all';
+    const shouldDelete = value === null || value === '' || isAllFilterSentinel;
+
+    if (shouldDelete) {
+      params.delete(key);
+      return;
+    }
+
+    params.set(key, value);
+  });
+
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+function FilterButtonGroup({
+  activeValue,
+  isNavigationPending,
+  label,
+  onSelect,
+  options,
+  testIdPrefix,
+}: {
+  activeValue: string;
+  isNavigationPending: boolean;
+  label: string;
+  onSelect: (value: string) => void;
+  options: FilterOption[];
+  testIdPrefix: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      {options.map(option => {
+        const isActive = activeValue === option.value;
+        const isInert = isNavigationPending || isActive;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={isActive}
+            aria-disabled={isInert}
+            disabled={isInert}
+            data-testid={`${testIdPrefix}-${option.value}`}
+            className={cn(
+              badgeVariants({ variant: isActive ? 'default' : 'outline' }),
+              'transition-all disabled:pointer-events-none disabled:cursor-default disabled:opacity-70',
+              isActive
+                ? 'bg-blue-600 hover:bg-blue-700 text-white shadow-lg shadow-blue-500/20 border-transparent'
+                : 'bg-white/5 hover:bg-white/10 border-white/10 hover:border-white/20 text-muted-foreground'
+            )}
+            onClick={() => onSelect(option.value)}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 export function UsersFilters({
   hideRole = false,
@@ -15,6 +97,7 @@ export function UsersFilters({
   hideAssignment?: boolean;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const t = useTranslations('admin.users_filters');
   const tCommon = useTranslations('common');
@@ -22,6 +105,20 @@ export function UsersFilters({
   const currentRole = searchParams.get('role') || 'all';
   const currentAssignment = searchParams.get('assignment') || 'all';
   const currentSearch = searchParams.get('search') || '';
+  const currentParamsString = searchParams.toString();
+
+  const [searchValue, setSearchValue] = useState(currentSearch);
+  const [isTransitionPending, startTransition] = useTransition();
+  const {
+    pendingValue: pendingKind,
+    pendingValueRef: pendingKindRef,
+    updatePendingValue: updatePendingKind,
+  } = useAdminUsersPendingValue<PendingKind>(currentParamsString);
+  const isNavigationPending = Boolean(pendingKind || isTransitionPending);
+
+  useEffect(() => {
+    setSearchValue(currentSearch);
+  }, [currentSearch]);
 
   const roleOptions = [
     { value: 'all', label: t('roles.all') },
@@ -37,89 +134,102 @@ export function UsersFilters({
     { value: 'unassigned', label: t('assignments.unassigned') },
   ];
 
-  const updateParams = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('page');
-    if (value === 'all' || value === '') {
-      params.delete(key);
-    } else {
-      params.set(key, value);
+  const updateParams = (key: 'role' | 'assignment', value: string) => {
+    const pendingKey = key === 'role' ? 'role' : 'assignment';
+
+    if (
+      pendingKindRef.current ||
+      (key === 'role' && currentRole === value) ||
+      (key === 'assignment' && currentAssignment === value)
+    ) {
+      return;
     }
-    router.push(`?${params.toString()}`);
+
+    const nextUrl = buildAdminUsersUrl(searchParams, { [key]: value });
+    const currentUrl = currentParamsString ? `?${currentParamsString}` : '';
+
+    if (nextUrl === currentUrl) {
+      return;
+    }
+
+    updatePendingKind(pendingKey);
+
+    startTransition(() => {
+      router.push(`${pathname}${nextUrl}`, { scroll: false });
+    });
   };
 
   const handleSearch = (value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('page');
-    if (value) {
-      params.set('search', value);
-    } else {
-      params.delete('search');
+    setSearchValue(value);
+
+    if (pendingKindRef.current) {
+      return;
     }
-    router.push(`?${params.toString()}`);
+
+    const nextUrl = buildAdminUsersUrl(searchParams, { search: value || null });
+    const currentUrl = currentParamsString ? `?${currentParamsString}` : '';
+
+    if (nextUrl === currentUrl) {
+      return;
+    }
+
+    updatePendingKind('search');
+
+    startTransition(() => {
+      router.push(`${pathname}${nextUrl}`, { scroll: false });
+    });
   };
 
   return (
-    <GlassCard className="p-4 space-y-4">
+    <GlassCard
+      className="w-full min-w-0 p-4 space-y-4"
+      data-testid="admin-users-filter-region"
+      aria-busy={isNavigationPending ? 'true' : 'false'}
+    >
       <div className="relative">
         <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
         <Input
           placeholder={t('search_placeholder') || `${tCommon('search')}...`}
           className="pl-9 bg-white/5 border-white/10 focus:bg-white/10 transition-colors"
-          defaultValue={currentSearch}
+          data-testid="admin-users-search-input"
+          disabled={isNavigationPending}
+          value={searchValue}
           onChange={e => handleSearch(e.target.value)}
         />
       </div>
 
+      {pendingKind ? (
+        <div
+          data-testid="admin-users-filters-pending"
+          role="status"
+          aria-live="polite"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          {tCommon('processing')}
+        </div>
+      ) : null}
+
       <div className="space-y-3">
         {!hideRole && (
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {t('labels.role')}
-            </span>
-            {roleOptions.map(option => {
-              const isActive = currentRole === option.value;
-              return (
-                <Badge
-                  key={option.value}
-                  variant={isActive ? 'default' : 'outline'}
-                  className={`cursor-pointer transition-all ${
-                    isActive
-                      ? 'bg-blue-600 hover:bg-blue-700 text-white shadow-lg shadow-blue-500/20 border-transparent'
-                      : 'bg-white/5 hover:bg-white/10 border-white/10 hover:border-white/20 text-muted-foreground'
-                  }`}
-                  onClick={() => updateParams('role', option.value)}
-                >
-                  {option.label}
-                </Badge>
-              );
-            })}
-          </div>
+          <FilterButtonGroup
+            activeValue={currentRole}
+            isNavigationPending={isNavigationPending}
+            label={t('labels.role')}
+            onSelect={value => updateParams('role', value)}
+            options={roleOptions}
+            testIdPrefix="admin-users-role-filter"
+          />
         )}
 
         {!hideAssignment && (
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {t('labels.assignment')}
-            </span>
-            {assignmentOptions.map(option => {
-              const isActive = currentAssignment === option.value;
-              return (
-                <Badge
-                  key={option.value}
-                  variant={isActive ? 'default' : 'outline'}
-                  className={`cursor-pointer transition-all ${
-                    isActive
-                      ? 'bg-blue-600 hover:bg-blue-700 text-white shadow-lg shadow-blue-500/20 border-transparent'
-                      : 'bg-white/5 hover:bg-white/10 border-white/10 hover:border-white/20 text-muted-foreground'
-                  }`}
-                  onClick={() => updateParams('assignment', option.value)}
-                >
-                  {option.label}
-                </Badge>
-              );
-            })}
-          </div>
+          <FilterButtonGroup
+            activeValue={currentAssignment}
+            isNavigationPending={isNavigationPending}
+            label={t('labels.assignment')}
+            onSelect={value => updateParams('assignment', value)}
+            options={assignmentOptions}
+            testIdPrefix="admin-users-assignment-filter"
+          />
         )}
       </div>
     </GlassCard>

--- a/apps/web/src/components/admin/users-table.tsx
+++ b/apps/web/src/components/admin/users-table.tsx
@@ -269,5 +269,5 @@ export function UsersTable({
     return tableContent;
   }
 
-  return <GlassCard className="overflow-hidden p-0">{tableContent}</GlassCard>;
+  return <GlassCard className="overflow-x-auto p-0">{tableContent}</GlassCard>;
 }


### PR DESCRIPTION
## Summary
- add pending feedback and inert in-flight behavior for /admin/users search and assignment controls
- preserve Link-backed role tabs while adding deterministic pending state and active/in-flight inertness
- tighten the admin users filter/table wrappers for responsive viewport behavior

## Verification
- pnpm --filter @interdomestik/web test:unit --run src/components/admin/users-filters.test.tsx src/components/admin/admin-users-role-tabs.test.tsx src/components/admin/users-table.test.tsx 'src/app/[locale]/admin/users/_core.entry.test.tsx'
- pnpm --filter @interdomestik/web lint
- pnpm --filter @interdomestik/web type-check
- git diff --check
- pnpm security:guard
- pnpm verify-slice -- --static
- pnpm pr:verify
- pnpm e2e:gate
- real-site Playwright validation on /sq/admin/users for search, role tabs, assignment filtering, pagination reset, and mobile viewport behavior

## Notes
- apps/web/src/proxy.ts untouched
- canonical /admin/users route and query semantics preserved