### PR TITLE
feat: track support handoff claim detail origin

### DIFF
--- a/apps/web/e2e/gate/staff-support-handoffs.spec.ts
+++ b/apps/web/e2e/gate/staff-support-handoffs.spec.ts
@@ -113,13 +113,17 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
         .first();
       await expect(supportLink).toBeVisible();
       await expect(supportLink).toHaveAttribute('href', new RegExp(`claimId=${claimId}`));
+      await expect(supportLink).toHaveAttribute('href', /source=member_claim_detail/);
       const supportHref = await supportLink.getAttribute('href');
       expect(supportHref).toBeTruthy();
       await gotoApp(memberPage, supportHref!, testInfo, {
         marker: 'member-support-handoff-form',
       });
       await expect(memberPage).toHaveURL(
-        url => url.pathname.endsWith('/member/help') && url.searchParams.get('claimId') === claimId,
+        url =>
+          url.pathname.endsWith('/member/help') &&
+          url.searchParams.get('claimId') === claimId &&
+          url.searchParams.get('source') === 'member_claim_detail',
         { timeout: 15000 }
       );
 
@@ -145,14 +149,14 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
           async () => {
             const handoff = await db.query.supportHandoffs.findFirst({
               where: eq(supportHandoffs.subject, subject),
-              columns: { claimId: true, id: true },
+              columns: { claimId: true, id: true, source: true },
             });
 
-            return handoff?.claimId ?? null;
+            return handoff?.claimId === claimId ? handoff.source : null;
           },
           { timeout: 15000, intervals: [250, 500, 1000] }
         )
-        .toBe(claimId);
+        .toBe('member_claim_detail');
 
       await loginAs('staff');
       await gotoApp(
@@ -173,6 +177,9 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
         /Phone callback|Телефон|telefon/i
       );
       await expect(row.getByTestId('staff-support-handoff-full-message')).toContainText(message);
