### PR TITLE
fix: keep support response acknowledgement in place

### DIFF
--- a/apps/web/src/actions/support-handoffs/acknowledgement.ts
+++ b/apps/web/src/actions/support-handoffs/acknowledgement.ts
@@ -1,10 +1,15 @@
 'use server';
 
+import { redirect } from 'next/navigation';
+import { getFormatter } from 'next-intl/server';
+
 import { getActionContext } from './context';
 import { acknowledgeSupportHandoffPublicResponseCore } from './acknowledgement.core';
+import { type SupportHandoffActionLocale } from './request-locale';
 
 export type PublicResponseAcknowledgementActionState = {
   acknowledgedAt?: string;
+  acknowledgedAtLabel?: string;
   code?: string;
   error?: string;
   success: boolean;
@@ -23,6 +28,43 @@ function getString(formData: FormData, key: string) {
 function getExpectedPublicResponseVersion(formData: FormData) {
   const parsed = Number(getString(formData, 'expectedPublicResponseVersion'));
   return Number.isFinite(parsed) ? parsed : -1;
+}
+
+function getSafeReturnTo(formData: FormData) {
+  const returnTo = getString(formData, 'returnTo');
+  return returnTo.startsWith('/') && !returnTo.startsWith('//')
+    ? returnTo
+    : `/${getAcknowledgementLocale(formData)}/member/help`;
+}
+
+function getAcknowledgementLocale(formData: FormData): SupportHandoffActionLocale {
+  const locale = getString(formData, 'locale');
+  return locale === 'en' || locale === 'sr' || locale === 'mk' ? locale : 'sq';
+}
+
+async function formatAcknowledgedAt(value: string, locale: SupportHandoffActionLocale) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const format = await getFormatter({ locale });
+  return format.dateTime(date, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+async function formatAcknowledgedAtLabel(formData: FormData, acknowledgedAt: string) {
+  const template = getString(formData, 'acknowledgedAtLabelTemplate');
+  if (!template) {
+    return undefined;
+  }
+
+  return template.replace(
+    '{date}',
+    await formatAcknowledgedAt(acknowledgedAt, getAcknowledgementLocale(formData))
+  );
 }
 
 export async function acknowledgeSupportHandoffPublicResponse(
@@ -47,6 +89,14 @@ export async function acknowledgeSupportHandoffPublicResponse(
 
   return {
     acknowledgedAt: result.data.acknowledgedAt,
+    acknowledgedAtLabel: await formatAcknowledgedAtLabel(formData, result.data.acknowledgedAt),
     success: true,
   };
+}
+
+export async function acknowledgeSupportHandoffPublicResponseAndRedirect(
+  formData: FormData
+): Promise<never> {
+  await acknowledgeSupportHandoffPublicResponse({ success: false }, formData);
+  redirect(getSafeReturnTo(formData));
 }

--- a/apps/web/src/app/[locale]/(app)/member/help/_public-response-acknowledgement-form.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_public-response-acknowledgement-form.tsx
@@ -2,15 +2,17 @@
 
 import {
   acknowledgeSupportHandoffPublicResponse,
+  acknowledgeSupportHandoffPublicResponseAndRedirect,
   type PublicResponseAcknowledgementActionState,
 } from '@/actions/support-handoffs/acknowledgement';
 import { Button } from '@interdomestik/ui';
 import { CheckCircle2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useActionState, useEffect, useState } from 'react';
+import { type FormEvent, useEffect, useState, useTransition } from 'react';
 
 type PublicResponseAcknowledgementFormProps = Readonly<{
   acknowledgedAt: string | null;
+  acknowledgedAtLabel: string | null;
   expectedPublicResponseVersion: number;
   handoffId: string;
   labels: {
@@ -21,22 +23,8 @@ type PublicResponseAcknowledgementFormProps = Readonly<{
     stale: string;
   };
   locale: string;
+  permalink: string;
 }>;
-
-function formatDateTime(value: string, locale: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return new Intl.DateTimeFormat(locale, {
-    dateStyle: 'medium',
-    timeZone: 'UTC',
-    timeStyle: 'short',
-  }).format(date);
-}
-
-function formatAcknowledgedAt(template: string, value: string, locale: string) {
-  const formatted = formatDateTime(value, locale);
-  return formatted ? template.replace('{date}', formatted) : template.replace('{date}', value);
-}
 
 function resolveAcknowledgementError(
   state: PublicResponseAcknowledgementActionState,
@@ -59,24 +47,46 @@ function shouldRefreshAfterFailure(code: PublicResponseAcknowledgementActionStat
 
 export function PublicResponseAcknowledgementForm({
   acknowledgedAt,
+  acknowledgedAtLabel,
   expectedPublicResponseVersion,
   handoffId,
   labels,
   locale,
+  permalink,
 }: PublicResponseAcknowledgementFormProps) {
   const router = useRouter();
-  const [optimisticAcknowledgedAt, setOptimisticAcknowledgedAt] = useState<string | null>(null);
-  const initialState: PublicResponseAcknowledgementActionState = acknowledgedAt
-    ? { acknowledgedAt, success: true }
-    : { success: false };
-  const [state, formAction, pending] = useActionState(
-    acknowledgeSupportHandoffPublicResponse,
-    initialState
+  const [optimisticAcknowledgedLabel, setOptimisticAcknowledgedLabel] = useState<string | null>(
+    null
   );
-  const currentAcknowledgedAt = state.success
-    ? state.acknowledgedAt
-    : optimisticAcknowledgedAt || acknowledgedAt;
+  const initialState: PublicResponseAcknowledgementActionState = acknowledgedAt
+    ? { acknowledgedAt, acknowledgedAtLabel: acknowledgedAtLabel ?? undefined, success: true }
+    : { success: false };
+  const [state, setState] = useState<PublicResponseAcknowledgementActionState>(initialState);
+  const [pending, startTransition] = useTransition();
+  const currentAcknowledgedLabel = state.success
+    ? state.acknowledgedAtLabel || acknowledgedAtLabel || optimisticAcknowledgedLabel
+    : optimisticAcknowledgedLabel || acknowledgedAtLabel;
   const error = resolveAcknowledgementError(state, labels);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    setOptimisticAcknowledgedLabel(labels.acknowledging);
+    setState({ success: false });
+    startTransition(() => {
+      void acknowledgeSupportHandoffPublicResponse({ success: false }, formData)
+        .then(result => {
+          setState(result);
+          if (result.success) {
+            router.refresh();
+          }
+        })
+        .catch(() => {
+          setOptimisticAcknowledgedLabel(null);
+          setState({ error: labels.error, success: false });
+        });
+    });
+  }
 
   useEffect(() => {
     if (shouldRefreshAfterFailure(state.code)) {
@@ -86,25 +96,25 @@ export function PublicResponseAcknowledgementForm({
 
   useEffect(() => {
     if (!state.success && (state.error || state.code)) {
-      setOptimisticAcknowledgedAt(null);
+      setOptimisticAcknowledgedLabel(null);
     }
   }, [state.code, state.error, state.success]);
 
   return (
     <div className="pt-1" aria-live="polite">
-      {currentAcknowledgedAt ? (
+      {currentAcknowledgedLabel ? (
         <div
           className="inline-flex items-center gap-2 rounded-md border border-emerald-200 bg-white/70 px-2.5 py-1.5 text-xs font-medium text-emerald-800"
           data-testid="member-support-handoff-public-response-acknowledged"
         >
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-          <span>{formatAcknowledgedAt(labels.acknowledgedAt, currentAcknowledgedAt, locale)}</span>
+          <span>{currentAcknowledgedLabel}</span>
         </div>
       ) : (
         <form
-          action={formAction}
+          action={acknowledgeSupportHandoffPublicResponseAndRedirect}
           data-testid="member-support-handoff-public-response-ack-form"
-          onSubmit={() => setOptimisticAcknowledgedAt(new Date().toISOString())}
+          onSubmit={handleSubmit}
         >
           <input type="hidden" name="handoffId" value={handoffId} />
           <input
@@ -112,6 +122,9 @@ export function PublicResponseAcknowledgementForm({
             name="expectedPublicResponseVersion"
             value={expectedPublicResponseVersion}
           />
+          <input type="hidden" name="acknowledgedAtLabelTemplate" value={labels.acknowledgedAt} />
+          <input type="hidden" name="locale" value={locale} />
+          <input type="hidden" name="returnTo" value={permalink} />
           <Button
             type="submit"
             size="sm"

--- a/apps/web/src/app/[locale]/(app)/member/help/_public-response-banner.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_public-response-banner.test.tsx
@@ -18,13 +18,19 @@ vi.mock('lucide-react', () => ({
 vi.mock('./_public-response-acknowledgement-form', () => ({
   PublicResponseAcknowledgementForm: (props: {
     acknowledgedAt: string | null;
+    acknowledgedAtLabel: string | null;
     expectedPublicResponseVersion: number;
     handoffId: string;
+    locale: string;
+    permalink: string;
   }) => (
     <div
       data-testid="mock-public-response-acknowledgement"
       data-acknowledged-at={props.acknowledgedAt ?? ''}
+      data-acknowledged-at-label={props.acknowledgedAtLabel ?? ''}
       data-handoff-id={props.handoffId}
+      data-locale={props.locale}
+      data-permalink={props.permalink}
       data-version={props.expectedPublicResponseVersion}
     />
   ),
@@ -101,7 +107,42 @@ describe('PublicResponseBanner', () => {
       'data-version',
       '2'
     );
+    expect(screen.getByTestId('mock-public-response-acknowledgement')).toHaveAttribute(
+      'data-permalink',
+      '/en/member/help?handoffId=handoff-1'
+    );
     expect(screen.queryByText('staff-1')).not.toBeInTheDocument();
+  });
+
+  it('passes a server-formatted acknowledgement label into the client form', async () => {
+    mocks.getMemberLatestPublicResponse.mockResolvedValueOnce({
+      handoffId: 'handoff-1',
+      publicResponse: 'Acknowledged response.',
+      publicResponseAt: '2026-05-04T11:00:00.000Z',
+      publicResponseAcknowledged: true,
+      publicResponseAcknowledgedAt: '2026-05-04T12:00:00.000Z',
+      publicResponseAcknowledgedVersion: 2,
+      publicResponseVersion: 2,
+    });
+
+    render(
+      await PublicResponseBanner({
+        handoffId: 'handoff-1',
+        locale: 'sq',
+        memberId: 'member-1',
+        selectedClaim: null,
+        tenantId: 'tenant-1',
+      })
+    );
+
+    expect(mocks.dateTime).toHaveBeenCalledWith(new Date('2026-05-04T12:00:00.000Z'), {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+    expect(screen.getByTestId('mock-public-response-acknowledgement')).toHaveAttribute(
+      'data-acknowledged-at-label',
+      'Acknowledged May 4, 2026, 1:00 PM'
+    );
   });
 
   it('renders nothing when no active handoff has a public response', async () => {

--- a/apps/web/src/app/[locale]/(app)/member/help/_public-response-banner.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_public-response-banner.tsx
@@ -46,6 +46,13 @@ export async function PublicResponseBanner({
     dateStyle: 'medium',
     timeStyle: 'short',
   });
+  const acknowledgedAt = response.publicResponseAcknowledgedAt
+    ? format.dateTime(new Date(response.publicResponseAcknowledgedAt), {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      })
+    : null;
+  const acknowledgementPermalink = `/${locale}/member/help?handoffId=${encodeURIComponent(response.handoffId)}`;
 
   return (
     <div
@@ -71,6 +78,9 @@ export async function PublicResponseBanner({
         </div>
         <PublicResponseAcknowledgementForm
           acknowledgedAt={response.publicResponseAcknowledgedAt}
+          acknowledgedAtLabel={
+            acknowledgedAt ? t('publicResponse.acknowledgedAt', { date: acknowledgedAt }) : null
+          }
           expectedPublicResponseVersion={response.publicResponseVersion}
           handoffId={response.handoffId}
           labels={{
@@ -81,6 +91,7 @@ export async function PublicResponseBanner({
             stale: t('publicResponse.acknowledgementStale'),
           }}
           locale={locale}
+          permalink={acknowledgementPermalink}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary\n- Keep CRM08 public-response acknowledgement on the member help permalink instead of navigating back to /member.\n- Move acknowledgement timestamp formatting to server-provided labels to avoid client/server locale mismatches.\n- Preserve progressive-enhancement fallback with a safe return path and add banner coverage for the server-formatted label.\n\n## Verification\n- pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(app)/member/help/_public-response-banner.test.tsx' src/actions/support-handoffs/acknowledgement.core.test.ts\n- pnpm --filter @interdomestik/web type-check\n- NEXT_PUBLIC_BILLING_TEST_MODE=1 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres DATABASE_URL_RLS=postgresql://postgres:postgres@127.0.0.1:54322/postgres BETTER_AUTH_SECRET=test-secret-for-local-dev-only-32chars-minimum pnpm --filter @interdomestik/web run build:ci\n- Playwright MCP watched member acknowledgement replay: stayed on /sq/member/help?handoffId=..., showed localized Albanian acknowledgement timestamp, console errors 0\n- Focused E2E: staff can send a public response that notifies the member until close\n- pnpm verify-slice -- --static\n- pnpm security:guard\n- pnpm verify-slice -- --required-gates (rerun passed: pr:verify, PR-fast gates, smoke 118 passed / 4 skipped)\n\nNote: The first required-gates attempt hit a non-deterministic unrelated v1 live-surface gate; isolated rerun passed, and the full required-gates rerun passed.