### PR TITLE
fix: align repo qa mcp server name

### DIFF
--- a/scripts/ci/qa-mcp-discovery-contracts.test.mjs
+++ b/scripts/ci/qa-mcp-discovery-contracts.test.mjs
@@ -119,6 +119,8 @@ async function createMcpClient() {
     protocolVersion: '2024-11-05',
     capabilities: {},
     clientInfo: { name: 'qa-mcp-contract', version: '1.0.0' },
+  }).then(response => {
+    assert.equal(response.result?.serverInfo?.name, 'interdomestik_qa');
   });
   child.stdin.write(
     JSON.stringify({

--- a/scripts/start-repo-qa.sh
+++ b/scripts/start-repo-qa.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export MCP_REPO_ROOT="$REPO_ROOT"
+export MCP_SERVER_NAME="interdomestik_qa"
 cd "$REPO_ROOT"
 
 exec "$REPO_ROOT/node_modules/.bin/tsx" packages/qa/src/index.ts


### PR DESCRIPTION
## Summary
- Set the repo QA MCP runtime server name to underscore-safe `interdomestik_qa`, matching the Codex config key and expected tool namespace.
- Add a discovery contract assertion for `serverInfo.name` so this cannot regress silently.
- No product code, proxy, routes, auth, tenancy, schema, Stripe, or documentation changes.

## Verification
- `node --test scripts/ci/qa-mcp-discovery-contracts.test.mjs`
- `pnpm mcp:preflight`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates`