### PR TITLE
ci: rename pilot gate required check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,5 +40,5 @@
 
 - [ ] All GitHub review threads resolved.
 - [ ] Copilot or bot findings were either fixed or explicitly closed with technical reasoning.
-- [ ] Required checks green (`CI / static`, `CI / unit`, `CI / audit`, `CI / e2e-gate`, `Pilot Gate / pr:verify + pilot:check`, `Security / pnpm-audit`, `Security / gitleaks`).
+- [ ] Required checks green (`CI / static`, `CI / unit`, `CI / audit`, `CI / e2e-gate`, `Pilot Gate / pilot-gate`, `Security / pnpm-audit`, `Security / gitleaks`).
 - [ ] Evidence artifact paths are present and complete.

--- a/.github/workflows/pilot-gate.yml
+++ b/.github/workflows/pilot-gate.yml
@@ -294,7 +294,7 @@ jobs:
           retention-days: 14
 
   pilot-gate:
-    name: pr:verify + pilot:check
+    name: pilot-gate
     if: always()
     needs:
       - pilot-gate-preflight

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -286,6 +286,7 @@ test('Required pilot gate wrapper fails or passes based on preflight and runner 
   const needs = normalizeNeeds(pilotGateJob.needs);
   assert.ok(needs.includes('pilot-gate-preflight'));
   assert.ok(needs.includes('pilot-gate-runner'));
+  assert.equal(pilotGateJob.name, 'pilot-gate');
   assert.equal(pilotGateJob.if, 'always()');
   assert.equal(pilotGateJob['runs-on'], 'ubuntu-latest');
   assert.equal(pilotGateJob.services, undefined);

--- a/scripts/pr-finalizer.sh
+++ b/scripts/pr-finalizer.sh
@@ -23,7 +23,7 @@ EOF
 required_checks=(
   "CI"
   "e2e-gate"
-  "pr:verify + pilot:check"
+  "pilot-gate"
   "pnpm-audit"
   "gitleaks"
 )
@@ -43,8 +43,8 @@ resolve_matching_checks() {
 
   if [[ "${check_name}" == "CI" ]]; then
     echo "${checks}" | jq '[.check_runs | .[] | select((.name // .workflow_name // "") | ascii_downcase | test("(^|.*/\\s*)(audit|static|unit|e2e-gate)$"))]'
-  elif [[ "${check_name}" == "pr:verify + pilot:check" ]]; then
-    echo "${checks}" | jq '[.check_runs | .[] | select((.name // .workflow_name // "") | ascii_downcase | test("(^|.*/\\s*)pr:verify\\s*\\+\\s*pilot:check\\s*$"))]'
+  elif [[ "${check_name}" == "pilot-gate" ]]; then
+    echo "${checks}" | jq '[.check_runs | .[] | select((.name // .workflow_name // "") | ascii_downcase | test("(^|.*/\\s*)pilot-gate\\s*$"))]'
   elif [[ "${check_name}" == "pnpm-audit" ]]; then
     echo "${checks}" | jq '[.check_runs | .[] | select((.name // .workflow_name // "") | ascii_downcase | test("(^|.*/\\s*)pnpm-audit$"))]'
   elif [[ "${check_name}" == "gitleaks" ]]; then


### PR DESCRIPTION
## Summary
- rename the Pilot Gate wrapper check from `pr:verify + pilot:check` to `pilot-gate`
- update the PR template and local finalizer matcher
- add a workflow contract assertion for the new wrapper name

## Verification
- `pnpm test:ci:contracts`