+      await expect(row.getByTestId('staff-support-handoff-source')).toContainText(
+        /Claim detail page|detajeve|detalja|детали/i
+      );
       await expect(row.getByTestId('staff-support-handoff-lifecycle-created')).toBeVisible();
     } finally {
       await cleanupHandoffBySubject(subject);

--- a/apps/web/src/app/[locale]/(app)/member/help/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_core.entry.test.tsx
@@ -157,6 +157,7 @@ describe('member help support handoff form', () => {
     expect(screen.getByTestId('member-support-handoff-subject')).toHaveAttribute('name', 'subject');
     expect(screen.getByTestId('member-support-handoff-message')).toHaveAttribute('name', 'message');
     expect(screen.getByTestId('member-support-handoff-claim')).toHaveTextContent('CLM-1');
+    expect(document.querySelector('input[name="source"]')).toHaveValue('member_help');
     expect(screen.queryByDisplayValue('tenant-1')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('member-1')).not.toBeInTheDocument();
   });
@@ -176,6 +177,14 @@ describe('member help support handoff form', () => {
       'request.claimContextStatus'
     );
     expect(screen.getByTestId('member-support-handoff-claim')).toHaveValue('claim-1');
+  });
+
+  it('passes through a claim-detail source hint from the search params', async () => {
+    await renderPage({ claimId: 'claim-1', source: 'member_claim_detail' });
+
+    expect(screen.getByTestId('member-support-handoff-claim')).toHaveValue('claim-1');
+    expect(document.querySelector('input[name="source"]')).toHaveValue('member_claim_detail');
+    expect(document.querySelector('input[name="sourceClaimId"]')).toHaveValue('claim-1');
   });
 
   it('includes and preselects a valid owned claim outside the initial claim options', async () => {
@@ -207,10 +216,12 @@ describe('member help support handoff form', () => {
   });
 
   it('ignores an inaccessible claimId search param before submission', async () => {
-    await renderPage({ claimId: 'claim-other-member' });
+    await renderPage({ claimId: 'claim-other-member', source: 'member_claim_detail' });
 
     expect(screen.queryByTestId('member-support-handoff-claim-context')).not.toBeInTheDocument();
     expect(screen.getByTestId('member-support-handoff-claim')).toHaveValue('');
+    expect(document.querySelector('input[name="source"]')).toHaveValue('member_help');
+    expect(document.querySelector('input[name="sourceClaimId"]')).not.toBeInTheDocument();
   });
 
   it('redirects non-member sessions to their canonical portal before rendering the form', async () => {

--- a/apps/web/src/app/[locale]/(app)/member/help/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_core.entry.tsx
@@ -90,6 +90,7 @@ export default async function HelpPage({ params, searchParams }: Props) {
   const resolvedSearchParams = await searchParams;
   const status = getSingleParam(resolvedSearchParams.support);
   const requestedClaimId = getSingleParam(resolvedSearchParams.claimId);
+  const sourceHint = getSingleParam(resolvedSearchParams.source);
   const claimOptions =
     session.user.tenantId && session.user.id
       ? await getMemberClaimOptions({
@@ -101,6 +102,8 @@ export default async function HelpPage({ params, searchParams }: Props) {
   const selectedClaim = requestedClaimId
     ? (claimOptions.find(claim => claim.id === requestedClaimId) ?? null)
     : null;
+  const sourceClaimId =
+    sourceHint === 'member_claim_detail' && selectedClaim ? selectedClaim.id : null;
 
   return (
     <div
@@ -198,6 +201,14 @@ export default async function HelpPage({ params, searchParams }: Props) {
               data-testid="member-support-handoff-form"
             >
               <input type="hidden" name="locale" value={locale} />
+              <input
+                type="hidden"
+                name="source"
+                value={sourceClaimId ? 'member_claim_detail' : 'member_help'}
+              />
+              {sourceClaimId ? (
+                <input type="hidden" name="sourceClaimId" value={sourceClaimId} />
+              ) : null}
               <div className="space-y-2">
                 <label htmlFor="support-subject" className="text-sm font-medium">
                   {t('request.subject')}

--- a/apps/web/src/app/[locale]/(staff)/staff/support-handoffs/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(staff)/staff/support-handoffs/_core.entry.test.tsx
@@ -201,6 +201,29 @@ describe('StaffSupportHandoffsPage', () => {
     );
   });
 
+  it('renders claim-detail source labels in the expanded detail panel', async () => {
+    mocks.getSupportHandoffDetail.mockResolvedValueOnce({
+      acceptedAt: null,
+      acceptedByName: null,
+      closedAt: null,
+      closedByName: null,
+      closeReason: null,
+      contactPreference: 'staff_reply',
+      reassignedAt: null,
+      reassignedByName: null,
+      reassignReason: null,
+      source: 'member_claim_detail',
+    });
+
+    await renderPage();
+
+    fireEvent.click(screen.getByTestId('staff-support-handoff-detail-toggle'));
+
+    expect(await screen.findByTestId('staff-support-handoff-source')).toHaveTextContent(
+      'detail.source_claim_detail'
+    );
+  });
+
   it('shows reassignment only for accepted handoffs owned by the current staff member', async () => {
     mocks.getQueue.mockResolvedValueOnce([
       {

--- a/apps/web/src/features/claims/tracking/memberTrustSummary.test.ts
+++ b/apps/web/src/features/claims/tracking/memberTrustSummary.test.ts
@@ -30,7 +30,7 @@ describe('buildMemberClaimTrustSummary', () => {
       titleKey: 'claims-tracking.tracking.assurance.title',
       bodyKey: 'claims-tracking.tracking.assurance.body.active_handling',
       stateLabelKey: 'claims-tracking.tracking.assurance.state.active_handling',
-      supportHref: '/member/help?claimId=claim-123',
+      supportHref: '/member/help?claimId=claim-123&source=member_claim_detail',
     });
   });
 

--- a/apps/web/src/features/claims/tracking/memberTrustSummary.ts
+++ b/apps/web/src/features/claims/tracking/memberTrustSummary.ts
@@ -48,7 +48,7 @@ export function buildMemberClaimTrustSummary(
     bodyKey: `claims-tracking.tracking.assurance.body.${state}`,
     stateLabelKey: `claims-tracking.tracking.assurance.state.${state}`,
     supportHref: args.claimId
-      ? `/member/help?claimId=${encodeURIComponent(args.claimId)}`
+      ? `/member/help?claimId=${encodeURIComponent(args.claimId)}&source=member_claim_detail`
       : '/member/help',
   };
 }

--- a/apps/web/src/features/claims/tracking/server/getMemberClaimDetail.test.ts
+++ b/apps/web/src/features/claims/tracking/server/getMemberClaimDetail.test.ts
@@ -244,7 +244,7 @@ describe('getMemberClaimDetail', () => {
           titleKey: 'claims-tracking.tracking.assurance.title',
           bodyKey: 'claims-tracking.tracking.assurance.body.member_action_required',
           stateLabelKey: 'claims-tracking.tracking.assurance.state.member_action_required',
-          supportHref: '/member/help?claimId=claim_1',
+          supportHref: '/member/help?claimId=claim_1&source=member_claim_detail',
         },
       })
     );

--- a/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx
+++ b/apps/web/src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx
@@ -255,7 +255,7 @@ describe('MemberClaimDetailOpsPage', () => {
         titleKey: 'claims-tracking.tracking.assurance.title',
         bodyKey: 'claims-tracking.tracking.assurance.body.active_handling',
         stateLabelKey: 'claims-tracking.tracking.assurance.state.active_handling',
-        supportHref: '/member/help?claimId=claim-1',
+        supportHref: '/member/help?claimId=claim-1&source=member_claim_detail',
       },
       progressSummary: {
         currentStatusLabelKey: 'claims-tracking.status.evaluation',
@@ -279,7 +279,7 @@ describe('MemberClaimDetailOpsPage', () => {
     );
     expect(screen.getByTestId('member-claim-trust-sla-support-link')).toHaveAttribute(
       'href',
-      '/member/help?claimId=claim-1'
+      '/member/help?claimId=claim-1&source=member_claim_detail'
     );
   });
 

--- a/packages/domain-claims/src/support-handoffs/create.test.ts
+++ b/packages/domain-claims/src/support-handoffs/create.test.ts
@@ -88,6 +88,16 @@ function memberSession(overrides: Partial<SupportHandoffSession['user']> = {}) {
   } as SupportHandoffSession;
 }
 
+const ownedClaimContext = {
+  branchId: 'branch-claim',
+  createdAt: new Date('2026-05-01T00:00:00.000Z'),
+  id: 'claim-1',
+  staffId: null,
+  status: 'submitted',
+  statusUpdatedAt: new Date('2026-05-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+} as const;
+
 describe('createMemberSupportHandoffCore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -148,18 +158,81 @@ describe('createMemberSupportHandoffCore', () => {
     expect(mocks.db.insert).not.toHaveBeenCalled();
   });
 
-  it('persists a governed handoff with server-derived ownership and risk signals', async () => {
-    mocks.selectChain.limit.mockResolvedValueOnce([
+  it.each([
+    ['no source hint and no claim', {}, false, 'member_help'],
+    ['no source hint and an owned claim', { claimId: 'claim-1' }, true, 'member_help'],
+    [
+      'a valid claim-detail hint and an owned claim',
+      { claimId: 'claim-1', source: 'member_claim_detail', sourceClaimId: 'claim-1' },
+      true,
+      'member_claim_detail',
+    ],
+    [
+      'a valid claim-detail hint without a claim',
+      { source: 'member_claim_detail' },
+      false,
+      'member_help',
+    ],
+    [
+      'a valid claim-detail hint without a source claim marker',
+      { claimId: 'claim-1', source: 'member_claim_detail' },
+      true,
+      'member_help',
+    ],
+    [
+      'a claim-detail hint for a different claim',
+      { claimId: 'claim-1', source: 'member_claim_detail', sourceClaimId: 'claim-2' },
+      true,
+      'member_help',
+    ],
+    [
+      'a forged source hint and an owned claim',
+      { claimId: 'claim-1', source: 'admin_override', sourceClaimId: 'claim-1' },
+      true,
+      'member_help',
+    ],
+    [
+      'a null source hint and an owned claim',
+      { claimId: 'claim-1', source: null },
+      true,
+      'member_help',
+    ],
+  ])('derives source as %s', async (_name, sourceInput, hasOwnedClaim, expectedSource) => {
+    if (hasOwnedClaim) {
+      mocks.selectChain.limit.mockResolvedValueOnce([ownedClaimContext]);
+    }
+
+    const result = await createMemberSupportHandoffCore(
       {
-        branchId: 'branch-claim',
-        createdAt: new Date('2026-05-01T00:00:00.000Z'),
-        id: 'claim-1',
-        staffId: null,
-        status: 'submitted',
-        statusUpdatedAt: new Date('2026-05-01T00:00:00.000Z'),
-        updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+        input: {
+          message: 'Please help me understand the next support step.',
+          subject: 'Source tracking',
+          ...sourceInput,
+        },
+        session: memberSession(),
       },
-    ]);
+      { logAuditEvent: mocks.logAuditEvent }
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        claimId: hasOwnedClaim ? 'claim-1' : null,
+        source: expectedSource,
+      })
+    );
+    expect(mocks.logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          claimId: hasOwnedClaim ? 'claim-1' : null,
+          source: expectedSource,
+        }),
+      })
+    );
+  });
+
+  it('persists a governed handoff with server-derived ownership and risk signals', async () => {
+    mocks.selectChain.limit.mockResolvedValueOnce([ownedClaimContext]);
 
     const result = await createMemberSupportHandoffCore(
       {
@@ -198,6 +271,9 @@ describe('createMemberSupportHandoffCore', () => {
         action: 'support_handoff.created',
         actorId: 'member-1',
         entityId: 'support_handoff_handoff-uuid',
+        metadata: expect.objectContaining({
+          source: 'member_help',
+        }),
       })
     );
   });

--- a/packages/domain-claims/src/support-handoffs/create.ts
+++ b/packages/domain-claims/src/support-handoffs/create.ts
@@ -7,12 +7,14 @@ import { ensureTenantId } from '@interdomestik/shared-auth';
 import { and } from 'drizzle-orm';
 
 import { deriveSupportHandoffSignals } from './derivation';
-import type {
-  CreateSupportHandoffInput,
-  SupportHandoffActionResult,
-  SupportHandoffContactPreference,
-  SupportHandoffDeps,
-  SupportHandoffSession,
+import {
+  SUPPORT_HANDOFF_SOURCES,
+  type CreateSupportHandoffInput,
+  type SupportHandoffActionResult,
+  type SupportHandoffContactPreference,
+  type SupportHandoffDeps,
+  type SupportHandoffSession,
+  type SupportHandoffSource,
 } from './types';
 
 const MAX_SUBJECT_LENGTH = 120;
@@ -23,6 +25,7 @@ const CONTACT_PREFERENCES = new Set<SupportHandoffContactPreference>([
   'email',
   'whatsapp',
 ]);
+const SUPPORT_HANDOFF_SOURCE_VALUES = new Set<SupportHandoffSource>(SUPPORT_HANDOFF_SOURCES);
 const FORBIDDEN_OWNERSHIP_FIELDS = [
   'tenantId',
   'memberId',
@@ -57,6 +60,31 @@ function normalizeContactPreference(value: unknown): SupportHandoffContactPrefer
     CONTACT_PREFERENCES.has(value as SupportHandoffContactPreference)
     ? (value as SupportHandoffContactPreference)
     : 'staff_reply';
+}
+
+function normalizeSourceHint(value: unknown): SupportHandoffSource | null {
+  return typeof value === 'string' &&
+    SUPPORT_HANDOFF_SOURCE_VALUES.has(value as SupportHandoffSource)
+    ? (value as SupportHandoffSource)
+    : null;
+}
+
+function deriveSource(args: {
+  claimContext: ClaimContext | null;
+  sourceClaimId: unknown;
+  sourceHint: unknown;
+}): SupportHandoffSource {
+  const sourceHint = normalizeSourceHint(args.sourceHint);
+  const sourceClaimId = normalizeText(
+    typeof args.sourceClaimId === 'string' ? args.sourceClaimId : undefined,
+    160
+  );
+
+  if (sourceHint === 'member_claim_detail' && sourceClaimId === args.claimContext?.id) {
+    return 'member_claim_detail';
+  }
+
+  return 'member_help';
 }
 
 function hasForbiddenOwnershipFields(input: Record<string, unknown>) {
@@ -158,6 +186,11 @@ export async function createMemberSupportHandoffCore(
     return { success: false, error: 'Branch is required for support routing' };
   }
   const signals = deriveSupportHandoffSignals({ claim: claimContext });
+  const source = deriveSource({
+    claimContext,
+    sourceClaimId: params.input.sourceClaimId,
+    sourceHint: params.input.source,
+  });
   const handoffId = `support_handoff_${randomUUID()}`;
   const now = new Date();
 
@@ -167,7 +200,7 @@ export async function createMemberSupportHandoffCore(
     memberId,
     branchId,
     claimId: claimContext?.id ?? null,
-    source: 'member_help',
+    source,
     subject,
     message,
     contactPreference,
@@ -188,7 +221,7 @@ export async function createMemberSupportHandoffCore(
       entityId: handoffId,
       metadata: {
         claimId: claimContext?.id ?? null,
-        source: 'member_help',
+        source,
         urgency: signals.urgency,
         trustRisk: signals.trustRisk,
       },

--- a/packages/domain-claims/src/support-handoffs/types.ts
+++ b/packages/domain-claims/src/support-handoffs/types.ts
@@ -11,6 +11,9 @@ export type SupportHandoffTrustRisk = (typeof SUPPORT_HANDOFF_TRUST_RISKS)[numbe
 
 export type SupportHandoffContactPreference = 'staff_reply' | 'phone' | 'email' | 'whatsapp';
 
+export const SUPPORT_HANDOFF_SOURCES = ['member_help', 'member_claim_detail'] as const;
+export type SupportHandoffSource = (typeof SUPPORT_HANDOFF_SOURCES)[number];
+
 export type SupportHandoffActionResult<T = void> =
   | { success: true; data: T; error?: undefined }
   | { success: false; error: string; data?: undefined };
@@ -23,6 +26,8 @@ export type CreateSupportHandoffInput = {
   message: string;
   contactPreference?: SupportHandoffContactPreference;
   claimId?: string | null;
+  source?: string | null;
+  sourceClaimId?: string | null;
 };
 
 export type SupportHandoffLifecycleInput = {


### PR DESCRIPTION
## Summary
- add an allowlisted support handoff source contract for `member_help` and `member_claim_detail`
- carry the claim-detail CTA source hint into `/member/help` and bind it to the originally selected claim before submission
- derive the persisted/audited source in the domain only when the hint, verified owned claim, and source claim marker match
- extend unit and E2E coverage for source fallback, claim-detail origin persistence, and staff detail source rendering

## Verification
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/support-handoffs/create.test.ts`
- `pnpm --filter @interdomestik/web test:unit --run src/features/claims/tracking/memberTrustSummary.test.ts src/features/claims/tracking/server/getMemberClaimDetail.test.ts src/features/member/claims/components/MemberClaimDetailOpsPage.test.tsx 'src/app/[locale]/(app)/member/help/_core.entry.test.tsx' 'src/app/[locale]/(staff)/staff/support-handoffs/_core.entry.test.tsx'`
- `git diff --check`
- `pnpm verify-slice -- --static`
- focused E2E broad run: `staff-support-handoffs.spec.ts` had 11 passed / 1 generic MK retry, exact failed MK test passed on rerun
- `pnpm verify-slice -- --required-gates` PASS

Reviewer pool: security/auth/tenancy, performance, maintainability, product/UX, and test/gate reviewers completed. Product must-fix on source binding was addressed and re-reviewed as resolved.