### PR TITLE
ci: skip heavy gates for finalizer policy changes

### DIFF
--- a/scripts/ci/validation-surface-policy-lib.mjs
+++ b/scripts/ci/validation-surface-policy-lib.mjs
@@ -2,8 +2,10 @@ const NON_PRODUCT_ONLY_PATTERNS = [
   /^docs\//,
   /^\.agent\//,
   /^\.github\/(?:workflows|actions)\//,
+  /^\.github\/pull_request_template\.md$/,
   /^scripts\/ci\//,
   /^scripts\/multi-agent\//,
+  /^scripts\/pr-finalizer\.sh$/,
   /^scripts\/plan[^/]*\.mjs$/,
   /^(?:README|CHANGELOG|CONTRIBUTING|LICENSE)(?:\.[^.]+)?$/,
 ];

--- a/scripts/ci/validation-surface-policy.test.mjs
+++ b/scripts/ci/validation-surface-policy.test.mjs
@@ -66,10 +66,25 @@ const DECISION_SCENARIOS = [
     ]),
   ],
   [
+    'PR finalizer and template changes skip heavy validation',
+    'pull_request',
+    ['scripts/pr-finalizer.sh', '.github/pull_request_template.md'],
+    decision(false, 'non_product_only_pr', [
+      'scripts/pr-finalizer.sh',
+      '.github/pull_request_template.md',
+    ]),
+  ],
+  [
     'runtime-sensitive product changes still run heavy validation',
     'pull_request',
     ['apps/web/src/features/member/home.tsx', 'docs/plans/current-program.md'],
     decision(true, 'runtime_sensitive_surface', ['docs/plans/current-program.md']),
+  ],
+  [
+    'product changes alongside PR finalizer still run heavy validation',
+    'pull_request',
+    ['apps/web/src/features/member/home.tsx', 'scripts/pr-finalizer.sh'],
+    decision(true, 'runtime_sensitive_surface', ['scripts/pr-finalizer.sh']),
   ],
   [
     'product changes alongside CI orchestration still run heavy validation',


### PR DESCRIPTION
## Summary
- classify PR template and `scripts/pr-finalizer.sh` changes as non-product-only
- keep product changes mixed with `scripts/pr-finalizer.sh` on the heavy validation path
- add validation-surface contract coverage

## Verification
- `pnpm test:ci:contracts`