### PR TITLE
storage: centralize evidence storage path invariants

### DIFF
--- a/apps/web/src/actions/uploads/upload.ts
+++ b/apps/web/src/actions/uploads/upload.ts
@@ -3,6 +3,10 @@
 import { auth } from '@/lib/auth';
 import { enforceRateLimitForAction } from '@/lib/rate-limit';
 import { createInitialClaimUploadIntentToken } from '@/features/claims/upload/server/initial-claim-upload';
+import {
+  assertEvidenceStoragePath,
+  buildEvidenceStoragePath,
+} from '@/features/claims/upload/server/storage-path';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { createClient } from '@supabase/supabase-js';
 import { headers } from 'next/headers';
@@ -166,6 +170,30 @@ async function uploadToStorage(params: {
     }
   }
 
+  function createVoiceNotePath(bucket: string): string {
+    const storagePath = buildEvidenceStoragePath({
+      actorId: userId,
+      bucket,
+      expectedBucket: bucket,
+      fileId,
+      fileName: `voicenote.${ext}`,
+      shape: 'initial',
+      tenantId,
+    });
+
+    assertEvidenceStoragePath({
+      actorId: userId,
+      bucket,
+      expectedBucket: bucket,
+      fileId,
+      shape: 'initial',
+      storagePath,
+      tenantId,
+    });
+
+    return storagePath;
+  }
+
   // 1. MinIO / S3 Path (Docker / Local)
   if (process.env.S3_ENDPOINT) {
     try {
@@ -180,7 +208,7 @@ async function uploadToStorage(params: {
       });
 
       const bucketName = process.env.S3_BUCKET_NAME || 'claim-evidence';
-      const fileName = `pii/tenants/${tenantId}/claims/${userId}/unassigned/${fileId}-voicenote.${ext}`;
+      const fileName = createVoiceNotePath(bucketName);
       const intentToken = createVoiceNoteIntent(bucketName, fileName);
 
       if (!intentToken) {
@@ -257,7 +285,15 @@ async function uploadToStorage(params: {
 
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
   const bucketName = process.env.NEXT_PUBLIC_SUPABASE_EVIDENCE_BUCKET || 'claim-evidence';
-  const fileName = `pii/tenants/${tenantId}/claims/${userId}/unassigned/${fileId}-voicenote.${ext}`;
+  let fileName: string;
+
+  try {
+    fileName = createVoiceNotePath(bucketName);
+  } catch (error) {
+    console.error('Voice note storage path creation failed:', error);
+    return { success: false, error: 'Upload unavailable. Please try again later.' };
+  }
+
   const intentToken = createVoiceNoteIntent(bucketName, fileName);
 
   if (!intentToken) {

--- a/apps/web/src/app/api/claims/evidence-upload/route.test.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.test.ts
@@ -11,7 +11,6 @@ const hoisted = vi.hoisted(() => ({
   confirmAdminUpload: vi.fn(),
   confirmUpload: vi.fn(),
   createClaimUploadIntentToken: vi.fn(),
-  sanitizeClaimUploadExtension: vi.fn(),
   captureMessage: vi.fn(),
   and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
   eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
@@ -47,7 +46,6 @@ vi.mock('@/features/claims/upload/server/access', () => ({
 }));
 vi.mock('@/features/claims/upload/server/shared-upload', () => ({
   createClaimUploadIntentToken: hoisted.createClaimUploadIntentToken,
-  sanitizeClaimUploadExtension: hoisted.sanitizeClaimUploadExtension,
 }));
 vi.mock('@sentry/nextjs', () => ({
   captureMessage: hoisted.captureMessage,
@@ -97,7 +95,6 @@ describe('POST /api/claims/evidence-upload', () => {
     hoisted.confirmAdminUpload.mockResolvedValue({ success: true });
     hoisted.confirmUpload.mockResolvedValue({ success: true });
     hoisted.createClaimUploadIntentToken.mockReturnValue('upload-intent-token');
-    hoisted.sanitizeClaimUploadExtension.mockReturnValue('pdf');
   });
 
   it('denies staff uploads outside branch or assignment scope before storage upload', async () => {
@@ -167,21 +164,17 @@ describe('POST /api/claims/evidence-upload', () => {
     expect(hoisted.upload).not.toHaveBeenCalled();
   });
 
-  it('sanitizes direct-upload extensions before storage upload', async () => {
-    hoisted.sanitizeClaimUploadExtension.mockReturnValueOnce('bin');
-
+  it('rejects slash injection in direct-upload filenames before storage upload', async () => {
     const response = await POST(
       createEvidenceUploadRequest(
         new File(['test'], 'evidence.pdf/..', { type: 'application/pdf' })
       )
     );
+    const data = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(hoisted.upload).toHaveBeenCalledWith(
-      expect.stringMatching(/^pii\/tenants\/tenant-1\/claims\/claim-1\/[^/]+\.bin$/),
-      expect.any(Buffer),
-      expect.objectContaining({ contentType: 'application/pdf' })
-    );
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'Invalid form payload' });
+    expect(hoisted.upload).not.toHaveBeenCalled();
   });
 
   it('fails upload intent configuration before storage upload', async () => {

--- a/apps/web/src/app/api/claims/evidence-upload/route.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.ts
@@ -3,10 +3,11 @@ import {
   resolveStorageUploadContentType,
   resolveUploadMimeType,
 } from '@/features/admin/claims/components/ops/file-upload-meta';
+import { createClaimUploadIntentToken } from '@/features/claims/upload/server/shared-upload';
 import {
-  createClaimUploadIntentToken,
-  sanitizeClaimUploadExtension,
-} from '@/features/claims/upload/server/shared-upload';
+  assertEvidenceStoragePath,
+  buildEvidenceStoragePath,
+} from '@/features/claims/upload/server/storage-path';
 import { findAccessibleAdminUploadClaim } from '@/features/claims/upload/server/access';
 import { confirmUpload } from '@/features/member/claims/actions';
 import { LOCALES } from '@/i18n/locales';
@@ -287,8 +288,29 @@ export async function POST(request: Request) {
   const resolvedMimeType = resolveUploadMimeType(file);
   const storageContentType = resolveStorageUploadContentType(file);
   const fileId = randomUUID();
-  const extension = sanitizeClaimUploadExtension(file.name);
-  const storagePath = `pii/tenants/${tenantId}/claims/${claimId}/${fileId}.${extension}`;
+  let storagePath: string;
+
+  try {
+    storagePath = buildEvidenceStoragePath({
+      bucket,
+      claimId,
+      fileId,
+      fileName: file.name,
+      shape: 'assigned',
+      tenantId,
+    });
+    assertEvidenceStoragePath({
+      bucket,
+      claimId,
+      fileId,
+      shape: 'assigned',
+      storagePath,
+      tenantId,
+    });
+  } catch {
+    return jsonError('Invalid form payload', 400);
+  }
+
   const uploadIntent = createUploadIntent({
     bucket,
     claimId,

--- a/apps/web/src/app/api/uploads/_core.ts
+++ b/apps/web/src/app/api/uploads/_core.ts
@@ -4,6 +4,10 @@ import { nanoid } from 'nanoid';
 import { z } from 'zod';
 import { DEFAULT_EVIDENCE_BUCKET } from '@/lib/storage/evidence-bucket';
 import { createInitialClaimUploadIntentToken } from '@/features/claims/upload/server/initial-claim-upload';
+import {
+  assertEvidenceStoragePath,
+  buildEvidenceStoragePath,
+} from '@/features/claims/upload/server/storage-path';
 
 type Session = {
   user: {
@@ -32,8 +36,6 @@ export const uploadRequestSchema = z.object({
 
 export type UploadRequest = z.infer<typeof uploadRequestSchema>;
 
-export const sanitizeFileName = (fileName: string) => fileName.replaceAll(/[^\w.-]+/g, '_');
-
 type UploadOk = {
   ok: true;
   status: 200;
@@ -55,8 +57,9 @@ type UploadOk = {
 
 type UploadErr = {
   ok: false;
-  status: 403 | 404 | 413 | 415 | 500;
+  status: 400 | 403 | 404 | 413 | 415 | 500;
   error:
+    | 'Invalid file name'
     | 'Forbidden'
     | 'Claim not found'
     | 'File too large'
@@ -69,6 +72,8 @@ export type UploadResult = UploadOk | UploadErr;
 type InitialUploadIntentResult =
   | { ok: true; intentToken: string }
   | { ok: false; result: UploadErr };
+
+type EvidenceUploadPathResult = { ok: true; path: string } | { ok: false; result: UploadErr };
 
 export async function createSignedUploadCore(args: {
   session: Session;
@@ -114,9 +119,18 @@ export async function createSignedUploadCore(args: {
   }
 
   const evidenceId = nanoid();
-  const safeName = sanitizeFileName(fileName);
   const classification = DEFAULT_CLASSIFICATION;
-  const path = `${classification}/tenants/${tenantId}/claims/${session.user.id}/${claimId ?? 'unassigned'}/${evidenceId}-${safeName}`;
+  const pathResult = createEvidenceUploadPath({
+    actorId: session.user.id,
+    bucket,
+    claimId,
+    evidenceId,
+    fileName,
+    tenantId,
+  });
+
+  if (!pathResult.ok) return pathResult.result;
+  const path = pathResult.path;
 
   let intentToken: string | undefined;
   if (!claimId) {
@@ -170,6 +184,83 @@ export async function createSignedUploadCore(args: {
       allowedMimeTypes: ALLOWED_MIME_TYPES,
     },
   };
+}
+
+function createEvidenceUploadPath(args: {
+  actorId: string;
+  bucket: string;
+  claimId?: string;
+  evidenceId: string;
+  fileName: string;
+  tenantId: string;
+}): EvidenceUploadPathResult {
+  const { actorId, bucket, claimId, evidenceId, fileName, tenantId } = args;
+
+  try {
+    return claimId
+      ? createAssignedEvidenceUploadPath({ bucket, claimId, evidenceId, fileName, tenantId })
+      : createInitialEvidenceUploadPath({ actorId, bucket, evidenceId, fileName, tenantId });
+  } catch {
+    return { ok: false, result: { ok: false, status: 400, error: 'Invalid file name' } };
+  }
+}
+
+function createAssignedEvidenceUploadPath(args: {
+  bucket: string;
+  claimId: string;
+  evidenceId: string;
+  fileName: string;
+  tenantId: string;
+}): { ok: true; path: string } {
+  const { bucket, claimId, evidenceId, fileName, tenantId } = args;
+  const path = buildEvidenceStoragePath({
+    bucket,
+    claimId,
+    fileId: evidenceId,
+    fileName,
+    shape: 'assigned',
+    tenantId,
+  });
+
+  assertEvidenceStoragePath({
+    bucket,
+    claimId,
+    fileId: evidenceId,
+    shape: 'assigned',
+    storagePath: path,
+    tenantId,
+  });
+
+  return { ok: true, path };
+}
+
+function createInitialEvidenceUploadPath(args: {
+  actorId: string;
+  bucket: string;
+  evidenceId: string;
+  fileName: string;
+  tenantId: string;
+}): { ok: true; path: string } {
+  const { actorId, bucket, evidenceId, fileName, tenantId } = args;
+  const path = buildEvidenceStoragePath({
+    actorId,
+    bucket,
+    fileId: evidenceId,
+    fileName,
+    shape: 'initial',
+    tenantId,
+  });
+
+  assertEvidenceStoragePath({
+    actorId,
+    bucket,
+    fileId: evidenceId,
+    shape: 'initial',
+    storagePath: path,
+    tenantId,
+  });
+
+  return { ok: true, path };
 }
 
 function createUnassignedUploadIntentToken(args: {

--- a/apps/web/src/app/api/uploads/route.test.ts
+++ b/apps/web/src/app/api/uploads/route.test.ts
@@ -309,9 +309,7 @@ describe('POST /api/uploads', () => {
     );
     expect(data.upload).not.toHaveProperty('intentToken');
 
-    expect(data.upload.path).toContain(
-      '/tenants/tenant_mk/claims/user-1/claim-1/evidence-123-My_File.pdf'
-    );
+    expect(data.upload.path).toBe('pii/tenants/tenant_mk/claims/claim-1/evidence-123.pdf');
     expect(hoisted.enforceRateLimit).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'api/uploads',

--- a/apps/web/src/features/claims/upload/server/initial-claim-upload.test.ts
+++ b/apps/web/src/features/claims/upload/server/initial-claim-upload.test.ts
@@ -76,6 +76,7 @@ describe('initial claim upload intents', () => {
     expect(
       expectedInitialClaimUploadPath({
         actorId: 'member-1',
+        bucket: 'claim-evidence',
         fileId: 'evidence-123',
         storagePath: 'pii/tenants/tenant-1/claims/member-1/unassigned/evidence-123-receipt.pdf',
         tenantId: 'tenant-1',
@@ -85,6 +86,7 @@ describe('initial claim upload intents', () => {
     expect(
       expectedInitialClaimUploadPath({
         actorId: 'member-1',
+        bucket: 'claim-evidence',
         fileId: 'evidence-123',
         storagePath: 'pii/tenants/tenant-1/claims/member-1/other/evidence-123-receipt.pdf',
         tenantId: 'tenant-1',

--- a/apps/web/src/features/claims/upload/server/initial-claim-upload.ts
+++ b/apps/web/src/features/claims/upload/server/initial-claim-upload.ts
@@ -2,6 +2,7 @@ import type { EvidenceFile } from '@interdomestik/domain-claims/validators/claim
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
 import { validateStoredObject } from './shared-upload';
+import { assertEvidenceStoragePath } from './storage-path';
 
 const INITIAL_CLAIM_UPLOAD_INTENT_TTL_MS = 15 * 60 * 1000;
 
@@ -52,18 +53,18 @@ function safeCompare(a: string, b: string): boolean {
 
 export function expectedInitialClaimUploadPath(params: {
   actorId: string;
+  bucket: string;
+  expectedBucket?: string;
   fileId: string;
   storagePath: string;
   tenantId: string;
 }): boolean {
-  const { actorId, fileId, storagePath, tenantId } = params;
-  const expectedPrefix = `pii/tenants/${tenantId}/claims/${actorId}/unassigned/${fileId}-`;
-
-  return (
-    storagePath.startsWith(expectedPrefix) &&
-    !storagePath.includes('..') &&
-    storagePath.split('/').length === 7
-  );
+  try {
+    assertEvidenceStoragePath({ ...params, shape: 'initial' });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function createInitialClaimUploadIntentToken(params: {
@@ -129,6 +130,7 @@ export function verifyInitialClaimUploadIntentToken(params: {
     payload.tenantId !== expected.tenantId ||
     !expectedInitialClaimUploadPath({
       actorId: expected.actorId,
+      bucket: expected.bucket,
       fileId: expected.fileId,
       storagePath: expected.storagePath,
       tenantId: expected.tenantId,

--- a/apps/web/src/features/claims/upload/server/shared-upload.ts
+++ b/apps/web/src/features/claims/upload/server/shared-upload.ts
@@ -9,6 +9,8 @@ import { createClient } from '@supabase/supabase-js';
 import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
 import { revalidatePath } from 'next/cache';
 
+import { assertEvidenceStoragePath, buildEvidenceStoragePath } from './storage-path';
+
 const SIGNED_UPLOAD_MAX_ATTEMPTS = 3;
 const SIGNED_UPLOAD_RETRY_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 250;
 const CLAIM_UPLOAD_MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
@@ -125,20 +127,20 @@ export function sanitizeClaimUploadExtension(fileName: string): string {
   return ext.slice(0, 16) || 'bin';
 }
 
-function expectedUploadPath(params: {
+export function expectedUploadPath(params: {
+  bucket: string;
   claimId: string;
+  expectedBucket?: string;
   fileId: string;
   storagePath: string;
   tenantId: string;
 }): boolean {
-  const { claimId, fileId, storagePath, tenantId } = params;
-  const expectedPrefix = `pii/tenants/${tenantId}/claims/${claimId}/${fileId}.`;
-
-  return (
-    storagePath.startsWith(expectedPrefix) &&
-    !storagePath.includes('..') &&
-    storagePath.split('/').length === 6
-  );
+  try {
+    assertEvidenceStoragePath({ ...params, shape: 'assigned' });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function createClaimUploadIntentToken(params: {
@@ -220,7 +222,14 @@ function verifyClaimUploadIntentToken(params: {
     payload.mimeType !== expected.mimeType ||
     payload.storageContentType !== (expected.storageContentType ?? expected.mimeType) ||
     payload.storagePath !== expected.storagePath ||
-    payload.tenantId !== expected.tenantId
+    payload.tenantId !== expected.tenantId ||
+    !expectedUploadPath({
+      bucket: expected.bucket,
+      claimId: expected.claimId,
+      fileId: expected.fileId,
+      storagePath: expected.storagePath,
+      tenantId: expected.tenantId,
+    })
   ) {
     return {
       success: false,
@@ -347,7 +356,7 @@ export async function validateConfirmedClaimUpload(params: {
     !Number.isSafeInteger(fileSize) ||
     fileSize <= 0 ||
     fileSize > CLAIM_UPLOAD_MAX_FILE_SIZE_BYTES ||
-    !expectedUploadPath({ claimId, fileId, storagePath, tenantId })
+    !expectedUploadPath({ bucket, claimId, fileId, storagePath, tenantId })
   ) {
     return {
       success: false,
@@ -402,9 +411,30 @@ export async function createSignedUploadUrl(params: {
     return { success: false, error: 'File too large (max 50MB)', status: 413 };
   }
 
-  const ext = sanitizeClaimUploadExtension(fileName);
   const fileId = randomUUID();
-  const path = `pii/tenants/${tenantId}/claims/${claimId}/${fileId}.${ext}`;
+  let path: string;
+
+  try {
+    path = buildEvidenceStoragePath({
+      bucket,
+      claimId,
+      fileId,
+      fileName,
+      shape: 'assigned',
+      tenantId,
+    });
+    assertEvidenceStoragePath({
+      bucket,
+      claimId,
+      fileId,
+      shape: 'assigned',
+      storagePath: path,
+      tenantId,
+    });
+  } catch {
+    return { success: false, error: 'Invalid file name', status: 400 };
+  }
+
   const supabase = getSupabaseStorageClient(logPrefix);
 
   if (!supabase) {

--- a/apps/web/src/features/claims/upload/server/storage-path.test.ts
+++ b/apps/web/src/features/claims/upload/server/storage-path.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createInitialClaimUploadIntentToken,
+  verifyInitialClaimUploadIntentToken,
+} from './initial-claim-upload';
+import { createClaimUploadIntentToken, validateConfirmedClaimUpload } from './shared-upload';
+import {
+  EVIDENCE_PATH_SEGMENTS,
+  assertEvidenceStoragePath,
+  buildEvidenceStoragePath,
+} from './storage-path';
+
+function expectInvalidAssignedStoragePath(
+  storagePath: string,
+  overrides: Partial<{
+    bucket: string;
+    claimId: string;
+    fileId: string;
+    tenantId: string;
+  }> = {}
+) {
+  expect(() =>
+    assertEvidenceStoragePath({
+      bucket: 'claim-evidence',
+      claimId: 'claim-1',
+      fileId: 'file-1',
+      shape: 'assigned',
+      storagePath,
+      tenantId: 'tenant-1',
+      ...overrides,
+    })
+  ).toThrow(/Invalid evidence storage path/);
+}
+
+describe('evidence storage path invariants', () => {
+  beforeEach(() => {
+    process.env.CLAIM_UPLOAD_INTENT_SECRET = 'test-upload-intent-secret-value-123456';
+    process.env.NEXT_PUBLIC_SUPABASE_EVIDENCE_BUCKET = 'claim-evidence';
+  });
+
+  afterEach(() => {
+    delete process.env.CLAIM_UPLOAD_INTENT_SECRET;
+    delete process.env.NEXT_PUBLIC_SUPABASE_EVIDENCE_BUCKET;
+  });
+
+  it('builds and asserts the assigned evidence path shape', () => {
+    const storagePath = buildEvidenceStoragePath({
+      bucket: 'claim-evidence',
+      claimId: 'claim-1',
+      fileId: 'file-1',
+      fileName: 'receipt.pdf',
+      shape: 'assigned',
+      tenantId: 'tenant-1',
+    });
+
+    expect(storagePath).toBe('pii/tenants/tenant-1/claims/claim-1/file-1.pdf');
+    expect(storagePath.split('/')).toHaveLength(EVIDENCE_PATH_SEGMENTS.assigned);
+    expect(() =>
+      assertEvidenceStoragePath({
+        bucket: 'claim-evidence',
+        claimId: 'claim-1',
+        fileId: 'file-1',
+        shape: 'assigned',
+        storagePath,
+        tenantId: 'tenant-1',
+      })
+    ).not.toThrow();
+  });
+
+  it('defaults assigned filenames without a real extension to bin', () => {
+    expect(
+      buildEvidenceStoragePath({
+        bucket: 'claim-evidence',
+        claimId: 'claim-1',
+        fileId: 'file-1',
+        fileName: 'john-doe-medical-record',
+        shape: 'assigned',
+        tenantId: 'tenant-1',
+      })
+    ).toBe('pii/tenants/tenant-1/claims/claim-1/file-1.bin');
+
+    expect(
+      buildEvidenceStoragePath({
+        bucket: 'claim-evidence',
+        claimId: 'claim-1',
+        fileId: 'file-1',
+        fileName: '.pdf',
+        shape: 'assigned',
+        tenantId: 'tenant-1',
+      })
+    ).toBe('pii/tenants/tenant-1/claims/claim-1/file-1.bin');
+  });
+
+  it('builds and asserts the initial unassigned evidence path shape', () => {
+    const storagePath = buildEvidenceStoragePath({
+      actorId: 'member-1',
+      bucket: 'claim-evidence',
+      fileId: 'file-1',
+      fileName: 'Receipt Final.pdf',
+      shape: 'initial',
+      tenantId: 'tenant-1',
+    });
+
+    expect(storagePath).toBe(
+      'pii/tenants/tenant-1/claims/member-1/unassigned/file-1-Receipt_Final.pdf'
+    );
+    expect(storagePath.split('/')).toHaveLength(EVIDENCE_PATH_SEGMENTS.initial);
+    expect(() =>
+      assertEvidenceStoragePath({
+        actorId: 'member-1',
+        bucket: 'claim-evidence',
+        fileId: 'file-1',
+        shape: 'initial',
+        storagePath,
+        tenantId: 'tenant-1',
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects cross-tenant assertion attempts', () => {
+    expectInvalidAssignedStoragePath('pii/tenants/tenant-2/claims/claim-1/file-1.pdf');
+  });
+
+  it('rejects the wrong actor for initial upload paths', () => {
+    expect(() =>
+      assertEvidenceStoragePath({
+        actorId: 'member-1',
+        bucket: 'claim-evidence',
+        fileId: 'file-1',
+        shape: 'initial',
+        storagePath: 'pii/tenants/tenant-1/claims/member-2/unassigned/file-1-receipt.pdf',
+        tenantId: 'tenant-1',
+      })
+    ).toThrow(/Invalid evidence storage path/);
+  });
+
+  it('rejects the wrong claim for assigned upload paths', () => {
+    expectInvalidAssignedStoragePath('pii/tenants/tenant-1/claims/claim-2/file-1.pdf');
+  });
+
+  it.each([
+    ['fileName', { fileName: '../receipt.pdf' }],
+    ['claimId', { claimId: 'claim-../1' }],
+    ['tenantId', { tenantId: 'tenant/1' }],
+  ])('rejects path traversal via %s', (_label, overrides) => {
+    expect(() =>
+      buildEvidenceStoragePath({
+        bucket: 'claim-evidence',
+        claimId: 'claim-1',
+        fileId: 'file-1',
+        fileName: 'receipt.pdf',
+        shape: 'assigned',
+        tenantId: 'tenant-1',
+        ...overrides,
+      })
+    ).toThrow(/Invalid evidence storage path/);
+  });
+
+  it('rejects assigned paths with too few segments', () => {
+    expectInvalidAssignedStoragePath('pii/tenants/tenant-1/claims/claim-1');
+  });
+
+  it('rejects assigned paths with too many segments', () => {
+    expectInvalidAssignedStoragePath('pii/tenants/tenant-1/claims/claim-1/file-1.pdf/extra');
+  });
+
+  it('rejects the wrong pii tenant prefix', () => {
+    expectInvalidAssignedStoragePath('pii/tenant/tenant-1/claims/claim-1/file-1.pdf');
+  });
+
+  it('keeps mismatched intent metadata rejected before storage verification', async () => {
+    const storagePath = buildEvidenceStoragePath({
+      bucket: 'claim-evidence',
+      claimId: 'claim-1',
+      fileId: 'file-1',
+      fileName: 'receipt.pdf',
+      shape: 'assigned',
+      tenantId: 'tenant-1',
+    });
+    const uploadIntentToken = createClaimUploadIntentToken({
+      actorId: 'member-1',
+      bucket: 'claim-evidence',
+      claimId: 'claim-1',
+      fileId: 'file-1',
+      fileSize: 1024,
+      mimeType: 'application/pdf',
+      storagePath,
+      tenantId: 'tenant-1',
+    });
+
+    await expect(
+      validateConfirmedClaimUpload({
+        actorId: 'member-1',
+        bucket: 'claim-evidence',
+        confirmation: {
+          claimId: 'claim-1',
+          fileId: 'file-1',
+          fileSize: 2048,
+          mimeType: 'application/pdf',
+          storagePath,
+          uploadIntentToken,
+        },
+        logPrefix: '[storage-path-test]',
+        tenantId: 'tenant-1',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: 'Upload confirmation expired. Please retry upload.',
+      status: 409,
+    });
+  });
+
+  it('rejects mismatched evidence buckets', () => {
+    expectInvalidAssignedStoragePath('pii/tenants/tenant-1/claims/claim-1/file-1.pdf', {
+      bucket: 'policy-documents',
+    });
+  });
+
+  it('normalizes unicode and whitespace filenames while rejecting slash injection', () => {
+    const storagePath = buildEvidenceStoragePath({
+      actorId: 'member-1',
+      bucket: 'claim-evidence',
+      fileId: 'file-1',
+      fileName: '  Resume 😄 final.pdf  ',
+      shape: 'initial',
+      tenantId: 'tenant-1',
+    });
+
+    expect(storagePath).toBe(
+      'pii/tenants/tenant-1/claims/member-1/unassigned/file-1-Resume_final.pdf'
+    );
+    expect(
+      buildEvidenceStoragePath({
+        actorId: 'member-1',
+        bucket: 'claim-evidence',
+        fileId: 'file-2',
+        fileName: '  фактура.pdf  ',
+        shape: 'initial',
+        tenantId: 'tenant-1',
+      })
+    ).toBe('pii/tenants/tenant-1/claims/member-1/unassigned/file-2-file.pdf');
+    expect(() =>
+      buildEvidenceStoragePath({
+        actorId: 'member-1',
+        bucket: 'claim-evidence',
+        fileId: 'file-1',
+        fileName: 'folder/receipt.pdf',
+        shape: 'initial',
+        tenantId: 'tenant-1',
+      })
+    ).toThrow(/Invalid evidence storage path/);
+  });
+
+  it('pins initial token verification to the centralized path invariant', () => {
+    const malformedPath =
+      'pii/tenants/tenant-1/claims/member-1/unassigned/file-1-receipt.pdf/extra';
+    const intentToken = createInitialClaimUploadIntentToken({
+      actorId: 'member-1',
+      bucket: 'claim-evidence',
+      fileId: 'file-1',
+      fileSize: 1024,
+      mimeType: 'application/pdf',
+      storagePath: malformedPath,
+      tenantId: 'tenant-1',
+    });
+
+    expect(
+      verifyInitialClaimUploadIntentToken({
+        actorId: 'member-1',
+        bucket: 'claim-evidence',
+        fileId: 'file-1',
+        fileSize: 1024,
+        intentToken,
+        mimeType: 'application/pdf',
+        storagePath: malformedPath,
+        tenantId: 'tenant-1',
+      })
+    ).toEqual({ success: false, error: 'Upload confirmation expired. Please retry upload.' });
+  });
+
+  it('pins assigned upload confirmation to the centralized bucket invariant', async () => {
+    const storagePath = 'pii/tenants/tenant-1/claims/claim-1/file-1.pdf';
+    const uploadIntentToken = createClaimUploadIntentToken({
+      actorId: 'member-1',
+      bucket: 'policy-documents',
+      claimId: 'claim-1',
+      fileId: 'file-1',
+      fileSize: 1024,
+      mimeType: 'application/pdf',
+      storagePath,
+      tenantId: 'tenant-1',
+    });
+
+    await expect(
+      validateConfirmedClaimUpload({
+        actorId: 'member-1',
+        bucket: 'policy-documents',
+        confirmation: {
+          claimId: 'claim-1',
+          fileId: 'file-1',
+          fileSize: 1024,
+          mimeType: 'application/pdf',
+          storagePath,
+          uploadIntentToken,
+        },
+        logPrefix: '[storage-path-test]',
+        tenantId: 'tenant-1',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: 'Uploaded file metadata mismatch. Please retry upload.',
+      status: 409,
+    });
+  });
+});

--- a/apps/web/src/features/claims/upload/server/storage-path.ts
+++ b/apps/web/src/features/claims/upload/server/storage-path.ts
@@ -1,0 +1,229 @@
+import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
+
+export type EvidenceStoragePathShape = 'initial' | 'assigned';
+
+export const EVIDENCE_PATH_SEGMENTS = {
+  initial: 7,
+  assigned: 6,
+} as const;
+
+const STORAGE_PREFIX = ['pii', 'tenants'] as const;
+const CLAIMS_SEGMENT = 'claims';
+const UNASSIGNED_SEGMENT = 'unassigned';
+const SAFE_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SAFE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
+const SAFE_EXTENSION_PATTERN = /^[a-z0-9]{1,16}$/;
+
+type InitialPathParams = {
+  actorId: string;
+  bucket: string;
+  expectedBucket?: string;
+  fileId: string;
+  fileName: string;
+  shape: 'initial';
+  tenantId: string;
+};
+
+type AssignedPathParams = {
+  bucket: string;
+  claimId: string;
+  expectedBucket?: string;
+  fileId: string;
+  fileName: string;
+  shape: 'assigned';
+  tenantId: string;
+};
+
+type BuildEvidenceStoragePathParams = InitialPathParams | AssignedPathParams;
+
+type InitialAssertParams = {
+  actorId: string;
+  bucket: string;
+  expectedBucket?: string;
+  fileId: string;
+  shape: 'initial';
+  storagePath: string;
+  tenantId: string;
+};
+
+type AssignedAssertParams = {
+  bucket: string;
+  claimId: string;
+  expectedBucket?: string;
+  fileId: string;
+  shape: 'assigned';
+  storagePath: string;
+  tenantId: string;
+};
+
+type AssertEvidenceStoragePathParams = InitialAssertParams | AssignedAssertParams;
+
+function invariant(message: string): never {
+  throw new Error(`Invalid evidence storage path: ${message}`);
+}
+
+function assertSafeSegment(label: string, value: string): string {
+  if (typeof value !== 'string') invariant(`${label} must be a string`);
+  const trimmedValue = value.trim();
+  if (!trimmedValue || trimmedValue !== value) invariant(`${label} must not be empty or padded`);
+  if (value === '.' || value === '..' || value.includes('..')) {
+    invariant(`${label} must not contain dot traversal`);
+  }
+  if (value.includes('/') || value.includes('\\')) invariant(`${label} must not contain slashes`);
+  if (!SAFE_PATH_SEGMENT_PATTERN.test(value)) invariant(`${label} contains unsupported characters`);
+  return value;
+}
+
+function assertEvidenceBucket(bucket: string, expectedBucket?: string): void {
+  const resolvedExpectedBucket = expectedBucket ?? resolveEvidenceBucketName();
+
+  if (!bucket || bucket !== resolvedExpectedBucket) {
+    invariant('bucket does not match the evidence bucket');
+  }
+}
+
+function assertSafeFileNameInput(fileName: string): string {
+  const trimmed = fileName.trim();
+
+  if (!trimmed) invariant('fileName must not be empty');
+  if (trimmed.includes('/') || trimmed.includes('\\'))
+    invariant('fileName must not contain slashes');
+  if (trimmed === '.' || trimmed === '..' || trimmed.includes('..')) {
+    invariant('fileName must not contain dot traversal');
+  }
+
+  const lastDotIndex = trimmed.lastIndexOf('.');
+  const basename = lastDotIndex > 0 ? trimmed.slice(0, lastDotIndex) : trimmed;
+  if (!basename || /^\.+$/.test(basename)) invariant('fileName basename must not be pure dots');
+
+  return trimmed;
+}
+
+function trimBoundaryUnderscores(value: string): string {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === '_') start += 1;
+  while (end > start && value[end - 1] === '_') end -= 1;
+
+  return value.slice(start, end);
+}
+
+function sanitizeInitialFileName(fileName: string): string {
+  const trimmed = assertSafeFileNameInput(fileName);
+  const lastDotIndex = trimmed.lastIndexOf('.');
+  const hasRealExtension = lastDotIndex > 0 && lastDotIndex < trimmed.length - 1;
+  const rawBasename = hasRealExtension ? trimmed.slice(0, lastDotIndex) : trimmed;
+  const rawExtension = hasRealExtension ? trimmed.slice(lastDotIndex + 1) : '';
+  const safeBasename = rawBasename
+    .normalize('NFKD')
+    .replaceAll(/[^\w.-]+/g, '_')
+    .slice(0, 160);
+  const trimmedSafeBasename = trimBoundaryUnderscores(safeBasename);
+  const safeExtension = rawExtension
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]/g, '')
+    .slice(0, 16);
+  const normalizedBasename =
+    trimmedSafeBasename &&
+    /^[A-Za-z0-9]/.test(trimmedSafeBasename) &&
+    !/^\.+$/.test(trimmedSafeBasename)
+      ? trimmedSafeBasename
+      : 'file';
+  const safeName = hasRealExtension
+    ? `${normalizedBasename}.${safeExtension || 'bin'}`
+    : normalizedBasename;
+
+  if (!safeName || /^\.+$/.test(safeName) || safeName.includes('..')) {
+    invariant('fileName did not produce a safe storage name');
+  }
+  if (safeName.includes('/') || safeName.includes('\\')) {
+    invariant('fileName produced an unsafe storage name');
+  }
+  if (!SAFE_FILE_NAME_PATTERN.test(safeName)) {
+    invariant('fileName produced unsupported storage characters');
+  }
+
+  return safeName;
+}
+
+function sanitizeAssignedExtension(fileName: string): string {
+  const trimmed = assertSafeFileNameInput(fileName);
+  const lastDotIndex = trimmed.lastIndexOf('.');
+  const rawExtension =
+    lastDotIndex > 0 && lastDotIndex < trimmed.length - 1 ? trimmed.slice(lastDotIndex + 1) : '';
+  const safeExtension = rawExtension
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]/g, '')
+    .slice(0, 16);
+
+  return safeExtension || 'bin';
+}
+
+function assertSafeGeneratedFileName(fileName: string): void {
+  if (!fileName || fileName.includes('/') || fileName.includes('\\') || fileName.includes('..')) {
+    invariant('stored file name segment is unsafe');
+  }
+  if (/^\.+$/.test(fileName) || !SAFE_FILE_NAME_PATTERN.test(fileName)) {
+    invariant('stored file name segment is unsupported');
+  }
+}
+
+export function buildEvidenceStoragePath(params: BuildEvidenceStoragePathParams): string {
+  assertEvidenceBucket(params.bucket, params.expectedBucket);
+  const tenantId = assertSafeSegment('tenantId', params.tenantId);
+  const fileId = assertSafeSegment('fileId', params.fileId);
+
+  if (params.shape === 'initial') {
+    const actorId = assertSafeSegment('actorId', params.actorId);
+    const safeName = sanitizeInitialFileName(params.fileName);
+    return `${STORAGE_PREFIX[0]}/${STORAGE_PREFIX[1]}/${tenantId}/${CLAIMS_SEGMENT}/${actorId}/${UNASSIGNED_SEGMENT}/${fileId}-${safeName}`;
+  }
+
+  const claimId = assertSafeSegment('claimId', params.claimId);
+  const extension = sanitizeAssignedExtension(params.fileName);
+  return `${STORAGE_PREFIX[0]}/${STORAGE_PREFIX[1]}/${tenantId}/${CLAIMS_SEGMENT}/${claimId}/${fileId}.${extension}`;
+}
+
+export function assertEvidenceStoragePath(params: AssertEvidenceStoragePathParams): void {
+  assertEvidenceBucket(params.bucket, params.expectedBucket);
+  const tenantId = assertSafeSegment('tenantId', params.tenantId);
+  const fileId = assertSafeSegment('fileId', params.fileId);
+  const segments = params.storagePath.split('/');
+
+  if (segments.some(segment => !segment)) invariant('path contains empty segments');
+  if (segments.length !== EVIDENCE_PATH_SEGMENTS[params.shape]) {
+    invariant(`${params.shape} path has the wrong segment count`);
+  }
+  if (
+    segments[0] !== STORAGE_PREFIX[0] ||
+    segments[1] !== STORAGE_PREFIX[1] ||
+    segments[2] !== tenantId ||
+    segments[3] !== CLAIMS_SEGMENT
+  ) {
+    invariant('path prefix does not match tenant evidence storage');
+  }
+
+  if (params.shape === 'initial') {
+    const actorId = assertSafeSegment('actorId', params.actorId);
+    if (segments[4] !== actorId || segments[5] !== UNASSIGNED_SEGMENT) {
+      invariant('initial upload path owner or shape does not match');
+    }
+
+    const fileName = segments[6];
+    const expectedFilePrefix = `${fileId}-`;
+    if (!fileName.startsWith(expectedFilePrefix)) invariant('initial upload file id mismatch');
+    assertSafeGeneratedFileName(fileName.slice(expectedFilePrefix.length));
+    return;
+  }
+
+  const claimId = assertSafeSegment('claimId', params.claimId);
+  if (segments[4] !== claimId) invariant('assigned upload claim id mismatch');
+
+  const fileName = segments[5];
+  const expectedFilePrefix = `${fileId}.`;
+  if (!fileName.startsWith(expectedFilePrefix)) invariant('assigned upload file id mismatch');
+
+  const extension = fileName.slice(expectedFilePrefix.length);
+  if (!SAFE_EXTENSION_PATTERN.test(extension)) invariant('assigned upload extension is unsafe');
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "mod:autopilot:apply": "node scripts/modularize-autopilot.mjs --apply",
     "check:entrypoints": "node scripts/check-entrypoints-no-db.mjs",
     "check:db-access": "node scripts/check-db-access-guard.mjs",
+    "check:evidence-storage-paths": "node scripts/check-evidence-storage-paths.mjs",
     "check:entrypoints:strict": "node scripts/check-entrypoints-no-db.mjs --strict",
     "test:release-gate": "tsx --test scripts/release-gate/run.test.ts",
     "test": "pnpm --filter @interdomestik/web test:unit --run",

--- a/scripts/check-evidence-storage-paths.mjs
+++ b/scripts/check-evidence-storage-paths.mjs
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_SCAN_ROOTS = ['apps/web/src'];
+const APPROVED_MODULE = 'apps/web/src/features/claims/upload/server/storage-path.ts';
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const RAW_EVIDENCE_PATH_PATTERNS = [
+  {
+    kind: 'template literal',
+    pattern: /`(?=[^`]*\$\{)[^`]*pii\/tenants\/[^`]*\/claims\/[^`]*`/gs,
+  },
+  {
+    kind: 'string concatenation',
+    pattern: /["']pii\/tenants\/["'][\s\S]{0,400}?\+[\s\S]{0,400}?["']\/claims\/["'][\s\S]{0,400}?\+/g,
+  },
+  {
+    kind: 'split string concatenation',
+    pattern:
+      /["']pii\/?["']\s*\+\s*["']\/?tenants\/["'][\s\S]{0,400}?\+[\s\S]{0,400}?["']\/claims\/["'][\s\S]{0,400}?\+/g,
+  },
+  {
+    kind: 'joined path segments',
+    pattern:
+      /\[\s*["']pii["']\s*,\s*["']tenants["'][\s\S]{0,400}?["']claims["'][\s\S]{0,400}?\.join\(\s*["']\/["']\s*\)/g,
+  },
+];
+
+function parseArgs(argv) {
+  const options = {
+    root: process.cwd(),
+    scanRoots: DEFAULT_SCAN_ROOTS,
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith('--root=')) {
+      options.root = path.resolve(arg.slice('--root='.length));
+      continue;
+    }
+    if (arg.startsWith('--scan-root=')) {
+      options.scanRoots = arg
+        .slice('--scan-root='.length)
+        .split(',')
+        .map(value => value.trim())
+        .filter(Boolean);
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      console.log(
+        'Usage: node scripts/check-evidence-storage-paths.mjs [--root=<repo>] [--scan-root=<path,...>]'
+      );
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function toPosixRelative(root, filePath) {
+  return path.relative(root, filePath).split(path.sep).join('/');
+}
+
+function walkSourceFiles(dir, files = []) {
+  if (!fs.existsSync(dir)) return files;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === 'coverage') {
+      continue;
+    }
+
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkSourceFiles(fullPath, files);
+      continue;
+    }
+    if (entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+export function findRawEvidenceStoragePathTemplates(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const scanRoots = options.scanRoots ?? DEFAULT_SCAN_ROOTS;
+  const findings = [];
+
+  for (const scanRoot of scanRoots) {
+    const absoluteScanRoot = path.resolve(root, scanRoot);
+    for (const filePath of walkSourceFiles(absoluteScanRoot)) {
+      const relPath = toPosixRelative(root, filePath);
+      if (relPath === APPROVED_MODULE) continue;
+
+      const source = fs.readFileSync(filePath, 'utf8');
+      for (const { kind, pattern } of RAW_EVIDENCE_PATH_PATTERNS) {
+        for (const match of source.matchAll(pattern)) {
+          const line = source.slice(0, match.index).split('\n').length;
+          findings.push({
+            file: relPath,
+            kind,
+            line,
+            snippet: match[0].replaceAll(/\s+/g, ' ').slice(0, 160),
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+export function runEvidenceStoragePathGuard(options = {}) {
+  const findings = findRawEvidenceStoragePathTemplates(options);
+
+  if (findings.length === 0) {
+    console.log('Evidence storage path guard passed: no raw claims evidence path templates found.');
+    return 0;
+  }
+
+  console.error(
+    'Evidence storage path guard failed: use buildEvidenceStoragePath/assertEvidenceStoragePath instead of raw claims evidence path templates.'
+  );
+  for (const finding of findings) {
+    console.error(`- ${finding.file}:${finding.line} [${finding.kind}] ${finding.snippet}`);
+  }
+  return 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = runEvidenceStoragePathGuard(parseArgs(process.argv.slice(2)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/evidence-storage-path-guard.test.mjs
+++ b/scripts/ci/evidence-storage-path-guard.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const guardScript = path.join(repoRoot, 'scripts/check-evidence-storage-paths.mjs');
+
+function makeTempRepo() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-evidence-path-'));
+  fs.mkdirSync(path.join(tempRoot, 'apps/web/src/features/claims/upload/server'), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(tempRoot, 'apps/web/src/features/claims/upload/server/storage-path.ts'),
+    'export const approved = `pii/tenants/${tenantId}/claims/${claimId}/${fileId}.pdf`;\n',
+    'utf8'
+  );
+  return tempRoot;
+}
+
+function runGuard(root) {
+  return spawnSync(process.execPath, [guardScript, `--root=${root}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+test('evidence path guard permits only the centralized storage-path module', () => {
+  const tempRoot = makeTempRepo();
+  const routePath = path.join(tempRoot, 'apps/web/src/app/api/uploads/_core.ts');
+  fs.mkdirSync(path.dirname(routePath), { recursive: true });
+  fs.writeFileSync(
+    routePath,
+    'const path = `pii/tenants/${tenantId}/claims/${claimId}/${fileId}.pdf`;\n',
+    'utf8'
+  );
+
+  const failed = runGuard(tempRoot);
+  assert.equal(failed.status, 1, failed.stderr);
+  assert.match(failed.stderr, /_core\.ts/);
+
+  fs.writeFileSync(
+    routePath,
+    "const path = buildEvidenceStoragePath({ bucket, claimId, fileId, fileName, shape: 'assigned', tenantId });\n",
+    'utf8'
+  );
+
+  const passed = runGuard(tempRoot);
+  assert.equal(passed.status, 0, passed.stderr);
+  assert.match(passed.stdout, /Evidence storage path guard passed/);
+});
+
+test('evidence path guard catches concatenated and joined raw evidence paths', () => {
+  const tempRoot = makeTempRepo();
+  const routePath = path.join(tempRoot, 'apps/web/src/app/api/uploads/_core.ts');
+  fs.mkdirSync(path.dirname(routePath), { recursive: true });
+  fs.writeFileSync(
+    routePath,
+    [
+      "const concatenated = 'pii/tenants/' + tenantId + '/claims/' + claimId + '/' + fileId + '.pdf';",
+      "const multiline = 'pii/tenants/' +",
+      "  tenantId +",
+      "  '/claims/' +",
+      "  claimId +",
+      "  '/' + fileId + '.pdf';",
+      "const splitPrefix = 'pii' + '/tenants/' + tenantId + '/claims/' + claimId + '/' + fileId + '.pdf';",
+      "const joined = ['pii', 'tenants', tenantId, 'claims', claimId, `${fileId}.pdf`].join('/');",
+    ].join('\n'),
+    'utf8'
+  );
+
+  const failed = runGuard(tempRoot);
+  assert.equal(failed.status, 1, failed.stderr);
+  assert.match(failed.stderr, /string concatenation/);
+  assert.match(failed.stderr, /split string concatenation/);
+  assert.match(failed.stderr, /joined path segments/);
+});
+
+test('evidence path guard does not block policies bucket path templates', () => {
+  const tempRoot = makeTempRepo();
+  const policyPath = path.join(tempRoot, 'apps/web/src/app/api/policies/analyze/_services.ts');
+  fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+  fs.writeFileSync(
+    policyPath,
+    'const path = `pii/tenants/${tenantId}/policies/${userId}/${fileId}.pdf`;\n',
+    'utf8'
+  );
+
+  const result = runGuard(tempRoot);
+  assert.equal(result.status, 0, result.stderr);
+});

--- a/scripts/security-guard.mjs
+++ b/scripts/security-guard.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { runEvidenceStoragePathGuard } from './check-evidence-storage-paths.mjs';
 
 const LOCKFILE_PATH = path.join(process.cwd(), 'pnpm-lock.yaml');
 
@@ -9,48 +10,48 @@ const BANNED_PACKAGES = [
   {
     name: 'tar',
     banned: [/@7\.5\.[0-6](?!\d)/, /@6\./, /@5\./],
-    reason: 'CVE-2024-37890 / High severity vulnerability in versions < 7.5.7'
+    reason: 'CVE-2024-37890 / High severity vulnerability in versions < 7.5.7',
   },
   {
     name: 'lodash',
     banned: [/@4\.17\.21(?!\d)/, /@4\.17\.[0-9](?!\d)/, /@4\.17\.1[0-9](?!\d)/, /@4\.17\.20(?!\d)/],
-    reason: 'Multiple high severity vulnerabilities, use ^4.17.23+'
+    reason: 'Multiple high severity vulnerabilities, use ^4.17.23+',
   },
   {
     name: '@isaacs/brace-expansion',
     banned: [/@5\.0\.0(?!\d)/],
-    reason: 'Security vulnerability in 5.0.0, use ^5.0.1+'
+    reason: 'Security vulnerability in 5.0.0, use ^5.0.1+',
   },
   {
     name: 'cross-spawn',
     banned: [/@5\./, /@6\.0\.[0-5](?!\d)/],
-    reason: 'Vulnerability in older versions, use ^7.0.6 or 6.0.6+'
+    reason: 'Vulnerability in older versions, use ^7.0.6 or 6.0.6+',
   },
   {
     name: 'undici',
     banned: [/@4\./, /@5\./, /@6\./, /@7\.(?:[0-9]|1[0-9])\./],
-    reason: 'Use >= 7.20.0'
+    reason: 'Use >= 7.20.0',
   },
   {
     name: 'esbuild',
     banned: [/@0\.(?:[0-9]|1[0-9]|2[0-4])\./],
-    reason: 'GHSA-67mh-4wv8-2f99: Security vulnerability in versions <= 0.24.2'
+    reason: 'GHSA-67mh-4wv8-2f99: Security vulnerability in versions <= 0.24.2',
   },
   {
     name: '@modelcontextprotocol/sdk',
     banned: [/@1\.(?:[0-9]|1[0-9]|2[0-5])\./],
-    reason: 'GHSA-345p-7cg4-v4c7: Cross-client data leak in versions <= 1.25.3'
+    reason: 'GHSA-345p-7cg4-v4c7: Cross-client data leak in versions <= 1.25.3',
   },
   {
     name: 'got',
     banned: [/@(?:[0-9]|10)\./, /@11\.[0-7]\./, /@11\.8\.[0-4]/],
-    reason: 'GHSA-pfrx-2q88-qq97: Redirect to UNIX socket in versions < 11.8.5'
+    reason: 'GHSA-pfrx-2q88-qq97: Redirect to UNIX socket in versions < 11.8.5',
   },
   {
     name: 'electron',
     banned: [/@23\./, /@22\./],
-    reason: 'Multiple vulnerabilities in older Electron versions used by dev tools'
-  }
+    reason: 'Multiple vulnerabilities in older Electron versions used by dev tools',
+  },
 ];
 
 async function runGuard() {
@@ -81,8 +82,15 @@ async function runGuard() {
   }
 
   if (foundVulnerabilities > 0) {
-    console.error(`🚨 Security Guard failed! ${foundVulnerabilities} banned package version(s) detected.`);
+    console.error(
+      `🚨 Security Guard failed! ${foundVulnerabilities} banned package version(s) detected.`
+    );
     process.exit(1);
+  }
+
+  const evidencePathStatus = runEvidenceStoragePathGuard();
+  if (evidencePathStatus !== 0) {
+    process.exit(evidencePathStatus);
   }
 
   console.log('✅ Security Guard passed. All enforced versions are clean.');


### PR DESCRIPTION
## Summary

- Centralizes evidence storage path construction and assertion in `storage-path.ts` for initial/unassigned and assigned claim evidence uploads.
- Replaces raw evidence path construction in upload routes/actions/helpers with `buildEvidenceStoragePath(...)` plus immediate `assertEvidenceStoragePath(...)` checks.
- Collapses existing expected-path predicates into thin wrappers over the centralized assertion helper.
- Adds bucket-bound path assertions, filename/path segment hardening, parameterized storage-path tests, and a security guard that blocks raw evidence path templates outside the approved module.

## Verification

- `pnpm --filter @interdomestik/web exec vitest run src/app/api/uploads src/app/api/claims/evidence-upload src/features/claims/upload`
- `node --test scripts/ci/evidence-storage-path-guard.test.mjs`
- `node scripts/check-evidence-storage-paths.mjs`
- `pnpm security:guard`
- `pnpm coverage:gate`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates`
- Codex Security diff-scoped scan: `/tmp/codex-security-scans/interdomestik-crystal-home/148578726d8c_20260506T115011Z/report.md`

## Residual Risk

- This closes the application-side path construction/assertion drift.
- It does not remove `createAdminClient` from upload paths.
- It does not make Supabase Storage RLS the backstop.
- User-scoped storage or Storage RLS backstop remains a separate future slice.
