### PR TITLE
fix: include bounded QA code search matches

### DIFF
--- a/packages/qa/src/tools/repo.ts
+++ b/packages/qa/src/tools/repo.ts
@@ -21,6 +21,7 @@ const DEFAULT_SCOPE_FORBIDDEN_PATHS = [
   'docs/architecture',
   'docs/architecture.md',
 ];
+const MAX_CODE_SEARCH_OUTPUT_CHARS = 10_000;
 
 function resolveRepoPath(file: string) {
   const resolvedPath = path.resolve(REPO_ROOT, file);
@@ -120,6 +121,14 @@ function repoIdentityFields() {
     repoRoot: REPO_ROOT,
     repoRootSource: REPO_ROOT_SOURCE,
   };
+}
+
+function formatCodeSearchOutput(stdout: string) {
+  return stdout.slice(0, MAX_CODE_SEARCH_OUTPUT_CHARS);
+}
+
+function codeSearchMatches(stdout: string) {
+  return formatCodeSearchOutput(stdout).split('\n').filter(Boolean);
 }
 
 export async function projectMap(args?: { maxDepth?: number }) {
@@ -463,15 +472,24 @@ export async function codeSearch(args: {
   rgArgs.push(query);
 
   try {
-    const { stdout } = await execAsync({ args: rgArgs, file: 'rg' }, { cwd: REPO_ROOT });
+    const { stdout, stdoutTruncated } = await execAsync(
+      { args: rgArgs, file: 'rg' },
+      { cwd: REPO_ROOT }
+    );
     if (!stdout) return { content: [{ type: 'text', text: 'No matches found.' }] };
     return {
       content: [
-        { type: 'text', text: `SEARCH RESULTS for "${query}":\n\n${stdout.slice(0, 10000)}` },
+        {
+          type: 'text',
+          text: `SEARCH RESULTS for "${query}":\n\n${formatCodeSearchOutput(stdout)}`,
+        },
       ],
       structuredContent: {
         engine: 'rg',
         filePattern: filePattern || null,
+        matches: codeSearchMatches(stdout),
+        matchesTruncated: stdoutTruncated || stdout.length > MAX_CODE_SEARCH_OUTPUT_CHARS,
+        stdoutTruncated,
         status: 'ok',
         tool: 'code_search',
       },
@@ -481,19 +499,27 @@ export async function codeSearch(args: {
 
     try {
       const gitGrepArgs = ['grep', '-n', '-I', query, '--', filePattern || '.'];
-      const { stdout } = await execAsync({ args: gitGrepArgs, file: 'git' }, { cwd: REPO_ROOT });
+      const { stdout, stdoutTruncated } = await execAsync(
+        { args: gitGrepArgs, file: 'git' },
+        { cwd: REPO_ROOT }
+      );
       if (!stdout) return { content: [{ type: 'text', text: 'No matches found.' }] };
 
       return {
         content: [
           {
             type: 'text',
-            text: `SEARCH RESULTS for "${query}" (git grep fallback):\n\n${stdout.slice(0, 10000)}`,
+            text: `SEARCH RESULTS for "${query}" (git grep fallback):\n\n${formatCodeSearchOutput(
+              stdout
+            )}`,
           },
         ],
         structuredContent: {
           engine: 'git grep',
           filePattern: filePattern || null,
+          matches: codeSearchMatches(stdout),
+          matchesTruncated: stdoutTruncated || stdout.length > MAX_CODE_SEARCH_OUTPUT_CHARS,
+          stdoutTruncated,
           status: 'ok',
           tool: 'code_search',
         },

--- a/packages/qa/src/tools/repo.ts
+++ b/packages/qa/src/tools/repo.ts
@@ -124,11 +124,22 @@ function repoIdentityFields() {
 }
 
 function formatCodeSearchOutput(stdout: string) {
-  return stdout.slice(0, MAX_CODE_SEARCH_OUTPUT_CHARS);
+  if (stdout.length <= MAX_CODE_SEARCH_OUTPUT_CHARS) {
+    return stdout;
+  }
+
+  const cappedOutput = stdout.slice(0, MAX_CODE_SEARCH_OUTPUT_CHARS);
+  const lastLineBreak = cappedOutput.lastIndexOf('\n');
+
+  return lastLineBreak > 0 ? cappedOutput.slice(0, lastLineBreak) : cappedOutput;
+}
+
+function codeSearchOutputLines(stdout: string) {
+  return formatCodeSearchOutput(stdout).split('\n');
 }
 
 function codeSearchMatches(stdout: string) {
-  return formatCodeSearchOutput(stdout).split('\n').filter(Boolean);
+  return codeSearchOutputLines(stdout).filter(Boolean);
 }
 
 export async function projectMap(args?: { maxDepth?: number }) {
@@ -489,6 +500,7 @@ export async function codeSearch(args: {
         filePattern: filePattern || null,
         matches: codeSearchMatches(stdout),
         matchesTruncated: stdoutTruncated || stdout.length > MAX_CODE_SEARCH_OUTPUT_CHARS,
+        outputLines: codeSearchOutputLines(stdout),
         stdoutTruncated,
         status: 'ok',
         tool: 'code_search',
@@ -519,6 +531,7 @@ export async function codeSearch(args: {
           filePattern: filePattern || null,
           matches: codeSearchMatches(stdout),
           matchesTruncated: stdoutTruncated || stdout.length > MAX_CODE_SEARCH_OUTPUT_CHARS,
+          outputLines: codeSearchOutputLines(stdout),
           stdoutTruncated,
           status: 'ok',
           tool: 'code_search',


### PR DESCRIPTION
## Summary
- adds bounded `matches` arrays to QA MCP `code_search` structured output for both `rg` and `git grep` paths
- derives structured matches from the same capped output shown in text responses
- exposes `matchesTruncated` and `stdoutTruncated` metadata so consumers do not treat large search output as complete

## Verification
- `pnpm --filter @interdomestik/qa build`
- direct `codeSearch` probe via `pnpm --filter @interdomestik/qa exec tsx -e ...`
- `git diff --check`
- `pnpm verify-slice -- --static`

## Review
- security/auth/tenancy reviewer: initial bounded-output finding fixed and rechecked clean
- maintainability/API-contract reviewer: initial truncation metadata finding fixed and rechecked clean
- test/gate reviewer: no must-fix findings

## Scope
Repository QA tooling only. No product runtime, proxy, canonical route, auth, tenancy, schema, Stripe, README, AGENTS, architecture-doc, or tracker changes.