### PR TITLE
fix: harden proxy security headers and tenant fallback

### DIFF
--- a/apps/web/e2e/security/headers.spec.ts
+++ b/apps/web/e2e/security/headers.spec.ts
@@ -2,30 +2,33 @@ import { expect, test } from '@playwright/test';
 import { gotoApp } from '../utils/navigation';
 
 test.describe('Security Headers', () => {
-  test('should have strict security headers', async ({ page }, testInfo) => {
-    const response = await gotoApp(page, '/', testInfo);
+  async function expectSecurityHeaders(
+    page: Parameters<typeof gotoApp>[0],
+    path: string,
+    marker: string,
+    testInfo: Parameters<typeof gotoApp>[2]
+  ) {
+    const response = await gotoApp(page, path, testInfo, { marker });
     expect(response?.ok()).toBeTruthy();
 
     const headers = response?.headers();
     if (!headers) throw new Error('No headers found');
 
-    // CSP
     const csp = headers['content-security-policy'];
     expect(csp).toBeDefined();
     expect(csp).toContain("default-src 'self'");
     expect(csp).toContain('script-src');
-    expect(csp).toContain("'nonce-"); // Ensure nonce is present
-
-    // HSTS (Only on HTTPS or production, but proxy.ts logic might skip on localhost HTTP unless forced.
-    // However, X-Frame-Options is unconditional in proxy.ts)
+    expect(csp).toContain("frame-ancestors 'none'");
     expect(headers['x-frame-options']).toBe('DENY');
     expect(headers['x-content-type-options']).toBe('nosniff');
     expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  }
 
-    // Check if nonce matches in the HTML (optional deep verify)
-    // The proxy sets an internal request header, which RootLayout should read.
-    // We can check if a script tag has a nonce attribute.
-    // Note: Playwright might not easily see the nonce attribute value if it's hidden or if we just check page content.
-    // But checking the header is the primary goal here.
+  test('should have security headers on static public pages', async ({ page }, testInfo) => {
+    await expectSecurityHeaders(page, '/', 'landing-page-ready', testInfo);
+  });
+
+  test('should have security headers on dynamic public pages', async ({ page }, testInfo) => {
+    await expectSecurityHeaders(page, '/pricing', 'pricing-page-ready', testInfo);
   });
 });

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -34,6 +34,7 @@ const JUNIT_REPORT_FILE = path.join(TEST_RESULTS_DIR, 'junit.xml');
 const JSON_REPORT_FILE = path.join(TEST_RESULTS_DIR, 'report.json');
 
 const GATE_DEFAULT_MATCH = ['gate/**/*.spec.ts'];
+const GATE_SECURITY_MATCH = ['security/headers.spec.ts'];
 const PILOT_MATRIX_MATCH_GUARD = '/pilot/';
 const RUNNING_PILOT_MATRIX = process.argv.some(arg => arg.includes(PILOT_MATRIX_MATCH_GUARD));
 const GATE_KS_PILOT_MATCH = ['pilot/scenario-01-ks-e2e.spec.ts'];
@@ -47,11 +48,11 @@ const GATE_AL_PILOT_MATCH = ['pilot/c2-03-cross-tenant-write-isolation.spec.ts']
 const NOOP_TEST_MATCH = ['__never__/__none__.spec.ts'];
 
 const GATE_KS_TEST_MATCH = RUNNING_PILOT_MATRIX
-  ? [...GATE_DEFAULT_MATCH, ...GATE_KS_PILOT_MATCH]
-  : GATE_DEFAULT_MATCH;
+  ? [...GATE_DEFAULT_MATCH, ...GATE_SECURITY_MATCH, ...GATE_KS_PILOT_MATCH]
+  : [...GATE_DEFAULT_MATCH, ...GATE_SECURITY_MATCH];
 const GATE_MK_TEST_MATCH = RUNNING_PILOT_MATRIX
-  ? [...GATE_DEFAULT_MATCH, ...GATE_MK_PILOT_MATCH]
-  : GATE_DEFAULT_MATCH;
+  ? [...GATE_DEFAULT_MATCH, ...GATE_SECURITY_MATCH, ...GATE_MK_PILOT_MATCH]
+  : [...GATE_DEFAULT_MATCH, ...GATE_SECURITY_MATCH];
 const GATE_AL_TEST_MATCH = RUNNING_PILOT_MATRIX ? GATE_AL_PILOT_MATCH : NOOP_TEST_MATCH;
 
 function requireState(statePath: string) {

--- a/apps/web/src/app/api/auth/[...all]/_core.test.ts
+++ b/apps/web/src/app/api/auth/[...all]/_core.test.ts
@@ -197,7 +197,7 @@ describe('resolveTenantIdForPasswordResetAudit', () => {
     ).toBe('tenant_ks');
   });
 
-  it('falls back to cookie/header when host is neutral in production', () => {
+  it('ignores cookie/header/query fallback hints when host is neutral in production', () => {
     MUTABLE_ENV.NODE_ENV = 'production';
     delete MUTABLE_ENV.VERCEL_ENV;
     const headers = new Headers({
@@ -209,6 +209,22 @@ describe('resolveTenantIdForPasswordResetAudit', () => {
     expect(
       resolveTenantIdForPasswordResetAudit(
         'https://interdomestik-web.vercel.app/api/auth/request-password-reset?tenantId=tenant_mk',
+        headers
+      )
+    ).toBe('tenant_ks');
+  });
+
+  it('allows loopback release-gate tenant hints in production builds', () => {
+    MUTABLE_ENV.NODE_ENV = 'production';
+    delete MUTABLE_ENV.VERCEL_ENV;
+    const headers = new Headers({
+      host: '127.0.0.1:3000',
+      'x-tenant-id': 'tenant_mk',
+    });
+
+    expect(
+      resolveTenantIdForPasswordResetAudit(
+        'http://127.0.0.1:3000/api/auth/request-password-reset',
         headers
       )
     ).toBe('tenant_mk');
@@ -272,13 +288,23 @@ describe('resolveTenantIdForEmailSignIn', () => {
     expect(resolveTenantIdForEmailSignIn(headers)).toBe('tenant_ks');
   });
 
-  it('falls back to cookie/header in production when host is neutral', () => {
+  it('ignores cookie/header fallback hints when host is neutral in production', () => {
     MUTABLE_ENV.NODE_ENV = 'production';
     delete MUTABLE_ENV.VERCEL_ENV;
     const headers = new Headers({
-      host: 'localhost:3000',
+      host: 'interdomestik-web.vercel.app',
       cookie: 'tenantId=tenant_mk',
       'x-tenant-id': 'tenant_ks',
+    });
+    expect(resolveTenantIdForEmailSignIn(headers)).toBe('tenant_ks');
+  });
+
+  it('allows loopback release-gate tenant hints in production builds', () => {
+    MUTABLE_ENV.NODE_ENV = 'production';
+    delete MUTABLE_ENV.VERCEL_ENV;
+    const headers = new Headers({
+      host: '127.0.0.1:3000',
+      'x-tenant-id': 'tenant_mk',
     });
     expect(resolveTenantIdForEmailSignIn(headers)).toBe('tenant_mk');
   });

--- a/apps/web/src/app/api/auth/[...all]/_core.ts
+++ b/apps/web/src/app/api/auth/[...all]/_core.ts
@@ -130,7 +130,7 @@ export function resolveTenantIdForPasswordResetAudit(
       headerTenantId: headers.get(TENANT_HEADER_NAME),
       queryTenantId,
     },
-    { productionSensitive: true }
+    { productionSensitive: true, allowLoopbackFallback: true }
   );
 }
 
@@ -150,7 +150,7 @@ export function resolveTenantIdForEmailSignIn(headers: Headers): TenantId | null
       cookieTenantId: parseCookieValue(headers.get('cookie'), TENANT_COOKIE_NAME),
       headerTenantId: headers.get(TENANT_HEADER_NAME),
     },
-    { productionSensitive: true }
+    { productionSensitive: true, allowLoopbackFallback: true }
   );
 }
 

--- a/apps/web/src/lib/proxy-logic.test.ts
+++ b/apps/web/src/lib/proxy-logic.test.ts
@@ -17,6 +17,9 @@ vi.mock('@/lib/telemetry', () => ({
 import { proxy } from './proxy-logic';
 
 const ORIGINAL_SECRET = process.env.BETTER_AUTH_SECRET;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_VERCEL_ENV = process.env.VERCEL_ENV;
+const mutableEnv = process.env as Record<string, string | undefined>;
 
 function toBase64Url(bytes: Uint8Array): string {
   let binary = '';
@@ -45,19 +48,37 @@ async function signSessionToken(token: string, secret: string): Promise<string> 
   return `${token}.${toBase64Url(new Uint8Array(signature))}`;
 }
 
-function makeRequest(pathname: string, cookieHeader?: string): NextRequest {
-  const headers = new Headers({ host: 'ks.localhost:3000' });
+function makeRequest(
+  pathname: string,
+  cookieHeader?: string,
+  init?: { protocol?: 'http:' | 'https:'; headers?: HeadersInit }
+): NextRequest {
+  const protocol = init?.protocol ?? 'http:';
+  const headers = new Headers({ host: 'ks.localhost:3000', ...init?.headers });
   if (cookieHeader) headers.set('cookie', cookieHeader);
-  return new NextRequest(`http://ks.localhost:3000${pathname}`, { headers });
+  return new NextRequest(`${protocol}//ks.localhost:3000${pathname}`, { headers });
 }
 
 function mockSessionLookup(payload: unknown, status = 200) {
-  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify(payload), {
-      status,
-      headers: { 'content-type': 'application/json' },
-    })
-  );
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(payload, status));
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function activeSessionPayload(token: string): unknown {
+  return {
+    session: {
+      id: 's1',
+      token,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    },
+    user: { id: 'u1', role: 'member' },
+  };
 }
 
 function expectRedirectToLogin(response: Response): void {
@@ -88,6 +109,24 @@ function expectAllowedProtectedRoute(response: Response): void {
   expect(response.headers.get('x-e2e-tenant')).toBe('tenant_ks');
 }
 
+function expectBaseSecurityHeaders(response: Response): string {
+  const csp = response.headers.get('content-security-policy');
+
+  expect(csp).toContain("default-src 'self'");
+  expect(csp).toContain("frame-ancestors 'none'");
+  expect(response.headers.get('x-frame-options')).toBe('DENY');
+  expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+  expect(response.headers.get('referrer-policy')).toBe('strict-origin-when-cross-origin');
+  expect(response.headers.get('permissions-policy')).toContain('camera=()');
+  return csp ?? '';
+}
+
+function expectCompatibleSecurityHeaders(response: Response): void {
+  const csp = expectBaseSecurityHeaders(response);
+
+  expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+}
+
 describe('proxy auth guard hardening', () => {
   beforeEach(() => {
     process.env.BETTER_AUTH_SECRET = 'proxy-guard-test-secret-which-is-long-enough-123456';
@@ -105,6 +144,8 @@ describe('proxy auth guard hardening', () => {
     delete process.env.INTERDOMESTIK_LOCAL_E2E;
     delete process.env.INTERDOMESTIK_E2E_DIAGNOSTICS;
     delete process.env.PLAYWRIGHT;
+    mutableEnv.NODE_ENV = ORIGINAL_NODE_ENV;
+    mutableEnv.VERCEL_ENV = ORIGINAL_VERCEL_ENV;
   });
 
   it('emits bounce telemetry when a protected route has no session cookie', async () => {
@@ -113,6 +154,7 @@ describe('proxy auth guard hardening', () => {
     const response = await proxy(request);
 
     expectRedirectToLogin(response);
+    expectCompatibleSecurityHeaders(response);
     expectProtectedRouteTelemetry({
       eventName: 'protected_route_bounce_to_login',
       reason: 'missing_cookie',
@@ -255,20 +297,14 @@ describe('proxy auth guard hardening', () => {
 
   it('allows protected routes only when signed cookie and introspected session are valid', async () => {
     const signed = await signSessionToken('token-xyz', process.env.BETTER_AUTH_SECRET as string);
-    const fetchSpy = mockSessionLookup({
-      session: {
-        id: 's1',
-        token: 'token-xyz',
-        expiresAt: new Date(Date.now() + 60_000).toISOString(),
-      },
-      user: { id: 'u1', role: 'member' },
-    });
+    const fetchSpy = mockSessionLookup(activeSessionPayload('token-xyz'));
     const request = makeRequest('/sq/member', `better-auth.session_token=${signed}`);
 
     const response = await proxy(request);
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expectAllowedProtectedRoute(response);
+    expectCompatibleSecurityHeaders(response);
     expect(mockEmitAuthTelemetryEvent).not.toHaveBeenCalled();
   });
 
@@ -277,14 +313,7 @@ describe('proxy auth guard hardening', () => {
       'token-active-cache',
       process.env.BETTER_AUTH_SECRET as string
     );
-    const fetchSpy = mockSessionLookup({
-      session: {
-        id: 's1',
-        token: 'token-active-cache',
-        expiresAt: new Date(Date.now() + 60_000).toISOString(),
-      },
-      user: { id: 'u1', role: 'member' },
-    });
+    const fetchSpy = mockSessionLookup(activeSessionPayload('token-active-cache'));
     const firstRequest = makeRequest('/sq/member', `better-auth.session_token=${signed}`);
     const secondRequest = makeRequest('/sq/member/claims', `better-auth.session_token=${signed}`);
 
@@ -294,7 +323,70 @@ describe('proxy auth guard hardening', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expectAllowedProtectedRoute(firstResponse);
     expectAllowedProtectedRoute(secondResponse);
+    expectCompatibleSecurityHeaders(firstResponse);
+    expectCompatibleSecurityHeaders(secondResponse);
     expect(mockEmitAuthTelemetryEvent).not.toHaveBeenCalled();
+  });
+
+  it('uses a client-compatible CSP for public static routes', async () => {
+    const request = makeRequest('/sq');
+
+    const response = await proxy(request);
+
+    expect(response.status).toBe(200);
+    expectCompatibleSecurityHeaders(response);
+  });
+
+  it('sets the tenant cookie with hardened defaults on allowed responses', async () => {
+    const signed = await signSessionToken(
+      'token-cookie-hardening',
+      process.env.BETTER_AUTH_SECRET as string
+    );
+    mockSessionLookup({
+      session: {
+        id: 's1',
+        token: 'token-cookie-hardening',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+      user: { id: 'u1', role: 'member' },
+    });
+    const request = makeRequest('/sq/member', `better-auth.session_token=${signed}`);
+
+    const response = await proxy(request);
+    const setCookie = response.headers.get('set-cookie');
+
+    expect(response.status).toBe(200);
+    expect(setCookie).toContain('tenantId=tenant_ks');
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('SameSite=lax');
+    expect(setCookie).toContain('Path=/');
+    expect(setCookie).toContain('Max-Age=2592000');
+  });
+
+  it('sets Secure on the tenant cookie in production deployments', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    const request = makeRequest('/sq/pricing', undefined, {
+      protocol: 'https:',
+    });
+
+    const response = await proxy(request);
+
+    expect(response.headers.get('set-cookie')).toContain('Secure');
+    expect(response.headers.get('strict-transport-security')).toBe(
+      'max-age=15552000; includeSubDomains'
+    );
+  });
+
+  it('does not emit HTTPS-only headers on local HTTP production builds', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    const request = makeRequest('/sq/pricing');
+
+    const response = await proxy(request);
+
+    expect(response.headers.get('content-security-policy')).not.toContain(
+      'upgrade-insecure-requests'
+    );
+    expect(response.headers.get('strict-transport-security')).toBeNull();
   });
 
   it('retries inactive sessions once for flagged tenants', async () => {
@@ -305,28 +397,8 @@ describe('proxy auth guard hardening', () => {
     );
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ session: null }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            session: {
-              id: 's1',
-              token: 'token-flagged',
-              expiresAt: new Date(Date.now() + 60_000).toISOString(),
-            },
-            user: { id: 'u1', role: 'member' },
-          }),
-          {
-            status: 200,
-            headers: { 'content-type': 'application/json' },
-          }
-        )
-      );
+      .mockResolvedValueOnce(jsonResponse({ session: null }))
+      .mockResolvedValueOnce(jsonResponse(activeSessionPayload('token-flagged')));
     const request = makeRequest('/sq/member', `better-auth.session_token=${signed}`);
 
     const response = await proxy(request);
@@ -344,18 +416,8 @@ describe('proxy auth guard hardening', () => {
     );
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ session: null }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ session: null }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      );
+      .mockResolvedValueOnce(jsonResponse({ session: null }))
+      .mockResolvedValueOnce(jsonResponse({ session: null }));
     const request = makeRequest('/sq/member', `better-auth.session_token=${signed}`);
 
     const response = await proxy(request);
@@ -383,18 +445,8 @@ describe('proxy auth guard hardening', () => {
     );
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ session: null }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: 'too many requests' }), {
-          status: 429,
-          headers: { 'content-type': 'application/json' },
-        })
-      );
+      .mockResolvedValueOnce(jsonResponse({ session: null }))
+      .mockResolvedValueOnce(jsonResponse({ error: 'too many requests' }, 429));
     const request = makeRequest('/sq/member', `better-auth.session_token=${signed}`);
 
     const response = await proxy(request);

--- a/apps/web/src/lib/proxy-logic.ts
+++ b/apps/web/src/lib/proxy-logic.ts
@@ -1,6 +1,6 @@
 import { routing } from '@/i18n/routing';
 import { isStaffAuthTolerantTenant } from '@/lib/feature-flags';
-import { isE2EDiagnosticsEnabled } from '@/lib/runtime-environment';
+import { isE2EDiagnosticsEnabled, isProductionDeployment } from '@/lib/runtime-environment';
 import { emitAuthTelemetryEvent } from '@/lib/telemetry';
 import {
   resolveTenantFromHost as resolveTenantFromCanonicalHost,
@@ -16,7 +16,83 @@ const SESSION_COOKIE_NAMES = [
 ] as const;
 const ACTIVE_SESSION_CACHE_TTL_MS = 2000;
 const ACTIVE_SESSION_CACHE_MAX_ENTRIES = 100;
+const TENANT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
 const activeSessionCache = new Map<string, number>();
+
+type SecurityHeaders = {
+  responseHeaders: Headers;
+};
+
+function isHttpsRequest(request: NextRequest): boolean {
+  return (
+    request.nextUrl.protocol === 'https:' ||
+    request.headers.get('x-forwarded-proto')?.toLowerCase() === 'https'
+  );
+}
+
+function compactHeader(value: string): string {
+  return value.replace(/\s{2,}/g, ' ').trim();
+}
+
+function buildContentSecurityPolicy(request: NextRequest): string {
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://connect.facebook.net https://www.google-analytics.com https://cdn.paddle.com https://*.paddle.com ${isDevelopment ? "'unsafe-eval'" : ''}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https://*.supabase.co https://www.facebook.com",
+    "font-src 'self' data:",
+    "connect-src 'self' https://*.supabase.co https://*.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://api.paddle.com https://*.paddle.com https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://connect.facebook.net https://graph.facebook.com",
+    "frame-src 'self' https://*.paddle.com https://buy.paddle.com",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    isProductionDeployment() && isHttpsRequest(request) ? 'upgrade-insecure-requests' : '',
+  ].filter(Boolean);
+
+  return compactHeader(directives.join('; '));
+}
+
+function createSecurityHeaders(request: NextRequest): SecurityHeaders {
+  const csp = buildContentSecurityPolicy(request);
+  const responseHeaders = new Headers();
+
+  responseHeaders.set('Content-Security-Policy', csp);
+  responseHeaders.set('X-Frame-Options', 'DENY');
+  responseHeaders.set('X-Content-Type-Options', 'nosniff');
+  responseHeaders.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  responseHeaders.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=()');
+
+  if (isProductionDeployment() && isHttpsRequest(request)) {
+    responseHeaders.set('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+  }
+
+  return { responseHeaders };
+}
+
+function applyResponseHardening(
+  response: NextResponse,
+  request: NextRequest,
+  tenant: string | null,
+  securityHeaders: SecurityHeaders
+): NextResponse {
+  for (const [name, value] of securityHeaders.responseHeaders.entries()) {
+    response.headers.set(name, value);
+  }
+
+  if (tenant) {
+    response.cookies.set(TENANT_COOKIE_NAME, tenant, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: isHttpsRequest(request),
+      maxAge: TENANT_COOKIE_MAX_AGE_SECONDS,
+      path: '/',
+    });
+  }
+
+  return response;
+}
 
 function resolveTenantFromHost(
   host: string
@@ -359,6 +435,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const topLevel = isLocale ? segments[2] : segments[1];
   const locale = isLocale ? possibleLocale : 'sq';
   const surface = getTelemetrySurface(topLevel);
+  const securityHeaders = createSecurityHeaders(request);
 
   const isProtected = PROTECTED_TOP_LEVEL.has(topLevel);
   const sessionCookieValue = isProtected ? getSessionCookieValue(request) : null;
@@ -372,7 +449,12 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   };
 
   if (isProtected && !sessionCookieValue) {
-    return redirectProtectedRouteToLogin(protectedRouteContext, 'missing_cookie');
+    return applyResponseHardening(
+      redirectProtectedRouteToLogin(protectedRouteContext, 'missing_cookie'),
+      request,
+      tenant,
+      securityHeaders
+    );
   }
 
   if (isProtected && sessionCookieValue) {
@@ -386,7 +468,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
       canUseTolerance
     );
     if (guardResponse) {
-      return guardResponse;
+      return applyResponseHardening(guardResponse, request, tenant, securityHeaders);
     }
   }
 
@@ -398,13 +480,5 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
     response.headers.set('x-e2e-host', host);
   }
 
-  if (tenant) {
-    response.cookies.set(TENANT_COOKIE_NAME, tenant);
-  }
-
-  // CSP Config could go here, but for "Pure Logic" we might skip heavy headers initially.
-  // Adding minimal security headers.
-  response.headers.set('X-Frame-Options', 'DENY');
-
-  return response;
+  return applyResponseHardening(response, request, tenant, securityHeaders);
 }

--- a/apps/web/src/lib/tenant/tenant-hosts.test.ts
+++ b/apps/web/src/lib/tenant/tenant-hosts.test.ts
@@ -140,9 +140,10 @@ describe('tenant-hosts', () => {
     ).toBe('tenant_ks');
   });
 
-  it('uses cookie/header fallback in production-sensitive mode when host is neutral', () => {
+  it('ignores cookie/header/query fallback in production-sensitive mode when host is neutral', () => {
     mutableEnv.NODE_ENV = 'production';
     delete mutableEnv.VERCEL_ENV;
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
 
     expect(
       resolveTenantIdFromSources(
@@ -154,7 +155,54 @@ describe('tenant-hosts', () => {
         },
         { productionSensitive: true }
       )
+    ).toBe('tenant_ks');
+  });
+
+  it('requires explicit opt-out for user-controlled fallback in production-like environments', () => {
+    mutableEnv.NODE_ENV = 'production';
+    delete mutableEnv.VERCEL_ENV;
+
+    expect(
+      resolveTenantIdFromSources(
+        {
+          host: 'localhost:3000',
+          cookieTenantId: 'tenant_mk',
+          headerTenantId: 'tenant_ks',
+          queryTenantId: 'tenant_ks',
+        },
+        { productionSensitive: false }
+      )
     ).toBe('tenant_mk');
+  });
+
+  it('allows explicit loopback fallback for production-built release gates', () => {
+    mutableEnv.NODE_ENV = 'production';
+    delete mutableEnv.VERCEL_ENV;
+
+    expect(
+      resolveTenantIdFromSources(
+        {
+          host: '127.0.0.1:3000',
+          headerTenantId: 'tenant_mk',
+        },
+        { productionSensitive: true, allowLoopbackFallback: true }
+      )
+    ).toBe('tenant_mk');
+  });
+
+  it('uses production-sensitive tenant resolution by default', () => {
+    mutableEnv.NODE_ENV = 'production';
+    delete mutableEnv.VERCEL_ENV;
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
+
+    expect(
+      resolveTenantIdFromSources({
+        host: 'localhost:3000',
+        cookieTenantId: 'tenant_mk',
+        headerTenantId: 'tenant_mk',
+        queryTenantId: 'tenant_mk',
+      })
+    ).toBe('tenant_ks');
   });
 
   it('blocks query-only fallback in production-sensitive mode', () => {

--- a/apps/web/src/lib/tenant/tenant-hosts.ts
+++ b/apps/web/src/lib/tenant/tenant-hosts.ts
@@ -13,6 +13,7 @@ export type TenantResolutionSources = {
 
 export type TenantResolutionOptions = {
   productionSensitive?: boolean;
+  allowLoopbackFallback?: boolean;
 };
 
 export type TenantResolutionSource = 'host' | 'cookie' | 'header' | 'query' | 'default_public';
@@ -162,6 +163,11 @@ function isProductionLikeEnvironment(): boolean {
   return process.env.NODE_ENV === 'production' || process.env.VERCEL_ENV === 'production';
 }
 
+function isLoopbackHost(host: string | null | undefined): boolean {
+  const normalized = normalizeHost(host ?? '');
+  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1';
+}
+
 export function resolveTenantIdFromSources(
   sources: TenantResolutionSources,
   options: TenantResolutionOptions = {}
@@ -176,14 +182,18 @@ export function resolveTenantContextFromSources(
   const hostTenant = resolveTenantFromHost(sources.host ?? '');
   if (hostTenant) return { tenantId: hostTenant, source: 'host' };
 
-  const cookieTenant = coerceTenantId(sources.cookieTenantId);
-  if (cookieTenant) return { tenantId: cookieTenant, source: 'cookie' };
+  const productionSensitive = options.productionSensitive ?? true;
+  const isLocalLoopbackFallbackAllowed =
+    options.allowLoopbackFallback === true && isLoopbackHost(sources.host);
+  const allowUserControlledFallback =
+    isLocalLoopbackFallbackAllowed || !(productionSensitive && isProductionLikeEnvironment());
+  if (allowUserControlledFallback) {
+    const cookieTenant = coerceTenantId(sources.cookieTenantId);
+    if (cookieTenant) return { tenantId: cookieTenant, source: 'cookie' };
 
-  const headerTenant = coerceTenantId(sources.headerTenantId);
-  if (headerTenant) return { tenantId: headerTenant, source: 'header' };
+    const headerTenant = coerceTenantId(sources.headerTenantId);
+    if (headerTenant) return { tenantId: headerTenant, source: 'header' };
 
-  const allowQueryFallback = !(options.productionSensitive && isProductionLikeEnvironment());
-  if (allowQueryFallback) {
     const queryTenant = coerceTenantId(sources.queryTenantId);
     if (queryTenant) return { tenantId: queryTenant, source: 'query' };
   }

--- a/apps/web/src/lib/tenant/tenant-request.test.ts
+++ b/apps/web/src/lib/tenant/tenant-request.test.ts
@@ -100,14 +100,14 @@ describe('tenant-request', () => {
     );
   });
 
-  it('keeps non-sensitive fallback behavior in production mode by design', async () => {
+  it('uses production-sensitive fallback behavior in production mode by default', async () => {
     mutableEnv.NODE_ENV = 'production';
     delete mutableEnv.VERCEL_ENV;
     mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
     mocks.headers.mockResolvedValue(new Headers({ host: 'localhost:3000' }));
     mocks.cookieGet.mockReturnValue(undefined);
 
-    await expect(resolveTenantIdFromRequest({ tenantIdFromQuery: 'tenant_ks' })).resolves.toBe(
+    await expect(resolveTenantIdFromRequest({ tenantIdFromQuery: 'tenant_mk' })).resolves.toBe(
       'tenant_ks'
     );
   });

--- a/apps/web/src/lib/tenant/tenant-request.ts
+++ b/apps/web/src/lib/tenant/tenant-request.ts
@@ -22,9 +22,9 @@ function getRequestHost(h: Headers): string {
  * 3) Header `x-tenant-id`
  * 4) Query param `tenantId` (back-compat)
  *
- * This helper intentionally uses the non-production-sensitive resolver mode.
- * Security-sensitive API entry points (auth/register/proxy) call
- * `resolveTenantIdFromSources(..., { productionSensitive: true })` directly.
+ * This helper uses the production-sensitive resolver default. In production-like
+ * environments, user-controlled cookie/header/query hints are ignored on neutral
+ * hosts unless a caller explicitly opts out through `resolveTenantIdFromSources`.
  */
 export async function resolveTenantIdFromRequest(
   options: ResolveTenantOptions = {}


### PR DESCRIPTION
## Summary
- Add enforced proxy-layer security headers and CSP while leaving `apps/web/src/proxy.ts` untouched for Phase C.
- Harden the tenant cookie and tighten production-sensitive tenant fallback behavior against forged cookie/header/query hints.
- Wire the security headers spec into gate projects and update focused unit coverage for the safer behavior.

## Phase C scope
- `apps/web/src/proxy.ts` was not modified.
- Canonical routes were not renamed or bypassed.
- This changes the imported proxy logic and related tests only.

## Verification
- [x] `pnpm pr:verify`
- [x] `pnpm security:guard`
- [x] `pnpm e2e:gate` (118 passed, 4 skipped)
- [x] Focused proxy/tenant/auth unit tests
- [x] Production build confirms `ƒ Proxy (Middleware)`

## Notes
A stricter nonce CSP was tested first but rejected because E2E showed hydration/client action breakage under the current app constraints. This PR keeps the defensible Phase C-compatible CSP and defers nonce CSP to a dedicated audited phase.
