### PR TITLE
ci: use PR gate lane for E2E checks

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -100,12 +100,12 @@ jobs:
             exit 1
           fi
 
-      - name: Run Full E2E Gate
+      - name: Run PR E2E Gate
         if: steps.validation_surface.outputs.should_run == 'true'
         env:
           E2E_DATABASE_URL: ${{ env.DATABASE_URL }}
           E2E_DATABASE_URL_RLS: ${{ env.DATABASE_URL }}
-        run: pnpm e2e:gate
+        run: pnpm e2e:gate:pr
 
       - name: Upload Playwright Artifacts
         if: always() && steps.validation_surface.outputs.should_run == 'true'

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -92,10 +92,10 @@ test('CI PR path keeps only RLS coverage while PR E2E owns the PR browser gate l
   const prStrictGuardStep = findStep(prE2eJob.steps, 'Strict Rule Guards (golden/gate)');
   assert.ok(prStrictGuardStep);
 
-  const fullGateStep = findStep(prE2eJob.steps, 'Run PR E2E Gate');
-  assert.ok(fullGateStep);
-  assert.equal(fullGateStep.run, 'pnpm e2e:gate:pr');
-  assert.deepEqual(fullGateStep.env, {
+  const prGateStep = findStep(prE2eJob.steps, 'Run PR E2E Gate');
+  assert.ok(prGateStep);
+  assert.equal(prGateStep.run, 'pnpm e2e:gate:pr');
+  assert.deepEqual(prGateStep.env, {
     E2E_DATABASE_URL: '${{ env.DATABASE_URL }}',
     E2E_DATABASE_URL_RLS: '${{ env.DATABASE_URL }}',
   });

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -48,7 +48,7 @@ const RELEASE_GATE_ENV_VARS = [
   'RELEASE_GATE_ADMIN_MK_PASSWORD',
 ];
 
-test('CI PR path keeps only RLS coverage while PR E2E owns the full browser gate lane', () => {
+test('CI PR path keeps only RLS coverage while PR E2E owns the PR browser gate lane', () => {
   const ciWorkflow = readWorkflow('.github/workflows/ci.yml');
   const prE2eWorkflow = readWorkflow('.github/workflows/e2e-pr.yml');
 
@@ -92,9 +92,9 @@ test('CI PR path keeps only RLS coverage while PR E2E owns the full browser gate
   const prStrictGuardStep = findStep(prE2eJob.steps, 'Strict Rule Guards (golden/gate)');
   assert.ok(prStrictGuardStep);
 
-  const fullGateStep = findStep(prE2eJob.steps, 'Run Full E2E Gate');
+  const fullGateStep = findStep(prE2eJob.steps, 'Run PR E2E Gate');
   assert.ok(fullGateStep);
-  assert.equal(fullGateStep.run, 'pnpm e2e:gate');
+  assert.equal(fullGateStep.run, 'pnpm e2e:gate:pr');
   assert.deepEqual(fullGateStep.env, {
     E2E_DATABASE_URL: '${{ env.DATABASE_URL }}',
     E2E_DATABASE_URL_RLS: '${{ env.DATABASE_URL }}',


### PR DESCRIPTION
## Summary
- switch the PR E2E workflow from the full `e2e:gate` lane to `e2e:gate:pr`
- keep the required check name `e2e` unchanged
- preserve full KS gate coverage and MK seed/tenant-resolution contract coverage on PRs

## Verification
- `pnpm test:ci:contracts`