### PR TITLE
ci: update pnpm action setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10.28.2
 


### PR DESCRIPTION
## Summary
- Update the shared CI setup action from `pnpm/action-setup@v4` to `pnpm/action-setup@v6`.
- Addresses the GitHub Actions Node.js 20 deprecation warning seen in Sonar Main Gate and other workflows that use `.github/actions/setup/action.yml`.

## Verification
- `git diff --check` passed
- `pnpm exec prettier --check .github/actions/setup/action.yml` passed
- `pnpm security:guard` passed
- `pnpm plan:status` passed
- `pnpm plan:audit` passed
- `pnpm track:audit` passed
- `pnpm verify-slice -- --static` passed
- `pnpm verify-slice -- --required-gates` passed

## Notes
- `pnpm yaml:lint` is not available in this repository.
- Repo-wide `pnpm format:check .github/actions/setup/action.yml .github/workflows/sonar-main-gate.yml` is currently blocked by unrelated pre-existing formatting drift outside this change; the changed YAML file passed direct Prettier verification.