### PR TITLE
feat: productize agent lead detail

### DIFF
--- a/apps/web/e2e/golden/agent-lead-detail.spec.ts
+++ b/apps/web/e2e/golden/agent-lead-detail.spec.ts
@@ -1,0 +1,66 @@
+import { db, E2E_USERS, eq, user } from '@interdomestik/database';
+import { crmDeals, crmLeads } from '@interdomestik/database/schema';
+import { expect, test } from '../fixtures/auth.fixture';
+import { gotoApp } from '../utils/navigation';
+
+test.describe('Agent Lead Detail (Golden)', () => {
+  test('agent can view a tenant-owned CRM lead detail with inert deal creation', async ({
+    agentPage: page,
+  }, testInfo) => {
+    const tenant = testInfo.project.name.includes('mk') ? 'mk' : 'ks';
+    const agentEmail = tenant === 'mk' ? E2E_USERS.MK_AGENT.email : E2E_USERS.KS_AGENT.email;
+    const suffix = `${tenant}-${testInfo.workerIndex}-${testInfo.retry}-${Date.now()}`;
+    const leadId = `crm-detail-${suffix}`;
+    const dealId = `crm-detail-deal-${suffix}`;
+    const leadEmail = `crm-detail-${suffix}@example.com`;
+
+    const agent = await db.query.user.findFirst({
+      where: eq(user.email, agentEmail),
+    });
+
+    if (!agent?.id || !agent.tenantId) {
+      throw new Error(`Expected seeded agent with tenant context for ${agentEmail}`);
+    }
+
+    await db.insert(crmLeads).values({
+      id: leadId,
+      tenantId: agent.tenantId,
+      agentId: agent.id,
+      type: 'business',
+      fullName: null,
+      companyName: 'P26 Detail Test Company',
+      phone: '+38344123123',
+      email: leadEmail,
+      source: 'referral',
+      stage: 'negotiation',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await db.insert(crmDeals).values({
+      id: dealId,
+      tenantId: agent.tenantId,
+      leadId,
+      agentId: agent.id,
+      valueCents: 25000,
+      stage: 'proposal',
+      status: 'open',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    try {
+      await gotoApp(page, `/agent/leads/${encodeURIComponent(leadId)}`, testInfo, {
+        marker: 'agent-lead-detail-ready',
+      });
+
+      const detail = page.getByTestId('agent-lead-detail-ready').first();
+      await expect(detail.getByRole('heading', { name: 'P26 Detail Test Company' })).toBeVisible();
+      await expect(detail.getByText(leadEmail)).toBeVisible();
+      await expect(detail.getByTestId('agent-lead-create-deal-unavailable').first()).toBeDisabled();
+    } finally {
+      await db.delete(crmDeals).where(eq(crmDeals.id, dealId));
+      await db.delete(crmLeads).where(eq(crmLeads.id, leadId));
+    }
+  });
+});

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/page.tsx
@@ -1,6 +1,11 @@
 import { AgentLeadDetailV2Page } from '@/features/agent/leads/components/AgentLeadDetailV2Page';
+import type { AppLocale } from '@/i18n/locales';
 
-export default async function LeadDetailsPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  return <AgentLeadDetailV2Page id={id} />;
+export default async function LeadDetailsPage({
+  params,
+}: Readonly<{
+  params: Promise<{ locale: AppLocale; id: string }>;
+}>) {
+  const { locale, id } = await params;
+  return <AgentLeadDetailV2Page id={id} locale={locale} />;
 }

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
@@ -1,15 +1,17 @@
 import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   headersMock: vi.fn(async () => new Headers()),
-  redirectMock: vi.fn((href: string) => {
-    throw new Error(`redirect:${href}`);
+  redirectMock: vi.fn((params: { href: string; locale: string }) => {
+    throw new Error(`redirect:${params.href}:${params.locale}`);
   }),
   notFoundMock: vi.fn(() => {
     throw new Error('not-found');
   }),
-  getTranslationsMock: vi.fn(async () => (key: string) => key),
+  setRequestLocaleMock: vi.fn(),
+  getTranslationsMock: vi.fn(async (_namespace?: string) => (key: string) => key),
   getSessionMock: vi.fn(),
   ensureTenantIdMock: vi.fn(() => 'tenant-1'),
   getAgentLeadDetailsCoreMock: vi.fn(),
@@ -22,11 +24,11 @@ vi.mock('next/headers', () => ({
 
 vi.mock('next/navigation', () => ({
   notFound: hoisted.notFoundMock,
-  redirect: hoisted.redirectMock,
 }));
 
 vi.mock('next-intl/server', () => ({
   getTranslations: hoisted.getTranslationsMock,
+  setRequestLocale: hoisted.setRequestLocaleMock,
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -58,15 +60,26 @@ vi.mock('@/components/crm/log-activity-dialog', () => ({
 }));
 
 vi.mock('@/i18n/routing', () => ({
-  Link: ({ children }: { children: ReactNode }) => children,
+  Link: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+  redirect: hoisted.redirectMock,
 }));
 
 vi.mock('@interdomestik/ui', () => ({
-  Button: ({ children }: { children: ReactNode }) => children,
-  Card: ({ children }: { children: ReactNode }) => children,
+  Button: ({
+    asChild,
+    children,
+    disabled,
+  }: {
+    asChild?: boolean;
+    children: ReactNode;
+    disabled?: boolean;
+  }) => (asChild ? children : <button disabled={disabled}>{children}</button>),
+  Card: ({ children }: { children: ReactNode }) => <section>{children}</section>,
   CardContent: ({ children }: { children: ReactNode }) => children,
   CardHeader: ({ children }: { children: ReactNode }) => children,
-  CardTitle: ({ children }: { children: ReactNode }) => children,
+  CardTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
 }));
 
 import { AgentLeadDetailV2Page } from './AgentLeadDetailV2Page';
@@ -77,10 +90,51 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
     hoisted.getSessionMock.mockResolvedValue({
       user: { id: 'agent-1', tenantId: 'tenant-1' },
     });
+    hoisted.getTranslationsMock.mockImplementation(
+      async (namespace = 'agent.leads_page') =>
+        key => {
+          const messages: Record<string, string> = {
+            'stages.new': 'New localized',
+            'stages.negotiation': 'Negotiation localized',
+            backToLeads: 'Back localized',
+            detailTitleFallback: 'Lead fallback localized',
+            sourceLabel: 'Source localized',
+            emptyValue: 'Empty localized',
+            'actions.createDealUnavailable': 'Deal creation unavailable localized',
+            'detail.contactInformation': 'Contact localized',
+            'detail.type': 'Type localized',
+            'detail.email': 'Email localized',
+            'detail.phone': 'Phone localized',
+            'detail.company': 'Company localized',
+            'types.individual': 'Individual localized',
+            'types.business': 'Business localized',
+            'deals.title': 'Deals localized',
+            'deals.empty': 'No deals localized',
+            'deals.membershipPlan': 'Membership plan localized',
+            'dealStatuses.open': 'Open localized',
+            'dealStatuses.won': 'Won localized',
+            'dealStatuses.lost': 'Lost localized',
+            'dealStatuses.unknown': 'Unknown localized',
+            activityHistory: 'Activity localized',
+          };
+
+          return `${namespace}:${messages[key] ?? key}`;
+        }
+    );
     hoisted.ensureTenantIdMock.mockReturnValue('tenant-1');
     hoisted.getAgentLeadDetailsCoreMock.mockResolvedValue({
       kind: 'ok',
-      lead: { id: 'lead-1', agentId: 'agent-1', fullName: 'Lead', stage: 'new' },
+      lead: {
+        id: 'lead-1',
+        agentId: 'agent-1',
+        fullName: 'Lead',
+        stage: 'new',
+        type: 'individual',
+        email: 'lead@example.com',
+        phone: null,
+        companyName: null,
+        source: 'referral',
+      },
       deals: [],
     });
     hoisted.getLeadActivitiesMock.mockResolvedValue([]);
@@ -93,7 +147,7 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
       throw new Error('Session missing tenantId. Data integrity issue.');
     });
 
-    await expect(AgentLeadDetailV2Page({ id: 'lead-1' })).rejects.toThrow(
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' })).rejects.toThrow(
       'Session missing tenantId. Data integrity issue.'
     );
 
@@ -103,8 +157,9 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
   });
 
   it('passes tenant identity into the lead detail core before loading activities', async () => {
-    await AgentLeadDetailV2Page({ id: 'lead-1' });
+    await AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' });
 
+    expect(hoisted.setRequestLocaleMock).toHaveBeenCalledWith('en');
     expect(hoisted.getAgentLeadDetailsCoreMock).toHaveBeenCalledWith({
       leadId: 'lead-1',
       tenantId: 'tenant-1',
@@ -118,9 +173,66 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
       kind: 'not_found',
     });
 
-    await expect(AgentLeadDetailV2Page({ id: 'lead-1' })).rejects.toThrow('not-found');
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' })).rejects.toThrow(
+      'not-found'
+    );
 
     expect(hoisted.notFoundMock).toHaveBeenCalled();
     expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves the route locale when redirecting unauthenticated sessions to login', async () => {
+    hoisted.getSessionMock.mockResolvedValueOnce(null);
+
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1', locale: 'sq' })).rejects.toThrow(
+      'redirect:/login:sq'
+    );
+
+    expect(hoisted.redirectMock).toHaveBeenCalledWith({ href: '/login', locale: 'sq' });
+    expect(hoisted.getAgentLeadDetailsCoreMock).not.toHaveBeenCalled();
+  });
+
+  it('renders localized detail copy and an inert deal action', async () => {
+    const element = await AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('agent.leads_page:Contact localized');
+    expect(html).toContain('agent.leads_page:New localized');
+    expect(html).toContain('agent.leads_page:Deal creation unavailable localized');
+    expect(html).toContain('disabled=""');
+    expect(html).not.toContain('Contact Information');
+    expect(html).not.toContain('Create Deal');
+  });
+
+  it('renders deal status and value through localized detail formatting', async () => {
+    hoisted.getAgentLeadDetailsCoreMock.mockResolvedValueOnce({
+      kind: 'ok',
+      lead: {
+        id: 'lead-1',
+        agentId: 'agent-1',
+        fullName: null,
+        companyName: null,
+        stage: 'negotiation',
+        type: 'business',
+        source: null,
+      },
+      deals: [
+        {
+          id: 'deal-1',
+          status: 'open',
+          valueCents: 15000,
+          closedAt: null,
+        },
+      ],
+    });
+
+    const element = await AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('agent.leads_page:Lead fallback localized');
+    expect(html).toContain('agent.leads_page:Negotiation localized');
+    expect(html).toContain('agent.leads_page:Business localized');
+    expect(html).toContain('agent.leads_page:Open localized');
+    expect(html).toContain('€150.00');
   });
 });

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
@@ -1,23 +1,85 @@
 import { getLeadActivities } from '@/actions/activities';
+import { getAgentLeadDetailsCore } from '@/app/[locale]/(agent)/agent/leads/[id]/_core';
 import { ActivityFeed } from '@/components/crm/activity-feed';
 import { LogActivityDialog } from '@/components/crm/log-activity-dialog';
-import { Link } from '@/i18n/routing';
+import type { AppLocale } from '@/i18n/locales';
+import { Link, redirect } from '@/i18n/routing';
 import { auth } from '@/lib/auth';
 import { Button, Card, CardContent, CardHeader, CardTitle } from '@interdomestik/ui';
 import { ensureTenantId } from '@interdomestik/shared-auth';
-import { getTranslations } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { headers } from 'next/headers';
-import { notFound, redirect } from 'next/navigation';
-import { getAgentLeadDetailsCore } from '@/app/[locale]/(agent)/agent/leads/[id]/_core';
+import { notFound } from 'next/navigation';
 
-export async function AgentLeadDetailV2Page({ id }: { id: string }) {
+type LeadDetailTranslator = Awaited<ReturnType<typeof getTranslations>>;
+
+function localizeLeadStage(stage: string | null | undefined, t: LeadDetailTranslator) {
+  switch (stage) {
+    case 'new':
+      return t('stages.new');
+    case 'contacted':
+      return t('stages.contacted');
+    case 'qualified':
+      return t('stages.qualified');
+    case 'proposal':
+      return t('stages.proposal');
+    case 'negotiation':
+      return t('stages.negotiation');
+    case 'won':
+      return t('stages.won');
+    case 'lost':
+      return t('stages.lost');
+    default:
+      return t('stages.unknown');
+  }
+}
+
+function localizeLeadType(type: string | null | undefined, t: LeadDetailTranslator) {
+  switch (type) {
+    case 'individual':
+      return t('types.individual');
+    case 'business':
+      return t('types.business');
+    default:
+      return type || t('emptyValue');
+  }
+}
+
+function localizeDealStatus(status: string | null | undefined, t: LeadDetailTranslator) {
+  switch (status) {
+    case 'open':
+      return t('dealStatuses.open');
+    case 'won':
+    case 'closed_won':
+      return t('dealStatuses.won');
+    case 'lost':
+    case 'closed_lost':
+      return t('dealStatuses.lost');
+    default:
+      return t('dealStatuses.unknown');
+  }
+}
+
+function formatDealValue(valueCents: number | null | undefined, locale: AppLocale) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: 'EUR',
+  }).format((valueCents ?? 0) / 100);
+}
+
+export async function AgentLeadDetailV2Page({
+  id,
+  locale,
+}: Readonly<{ id: string; locale: AppLocale }>) {
+  setRequestLocale(locale);
   const t = await getTranslations('agent.leads_page');
   const session = await auth.api.getSession({
     headers: await headers(),
   });
 
   if (!session?.user) {
-    redirect('/auth/login');
+    redirect({ href: '/login', locale });
+    return null;
   }
 
   const tenantId = ensureTenantId(session);
@@ -36,26 +98,33 @@ export async function AgentLeadDetailV2Page({ id }: { id: string }) {
   const deals = leadResult.deals;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="agent-lead-detail-ready">
       <div className="flex items-center justify-between">
         <div>
           <Button variant="ghost" size="sm" asChild className="mb-2 pl-0 hover:bg-transparent">
-            <Link href="/agent/leads">← Back to Leads</Link>
+            <Link href="/agent/leads">{t('backToLeads')}</Link>
           </Button>
           <h1 className="text-3xl font-bold tracking-tight">
-            {lead.fullName || lead.companyName || 'Lead Details'}
+            {lead.fullName || lead.companyName || t('detailTitleFallback')}
           </h1>
           <div className="flex items-center gap-2 mt-2">
             <span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold border-transparent bg-primary/10 text-primary">
-              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-              {t(`stages.${lead.stage}` as any)}
+              {localizeLeadStage(lead.stage, t)}
             </span>
-            <span className="text-sm text-muted-foreground">• {lead.source}</span>
+            <span className="text-sm text-muted-foreground">
+              {t('sourceLabel')}: {lead.source || t('emptyValue')}
+            </span>
           </div>
         </div>
         <div className="flex gap-2">
-          {/* We handle logging in the card below, but could also have one here */}
-          <Button>Create Deal</Button>
+          <Button
+            variant="outline"
+            disabled
+            aria-disabled="true"
+            data-testid="agent-lead-create-deal-unavailable"
+          >
+            {t('actions.createDealUnavailable')}
+          </Button>
         </div>
       </div>
 
@@ -63,32 +132,32 @@ export async function AgentLeadDetailV2Page({ id }: { id: string }) {
         <div className="space-y-6">
           <Card>
             <CardHeader>
-              <CardTitle>Contact Information</CardTitle>
+              <CardTitle>{t('detail.contactInformation')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-2 gap-4 text-sm">
-                <div className="text-muted-foreground">Type</div>
-                <div className="font-medium capitalize">{lead.type}</div>
+                <div className="text-muted-foreground">{t('detail.type')}</div>
+                <div className="font-medium">{localizeLeadType(lead.type, t)}</div>
 
-                <div className="text-muted-foreground">Email</div>
-                <div className="font-medium">{lead.email || '-'}</div>
+                <div className="text-muted-foreground">{t('detail.email')}</div>
+                <div className="font-medium">{lead.email || t('emptyValue')}</div>
 
-                <div className="text-muted-foreground">Phone</div>
-                <div className="font-medium">{lead.phone || '-'}</div>
+                <div className="text-muted-foreground">{t('detail.phone')}</div>
+                <div className="font-medium">{lead.phone || t('emptyValue')}</div>
 
-                <div className="text-muted-foreground">Company</div>
-                <div className="font-medium">{lead.companyName || '-'}</div>
+                <div className="text-muted-foreground">{t('detail.company')}</div>
+                <div className="font-medium">{lead.companyName || t('emptyValue')}</div>
               </div>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader>
-              <CardTitle>Deals</CardTitle>
+              <CardTitle>{t('deals.title')}</CardTitle>
             </CardHeader>
             <CardContent>
               {deals.length === 0 ? (
-                <p className="text-sm text-muted-foreground">No deals created yet.</p>
+                <p className="text-sm text-muted-foreground">{t('deals.empty')}</p>
               ) : (
                 <div className="space-y-4">
                   {deals.map(deal => (
@@ -97,13 +166,19 @@ export async function AgentLeadDetailV2Page({ id }: { id: string }) {
                       className="flex items-center justify-between border-b pb-4 last:border-0 last:pb-0"
                     >
                       <div>
-                        <p className="font-medium text-sm">Membership Plan</p>
-                        <p className="text-xs text-muted-foreground capitalize">{deal.status}</p>
+                        <p className="font-medium text-sm">{t('deals.membershipPlan')}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {localizeDealStatus(deal.status, t)}
+                        </p>
                       </div>
                       <div className="text-right">
-                        <p className="font-medium text-sm">€ {(deal.valueCents || 0) / 100}</p>
+                        <p className="font-medium text-sm">
+                          {formatDealValue(deal.valueCents, locale)}
+                        </p>
                         <p className="text-xs text-muted-foreground">
-                          {deal.closedAt ? new Date(deal.closedAt).toLocaleDateString() : 'Open'}
+                          {deal.closedAt
+                            ? new Date(deal.closedAt).toLocaleDateString(locale)
+                            : t('dealStatuses.open')}
                         </p>
                       </div>
                     </div>
@@ -117,7 +192,7 @@ export async function AgentLeadDetailV2Page({ id }: { id: string }) {
         <div className="space-y-6">
           <Card className="h-full flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between">
-              <CardTitle>Activity History</CardTitle>
+              <CardTitle>{t('activityHistory')}</CardTitle>
               <LogActivityDialog entityId={id} entityType="lead" />
             </CardHeader>
             <CardContent className="px-0 flex-1">

--- a/apps/web/src/messages/en/agent.json
+++ b/apps/web/src/messages/en/agent.json
@@ -204,14 +204,46 @@
       }
     },
     "leads_page": {
+      "backToLeads": "Back to Leads",
+      "detailTitleFallback": "Lead Details",
+      "sourceLabel": "Source",
+      "emptyValue": "Not provided",
+      "detail": {
+        "contactInformation": "Contact Information",
+        "type": "Type",
+        "email": "Email",
+        "phone": "Phone",
+        "company": "Company"
+      },
+      "types": {
+        "individual": "Individual",
+        "business": "Business"
+      },
       "stages": {
         "new": "New",
         "contacted": "Contacted",
         "qualified": "Qualified",
         "proposal": "Proposal",
+        "negotiation": "Negotiation",
         "won": "Won",
-        "lost": "Lost"
-      }
+        "lost": "Lost",
+        "unknown": "Unknown stage"
+      },
+      "actions": {
+        "createDealUnavailable": "Deal creation unavailable"
+      },
+      "deals": {
+        "title": "Deals",
+        "empty": "No deals created yet.",
+        "membershipPlan": "Membership Plan"
+      },
+      "dealStatuses": {
+        "open": "Open",
+        "won": "Won",
+        "lost": "Lost",
+        "unknown": "Unknown"
+      },
+      "activityHistory": "Activity History"
     },
     "workspace": {
       "title": "Agent Pro Workspace",

--- a/apps/web/src/messages/mk/agent.json
+++ b/apps/web/src/messages/mk/agent.json
@@ -230,6 +230,21 @@
     "leads_page": {
       "title": "Lead Management",
       "subtitle": "Manage and convert your potential members.",
+      "backToLeads": "Назад кон потенцијални клиенти",
+      "detailTitleFallback": "Детали за потенцијален клиент",
+      "sourceLabel": "Извор",
+      "emptyValue": "Не е наведено",
+      "detail": {
+        "contactInformation": "Контакт информации",
+        "type": "Тип",
+        "email": "Е-пошта",
+        "phone": "Телефон",
+        "company": "Компанија"
+      },
+      "types": {
+        "individual": "Физичко лице",
+        "business": "Бизнис"
+      },
       "table": {
         "name": "Name",
         "stage": "Stage",
@@ -242,9 +257,26 @@
         "contacted": "Контактиран",
         "qualified": "Квалификуван",
         "proposal": "Понуда",
+        "negotiation": "Преговори",
         "won": "Добиен",
-        "lost": "Изгубен"
-      }
+        "lost": "Изгубен",
+        "unknown": "Непозната фаза"
+      },
+      "actions": {
+        "createDealUnavailable": "Креирањето договор не е достапно"
+      },
+      "deals": {
+        "title": "Договори",
+        "empty": "Сè уште нема креирани договори.",
+        "membershipPlan": "План за членство"
+      },
+      "dealStatuses": {
+        "open": "Отворен",
+        "won": "Добиен",
+        "lost": "Изгубен",
+        "unknown": "Непознато"
+      },
+      "activityHistory": "Историја на активности"
     },
     "commissions": {
       "title": "Провизии",

--- a/apps/web/src/messages/sq/agent.json
+++ b/apps/web/src/messages/sq/agent.json
@@ -203,14 +203,46 @@
       }
     },
     "leads_page": {
+      "backToLeads": "Kthehu te lead-et",
+      "detailTitleFallback": "Detajet e lead-it",
+      "sourceLabel": "Burimi",
+      "emptyValue": "Nuk është dhënë",
+      "detail": {
+        "contactInformation": "Informacioni i kontaktit",
+        "type": "Lloji",
+        "email": "E-mail",
+        "phone": "Telefoni",
+        "company": "Kompania"
+      },
+      "types": {
+        "individual": "Individ",
+        "business": "Biznes"
+      },
       "stages": {
         "new": "I/E Re",
         "contacted": "Kontakuar",
         "qualified": "Kualifikuar",
         "proposal": "Propozim",
+        "negotiation": "Negocim",
         "won": "Fituar",
-        "lost": "Humbur"
-      }
+        "lost": "Humbur",
+        "unknown": "Fazë e panjohur"
+      },
+      "actions": {
+        "createDealUnavailable": "Krijimi i marrëveshjes nuk është i disponueshëm"
+      },
+      "deals": {
+        "title": "Marrëveshjet",
+        "empty": "Ende nuk është krijuar asnjë marrëveshje.",
+        "membershipPlan": "Plani i anëtarësimit"
+      },
+      "dealStatuses": {
+        "open": "E hapur",
+        "won": "Fituar",
+        "lost": "Humbur",
+        "unknown": "E panjohur"
+      },
+      "activityHistory": "Historiku i aktivitetit"
     },
     "workspace": {
       "title": "Hapësira Pro e Agjentit",

--- a/apps/web/src/messages/sr/agent.json
+++ b/apps/web/src/messages/sr/agent.json
@@ -233,6 +233,21 @@
     "leads_page": {
       "title": "Upravljanje potencijalnim klijentima",
       "subtitle": "Upravljajte i konvertujte svoje potencijalne članove.",
+      "backToLeads": "Nazad na potencijalne klijente",
+      "detailTitleFallback": "Detalji potencijalnog klijenta",
+      "sourceLabel": "Izvor",
+      "emptyValue": "Nije navedeno",
+      "detail": {
+        "contactInformation": "Kontakt informacije",
+        "type": "Tip",
+        "email": "E-pošta",
+        "phone": "Telefon",
+        "company": "Kompanija"
+      },
+      "types": {
+        "individual": "Fizičko lice",
+        "business": "Biznis"
+      },
       "table": {
         "name": "Ime",
         "stage": "Faza",
@@ -245,9 +260,26 @@
         "contacted": "Kontaktirani",
         "qualified": "Kvalifikovani",
         "proposal": "Ponuda",
+        "negotiation": "Pregovori",
         "won": "Dobijeni",
-        "lost": "Izgubljeni"
-      }
+        "lost": "Izgubljeni",
+        "unknown": "Nepoznata faza"
+      },
+      "actions": {
+        "createDealUnavailable": "Kreiranje dogovora nije dostupno"
+      },
+      "deals": {
+        "title": "Dogovori",
+        "empty": "Još nema kreiranih dogovora.",
+        "membershipPlan": "Plan članstva"
+      },
+      "dealStatuses": {
+        "open": "Otvoren",
+        "won": "Dobijen",
+        "lost": "Izgubljen",
+        "unknown": "Nepoznato"
+      },
+      "activityHistory": "Istorija aktivnosti"
     },
     "commissions": {
       "title": "Provizije",


### PR DESCRIPTION
## Summary
- Productizes the canonical `/agent/leads/[id]` detail route with localized lead detail, deals, and activity labels.
- Preserves the existing tenant/agent-scoped read core while fixing locale-aware unauthenticated redirects.
- Replaces the unbacked Create Deal action with an explicit disabled/unavailable action and adds focused unit plus golden E2E coverage.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx 'src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts'`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm --filter @interdomestik/web lint`
- `git diff --check`
- `pnpm security:guard`
- `pnpm verify-slice -- --static`
- `pnpm --filter @interdomestik/web exec playwright test --project=ks-sq e2e/golden/agent-lead-detail.spec.ts`
- `pnpm pr:verify`
- `pnpm e2e:gate`

## Notes
- `apps/web/src/proxy.ts` was not changed.
- No routing, auth, tenancy, schema, Stripe, README, AGENTS, or architecture docs were changed.
- Playwright MCP was used to validate the localized unauthenticated `/agent/leads/[id]` redirect to `/sq/login`; authenticated detail coverage is handled by the new repo Playwright golden spec.