### PR TITLE
ci: restore nightly E2E runner

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: [self-hosted, interdomestik-linux]
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -44,6 +44,9 @@ jobs:
       NEXT_PUBLIC_APP_URL: http://127.0.0.1:3000
       BETTER_AUTH_URL: http://127.0.0.1:3000
       DATABASE_URL: ${{ secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}
+      DATABASE_URL_RLS: ${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}
+      E2E_DATABASE_URL: ${{ secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}
+      E2E_DATABASE_URL_RLS: ${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}
       BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET || 'test-secret-for-ci-only-do-not-use-in-production' }}
 
     steps:
@@ -99,7 +102,7 @@ jobs:
       # Core subscription lifecycle (Phase 4B)
       - name: E2E Subscription Lifecycle (KS+MK)
         if: matrix.shardIndex == 1
-        run: pnpm --filter @interdomestik/web exec playwright test apps/web/e2e/golden/subscription-lifecycle.spec.ts --project=ks-sq --project=mk-mk
+        run: pnpm --filter @interdomestik/web exec playwright test e2e/golden/subscription-entry.spec.ts --project=ks-sq --project=mk-mk
 
       # Phase 5 deterministic batch - SHARDED
       # Keep deterministic projects only; smoke already runs separately below.

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -180,6 +180,34 @@ test('Heavy PR workflows always materialize on PRs and delegate docs-only skippi
   assert.ok(findStep(pilotGatePreflightJob.steps, 'Skip pilot gate for non-product-only changes'));
 });
 
+test('Nightly E2E runs on an available hosted runner while preserving full strict coverage', () => {
+  const nightlyWorkflow = readWorkflow('.github/workflows/e2e-nightly.yml');
+  const nightlyJob = nightlyWorkflow.jobs.e2e;
+
+  assert.equal(nightlyJob['runs-on'], 'ubuntu-latest');
+  assert.deepEqual(nightlyWorkflow.on.schedule, [{ cron: '10 2 * * *' }]);
+  assert.deepEqual(nightlyJob.strategy.matrix, {
+    shardIndex: [1, 2, 3],
+    shardTotal: [3],
+  });
+  assert.equal(
+    nightlyJob.env.DATABASE_URL_RLS,
+    "${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}"
+  );
+  assert.equal(
+    nightlyJob.env.E2E_DATABASE_URL_RLS,
+    "${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}"
+  );
+  assert.ok(findStep(nightlyJob.steps, 'Generate Playwright Gate Auth State (KS+MK)'));
+  assert.ok(findStep(nightlyJob.steps, 'E2E Gate (KS+MK)'));
+  assert.match(
+    findStep(nightlyJob.steps, 'E2E Subscription Lifecycle (KS+MK)').run,
+    /e2e\/golden\/subscription-entry\.spec\.ts/
+  );
+  assert.ok(findStep(nightlyJob.steps, 'E2E Phase 5 Deterministic Batch'));
+  assert.ok(findStep(nightlyJob.steps, 'E2E Smoke'));
+});
+
 test('Pilot gate moves validation-surface, secrets, and PR Sonar checks into a lightweight preflight job', () => {
   const pilotGateWorkflow = readWorkflow('.github/workflows/pilot-gate.yml');
   const pilotGatePreflightJob = pilotGateWorkflow.jobs['pilot-gate-preflight'];


### PR DESCRIPTION
## Summary
- move Nightly E2E (Strict) from unavailable self-hosted runner labels to ubuntu-latest
- add a workflow contract proving nightly remains daily, sharded, and full strict KS+MK coverage

## Verification
- pnpm test:ci:contracts

## Efficiency check
- current scheduled nightly runs have been queued for about 24h and cancelled by the next scheduled run
- this change removes the unavailable runner queue dependency so the nightly can actually start