### PR TITLE
test: stabilize QA MCP and tracking contracts

### DIFF
--- a/apps/web/src/features/claims/tracking/server/trackingLifecycle.integration.test.ts
+++ b/apps/web/src/features/claims/tracking/server/trackingLifecycle.integration.test.ts
@@ -206,6 +206,9 @@ import { getPublicClaimStatus } from './getPublicClaimStatus';
 
 describe('tracking link lifecycle', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-17T09:00:00.000Z'));
+
     hoisted.store.claims = [
       {
         id: 'claim-1',
@@ -235,6 +238,7 @@ describe('tracking link lifecycle', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
   });
 

--- a/scripts/ci/qa-mcp-discovery-contracts.test.mjs
+++ b/scripts/ci/qa-mcp-discovery-contracts.test.mjs
@@ -217,7 +217,7 @@ test('repo QA MCP repo helpers return structured results for faster agent inspec
     assert.ok(Array.isArray(changedResult.structuredContent.files));
 
     const scopeResult = await client.callTool('scope_audit', {
-      allowedPaths: ['.github/workflows', 'docs/plans', 'packages/qa', 'scripts/ci'],
+      forbiddenPaths: ['__qa_mcp_contract_forbidden_path__'],
     });
     assert.equal(scopeResult.structuredContent.tool, 'scope_audit');
     assert.equal(scopeResult.structuredContent.status, 'pass');

--- a/scripts/ci/qa-mcp-discovery-contracts.test.mjs
+++ b/scripts/ci/qa-mcp-discovery-contracts.test.mjs
@@ -216,11 +216,12 @@ test('repo QA MCP repo helpers return structured results for faster agent inspec
     assert.equal(changedResult.structuredContent.tool, 'changed_files');
     assert.ok(Array.isArray(changedResult.structuredContent.files));
 
-    const scopeResult = await client.callTool('scope_audit', {
-      forbiddenPaths: ['__qa_mcp_contract_forbidden_path__'],
-    });
+    const forbiddenPaths = ['__qa_mcp_contract_forbidden_path__'];
+    const scopeResult = await client.callTool('scope_audit', { forbiddenPaths });
     assert.equal(scopeResult.structuredContent.tool, 'scope_audit');
     assert.equal(scopeResult.structuredContent.status, 'pass');
+    assert.deepEqual(scopeResult.structuredContent.allowedPaths, []);
+    assert.deepEqual(scopeResult.structuredContent.forbiddenPaths, forbiddenPaths);
   } finally {
     await client.close();
   }


### PR DESCRIPTION
## Summary
- make the QA MCP discovery contract independent of unrelated dirty worktree paths
- freeze the tracking lifecycle integration test clock so token expiry fixtures stay deterministic after 2026-05-01

## Local validation
- node --test scripts/ci/qa-mcp-discovery-contracts.test.mjs
- pnpm mcp:preflight
- pnpm security:guard
- pnpm e2e:gate (110 passed, 4 skipped)
- pnpm pr:verify progressed through release-gate, contracts, lint baseline, migrations, RLS, i18n, coverage, and build stages repeatedly; local monolithic completion was blocked by concurrent original-worktree verification processes repeatedly taking port 3000 / SIGTERMing builds. CI should be the canonical final signal.