### PR TITLE
P32-CRM07 Support Handoff Public Response In-App Notification

### DIFF
--- a/apps/web/e2e/gate/staff-support-handoffs.spec.ts
+++ b/apps/web/e2e/gate/staff-support-handoffs.spec.ts
@@ -1,12 +1,102 @@
-import { claims, db, eq, supportHandoffs } from '@interdomestik/database';
+import { and, claims, db, eq, notifications, supportHandoffs } from '@interdomestik/database';
 import type { Page, TestInfo } from '@playwright/test';
 import { expect, test } from '../fixtures/auth.fixture';
-import { routes } from '../routes';
+import {
+  buildUiLoginUrl,
+  credsFor,
+  getProjectUrlInfo,
+  getTenantFromTestInfo,
+  ipForRole,
+} from '../fixtures/auth.project';
+import { type Locale, routes } from '../routes';
 import { gotoApp } from '../utils/navigation';
 import { resolveSeededClaimContext } from '../utils/seeded-claim-context';
 
+const DEFAULT_PUBLIC_RESPONSE_NOTIFICATION_COPY = {
+  content: 'A staff update is available on your support request.',
+  title: 'Staff update available',
+};
+
+const PUBLIC_RESPONSE_NOTIFICATION_COPY: Partial<
+  Record<Locale, { content: string; title: string }>
+> = {
+  en: DEFAULT_PUBLIC_RESPONSE_NOTIFICATION_COPY,
+  mk: {
+    content: 'Достапно е ажурирање од персоналот за вашето барање за поддршка.',
+    title: 'Достапно е ажурирање од персоналот',
+  },
+  sq: {
+    content: 'Një përditësim nga stafi është i disponueshëm për kërkesën tuaj të mbështetjes.',
+    title: 'Përditësim nga stafi',
+  },
+  sr: {
+    content: 'Dostupno je ažuriranje osoblja za vaš zahtev za podršku.',
+    title: 'Dostupno je ažuriranje osoblja',
+  },
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 async function cleanupHandoffBySubject(subject: string): Promise<void> {
   await db.delete(supportHandoffs).where(eq(supportHandoffs.subject, subject));
+}
+
+async function cleanupPublicResponseNotifications(memberId: string): Promise<void> {
+  await db
+    .delete(notifications)
+    .where(
+      and(
+        eq(notifications.userId, memberId),
+        eq(notifications.type, 'support_handoff_public_response')
+      )
+    );
+}
+
+async function countPublicResponseNotifications(
+  memberId: string,
+  actionUrl: string
+): Promise<number> {
+  const rows = await db.query.notifications.findMany({
+    where: (table, { and, eq }) =>
+      and(
+        eq(table.userId, memberId),
+        eq(table.type, 'support_handoff_public_response'),
+        eq(table.actionUrl, actionUrl)
+      ),
+    columns: { id: true },
+  });
+
+  return rows.length;
+}
+
+async function restoreMemberSession(page: Page, testInfo: TestInfo): Promise<void> {
+  const info = getProjectUrlInfo(testInfo, null);
+  const tenant = getTenantFromTestInfo(testInfo);
+  const { email, password } = credsFor('member', tenant);
+  const projectHeaders = testInfo.project.use.extraHTTPHeaders || {};
+  const host = new URL(info.origin).hostname;
+
+  await page.context().clearCookies();
+  const response = await page.request.post(
+    new URL('/api/auth/sign-in/email', info.origin).toString(),
+    {
+      data: { email, password },
+      headers: {
+        Origin: info.origin,
+        Referer: buildUiLoginUrl(info),
+        'x-forwarded-for': ipForRole('member'),
+        ...projectHeaders,
+      },
+    }
+  );
+
+  expect(response.ok(), `member session restore should succeed: ${response.status()}`).toBe(true);
+  const requestState = await page.request.storageState();
+  const memberCookies = requestState.cookies.filter(cookie => cookie.domain === host);
+  expect(memberCookies.length, 'member session restore should set host cookies').toBeGreaterThan(0);
+  await page.context().addCookies(memberCookies);
 }
 
 async function submitMemberHelpHandoff(args: {
@@ -18,11 +108,12 @@ async function submitMemberHelpHandoff(args: {
   await gotoApp(args.memberPage, routes.memberHelp(args.testInfo), args.testInfo, {
     marker: 'member-page-ready',
   });
-  await expect(args.memberPage.getByTestId('member-support-handoff-form')).toBeVisible();
+  const supportForm = args.memberPage.getByTestId('member-support-handoff-form').last();
+  await expect(supportForm).toBeVisible();
 
-  await args.memberPage.getByTestId('member-support-handoff-subject').fill(args.subject);
-  await args.memberPage.getByTestId('member-support-handoff-message').fill(args.message);
-  await args.memberPage.getByTestId('member-support-handoff-submit').click();
+  await supportForm.getByTestId('member-support-handoff-subject').fill(args.subject);
+  await supportForm.getByTestId('member-support-handoff-message').fill(args.message);
+  await supportForm.getByTestId('member-support-handoff-submit').click();
 
   await expect(args.memberPage).toHaveURL(/\/member\/help\?support=created$/, {
     timeout: 15000,
@@ -262,7 +353,7 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
     }
   });
 
-  test('staff can send a public response that is visible to the member until close', async ({
+  test('staff can send a public response that notifies the member until close', async ({
     authenticatedPage: memberPage,
     branchManagerPage,
     staffPage,
@@ -270,6 +361,9 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
     const subject = `E2E CRM06 public response ${testInfo.project.name} ${Date.now()}`;
     const firstResponse = `CRM06 member-visible update ${Date.now()}`;
     const updatedResponse = `${firstResponse} updated`;
+    const memberHelpRoute = routes.memberHelp(testInfo);
+    let handoffId: string | null = null;
+    let memberId: string | null = null;
 
     await cleanupHandoffBySubject(subject);
 
@@ -280,6 +374,28 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
         subject,
         testInfo,
       });
+
+      await expect
+        .poll(
+          async () => {
+            const handoff = await db.query.supportHandoffs.findFirst({
+              where: eq(supportHandoffs.subject, subject),
+              columns: { id: true, memberId: true },
+            });
+
+            handoffId = handoff?.id ?? null;
+            memberId = handoff?.memberId ?? null;
+            return handoffId && memberId ? memberId : null;
+          },
+          { timeout: 15000, intervals: [250, 500, 1000] }
+        )
+        .toBeTruthy();
+      if (!handoffId || !memberId) {
+        throw new Error(`Expected handoff and member ids for support handoff ${subject}`);
+      }
+      const memberHelpUrl = `${memberHelpRoute}?handoffId=${encodeURIComponent(handoffId)}`;
+      const responseNotificationMemberId = memberId;
+      await cleanupPublicResponseNotifications(responseNotificationMemberId);
 
       await gotoApp(
         staffPage,
@@ -344,13 +460,44 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
         )
         .toBe(1);
 
-      await gotoApp(memberPage, routes.memberHelp(testInfo), testInfo, {
-        marker: 'member-page-ready',
+      await expect
+        .poll(() => countPublicResponseNotifications(responseNotificationMemberId, memberHelpUrl), {
+          timeout: 15000,
+          intervals: [250, 500, 1000],
+        })
+        .toBe(1);
+
+      await restoreMemberSession(memberPage, testInfo);
+      await gotoApp(memberPage, routes.member(testInfo), testInfo, {
+        marker: 'dashboard-page-ready',
       });
-      await expect(memberPage.getByTestId('member-support-handoff-public-response')).toContainText(
-        firstResponse,
-        { timeout: 15000 }
-      );
+      await expect(memberPage.getByTestId('notification-center-trigger')).toBeVisible({
+        timeout: 15000,
+      });
+      await memberPage.getByTestId('notification-center-trigger').click();
+      const notificationItem = memberPage
+        .getByTestId('notification-item-support_handoff_public_response')
+        .first();
+      const notificationCopy =
+        PUBLIC_RESPONSE_NOTIFICATION_COPY[routes.getLocale(testInfo)] ??
+        DEFAULT_PUBLIC_RESPONSE_NOTIFICATION_COPY;
+      await expect(notificationItem).toContainText(notificationCopy.title, { timeout: 15000 });
+      await expect(notificationItem).toContainText(notificationCopy.content, { timeout: 15000 });
+      const notificationAction = notificationItem.getByTestId('notification-action');
+      await expect(notificationAction).toHaveAttribute('href', memberHelpUrl);
+      await notificationAction.scrollIntoViewIfNeeded();
+      await notificationAction.click();
+      await expect(memberPage).toHaveURL(new RegExp(`${escapeRegExp(memberHelpUrl)}$`), {
+        timeout: 15000,
+      });
+      await expect(
+        memberPage
+          .getByTestId('member-support-handoff-public-response')
+          .filter({
+            hasText: firstResponse,
+          })
+          .first()
+      ).toBeVisible({ timeout: 15000 });
 
       await gotoApp(
         staffPage,
@@ -391,13 +538,24 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
         )
         .toBe(2);
 
-      await gotoApp(memberPage, routes.memberHelp(testInfo), testInfo, {
+      await expect
+        .poll(() => countPublicResponseNotifications(responseNotificationMemberId, memberHelpUrl), {
+          timeout: 15000,
+          intervals: [250, 500, 1000],
+        })
+        .toBe(2);
+
+      await gotoApp(memberPage, memberHelpUrl, testInfo, {
         marker: 'member-page-ready',
       });
-      await expect(memberPage.getByTestId('member-support-handoff-public-response')).toContainText(
-        updatedResponse,
-        { timeout: 15000 }
-      );
+      await expect(
+        memberPage
+          .getByTestId('member-support-handoff-public-response')
+          .filter({
+            hasText: updatedResponse,
+          })
+          .first()
+      ).toBeVisible({ timeout: 15000 });
 
       await gotoApp(
         branchManagerPage,
@@ -446,11 +604,27 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
         )
         .toBe('closed');
 
-      await gotoApp(memberPage, routes.memberHelp(testInfo), testInfo, {
+      await gotoApp(memberPage, memberHelpUrl, testInfo, {
         marker: 'member-page-ready',
       });
       await expect(memberPage.getByTestId('member-support-handoff-public-response')).toHaveCount(0);
+      await expect
+        .poll(() => countPublicResponseNotifications(responseNotificationMemberId, memberHelpUrl), {
+          timeout: 15000,
+          intervals: [250, 500, 1000],
+        })
+        .toBe(0);
+      await gotoApp(memberPage, routes.member(testInfo), testInfo, {
+        marker: 'dashboard-page-ready',
+      });
+      await memberPage.getByTestId('notification-center-trigger').click();
+      await expect(
+        memberPage.getByTestId('notification-item-support_handoff_public_response')
+      ).toHaveCount(0);
     } finally {
+      if (memberId) {
+        await cleanupPublicResponseNotifications(memberId);
+      }
       await cleanupHandoffBySubject(subject);
     }
   });

--- a/apps/web/src/actions/support-handoffs/lifecycle.core.ts
+++ b/apps/web/src/actions/support-handoffs/lifecycle.core.ts
@@ -5,6 +5,7 @@ import {
 } from '@interdomestik/domain-claims/support-handoffs/lifecycle';
 
 import { logAuditEvent } from '@/lib/audit';
+import { clearSupportHandoffPublicResponseNotifications } from '@/lib/notifications';
 import { revalidatePath } from 'next/cache';
 
 import type { Session } from './context';
@@ -19,6 +20,10 @@ function revalidatePathForAllLocales(path: string) {
 
 function revalidateSupportHandoffPaths() {
   revalidatePathForAllLocales('/staff/support-handoffs');
+}
+
+function revalidateMemberHelpPaths() {
+  revalidatePathForAllLocales('/member/help');
 }
 
 export async function acceptSupportHandoffCore(params: {
@@ -63,7 +68,28 @@ export async function closeSupportHandoffCore(params: {
   const result = await closeDomainSupportHandoff(params, { logAuditEvent });
 
   if (result.success) {
+    try {
+      const notificationResult = await clearSupportHandoffPublicResponseNotifications(
+        result.data.memberId,
+        { id: result.data.handoffId },
+        { tenantId: result.data.tenantId }
+      );
+
+      if (!notificationResult.success) {
+        console.error('Failed to clear support handoff public response notifications:', {
+          error: notificationResult.error,
+          handoffId: result.data.handoffId,
+        });
+      }
+    } catch (error) {
+      console.error('Failed to clear support handoff public response notifications:', {
+        error,
+        handoffId: result.data.handoffId,
+      });
+    }
+
     revalidateSupportHandoffPaths();
+    revalidateMemberHelpPaths();
   }
 
   return result;

--- a/apps/web/src/actions/support-handoffs/response.core.test.ts
+++ b/apps/web/src/actions/support-handoffs/response.core.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   logAuditEvent: vi.fn(),
+  notifySupportHandoffPublicResponse: vi.fn(),
   revalidatePath: vi.fn(),
   updateDomainPublicResponse: vi.fn(),
 }));
@@ -12,6 +13,10 @@ vi.mock('@interdomestik/domain-claims/support-handoffs/response', () => ({
 
 vi.mock('@/lib/audit', () => ({
   logAuditEvent: mocks.logAuditEvent,
+}));
+
+vi.mock('@/lib/notifications', () => ({
+  notifySupportHandoffPublicResponse: mocks.notifySupportHandoffPublicResponse,
 }));
 
 vi.mock('next/cache', () => ({
@@ -31,23 +36,35 @@ const staffSession = {
 describe('updateSupportHandoffPublicResponseCore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.notifySupportHandoffPublicResponse.mockResolvedValue({ success: true });
   });
 
-  it('revalidates staff and member help paths across locales after a successful write', async () => {
+  it('notifies the member and revalidates staff and member help paths after a successful write', async () => {
     mocks.updateDomainPublicResponse.mockResolvedValueOnce({
-      data: { publicResponseVersion: 2 },
+      data: {
+        handoffId: 'handoff-1',
+        memberId: 'member-1',
+        publicResponseVersion: 2,
+        tenantId: 'tenant-1',
+      },
       success: true,
     });
 
     const result = await updateSupportHandoffPublicResponseCore({
       expectedVersion: 1,
       handoffId: 'handoff-1',
+      requestHeaders: new Headers({ referer: 'https://ks.example.test/sq/staff/support-handoffs' }),
       response: 'Member-visible response',
       session: staffSession,
     });
 
     expect(result).toEqual({
-      data: { publicResponseVersion: 2 },
+      data: {
+        handoffId: 'handoff-1',
+        memberId: 'member-1',
+        publicResponseVersion: 2,
+        tenantId: 'tenant-1',
+      },
       success: true,
     });
     expect(mocks.updateDomainPublicResponse).toHaveBeenCalledWith(
@@ -57,6 +74,16 @@ describe('updateSupportHandoffPublicResponseCore', () => {
         response: 'Member-visible response',
       }),
       { logAuditEvent: mocks.logAuditEvent }
+    );
+    expect(mocks.notifySupportHandoffPublicResponse).toHaveBeenCalledWith(
+      'member-1',
+      { id: 'handoff-1', publicResponseVersion: 2 },
+      {
+        actionUrl: '/sq/member/help?handoffId=handoff-1',
+        content: 'Një përditësim nga stafi është i disponueshëm për kërkesën tuaj të mbështetjes.',
+        tenantId: 'tenant-1',
+        title: 'Përditësim nga stafi',
+      }
     );
     expect(mocks.revalidatePath).toHaveBeenCalledTimes(8);
     for (const locale of ['sq', 'en', 'sr', 'mk']) {
@@ -82,6 +109,42 @@ describe('updateSupportHandoffPublicResponseCore', () => {
       error: 'Unauthorized',
       success: false,
     });
+    expect(mocks.notifySupportHandoffPublicResponse).not.toHaveBeenCalled();
     expect(mocks.revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('keeps the response write successful when notification creation fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.updateDomainPublicResponse.mockResolvedValueOnce({
+      data: {
+        handoffId: 'handoff-1',
+        memberId: 'member-1',
+        publicResponseVersion: 2,
+        tenantId: 'tenant-1',
+      },
+      success: true,
+    });
+    mocks.notifySupportHandoffPublicResponse.mockResolvedValueOnce({
+      error: 'Database error',
+      success: false,
+    });
+
+    const result = await updateSupportHandoffPublicResponseCore({
+      expectedVersion: 1,
+      handoffId: 'handoff-1',
+      response: 'Member-visible response',
+      session: staffSession,
+    });
+
+    expect(result.success).toBe(true);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to create support handoff public response notification:',
+      expect.objectContaining({
+        error: 'Database error',
+        handoffId: 'handoff-1',
+      })
+    );
+    expect(mocks.revalidatePath).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/web/src/actions/support-handoffs/response.core.ts
+++ b/apps/web/src/actions/support-handoffs/response.core.ts
@@ -1,11 +1,61 @@
 import { updateSupportHandoffPublicResponseCore as updateDomainPublicResponse } from '@interdomestik/domain-claims/support-handoffs/response';
 
 import { logAuditEvent } from '@/lib/audit';
+import { notifySupportHandoffPublicResponse } from '@/lib/notifications';
 import { revalidatePath } from 'next/cache';
 
 import type { Session } from './context';
 
 const LOCALES = ['sq', 'en', 'sr', 'mk'] as const;
+type Locale = (typeof LOCALES)[number];
+
+const SUPPORT_HANDOFF_PUBLIC_RESPONSE_NOTIFICATION_COPY: Record<
+  Locale,
+  { content: string; title: string }
+> = {
+  en: {
+    content: 'A staff update is available on your support request.',
+    title: 'Staff update available',
+  },
+  mk: {
+    content: 'Достапно е ажурирање од персоналот за вашето барање за поддршка.',
+    title: 'Достапно е ажурирање од персоналот',
+  },
+  sq: {
+    content: 'Një përditësim nga stafi është i disponueshëm për kërkesën tuaj të mbështetjes.',
+    title: 'Përditësim nga stafi',
+  },
+  sr: {
+    content: 'Dostupno je ažuriranje osoblja za vaš zahtev za podršku.',
+    title: 'Dostupno je ažuriranje osoblja',
+  },
+};
+
+function isLocale(value: string | undefined): value is Locale {
+  return LOCALES.includes(value as Locale);
+}
+
+function resolveRequestLocale(requestHeaders?: Headers): Locale {
+  const referer = requestHeaders?.get('referer');
+  if (referer) {
+    try {
+      const [, locale] = new URL(referer).pathname.split('/');
+      if (isLocale(locale)) {
+        return locale;
+      }
+    } catch {
+      // Fall through to Accept-Language.
+    }
+  }
+
+  const acceptLanguage = requestHeaders?.get('accept-language') ?? '';
+  const requestedLocale = acceptLanguage
+    .split(',')
+    .map(value => value.trim().split(';')[0]?.split('-')[0])
+    .find(isLocale);
+
+  return requestedLocale ?? 'sq';
+}
 
 function revalidatePathForAllLocales(path: string) {
   for (const locale of LOCALES) {
@@ -31,6 +81,36 @@ export async function updateSupportHandoffPublicResponseCore(params: {
   const result = await updateDomainPublicResponse(params, { logAuditEvent });
 
   if (result.success) {
+    try {
+      const locale = resolveRequestLocale(params.requestHeaders);
+      const notificationCopy = SUPPORT_HANDOFF_PUBLIC_RESPONSE_NOTIFICATION_COPY[locale];
+      const notificationResult = await notifySupportHandoffPublicResponse(
+        result.data.memberId,
+        {
+          id: result.data.handoffId,
+          publicResponseVersion: result.data.publicResponseVersion,
+        },
+        {
+          actionUrl: `/${locale}/member/help?handoffId=${encodeURIComponent(result.data.handoffId)}`,
+          content: notificationCopy.content,
+          tenantId: result.data.tenantId,
+          title: notificationCopy.title,
+        }
+      );
+
+      if (!notificationResult.success) {
+        console.error('Failed to create support handoff public response notification:', {
+          error: notificationResult.error,
+          handoffId: result.data.handoffId,
+        });
+      }
+    } catch (error) {
+      console.error('Failed to create support handoff public response notification:', {
+        error,
+        handoffId: result.data.handoffId,
+      });
+    }
+
     revalidateSupportHandoffPaths();
     revalidateMemberHelpPaths();
   }

--- a/apps/web/src/app/[locale]/(app)/member/help/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_core.entry.test.tsx
@@ -114,6 +114,7 @@ vi.mock('./_advisory-banner', () => ({
 
 vi.mock('./_public-response-banner', () => ({
   PublicResponseBanner: (props: {
+    handoffId?: string | null;
     memberId: string;
     selectedClaim: { id: string } | null;
     tenantId: string;
@@ -121,6 +122,7 @@ vi.mock('./_public-response-banner', () => ({
     mocks.publicResponseBanner(props);
     return (
       <div
+        data-handoff-id={props.handoffId ?? ''}
         data-selected-claim={props.selectedClaim?.id ?? ''}
         data-testid="mock-member-support-handoff-public-response"
       />
@@ -193,6 +195,7 @@ describe('member help support handoff form', () => {
       tenantId: 'tenant-1',
     });
     expect(mocks.publicResponseBanner).toHaveBeenCalledWith({
+      handoffId: null,
       memberId: 'member-1',
       selectedClaim: null,
       tenantId: 'tenant-1',
@@ -241,6 +244,18 @@ describe('member help support handoff form', () => {
       publicResponse.compareDocumentPosition(advisory) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(advisory.compareDocumentPosition(form) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('passes a targeted handoff id from the notification URL to the public response banner', async () => {
+    await renderPage({ handoffId: 'handoff-1' });
+
+    expect(screen.getByTestId('mock-member-support-handoff-public-response')).toHaveAttribute(
+      'data-handoff-id',
+      'handoff-1'
+    );
+    expect(mocks.publicResponseBanner).toHaveBeenCalledWith(
+      expect.objectContaining({ handoffId: 'handoff-1' })
+    );
   });
 
   it('passes through a claim-detail source hint from the search params', async () => {

--- a/apps/web/src/app/[locale]/(app)/member/help/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_core.entry.tsx
@@ -92,6 +92,7 @@ export default async function HelpPage({ params, searchParams }: Props) {
   }
   const resolvedSearchParams = await searchParams;
   const status = getSingleParam(resolvedSearchParams.support);
+  const requestedHandoffId = getSingleParam(resolvedSearchParams.handoffId);
   const requestedClaimId = getSingleParam(resolvedSearchParams.claimId);
   const sourceHint = getSingleParam(resolvedSearchParams.source);
   const claimOptions =
@@ -201,6 +202,7 @@ export default async function HelpPage({ params, searchParams }: Props) {
             {session.user.tenantId && session.user.id ? (
               <>
                 <PublicResponseBanner
+                  handoffId={requestedHandoffId ?? null}
                   memberId={session.user.id}
                   selectedClaim={selectedClaim}
                   tenantId={session.user.tenantId}

--- a/apps/web/src/app/[locale]/(app)/member/help/_public-response-banner.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_public-response-banner.test.tsx
@@ -40,6 +40,7 @@ describe('PublicResponseBanner', () => {
 
     render(
       await PublicResponseBanner({
+        handoffId: 'handoff-1',
         memberId: 'member-1',
         selectedClaim: { id: 'claim-1' },
         tenantId: 'tenant-1',
@@ -48,6 +49,7 @@ describe('PublicResponseBanner', () => {
 
     expect(mocks.getMemberLatestPublicResponse).toHaveBeenCalledWith({
       claimId: 'claim-1',
+      handoffId: 'handoff-1',
       memberId: 'member-1',
       tenantId: 'tenant-1',
     });

--- a/apps/web/src/app/[locale]/(app)/member/help/_public-response-banner.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_public-response-banner.tsx
@@ -7,12 +7,14 @@ type SelectedClaim = {
 } | null;
 
 type PublicResponseBannerProps = {
+  handoffId?: string | null;
   memberId: string;
   selectedClaim: SelectedClaim;
   tenantId: string;
 };
 
 export async function PublicResponseBanner({
+  handoffId,
   memberId,
   selectedClaim,
   tenantId,
@@ -21,6 +23,7 @@ export async function PublicResponseBanner({
   try {
     response = await getMemberLatestPublicResponse({
       claimId: selectedClaim?.id ?? null,
+      handoffId: handoffId ?? null,
       memberId,
       tenantId,
     });

--- a/apps/web/src/components/notifications/notification-center.tsx
+++ b/apps/web/src/components/notifications/notification-center.tsx
@@ -156,6 +156,7 @@ export function NotificationCenter({ subscriberId, fetchOnMount = true }: Notifi
           variant="ghost"
           size="icon"
           className="relative h-9 w-9 rounded-full transition-colors hover:bg-accent/50"
+          data-testid="notification-center-trigger"
         >
           <Bell className="h-5 w-5" />
           {unreadCount > 0 && (
@@ -207,6 +208,7 @@ function NotificationItem({
 
   return (
     <div
+      data-testid={`notification-item-${notification.type}`}
       className={cn(
         'relative flex gap-3 p-4 transition-all duration-200 hover:bg-accent/30 list-none border-b last:border-0',
         !isRead && 'bg-primary/5 border-l-2 border-primary'
@@ -247,10 +249,11 @@ function NotificationItem({
             <Link
               href={notification.actionUrl}
               onClick={() => {
-                if (!isRead) onMarkAsRead(notification.id);
-                onClose();
+                if (!isRead) void onMarkAsRead(notification.id);
+                window.setTimeout(onClose, 0);
               }}
               className="inline-flex items-center gap-1 text-[10px] font-bold text-primary hover:underline"
+              data-testid="notification-action"
             >
               View <ExternalLink className="h-2 w-2" />
             </Link>

--- a/apps/web/src/lib/notifications.core.ts
+++ b/apps/web/src/lib/notifications.core.ts
@@ -1,4 +1,5 @@
 import {
+  clearSupportHandoffPublicResponseNotifications as clearSupportHandoffPublicResponseNotificationsDomain,
   notifyClaimAssigned as notifyClaimAssignedDomain,
   notifyClaimPackGenerated as notifyClaimPackGeneratedDomain,
   notifyClaimSubmitted as notifyClaimSubmittedDomain,
@@ -9,6 +10,7 @@ import {
   notifyRecoveryDecision as notifyRecoveryDecisionDomain,
   notifySlaWarning as notifySlaWarningDomain,
   notifyStatusChanged as notifyStatusChangedDomain,
+  notifySupportHandoffPublicResponse as notifySupportHandoffPublicResponseDomain,
   notifyTriageComplete as notifyTriageCompleteDomain,
   sendNotification as sendNotificationDomain,
 } from '@interdomestik/domain-communications/notifications';
@@ -99,6 +101,27 @@ export function notifyClaimPackGenerated(
   confidenceLevel: string
 ) {
   return notifyClaimPackGeneratedDomain(userId, claimCategory, confidenceLevel);
+}
+
+export function notifySupportHandoffPublicResponse(
+  memberId: string,
+  handoff: { id: string; publicResponseVersion: number },
+  options: {
+    actionUrl?: string;
+    content?: string;
+    tenantId: string;
+    title?: string;
+  }
+) {
+  return notifySupportHandoffPublicResponseDomain(memberId, handoff, options);
+}
+
+export function clearSupportHandoffPublicResponseNotifications(
+  memberId: string,
+  handoff: { id: string },
+  options: { tenantId: string }
+) {
+  return clearSupportHandoffPublicResponseNotificationsDomain(memberId, handoff, options);
 }
 
 export function notifyRecoveryDecision(

--- a/apps/web/src/lib/notifications.test.ts
+++ b/apps/web/src/lib/notifications.test.ts
@@ -7,7 +7,9 @@ vi.stubEnv('NOVU_API_KEY', 'test-api-key');
 vi.mock('@interdomestik/database', () => ({
   db: {
     insert: vi.fn().mockReturnValue({
-      values: vi.fn().mockResolvedValue({}),
+      values: vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn().mockResolvedValue({}),
+      }),
     }),
     query: {
       user: {
@@ -36,6 +38,7 @@ import {
   notifyClaimAssigned,
   notifyClaimSubmitted,
   notifyNewMessage,
+  notifySupportHandoffPublicResponse,
   notifyStatusChanged,
   sendNotification,
 } from './notifications';
@@ -127,6 +130,18 @@ describe('Notifications Service', () => {
         { id: 'claim-1', title: 'My Claim' },
         'Agent Smith',
         'Hello...'
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('notifySupportHandoffPublicResponse', () => {
+    it('should send an in-app support handoff public response notification', async () => {
+      const result = await notifySupportHandoffPublicResponse(
+        'member-1',
+        { id: 'handoff-1', publicResponseVersion: 2 },
+        { tenantId: 'tenant_mk' }
       );
 
       expect(result.success).toBe(true);

--- a/packages/domain-claims/src/support-handoffs/lifecycle.test.ts
+++ b/packages/domain-claims/src/support-handoffs/lifecycle.test.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => {
       closeReason: 'support_handoffs.close_reason',
       id: 'support_handoffs.id',
       lifecycleVersion: 'support_handoffs.lifecycle_version',
+      memberId: 'support_handoffs.member_id',
       staffId: 'support_handoffs.staff_id',
       status: 'support_handoffs.status',
       tenantId: 'support_handoffs.tenant_id',
@@ -91,7 +92,14 @@ describe('support handoff lifecycle', () => {
     mocks.db.update.mockReturnValue({ set: mocks.updateSet });
     mocks.updateSet.mockReturnValue({ where: mocks.updateWhere });
     mocks.updateWhere.mockReturnValue({ returning: mocks.updateReturning });
-    mocks.updateReturning.mockResolvedValue([{ lifecycleVersion: 2 }]);
+    mocks.updateReturning.mockResolvedValue([
+      {
+        handoffId: 'handoff-1',
+        lifecycleVersion: 2,
+        memberId: 'member-1',
+        tenantId: 'tenant-1',
+      },
+    ]);
   });
 
   it('accepts only open handoffs at the expected lifecycle version', async () => {
@@ -210,7 +218,15 @@ describe('support handoff lifecycle', () => {
       session: staffSession(),
     });
 
-    expect(result).toEqual({ data: { lifecycleVersion: 2 }, success: true });
+    expect(result).toEqual({
+      data: {
+        handoffId: 'handoff-1',
+        lifecycleVersion: 2,
+        memberId: 'member-1',
+        tenantId: 'tenant-1',
+      },
+      success: true,
+    });
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         closeReason: 'Resolved by phone',

--- a/packages/domain-claims/src/support-handoffs/lifecycle.ts
+++ b/packages/domain-claims/src/support-handoffs/lifecycle.ts
@@ -3,6 +3,7 @@ import { withTenant } from '@interdomestik/database/tenant-security';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 
 import type {
+  CloseSupportHandoffResult,
   SupportHandoffActionResult,
   SupportHandoffDeps,
   SupportHandoffLifecycleInput,
@@ -200,7 +201,7 @@ export async function closeSupportHandoffCore(
     session: SupportHandoffSession | null;
   },
   deps: SupportHandoffDeps = {}
-): Promise<SupportHandoffActionResult<{ lifecycleVersion: number }>> {
+): Promise<SupportHandoffActionResult<CloseSupportHandoffResult>> {
   const staffSession = requireStaffSession(params.session);
   if (!staffSession) {
     return { success: false, error: 'Unauthorized' };
@@ -235,7 +236,12 @@ export async function closeSupportHandoffCore(
         )
       )
     )
-    .returning({ lifecycleVersion: supportHandoffs.lifecycleVersion });
+    .returning({
+      handoffId: supportHandoffs.id,
+      lifecycleVersion: supportHandoffs.lifecycleVersion,
+      memberId: supportHandoffs.memberId,
+      tenantId: supportHandoffs.tenantId,
+    });
 
   const row = updated[0];
   if (!row) {
@@ -255,5 +261,13 @@ export async function closeSupportHandoffCore(
     });
   }
 
-  return { success: true, data: { lifecycleVersion: row.lifecycleVersion } };
+  return {
+    success: true,
+    data: {
+      handoffId: row.handoffId,
+      lifecycleVersion: row.lifecycleVersion,
+      memberId: row.memberId,
+      tenantId: row.tenantId,
+    },
+  };
 }

--- a/packages/domain-claims/src/support-handoffs/response.test.ts
+++ b/packages/domain-claims/src/support-handoffs/response.test.ts
@@ -95,7 +95,14 @@ describe('support handoff public response', () => {
     mocks.db.update.mockReturnValue({ set: mocks.updateSet });
     mocks.updateSet.mockReturnValue({ where: mocks.updateWhere });
     mocks.updateWhere.mockReturnValue({ returning: mocks.updateReturning });
-    mocks.updateReturning.mockResolvedValue([{ publicResponseVersion: 2 }]);
+    mocks.updateReturning.mockResolvedValue([
+      {
+        handoffId: 'handoff-1',
+        memberId: 'member-1',
+        publicResponseVersion: 2,
+        tenantId: 'tenant-1',
+      },
+    ]);
     mocks.db.select.mockReturnValue({ from: mocks.selectFrom });
     mocks.selectFrom.mockReturnValue({ where: mocks.selectWhere });
     mocks.selectWhere.mockReturnValue({ orderBy: mocks.selectOrderBy });
@@ -145,7 +152,15 @@ describe('support handoff public response', () => {
       { logAuditEvent: mocks.logAuditEvent }
     );
 
-    expect(result).toEqual({ data: { publicResponseVersion: 2 }, success: true });
+    expect(result).toEqual({
+      data: {
+        handoffId: 'handoff-1',
+        memberId: 'member-1',
+        publicResponseVersion: 2,
+        tenantId: 'tenant-1',
+      },
+      success: true,
+    });
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         publicResponse: 'We reviewed your request and will follow up here.',
@@ -227,6 +242,30 @@ describe('support handoff public response', () => {
     expect(mocks.inArray).toHaveBeenCalledWith('support_handoffs.status', ACTIVE_HANDOFF_STATUSES);
     expect(mocks.isNotNull).toHaveBeenCalledWith('support_handoffs.public_response');
     expect(Object.keys(result ?? {})).toEqual(['publicResponse', 'publicResponseAt']);
+  });
+
+  it('returns the targeted active handoff response without falling back to another handoff', async () => {
+    mocks.selectLimit.mockResolvedValueOnce([
+      {
+        publicResponse: 'Targeted staff update',
+        publicResponseAt: new Date('2026-05-04T11:00:00.000Z'),
+      },
+    ]);
+
+    const result = await getMemberLatestPublicResponse({
+      claimId: 'claim-1',
+      handoffId: 'handoff-1',
+      memberId: 'member-1',
+      tenantId: 'tenant-1',
+    });
+
+    expect(result).toEqual({
+      publicResponse: 'Targeted staff update',
+      publicResponseAt: '2026-05-04T11:00:00.000Z',
+    });
+    expect(mocks.eq).toHaveBeenCalledWith('support_handoffs.id', 'handoff-1');
+    expect(mocks.eq).not.toHaveBeenCalledWith('support_handoffs.claim_id', 'claim-1');
+    expect(mocks.selectLimit).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to the latest active member response when no same-claim response exists', async () => {

--- a/packages/domain-claims/src/support-handoffs/response.ts
+++ b/packages/domain-claims/src/support-handoffs/response.ts
@@ -9,6 +9,7 @@ import type {
   SupportHandoffDeps,
   SupportHandoffSession,
   UpdateSupportHandoffPublicResponseInput,
+  UpdateSupportHandoffPublicResponseResult,
 } from './types';
 import { ACTIVE_HANDOFF_STATUSES, MAX_PUBLIC_RESPONSE_LENGTH } from './types';
 
@@ -54,7 +55,7 @@ export async function updateSupportHandoffPublicResponseCore(
     session: SupportHandoffSession | null;
   },
   deps: SupportHandoffDeps = {}
-): Promise<SupportHandoffActionResult<{ publicResponseVersion: number }>> {
+): Promise<SupportHandoffActionResult<UpdateSupportHandoffPublicResponseResult>> {
   const staffSession = requireStaffSession(params.session);
   if (!staffSession) {
     return { success: false, error: 'Unauthorized' };
@@ -89,7 +90,12 @@ export async function updateSupportHandoffPublicResponseCore(
         )
       )
     )
-    .returning({ publicResponseVersion: supportHandoffs.publicResponseVersion });
+    .returning({
+      handoffId: supportHandoffs.id,
+      memberId: supportHandoffs.memberId,
+      publicResponseVersion: supportHandoffs.publicResponseVersion,
+      tenantId: supportHandoffs.tenantId,
+    });
 
   const row = updated[0];
   if (!row) {
@@ -112,11 +118,20 @@ export async function updateSupportHandoffPublicResponseCore(
     });
   }
 
-  return { success: true, data: { publicResponseVersion: row.publicResponseVersion } };
+  return {
+    success: true,
+    data: {
+      handoffId: row.handoffId,
+      memberId: row.memberId,
+      publicResponseVersion: row.publicResponseVersion,
+      tenantId: row.tenantId,
+    },
+  };
 }
 
 async function getLatestPublicResponseForScope(args: {
   claimId?: string | null;
+  handoffId?: string | null;
   memberId: string;
   tenantId: string;
 }): Promise<MemberSupportHandoffPublicResponse | null> {
@@ -125,6 +140,10 @@ async function getLatestPublicResponseForScope(args: {
     inArray(supportHandoffs.status, ACTIVE_HANDOFF_STATUSES),
     isNotNull(supportHandoffs.publicResponse),
   ];
+
+  if (args.handoffId) {
+    conditions.push(eq(supportHandoffs.id, args.handoffId));
+  }
 
   if (args.claimId) {
     conditions.push(eq(supportHandoffs.claimId, args.claimId));
@@ -153,9 +172,18 @@ async function getLatestPublicResponseForScope(args: {
 
 export async function getMemberLatestPublicResponse(args: {
   claimId?: string | null;
+  handoffId?: string | null;
   memberId: string;
   tenantId: string;
 }): Promise<MemberSupportHandoffPublicResponse | null> {
+  if (args.handoffId) {
+    return getLatestPublicResponseForScope({
+      handoffId: args.handoffId,
+      memberId: args.memberId,
+      tenantId: args.tenantId,
+    });
+  }
+
   if (args.claimId) {
     const claimResponse = await getLatestPublicResponseForScope(args);
     if (claimResponse) {

--- a/packages/domain-claims/src/support-handoffs/types.ts
+++ b/packages/domain-claims/src/support-handoffs/types.ts
@@ -46,6 +46,13 @@ export type UpdateSupportHandoffPublicResponseInput = {
   response: string;
 };
 
+export type UpdateSupportHandoffPublicResponseResult = {
+  handoffId: string;
+  memberId: string;
+  publicResponseVersion: number;
+  tenantId: string;
+};
+
 export type SupportHandoffQueueAssignmentFilter = 'all' | 'mine' | 'unassigned';
 export type SupportHandoffQueueStatusFilter = SupportHandoffStatus | 'all';
 export type SupportHandoffQueueOwnerFilter = SupportHandoffQueueAssignmentFilter;
@@ -96,6 +103,13 @@ export type MemberSupportHandoffPublicResponse = {
   publicResponse: string | null;
   /** ISO timestamp of when the response was last sent or updated. */
   publicResponseAt: string | null;
+};
+
+export type CloseSupportHandoffResult = {
+  handoffId: string;
+  lifecycleVersion: number;
+  memberId: string;
+  tenantId: string;
 };
 
 export type SupportHandoffQueueItemWithDetail = SupportHandoffQueueItem & {

--- a/packages/domain-communications/src/index.ts
+++ b/packages/domain-communications/src/index.ts
@@ -9,6 +9,7 @@ export type { MessageWithSender, SelectedMessageRow } from './messages/types';
 export { getNotificationsCore } from './notifications/get';
 export { markAllAsReadCore, markAsReadCore } from './notifications/mark-read';
 export {
+  clearSupportHandoffPublicResponseNotifications,
   notifyClaimAssigned,
   notifyClaimPackGenerated,
   notifyClaimSubmitted,
@@ -19,6 +20,7 @@ export {
   notifyRecoveryDecision,
   notifySlaWarning,
   notifyStatusChanged,
+  notifySupportHandoffPublicResponse,
   notifyTriageComplete,
   sendNotification,
 } from './notifications/notify';

--- a/packages/domain-communications/src/notifications/notify.test.ts
+++ b/packages/domain-communications/src/notifications/notify.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  delete: vi.fn(),
+  deleteWhere: vi.fn(),
   findFirst: vi.fn(),
   insertValues: vi.fn(),
   insert: vi.fn(),
+  onConflictDoNothing: vi.fn(),
   withTenant: vi.fn(() => ({ scoped: true })),
 }));
 
@@ -14,12 +17,18 @@ vi.mock('@interdomestik/database', () => ({
     query: {
       user: { findFirst: mocks.findFirst },
     },
+    delete: mocks.delete,
     insert: mocks.insert,
   },
 }));
 
 vi.mock('@interdomestik/database/schema', () => ({
-  notifications: 'notifications',
+  notifications: {
+    id: 'notifications.id',
+    tenantId: 'notifications.tenant_id',
+    type: 'notifications.type',
+    userId: 'notifications.user_id',
+  },
 }));
 
 vi.mock('@interdomestik/database/tenant-security', () => ({
@@ -36,12 +45,20 @@ vi.mock('../email', () => ({
 }));
 
 import { sendEmail } from '../email';
-import { notifyRecoveryDecision, sendNotification } from './notify';
+import {
+  clearSupportHandoffPublicResponseNotifications,
+  notifyRecoveryDecision,
+  notifySupportHandoffPublicResponse,
+  sendNotification,
+} from './notify';
 
 describe('sendNotification', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.delete.mockReturnValue({ where: mocks.deleteWhere });
+    mocks.deleteWhere.mockResolvedValue(undefined);
     mocks.insert.mockReturnValue({ values: mocks.insertValues });
+    mocks.onConflictDoNothing.mockResolvedValue(undefined);
   });
 
   it('rejects when tenant does not match user tenant', async () => {
@@ -124,6 +141,66 @@ describe('sendNotification', () => {
         'verified@example.com',
         expect.objectContaining({ subject: 'Recovery accepted' })
       )
+    );
+  });
+
+  it('persists an in-app support handoff public response notification without email dispatch', async () => {
+    mocks.insertValues.mockReturnValueOnce({ onConflictDoNothing: mocks.onConflictDoNothing });
+    mocks.findFirst.mockImplementationOnce(({ where }: { where: Function }) => {
+      where({ id: 'user.id', tenantId: 'user.tenant_id' }, { eq: vi.fn(() => ({ eq: true })) });
+      return Promise.resolve({
+        email: 'verified@example.com',
+        emailVerified: true,
+        tenantId: 'tenant-1',
+      });
+    });
+
+    const result = await notifySupportHandoffPublicResponse(
+      'member-1',
+      { id: 'handoff-1', publicResponseVersion: 3 },
+      {
+        actionUrl: '/sq/member/help?handoffId=handoff-1',
+        content: 'Një përditësim nga stafi është i disponueshëm për kërkesën tuaj të mbështetjes.',
+        tenantId: 'tenant-1',
+        title: 'Përditësim nga stafi',
+      }
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mocks.withTenant).toHaveBeenCalledWith(
+      'tenant-1',
+      expect.anything(),
+      expect.any(Object)
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionUrl: '/sq/member/help?handoffId=handoff-1',
+        content: 'Një përditësim nga stafi është i disponueshëm për kërkesën tuaj të mbështetjes.',
+        id: 'ntf_support_handoff_tenant-1_handoff-1_3',
+        tenantId: 'tenant-1',
+        title: 'Përditësim nga stafi',
+        type: 'support_handoff_public_response',
+        userId: 'member-1',
+      })
+    );
+    expect(mocks.onConflictDoNothing).toHaveBeenCalledWith({ target: expect.anything() });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('clears in-app support handoff public response notifications for a closed handoff', async () => {
+    const result = await clearSupportHandoffPublicResponseNotifications(
+      'member-1',
+      { id: 'handoff-1' },
+      { tenantId: 'tenant-1' }
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mocks.delete).toHaveBeenCalledWith(expect.anything());
+    expect(mocks.deleteWhere).toHaveBeenCalledWith(expect.objectContaining({ scoped: true }));
+    expect(mocks.withTenant).toHaveBeenCalledWith(
+      'tenant-1',
+      'notifications.tenant_id',
+      expect.any(Object)
     );
   });
 });

--- a/packages/domain-communications/src/notifications/notify.ts
+++ b/packages/domain-communications/src/notifications/notify.ts
@@ -1,6 +1,7 @@
 import { db } from '@interdomestik/database';
 import { notifications } from '@interdomestik/database/schema';
 import { withTenant } from '@interdomestik/database/tenant-security';
+import { and, eq, like } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import {
   sendEmail,
@@ -29,7 +30,8 @@ export type NotificationEvent =
   | 'sla_warning'
   | 'sla_breached'
   | 'membership_renewal'
-  | 'payment_verification_update';
+  | 'payment_verification_update'
+  | 'support_handoff_public_response';
 
 type NotificationDeps = {
   sendPushToUser?: typeof sendPushToUser;
@@ -90,6 +92,18 @@ function sendLifecycleEmail(
   );
 }
 
+function resolveNotificationContent(
+  event: NotificationEvent,
+  payload: Record<string, string | number | boolean>,
+  override?: string
+) {
+  if (override) {
+    return override;
+  }
+
+  return payload.claimTitle ? `Update on: ${payload.claimTitle}` : `New update: ${event}`;
+}
+
 /**
  * Send a notification (In-app DB + Email is handled in notify functions)
  */
@@ -99,6 +113,8 @@ export async function sendNotification(
   payload: Record<string, string | number | boolean>,
   options?: {
     actionUrl?: string;
+    content?: string;
+    notificationId?: string;
     title?: string;
     tenantId?: string | null;
   }
@@ -116,12 +132,10 @@ export async function sendNotification(
     }
 
     const title = options?.title ?? event.replaceAll('_', ' ').toUpperCase();
-    const content = payload.claimTitle
-      ? `Update on: ${payload.claimTitle}`
-      : `New update: ${event}`;
+    const content = resolveNotificationContent(event, payload, options?.content);
 
-    await db.insert(notifications).values({
-      id: `ntf_${nanoid()}`,
+    const insertNotification = db.insert(notifications).values({
+      id: options?.notificationId ?? `ntf_${nanoid()}`,
       tenantId: resolvedTenantId,
       userId,
       type: event,
@@ -131,9 +145,75 @@ export async function sendNotification(
       isRead: false,
     });
 
+    if (options?.notificationId) {
+      await insertNotification.onConflictDoNothing({ target: notifications.id });
+    } else {
+      await insertNotification;
+    }
+
     return { success: true };
   } catch (error) {
     console.error(`Failed to create in-app notification [${event}]:`, error);
+    return { success: false, error: 'Database error' };
+  }
+}
+
+/**
+ * Notify a member that staff sent or updated the latest public support handoff response.
+ *
+ * This is intentionally in-app only for P32-CRM07; email, push, acknowledgements,
+ * and support-handoff-specific unread semantics remain out of scope.
+ */
+export async function notifySupportHandoffPublicResponse(
+  memberId: string,
+  handoff: { id: string; publicResponseVersion: number },
+  options: {
+    actionUrl?: string;
+    content?: string;
+    tenantId: string;
+    title?: string;
+  }
+) {
+  return sendNotification(
+    memberId,
+    'support_handoff_public_response',
+    {
+      handoffId: handoff.id,
+      publicResponseVersion: handoff.publicResponseVersion,
+    },
+    {
+      actionUrl: options.actionUrl ?? '/member/help',
+      content: options.content ?? 'A staff update is available on your support request.',
+      notificationId: `ntf_support_handoff_${options.tenantId}_${handoff.id}_${handoff.publicResponseVersion}`,
+      tenantId: options.tenantId,
+      title: options.title ?? 'Staff update available',
+    }
+  );
+}
+
+export async function clearSupportHandoffPublicResponseNotifications(
+  memberId: string,
+  handoff: { id: string },
+  options: { tenantId: string }
+) {
+  try {
+    await db
+      .delete(notifications)
+      .where(
+        withTenant(
+          options.tenantId,
+          notifications.tenantId,
+          and(
+            eq(notifications.userId, memberId),
+            eq(notifications.type, 'support_handoff_public_response'),
+            like(notifications.id, `ntf_support_handoff_${options.tenantId}_${handoff.id}_%`)
+          )
+        )
+      );
+
+    return { success: true };
+  } catch (error) {
+    console.error('Failed to clear support handoff public response notifications:', error);
     return { success: false, error: 'Database error' };
   }
 }


### PR DESCRIPTION
## Summary
- Add deterministic in-app notifications for support handoff public-response updates, keyed by handoff and public-response version.
- Localize the notification title/content and route members back to the locale-specific member help surface.
- Extend the CRM support handoff gate to verify notification creation, notification-center display/action behavior, updates, and close behavior across tenant/locale gates.

## Test Plan
- [x] `pnpm verify-slice -- --static`
- [x] `pnpm verify-slice -- --required-gates`
- [x] `pnpm --filter @interdomestik/domain-claims test:unit --run src/support-handoffs/response.test.ts`
- [x] `pnpm --filter @interdomestik/domain-communications test:unit --run src/notifications/notify.test.ts`
- [x] `pnpm --filter @interdomestik/web test:unit --run src/actions/support-handoffs/response.core.test.ts src/lib/notifications.test.ts src/components/notifications/notification-center.test.tsx`
- [x] Focused CRM07 Playwright gate in `gate-ks-sq`
- [x] Focused CRM07 Playwright gate in `gate-mk-mk`
