### PR TITLE
fix: make interdomestik QA MCP setup durable

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -38,6 +38,20 @@ args = [
 command = "/bin/bash"
 args = ["scripts/start-repo-qa.sh"]
 cwd = "."
+enabled_tools = [
+  "project_map",
+  "read_files",
+  "read_file_range",
+  "code_search",
+  "git_status_compact",
+  "git_branch_info",
+  "changed_files",
+  "scope_audit",
+  "check_health",
+  "pr_verify",
+  "security_guard",
+  "e2e_gate",
+]
 
 [roles.scribe]
 config = ".codex/agents/scribe.toml"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "seed:e2e:local": "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres pnpm seed:e2e",
     "seed:assert-e2e": "pnpm --filter @interdomestik/database seed:assert-e2e",
     "mcp:setup": "./scripts/setup-mcp.sh",
+    "mcp:local-config": "node scripts/configure-codex-local-mcp.mjs",
     "mcp:preflight": "node scripts/codex-mcp-preflight.mjs",
     "mcp:audit": "pnpm --filter @interdomestik/qa run-all-audits",
     "mcp:test": "pnpm mcp:audit && pnpm test",

--- a/scripts/ci/codex-contracts.test.mjs
+++ b/scripts/ci/codex-contracts.test.mjs
@@ -32,6 +32,16 @@ test('project-scoped Codex config registers the repo MCP servers Interdomestik d
   assert.match(configToml, new RegExp(`${interdomestikEvidenceRoot}/playwright-mcp-output`));
   assert.match(configToml, /command = "\/bin\/bash"/);
   assert.match(configToml, /scripts\/start-repo-qa\.sh/);
+  assert.match(configToml, /cwd = "\."/);
+  assert.match(configToml, /enabled_tools = \[/);
+  assert.match(configToml, /project_map/);
+  assert.match(configToml, /read_file_range/);
+  assert.match(configToml, /git_status_compact/);
+  assert.match(configToml, /security_guard/);
+  assert.doesNotMatch(
+    configToml,
+    new RegExp(`cwd = "${rootDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`)
+  );
   assert.doesNotMatch(configToml, /packages\/qa\/src\/index\.ts/);
   assert.doesNotMatch(configToml, /packages\/qa\/dist\/index\.js/);
 });
@@ -46,11 +56,28 @@ test('mcp setup verifies Codex project config as well as local QA server prerequ
   assert.match(setupScript, /playwright/);
   assert.match(setupScript, /interdomestik_qa/);
   assert.match(setupScript, /scripts\/start-repo-qa\.sh/);
+  assert.match(setupScript, /mcp:local-config/);
   assert.match(setupScript, /tools\/list/);
+  assert.equal(
+    packageJson.scripts['mcp:local-config'],
+    'node scripts/configure-codex-local-mcp.mjs'
+  );
   assert.equal(packageJson.scripts['mcp:preflight'], 'node scripts/codex-mcp-preflight.mjs');
   assert.match(setupScript, /command -v codex/);
   assert.match(setupScript, /\bpnpm mcp:preflight\b/);
-  assert.match(setupScript, /Skipping Codex MCP preflight/);
+  assert.match(setupScript, /Skipping Codex local config and preflight/);
+});
+
+test('Codex local MCP generator writes machine-specific user config without changing project config', () => {
+  const localConfigGenerator = readText('scripts/configure-codex-local-mcp.mjs');
+
+  assert.match(localConfigGenerator, /CODEX_HOME/);
+  assert.match(localConfigGenerator, /config\.toml/);
+  assert.match(localConfigGenerator, /mcp_servers\.\$\{serverName\}/);
+  assert.match(localConfigGenerator, /scripts\/start-repo-qa\.sh/);
+  assert.match(localConfigGenerator, /cwd = \$\{tomlString\(rootDir\)\}/);
+  assert.match(localConfigGenerator, /enabled_tools = \[/);
+  assert.match(localConfigGenerator, /replaceTomlTable/);
 });
 
 test('Codex MCP preflight checks CLI registration and live repo QA tool discovery', () => {
@@ -61,10 +88,14 @@ test('Codex MCP preflight checks CLI registration and live repo QA tool discover
   assert.match(preflight, /mcp/);
   assert.match(preflight, /list/);
   assert.match(preflight, /--json/);
+  assert.match(preflight, /mcp', 'get', serverName, '--json/);
   assert.match(preflight, /Array\.isArray\(servers\)/);
   assert.match(preflight, /typeof server\.name !== 'string'/);
   assert.match(preflight, /interdomestik_qa/);
   assert.match(preflight, /scripts\/start-repo-qa\.sh/);
+  assert.match(preflight, /enabled_tools/);
+  assert.match(preflight, /cwd = "\."/);
+  assert.match(preflight, /must not hard-code this machine path/);
   assert.match(preflight, /qa-mcp-discovery-contracts\.test\.mjs/);
   assert.match(discoveryContract, /tools\/list/);
   assert.match(discoveryContract, /project_map/);

--- a/scripts/ci/codex-contracts.test.mjs
+++ b/scripts/ci/codex-contracts.test.mjs
@@ -38,10 +38,7 @@ test('project-scoped Codex config registers the repo MCP servers Interdomestik d
   assert.match(configToml, /read_file_range/);
   assert.match(configToml, /git_status_compact/);
   assert.match(configToml, /security_guard/);
-  assert.doesNotMatch(
-    configToml,
-    new RegExp(`cwd = "${rootDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`)
-  );
+  assert.equal(configToml.includes(`cwd = "${rootDir}"`), false);
   assert.doesNotMatch(configToml, /packages\/qa\/src\/index\.ts/);
   assert.doesNotMatch(configToml, /packages\/qa\/dist\/index\.js/);
 });

--- a/scripts/codex-mcp-preflight.mjs
+++ b/scripts/codex-mcp-preflight.mjs
@@ -157,7 +157,7 @@ function verifyConfigToml() {
   }
 }
 
-function verifyCodexCliServers(servers, qaServerDetails) {
+function verifyRequiredCodexCliServers(servers) {
   if (!Array.isArray(servers)) {
     fail('Codex MCP server list must be an array.', JSON.stringify(servers, null, 2));
   }
@@ -174,7 +174,10 @@ function verifyCodexCliServers(servers, qaServerDetails) {
     }
   }
 
-  const qaServer = byName.get('interdomestik_qa');
+  return byName;
+}
+
+function verifyRepoQaTransport(qaServer) {
   if (qaServer.transport?.type !== 'stdio') {
     fail('interdomestik_qa must be a stdio MCP server.', JSON.stringify(qaServer, null, 2));
   }
@@ -198,7 +201,9 @@ function verifyCodexCliServers(servers, qaServerDetails) {
       JSON.stringify(qaServer, null, 2)
     );
   }
+}
 
+function verifyRepoQaEnabledTools(qaServerDetails) {
   if (!Array.isArray(qaServerDetails.enabled_tools)) {
     fail(
       'interdomestik_qa must expose an enabled_tools allowlist.',
@@ -214,6 +219,12 @@ function verifyCodexCliServers(servers, qaServerDetails) {
       );
     }
   }
+}
+
+function verifyCodexCliServers(servers, qaServerDetails) {
+  const byName = verifyRequiredCodexCliServers(servers);
+  verifyRepoQaTransport(byName.get('interdomestik_qa'));
+  verifyRepoQaEnabledTools(qaServerDetails);
 }
 
 async function verifyRepoQaLiveTools() {

--- a/scripts/codex-mcp-preflight.mjs
+++ b/scripts/codex-mcp-preflight.mjs
@@ -8,6 +8,20 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '..');
 const requiredCodexServers = ['openai_docs', 'context7', 'playwright', 'interdomestik_qa'];
+const requiredRepoQaTools = [
+  'project_map',
+  'read_files',
+  'read_file_range',
+  'code_search',
+  'git_status_compact',
+  'git_branch_info',
+  'changed_files',
+  'scope_audit',
+  'check_health',
+  'pr_verify',
+  'security_guard',
+  'e2e_gate',
+];
 
 function fail(message, details) {
   console.error(`Codex MCP preflight failed: ${message}`);
@@ -100,6 +114,15 @@ async function readCodexMcpServers() {
   }
 }
 
+async function readCodexMcpServer(serverName) {
+  try {
+    const { stdout } = await runProcess('codex', ['mcp', 'get', serverName, '--json']);
+    return JSON.parse(stdout);
+  } catch (error) {
+    fail(`codex mcp get ${serverName} --json failed.`, formatError(error));
+  }
+}
+
 function verifyConfigToml() {
   const configPath = path.join(rootDir, '.codex/config.toml');
   if (!fs.existsSync(configPath)) {
@@ -116,9 +139,25 @@ function verifyConfigToml() {
   if (!configToml.includes('args = ["scripts/start-repo-qa.sh"]')) {
     fail('interdomestik_qa must launch through scripts/start-repo-qa.sh');
   }
+
+  if (!configToml.includes('cwd = "."')) {
+    fail('project interdomestik_qa config must keep portable cwd = "."');
+  }
+
+  if (configToml.includes(`cwd = "${rootDir}"`)) {
+    fail(
+      'project interdomestik_qa config must not hard-code this machine path; run pnpm mcp:setup to generate the local user config instead.'
+    );
+  }
+
+  for (const toolName of requiredRepoQaTools) {
+    if (!configToml.includes(`"${toolName}"`)) {
+      fail(`interdomestik_qa enabled_tools must include ${toolName}`);
+    }
+  }
 }
 
-function verifyCodexCliServers(servers) {
+function verifyCodexCliServers(servers, qaServerDetails) {
   if (!Array.isArray(servers)) {
     fail('Codex MCP server list must be an array.', JSON.stringify(servers, null, 2));
   }
@@ -142,11 +181,38 @@ function verifyCodexCliServers(servers) {
   if (qaServer.transport?.command !== '/bin/bash') {
     fail('interdomestik_qa must launch with /bin/bash.', JSON.stringify(qaServer, null, 2));
   }
-  if (!qaServer.transport?.args?.includes('scripts/start-repo-qa.sh')) {
+  const qaArgs = qaServer.transport?.args ?? [];
+  const expectedRelativeLauncher = 'scripts/start-repo-qa.sh';
+  const expectedAbsoluteLauncher = path.join(rootDir, expectedRelativeLauncher);
+  if (!qaArgs.includes(expectedRelativeLauncher) && !qaArgs.includes(expectedAbsoluteLauncher)) {
     fail(
       'interdomestik_qa must use scripts/start-repo-qa.sh in Codex MCP registration.',
       JSON.stringify(qaServer, null, 2)
     );
+  }
+
+  const qaCwd = qaServer.transport?.cwd;
+  if (qaCwd !== '.' && qaCwd !== rootDir) {
+    fail(
+      `interdomestik_qa cwd must be portable "." or this repo root: ${rootDir}`,
+      JSON.stringify(qaServer, null, 2)
+    );
+  }
+
+  if (!Array.isArray(qaServerDetails.enabled_tools)) {
+    fail(
+      'interdomestik_qa must expose an enabled_tools allowlist.',
+      JSON.stringify(qaServerDetails, null, 2)
+    );
+  }
+
+  for (const toolName of requiredRepoQaTools) {
+    if (!qaServerDetails.enabled_tools.includes(toolName)) {
+      fail(
+        `interdomestik_qa enabled_tools must include ${toolName}.`,
+        JSON.stringify(qaServerDetails, null, 2)
+      );
+    }
   }
 }
 
@@ -167,7 +233,8 @@ async function verifyRepoQaLiveTools() {
 async function main() {
   verifyConfigToml();
   const codexServers = await readCodexMcpServers();
-  verifyCodexCliServers(codexServers);
+  const repoQaServer = await readCodexMcpServer('interdomestik_qa');
+  verifyCodexCliServers(codexServers, repoQaServer);
   await verifyRepoQaLiveTools();
 
   console.log('Codex MCP preflight passed.');

--- a/scripts/configure-codex-local-mcp.mjs
+++ b/scripts/configure-codex-local-mcp.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '..');
+const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+const codexConfigPath = path.join(codexHome, 'config.toml');
+const serverName = 'interdomestik_qa';
+const requiredRepoQaTools = [
+  'project_map',
+  'read_files',
+  'read_file_range',
+  'code_search',
+  'git_status_compact',
+  'git_branch_info',
+  'changed_files',
+  'scope_audit',
+  'check_health',
+  'pr_verify',
+  'security_guard',
+  'e2e_gate',
+];
+
+function tomlString(value) {
+  return JSON.stringify(value);
+}
+
+function createRepoQaBlock() {
+  const launcherPath = path.join(rootDir, 'scripts/start-repo-qa.sh');
+  const enabledTools = requiredRepoQaTools.map(tool => `  ${tomlString(tool)},`).join('\n');
+
+  return [
+    `[mcp_servers.${serverName}]`,
+    'command = "/bin/bash"',
+    `args = [${tomlString(launcherPath)}]`,
+    `cwd = ${tomlString(rootDir)}`,
+    'enabled_tools = [',
+    enabledTools,
+    ']',
+  ].join('\n');
+}
+
+function replaceTomlTable(input, tableName, replacement) {
+  const lines = input.split(/\r?\n/);
+  const tableHeader = `[${tableName}]`;
+  const startIndex = lines.findIndex(line => line.trim() === tableHeader);
+
+  if (startIndex === -1) {
+    const trimmed = input.replace(/\s*$/, '');
+    return `${trimmed}${trimmed ? '\n\n' : ''}${replacement}\n`;
+  }
+
+  let endIndex = lines.length;
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const trimmed = lines[index].trim();
+    if (
+      trimmed.startsWith('[') &&
+      trimmed.endsWith(']') &&
+      trimmed !== tableHeader &&
+      !trimmed.startsWith(`[${tableName}.`)
+    ) {
+      endIndex = index;
+      break;
+    }
+  }
+
+  const nextLines = [...lines.slice(0, startIndex), replacement, ...lines.slice(endIndex)];
+  return `${nextLines.join('\n').replace(/\s*$/, '')}\n`;
+}
+
+fs.mkdirSync(codexHome, { recursive: true });
+
+const currentConfig = fs.existsSync(codexConfigPath)
+  ? fs.readFileSync(codexConfigPath, 'utf8')
+  : '';
+const nextConfig = replaceTomlTable(
+  currentConfig,
+  `mcp_servers.${serverName}`,
+  createRepoQaBlock()
+);
+
+if (nextConfig !== currentConfig) {
+  fs.writeFileSync(codexConfigPath, nextConfig);
+}
+
+console.log(`Codex local MCP config updated: ${codexConfigPath}`);
+console.log(`Configured ${serverName} with cwd: ${rootDir}`);

--- a/scripts/configure-codex-local-mcp.mjs
+++ b/scripts/configure-codex-local-mcp.mjs
@@ -50,7 +50,7 @@ function replaceTomlTable(input, tableName, replacement) {
   const startIndex = lines.findIndex(line => line.trim() === tableHeader);
 
   if (startIndex === -1) {
-    const trimmed = input.replace(/\s*$/, '');
+    const trimmed = input.trimEnd();
     return `${trimmed}${trimmed ? '\n\n' : ''}${replacement}\n`;
   }
 
@@ -69,7 +69,7 @@ function replaceTomlTable(input, tableName, replacement) {
   }
 
   const nextLines = [...lines.slice(0, startIndex), replacement, ...lines.slice(endIndex)];
-  return `${nextLines.join('\n').replace(/\s*$/, '')}\n`;
+  return `${nextLines.join('\n').trimEnd()}\n`;
 }
 
 fs.mkdirSync(codexHome, { recursive: true });

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -63,13 +63,18 @@ if [ "$ALL_CONFIGURED" = false ]; then
     exit 1
 fi
 
-# 2b. Verify Codex sees the project-scoped MCP config and the repo QA server answers tools/list.
+# 2b. Generate the user-scoped Codex MCP registration with this machine's absolute repo path,
+# then verify Codex sees the project-scoped MCP config and the repo QA server answers tools/list.
 if command -v codex >/dev/null 2>&1; then
+    echo -e "\n${YELLOW}🧭 Generating local Codex MCP config...${NC}"
+    cd "$PROJECT_ROOT"
+    pnpm mcp:local-config
+
     echo -e "\n${YELLOW}🩺 Running Codex MCP preflight...${NC}"
     cd "$PROJECT_ROOT"
     pnpm mcp:preflight
 else
-    echo -e "\n${YELLOW}⚠️  Skipping Codex MCP preflight because codex CLI is not on PATH${NC}"
+    echo -e "\n${YELLOW}⚠️  Skipping Codex local config and preflight because codex CLI is not on PATH${NC}"
 fi
 
 # 3. Test QA MCP discovery


### PR DESCRIPTION
## Summary
- keep repo-scoped interdomestik_qa MCP config portable while explicitly allowlisting exposed tools
- add an idempotent local Codex config generator for machine-specific absolute paths
- extend MCP setup/preflight contracts so regressions are caught before agents rely on the QA MCP

## Verification
- [x] node --test scripts/ci/codex-contracts.test.mjs
- [x] pnpm mcp:setup
- [x] pnpm pr:verify
- [x] pnpm security:guard
- [x] pnpm e2e:gate