### PR TITLE
[codex] Align member dashboard support handoffs

### DIFF
--- a/apps/web/src/components/dashboard/member-dashboard-view.test.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view.test.tsx
@@ -410,6 +410,32 @@ describe('MemberDashboardView MK localization', () => {
     );
   });
 
+  it('keeps dashboard support CTAs aligned with the canonical support handoff', async () => {
+    mockActiveMembership();
+    const supportHref = '/member/help/tenant-support';
+
+    const tree = await MemberDashboardView({
+      data: makeData({ supportHref }),
+      locale: 'mk',
+    });
+
+    render(tree);
+
+    expect(screen.getByRole('link', { name: 'Контактирај поддршка' })).toHaveAttribute(
+      'href',
+      supportHref
+    );
+    expect(screen.getByRole('link', { name: 'support' })).toHaveAttribute('href', supportHref);
+    expect(screen.getByRole('link', { name: 'Отвори членска поддршка' })).toHaveAttribute(
+      'href',
+      supportHref
+    );
+    expect(screen.getByRole('link', { name: 'Провери безбедносни параметри' })).toHaveAttribute(
+      'href',
+      supportHref
+    );
+  });
+
   it('uses the member action CTA when the active claim requires member input', async () => {
     mockActiveMembership();
 

--- a/apps/web/src/components/dashboard/member-dashboard-view.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view.tsx
@@ -293,7 +293,7 @@ export async function MemberDashboardView({ data, locale }: MemberDashboardViewP
   ]);
   const { member, claims, activeClaimId, supportHref } = data;
   const activeClaim = claims.find(claim => claim.id === activeClaimId) ?? null;
-  const orientationHref = '/member/help';
+  const orientationHref = supportHref;
 
   const userDetails = await getCachedUser(member.id);
 
@@ -628,7 +628,7 @@ export async function MemberDashboardView({ data, locale }: MemberDashboardViewP
                 variant="outline"
                 className="w-full rounded-2xl border-sky-200 font-bold transition-all hover:border-sky-300 hover:bg-sky-50 dark:border-sky-400/20 dark:hover:bg-sky-400/5"
               >
-                <Link href="/member/help" className="flex items-center justify-center gap-2">
+                <Link href={supportHref} className="flex items-center justify-center gap-2">
                   <span>{tLanding('support_panel_cta')}</span>
                   <ArrowRight className="w-4 h-4 transition-transform" />
                 </Link>
@@ -760,7 +760,7 @@ export async function MemberDashboardView({ data, locale }: MemberDashboardViewP
                   {tLanding('status_insight_body')}
                 </p>
                 <Button variant="secondary" asChild className="w-full rounded-xl font-bold">
-                  <Link href="/member/help">{tLanding('review_security_parameters')}</Link>
+                  <Link href={supportHref}>{tLanding('review_security_parameters')}</Link>
                 </Button>
               </div>
             </Card>


### PR DESCRIPTION
## Summary
- Align member dashboard orientation/support/status CTAs with the existing `supportHref` contract instead of hardcoded `/member/help` links.
- Add focused coverage proving the dashboard support links resolve through the canonical support handoff.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/components/dashboard/member-dashboard-view.test.tsx`
- `pnpm verify-slice -- --static`
- Pre-PR reviewer pool: security reviewer READY FOR PR; architecture/QA reviewer SHOULD_FIX addressed, READY FOR PR.
- `pnpm verify-slice -- --required-gates` (`pr:verify`, `security:guard`, `e2e:gate`)

## Scope Notes
- Product-facing slice only; no workflow/documentation promotion changes.
- `apps/web/src/proxy.ts` unchanged.
- Canonical routes and `*-page-ready` markers preserved.
- No auth, tenancy, routing architecture, API, schema, or Stripe changes.