### PR TITLE
fix: harden policy document storage authorization

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/policies/_core.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/policies/_core.test.ts
@@ -4,32 +4,30 @@ const hoisted = vi.hoisted(() => {
   const and = vi.fn((...args: unknown[]) => ({ op: 'and', args }));
   const eq = vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right }));
   const inArray = vi.fn((left: unknown, right: unknown[]) => ({ op: 'inArray', left, right }));
+  const isNull = vi.fn((value: unknown) => ({ op: 'isNull', value }));
   const desc = vi.fn((value: unknown) => ({ op: 'desc', value }));
 
   return {
     and,
-    createSignedUrl: vi.fn(),
     desc,
     eq,
     findDocumentExtractionsMany: vi.fn(),
+    findDocumentsMany: vi.fn(),
     findPoliciesMany: vi.fn(),
     inArray,
+    isNull,
   };
 });
 
 vi.mock('@interdomestik/database', () => ({
   and: hoisted.and,
-  createAdminClient: () => ({
-    storage: {
-      from: () => ({
-        createSignedUrl: hoisted.createSignedUrl,
-      }),
-    },
-  }),
   db: {
     query: {
       documentExtractions: {
         findMany: hoisted.findDocumentExtractionsMany,
+      },
+      documents: {
+        findMany: hoisted.findDocumentsMany,
       },
       policies: {
         findMany: hoisted.findPoliciesMany,
@@ -44,6 +42,9 @@ vi.mock('@interdomestik/database/schema', () => ({
   documentExtractions: {
     createdAt: 'document_extractions.created_at',
   },
+  documents: {
+    uploadedAt: 'documents.uploaded_at',
+  },
   policies: {
     createdAt: 'policies.created_at',
   },
@@ -53,20 +54,17 @@ vi.mock('drizzle-orm', () => ({
   desc: hoisted.desc,
 }));
 
-import { getPoliciesWithSignedUrlsCore } from './_core';
+import { getPoliciesWithDocumentLinksCore } from './_core';
 
-describe('getPoliciesWithSignedUrlsCore', () => {
+describe('getPoliciesWithDocumentLinksCore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.findPoliciesMany.mockResolvedValue([]);
     hoisted.findDocumentExtractionsMany.mockResolvedValue([]);
-    hoisted.createSignedUrl.mockResolvedValue({
-      data: { signedUrl: 'https://signed.example/policy.pdf' },
-      error: null,
-    });
+    hoisted.findDocumentsMany.mockResolvedValue([]);
   });
 
-  it('prefers the latest extraction over legacy analysisJson', async () => {
+  it('uses the latest tenant-scoped policy document link and latest extraction', async () => {
     hoisted.findPoliciesMany.mockResolvedValue([
       {
         id: 'policy-1',
@@ -91,28 +89,33 @@ describe('getPoliciesWithSignedUrlsCore', () => {
         createdAt: new Date('2026-03-08T10:01:00.000Z'),
       },
     ]);
+    hoisted.findDocumentsMany.mockResolvedValue([
+      { id: 'doc-new', entityId: 'policy-1' },
+      { id: 'doc-old', entityId: 'policy-1' },
+    ]);
 
-    const result = await getPoliciesWithSignedUrlsCore({
+    const result = await getPoliciesWithDocumentLinksCore({
       tenantId: 'tenant-1',
       userId: 'user-1',
     });
 
     expect(result).toEqual([
       expect.objectContaining({
-        fileHref: 'https://signed.example/policy.pdf',
+        documentDownloadHref: '/api/documents/doc-new/download?disposition=inline',
         resolvedAnalysis: {
           summary: 'fresh extraction',
           coverageAmount: '900',
         },
       }),
     ]);
-    expect(hoisted.createSignedUrl).toHaveBeenCalledWith(
-      'pii/tenants/tenant-1/policies/user-1/policy.pdf',
-      300
+    expect(hoisted.findDocumentsMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [expect.objectContaining({ op: 'desc', value: 'documents.uploaded_at' })],
+      })
     );
   });
 
-  it('falls back to legacy analysisJson when no extraction exists', async () => {
+  it('keeps legacy raw policy URLs disabled when no document row exists', async () => {
     hoisted.findPoliciesMany.mockResolvedValue([
       {
         id: 'policy-1',
@@ -126,20 +129,68 @@ describe('getPoliciesWithSignedUrlsCore', () => {
       },
     ]);
 
-    const result = await getPoliciesWithSignedUrlsCore({
+    const result = await getPoliciesWithDocumentLinksCore({
       tenantId: 'tenant-1',
       userId: 'user-1',
     });
 
     expect(result).toEqual([
       expect.objectContaining({
-        fileHref: 'https://cdn.example/policy.pdf',
+        documentDownloadHref: '',
         resolvedAnalysis: {
           summary: 'legacy summary',
           coverageAmount: '500',
         },
       }),
     ]);
-    expect(hoisted.createSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('does not surface a cross-tenant document row for an otherwise matching policy id', async () => {
+    hoisted.findPoliciesMany.mockResolvedValue([
+      {
+        id: 'policy-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        provider: 'Legacy Carrier',
+        policyNumber: 'POL-123',
+        analysisJson: {},
+        fileUrl: 'pii/tenants/tenant-1/policies/user-1/policy.pdf',
+        createdAt: new Date('2026-03-08T10:00:00.000Z'),
+      },
+    ]);
+    hoisted.findDocumentsMany.mockImplementationOnce(async options => {
+      const filter = options.where(
+        {
+          tenantId: 'documents.tenant_id',
+          entityType: 'documents.entity_type',
+          entityId: 'documents.entity_id',
+          deletedAt: 'documents.deleted_at',
+        },
+        {
+          and: hoisted.and,
+          eq: hoisted.eq,
+          inArray: hoisted.inArray,
+          isNull: hoisted.isNull,
+        }
+      );
+
+      expect(filter).toEqual(
+        expect.objectContaining({
+          op: 'and',
+          args: expect.arrayContaining([
+            { op: 'eq', left: 'documents.tenant_id', right: 'tenant-1' },
+          ]),
+        })
+      );
+
+      return [];
+    });
+
+    const result = await getPoliciesWithDocumentLinksCore({
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual([expect.objectContaining({ documentDownloadHref: '' })]);
   });
 });

--- a/apps/web/src/app/[locale]/(app)/member/policies/_core.ts
+++ b/apps/web/src/app/[locale]/(app)/member/policies/_core.ts
@@ -1,14 +1,19 @@
 import type { PolicyAnalysis } from '@/lib/ai/policy-analyzer';
-import { createAdminClient, db } from '@interdomestik/database';
-import { documentExtractions, policies } from '@interdomestik/database/schema';
+import { db } from '@interdomestik/database';
+import { documentExtractions, documents, policies } from '@interdomestik/database/schema';
 import { desc } from 'drizzle-orm';
 
 type PolicyRow = typeof policies.$inferSelect;
 
-export type PolicyWithSignedUrl = {
+export type PolicyWithDocumentLink = {
   policy: PolicyRow;
   resolvedAnalysis: PolicyAnalysis | null;
-  fileHref: string;
+  documentDownloadHref: string;
+};
+
+type PolicyDocumentLink = {
+  id: string;
+  entityId: string;
 };
 
 function resolvePolicyAnalysis(
@@ -26,10 +31,10 @@ function resolvePolicyAnalysis(
   return value as PolicyAnalysis;
 }
 
-export async function getPoliciesWithSignedUrlsCore(args: {
+export async function getPoliciesWithDocumentLinksCore(args: {
   tenantId: string;
   userId: string;
-}): Promise<PolicyWithSignedUrl[]> {
+}): Promise<PolicyWithDocumentLink[]> {
   const { tenantId, userId } = args;
   const userPolicies = await db.query.policies.findMany({
     where: (policiesTable, { and, eq }) =>
@@ -41,15 +46,14 @@ export async function getPoliciesWithSignedUrlsCore(args: {
     return [];
   }
 
+  const policyIds = userPolicies.map(policy => policy.id);
+
   const extractions = await db.query.documentExtractions.findMany({
     where: (extractionsTable, { and, eq, inArray: whereInArray }) =>
       and(
         eq(extractionsTable.tenantId, tenantId),
         eq(extractionsTable.entityType, 'policy'),
-        whereInArray(
-          extractionsTable.entityId,
-          userPolicies.map(policy => policy.id)
-        )
+        whereInArray(extractionsTable.entityId, policyIds)
       ),
     orderBy: [desc(documentExtractions.createdAt)],
   });
@@ -66,27 +70,39 @@ export async function getPoliciesWithSignedUrlsCore(args: {
     }
   }
 
-  const adminClient = createAdminClient();
-  const policiesBucket = process.env.NEXT_PUBLIC_SUPABASE_POLICY_BUCKET || 'policies';
+  const policyDocuments = (await db.query.documents.findMany({
+    columns: {
+      id: true,
+      entityId: true,
+    },
+    where: (documentsTable, { and, eq, inArray: whereInArray, isNull }) =>
+      and(
+        eq(documentsTable.tenantId, tenantId),
+        eq(documentsTable.entityType, 'policy'),
+        whereInArray(documentsTable.entityId, policyIds),
+        isNull(documentsTable.deletedAt)
+      ),
+    orderBy: [desc(documents.uploadedAt)],
+  })) as PolicyDocumentLink[];
 
-  return Promise.all(
-    userPolicies.map(async policy => {
-      const resolvedAnalysis =
-        latestExtractionByPolicyId.get(policy.id) ?? resolvePolicyAnalysis(policy.analysisJson);
-      const storedUrl = policy.fileUrl || '';
-      if (!storedUrl) {
-        return { policy, resolvedAnalysis, fileHref: '' };
-      }
+  const latestDocumentByPolicyId = new Map<string, PolicyDocumentLink>();
+  for (const document of policyDocuments) {
+    if (!latestDocumentByPolicyId.has(document.entityId)) {
+      latestDocumentByPolicyId.set(document.entityId, document);
+    }
+  }
 
-      if (storedUrl.startsWith('http://') || storedUrl.startsWith('https://')) {
-        return { policy, resolvedAnalysis, fileHref: storedUrl };
-      }
+  return userPolicies.map(policy => {
+    const resolvedAnalysis =
+      latestExtractionByPolicyId.get(policy.id) ?? resolvePolicyAnalysis(policy.analysisJson);
+    const document = latestDocumentByPolicyId.get(policy.id);
 
-      const { data, error } = await adminClient.storage
-        .from(policiesBucket)
-        .createSignedUrl(storedUrl, 300);
-
-      return { policy, resolvedAnalysis, fileHref: error ? '' : (data?.signedUrl ?? '') };
-    })
-  );
+    return {
+      policy,
+      resolvedAnalysis,
+      documentDownloadHref: document
+        ? `/api/documents/${encodeURIComponent(document.id)}/download?disposition=inline`
+        : '',
+    };
+  });
 }

--- a/apps/web/src/app/api/documents/_core.test.ts
+++ b/apps/web/src/app/api/documents/_core.test.ts
@@ -174,6 +174,36 @@ describe('getDocumentAccessCore Hardening', () => {
       expect((await execAccess(memberSession, 'doc-policy')).ok).toBe(true);
     });
 
+    it('uses the policy storage bucket for policy documents', async () => {
+      setupMocks([polymorphicDocs.policy], [{ policyOwnerId: 'member-1' }]);
+
+      await expect(execAccess(memberSession, 'doc-policy')).resolves.toEqual(
+        expect.objectContaining({
+          ok: true,
+          audit: expect.objectContaining({
+            entityType: 'policy_document',
+          }),
+          document: expect.objectContaining({
+            bucket: 'policies',
+            filePath: 'path/to/policy',
+          }),
+        })
+      );
+    });
+
+    it('denies policy document access to uploader when the policy belongs to another member', async () => {
+      setupMocks(
+        [{ ...polymorphicDocs.policy, uploadedBy: 'member-1' }],
+        [{ policyOwnerId: 'member-2' }]
+      );
+
+      await expect(execAccess(memberSession, 'doc-policy')).resolves.toEqual({
+        ok: false,
+        code: 'FORBIDDEN',
+        message: 'Forbidden',
+      });
+    });
+
     it('denies access if tenant mismatches', async () => {
       setupMocks([], []);
       const session = { user: { ...memberSession.user, tenantId: 'wrong' } };

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -52,7 +52,7 @@ export type DocumentAccessResult =
 
 type AuditContext = {
   action: string;
-  entityType: 'claim_document';
+  entityType: 'claim_document' | 'policy_document';
   entityId: string;
   actorRole: string | null;
   metadata: Record<string, unknown>;
@@ -136,6 +136,7 @@ function getDocumentAction(disposition: 'inline' | 'attachment', mode: DocumentA
 
 function buildPolymorphicDocument(polyDoc: {
   id: string;
+  entityType: string;
   storagePath: string;
   uploadedBy: string | null;
   fileName: string | null;
@@ -145,7 +146,7 @@ function buildPolymorphicDocument(polyDoc: {
   return {
     id: polyDoc.id,
     claimId: null,
-    bucket: 'claim-evidence',
+    bucket: getPolymorphicDocumentBucket(polyDoc.entityType),
     filePath: polyDoc.storagePath,
     uploadedBy: polyDoc.uploadedBy,
     name: polyDoc.fileName,
@@ -154,14 +155,38 @@ function buildPolymorphicDocument(polyDoc: {
   };
 }
 
+function getPolymorphicDocumentBucket(entityType: string): string {
+  if (entityType === 'policy') {
+    return process.env.NEXT_PUBLIC_SUPABASE_POLICY_BUCKET || 'policies';
+  }
+
+  return process.env.NEXT_PUBLIC_SUPABASE_EVIDENCE_BUCKET || 'claim-evidence';
+}
+
+function getPolymorphicDocumentAuditEntityType(entityType: string): AuditContext['entityType'] {
+  if (entityType === 'policy') {
+    return 'policy_document';
+  }
+
+  return 'claim_document';
+}
+
 function buildDocumentAudit(args: {
   actorRole: string | null | undefined;
   disposition: 'inline' | 'attachment';
   document: DocumentRow;
   documentId: string;
+  entityType?: AuditContext['entityType'];
   mode: DocumentAccessMode;
 }): AuditContext {
-  const { actorRole, disposition, document, documentId, mode } = args;
+  const {
+    actorRole,
+    disposition,
+    document,
+    documentId,
+    entityType = 'claim_document',
+    mode,
+  } = args;
   const metadata =
     mode === 'signed_url'
       ? {
@@ -181,7 +206,7 @@ function buildDocumentAudit(args: {
 
   return {
     action: getDocumentAction(disposition, mode),
-    entityType: 'claim_document',
+    entityType,
     entityId: documentId,
     actorRole: actorRole ?? null,
     metadata,
@@ -202,10 +227,12 @@ async function canReadPolymorphicDocument(args: {
     return true;
   }
 
-  // 2. Uploader access, except agents must still be assigned to claim documents.
+  // 2. Uploader access, except agents must still be assigned to claim documents and
+  // policy documents must pass the policy-owner check below.
   if (
     polyDoc.uploadedBy === session.user.id &&
-    !(userRole === 'agent' && polyDoc.entityType === 'claim')
+    !(userRole === 'agent' && polyDoc.entityType === 'claim') &&
+    polyDoc.entityType !== 'policy'
   ) {
     return true;
   }
@@ -363,6 +390,7 @@ export async function getDocumentAccessCore(args: {
         disposition: finalDisposition,
         document,
         documentId,
+        entityType: getPolymorphicDocumentAuditEntityType(polyDoc.entityType),
         mode,
       }),
     };

--- a/apps/web/src/features/member/policies/components/MemberPoliciesV2Page.test.tsx
+++ b/apps/web/src/features/member/policies/components/MemberPoliciesV2Page.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getPoliciesWithDocumentLinksCore: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+vi.mock('@/app/[locale]/(app)/member/policies/_core', () => ({
+  getPoliciesWithDocumentLinksCore: hoisted.getPoliciesWithDocumentLinksCore,
+}));
+
+vi.mock('@/i18n/routing', () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: hoisted.getSession,
+    },
+  },
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: () => 'tenant-1',
+}));
+
+vi.mock('next/headers', () => ({
+  headers: () => new Headers(),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+}));
+
+import { MemberPoliciesV2Page } from './MemberPoliciesV2Page';
+
+describe('MemberPoliciesV2Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'user-1', tenantId: 'tenant-1' },
+    });
+  });
+
+  it('does not render legacy raw policy URLs when no authorized document link exists', async () => {
+    hoisted.getPoliciesWithDocumentLinksCore.mockResolvedValue([
+      {
+        policy: {
+          id: 'policy-1',
+          provider: 'Legacy Carrier',
+          policyNumber: 'POL-123',
+          fileUrl: 'https://cdn.example/policy.pdf',
+        },
+        resolvedAnalysis: { summary: 'legacy summary' },
+        documentDownloadHref: '',
+      },
+    ]);
+
+    const tree = await MemberPoliciesV2Page({ locale: 'en' });
+    const { container } = render(tree);
+
+    expect(screen.getByRole('button', { name: 'View PDF' })).toBeDisabled();
+    expect(container.innerHTML).not.toContain('https://cdn.example/policy.pdf');
+  });
+});

--- a/apps/web/src/features/member/policies/components/MemberPoliciesV2Page.tsx
+++ b/apps/web/src/features/member/policies/components/MemberPoliciesV2Page.tsx
@@ -15,7 +15,7 @@ import {
 import { Link } from '@/i18n/routing';
 import { auth } from '@/lib/auth';
 
-import { getPoliciesWithSignedUrlsCore } from '@/app/[locale]/(app)/member/policies/_core';
+import { getPoliciesWithDocumentLinksCore } from '@/app/[locale]/(app)/member/policies/_core';
 import type { PolicyAnalysis } from '@/lib/ai/policy-analyzer';
 
 interface MemberPoliciesV2PageProps {
@@ -32,7 +32,7 @@ export async function MemberPoliciesV2Page({ locale }: MemberPoliciesV2PageProps
   }
 
   const tenantId = ensureTenantId(session);
-  const policiesWithUrls = await getPoliciesWithSignedUrlsCore({
+  const policiesWithDocumentLinks = await getPoliciesWithDocumentLinksCore({
     tenantId,
     userId: session.user.id,
   });
@@ -54,7 +54,7 @@ export async function MemberPoliciesV2Page({ locale }: MemberPoliciesV2PageProps
         </Link>
       </div>
 
-      {policiesWithUrls.length === 0 ? (
+      {policiesWithDocumentLinks.length === 0 ? (
         <Card className="flex flex-col items-center justify-center p-12 text-center border-dashed">
           <div className="bg-primary/10 p-4 rounded-full mb-4">
             <Shield className="h-8 w-8 text-primary" />
@@ -70,7 +70,7 @@ export async function MemberPoliciesV2Page({ locale }: MemberPoliciesV2PageProps
         </Card>
       ) : (
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {policiesWithUrls.map(({ policy, fileHref, resolvedAnalysis }) => {
+          {policiesWithDocumentLinks.map(({ policy, documentDownloadHref, resolvedAnalysis }) => {
             const analysis = resolvedAnalysis as PolicyAnalysis | null;
             return (
               <Card key={policy.id} className="overflow-hidden hover:shadow-md transition-shadow">
@@ -130,11 +130,11 @@ export async function MemberPoliciesV2Page({ locale }: MemberPoliciesV2PageProps
                   )}
 
                   <div className="pt-4 flex gap-2">
-                    {fileHref ? (
+                    {documentDownloadHref ? (
                       <Button variant="outline" className="w-full text-xs" asChild>
-                        <Link href={fileHref} target="_blank">
+                        <a href={documentDownloadHref} target="_blank" rel="noreferrer">
                           View PDF
-                        </Link>
+                        </a>
                       </Button>
                     ) : (
                       <Button variant="outline" className="w-full text-xs" disabled>


### PR DESCRIPTION
## Summary
- Route member policy "View PDF" links through `/api/documents/:id/download?disposition=inline` instead of direct storage signing or raw URL passthrough.
- Resolve the latest tenant-scoped policy document from `documents` by `uploadedAt DESC`; when no authorized document row exists, render View PDF disabled.
- Use the policy bucket for polymorphic policy document downloads and require policy-owner authorization for policy docs, even when `uploadedBy` matches the requester.

## Recommendation Coverage
- Legacy raw `http(s)` `policies.fileUrl` rows with no matching `documents` row now produce an empty document href; the UI renders View PDF disabled and does not leak the raw URL. This is the intentional secure default. A one-row-per-legacy-policy backfill is a clean follow-up slice.
- Multiple documents for the same policy resolve to the newest `documents.uploadedAt` row.
- Added negative coverage for raw `http(s)` policy URLs with no document row.
- Added cross-tenant negative coverage proving a policy cannot surface a document from another tenant by id collision.

## Scope Boundaries
- Did not touch `apps/web/src/proxy.ts`.
- Did not change schema, auth orchestration, canonical routes, tenant routing, or Stripe flows.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(app)/member/policies/_core.test.ts' src/app/api/documents/_core.test.ts 'src/app/api/documents/[id]/download/route.test.ts' src/features/member/policies/components/MemberPoliciesV2Page.test.tsx`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates`

## Reviewer Notes
- Pre-PR reviewer pool completed: security, performance, maintainability, product/UX, and test/gate review.
- Fixed reviewer findings for policy bucket selection, inline download link behavior, and policy document non-owner/uploader denial.
