### PR TITLE
e2e: gate cross-tenant upload authorization

### DIFF
--- a/apps/web/e2e/security/upload-cross-tenant.spec.ts
+++ b/apps/web/e2e/security/upload-cross-tenant.spec.ts
@@ -1,0 +1,336 @@
+import { E2E_USERS, and, claims, db, desc, eq, user } from '@interdomestik/database';
+import { expect, request as playwrightRequest, test, type TestInfo } from '@playwright/test';
+import fs from 'node:fs/promises';
+
+import {
+  createSignedUploadCore,
+  DEFAULT_BUCKET,
+  MAX_FILE_SIZE_BYTES,
+  type UploadRequest,
+} from '@/app/api/uploads/_core';
+import {
+  assertEvidenceStoragePath,
+  buildEvidenceStoragePath,
+} from '@/features/claims/upload/server/storage-path';
+
+type SeededE2EUser = (typeof E2E_USERS)[keyof typeof E2E_USERS];
+
+type SessionUser = {
+  id: string;
+  role: string | null;
+  tenantId: string | null;
+};
+
+type ClaimRecord = {
+  id: string;
+  tenantId: string;
+  userId: string;
+  agentId: string | null;
+};
+
+type ProjectTenantContext = {
+  actor: SeededE2EUser;
+  injectedTenantId: string;
+  targetTenantId: string;
+};
+
+type ProjectStorageState = {
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: 'Strict' | 'Lax' | 'None';
+  }>;
+  origins: Array<{
+    origin: string;
+    localStorage: Array<{ name: string; value: string }>;
+  }>;
+};
+
+const DEFAULT_UPLOAD: UploadRequest = {
+  fileName: 'cross-tenant-proof.pdf',
+  fileType: 'application/pdf',
+  fileSize: 1024,
+};
+
+function projectTenantContext(testInfo: TestInfo): ProjectTenantContext {
+  if (testInfo.project.name.includes('mk')) {
+    return {
+      actor: E2E_USERS.MK_MEMBER,
+      injectedTenantId: E2E_USERS.KS_MEMBER.tenantId,
+      targetTenantId: E2E_USERS.KS_MEMBER.tenantId,
+    };
+  }
+
+  return {
+    actor: E2E_USERS.KS_MEMBER,
+    injectedTenantId: E2E_USERS.MK_MEMBER.tenantId,
+    targetTenantId: E2E_USERS.MK_MEMBER.tenantId,
+  };
+}
+
+async function requireSeededUser(seed: SeededE2EUser): Promise<SessionUser> {
+  const row = await db.query.user.findFirst({
+    where: and(eq(user.email, seed.email), eq(user.tenantId, seed.tenantId)),
+    columns: { id: true, role: true, tenantId: true },
+  });
+
+  if (!row?.id || row.tenantId !== seed.tenantId) {
+    throw new Error(`Expected seeded user ${seed.email} in ${seed.tenantId}`);
+  }
+
+  return {
+    id: row.id,
+    role: row.role,
+    tenantId: row.tenantId,
+  };
+}
+
+async function requireClaimForTenant(tenantId: string): Promise<ClaimRecord> {
+  const row = await db.query.claims.findFirst({
+    where: eq(claims.tenantId, tenantId),
+    columns: { id: true, tenantId: true, userId: true, agentId: true },
+    orderBy: [desc(claims.createdAt), desc(claims.id)],
+  });
+
+  if (!row?.id || row.tenantId !== tenantId) {
+    throw new Error(`Expected seeded claim in ${tenantId}`);
+  }
+
+  return row;
+}
+
+async function requireClaimNotOwnedBy(actor: SessionUser): Promise<ClaimRecord> {
+  if (!actor.tenantId) {
+    throw new Error('Expected tenant-scoped actor session');
+  }
+
+  const rows = await db.query.claims.findMany({
+    where: eq(claims.tenantId, actor.tenantId),
+    columns: { id: true, tenantId: true, userId: true, agentId: true },
+    orderBy: [desc(claims.createdAt), desc(claims.id)],
+    limit: 50,
+  });
+  const claim = rows.find(row => row.userId !== actor.id);
+
+  if (!claim) {
+    throw new Error(`Expected seeded ${actor.tenantId} claim not owned by ${actor.id}`);
+  }
+
+  return claim;
+}
+
+function sessionFor(userRow: SessionUser) {
+  return {
+    user: userRow,
+  };
+}
+
+function projectBaseOrigin(testInfo: TestInfo): string {
+  const baseURL = testInfo.project.use.baseURL?.toString();
+  if (!baseURL) {
+    throw new Error('Expected Playwright project baseURL');
+  }
+  return new URL(baseURL).origin;
+}
+
+function projectExtraHeaders(testInfo: TestInfo): Record<string, string> {
+  return (testInfo.project.use.extraHTTPHeaders ?? {}) as Record<string, string>;
+}
+
+function projectStorageStatePath(testInfo: TestInfo): string {
+  const storageState = testInfo.project.use.storageState;
+  if (typeof storageState !== 'string') {
+    throw new TypeError('Expected Playwright project storageState path');
+  }
+  return storageState;
+}
+
+function hasProjectStorageState(testInfo: TestInfo): boolean {
+  return typeof testInfo.project.use.storageState === 'string';
+}
+
+async function projectStorageStateWithForgedTenantCookie(
+  testInfo: TestInfo,
+  injectedTenantId: string
+): Promise<ProjectStorageState> {
+  const storageState = JSON.parse(await fs.readFile(projectStorageStatePath(testInfo), 'utf8')) as {
+    cookies?: ProjectStorageState['cookies'];
+    origins?: ProjectStorageState['origins'];
+  };
+  const { hostname } = new URL(projectBaseOrigin(testInfo));
+  const forgedTenantCookie: ProjectStorageState['cookies'][number] = {
+    name: 'tenantId',
+    value: injectedTenantId,
+    domain: hostname,
+    path: '/',
+    expires: -1,
+    httpOnly: false,
+    secure: false,
+    sameSite: 'Lax',
+  };
+
+  return {
+    ...storageState,
+    cookies: [
+      ...(storageState.cookies ?? []).filter(cookie => cookie.name !== forgedTenantCookie.name),
+      forgedTenantCookie,
+    ],
+    origins: storageState.origins ?? [],
+  };
+}
+
+test.describe('upload cross-tenant authorization @security', () => {
+  test('createSignedUploadCore returns 404 for a foreign-tenant claimId', async () => {
+    const actor = await requireSeededUser(E2E_USERS.KS_MEMBER);
+    const foreignClaim = await requireClaimForTenant(E2E_USERS.MK_MEMBER.tenantId);
+
+    const result = await createSignedUploadCore({
+      session: sessionFor(actor),
+      input: {
+        ...DEFAULT_UPLOAD,
+        claimId: foreignClaim.id,
+      },
+      bucket: DEFAULT_BUCKET,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected cross-tenant claimId to be rejected');
+    }
+    expect(result.status).toBe(404);
+    expect(result.error).toBe('Claim not found');
+  });
+
+  test('POST /api/uploads returns 404 for a foreign-tenant claimId', async ({}, testInfo) => {
+    test.skip(!hasProjectStorageState(testInfo), 'Project does not provide upload API auth state');
+
+    const { targetTenantId } = projectTenantContext(testInfo);
+    const foreignClaim = await requireClaimForTenant(targetTenantId);
+    const api = await playwrightRequest.newContext({
+      baseURL: projectBaseOrigin(testInfo),
+      extraHTTPHeaders: projectExtraHeaders(testInfo),
+      storageState: projectStorageStatePath(testInfo),
+    });
+
+    try {
+      const response = await api.post('/api/uploads', {
+        data: {
+          ...DEFAULT_UPLOAD,
+          claimId: foreignClaim.id,
+        },
+      });
+
+      expect(response.status()).toBe(404);
+      expect(await response.json()).toEqual({ error: 'Claim not found' });
+    } finally {
+      await api.dispose();
+    }
+  });
+
+  test('createSignedUploadCore returns 403 for a member uploading to another same-tenant owner claim', async () => {
+    const actor = await requireSeededUser(E2E_USERS.KS_MEMBER);
+    const otherOwnerClaim = await requireClaimNotOwnedBy(actor);
+
+    const result = await createSignedUploadCore({
+      session: sessionFor({ ...actor, role: 'member' }),
+      input: {
+        ...DEFAULT_UPLOAD,
+        claimId: otherOwnerClaim.id,
+      },
+      bucket: DEFAULT_BUCKET,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected non-owner member upload to be rejected');
+    }
+    expect(result.status).toBe(403);
+    expect(result.error).toBe('Forbidden');
+  });
+
+  test('POST /api/uploads ignores injected tenant headers and cookies for unassigned upload paths', async ({}, testInfo) => {
+    test.skip(!hasProjectStorageState(testInfo), 'Project does not provide upload API auth state');
+
+    const { actor, injectedTenantId } = projectTenantContext(testInfo);
+    const api = await playwrightRequest.newContext({
+      baseURL: projectBaseOrigin(testInfo),
+      extraHTTPHeaders: projectExtraHeaders(testInfo),
+      storageState: await projectStorageStateWithForgedTenantCookie(testInfo, injectedTenantId),
+    });
+
+    try {
+      const response = await api.post('/api/uploads', {
+        data: DEFAULT_UPLOAD,
+        headers: {
+          'x-tenant-id': injectedTenantId,
+        },
+      });
+
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as { upload?: { path?: string } };
+      expect(body.upload?.path).toEqual(expect.any(String));
+      expect(body.upload?.path).toContain(`/tenants/${actor.tenantId}/`);
+      expect(body.upload?.path).not.toContain(`/tenants/${injectedTenantId}/`);
+    } finally {
+      await api.dispose();
+    }
+  });
+
+  test('createSignedUploadCore returns 413 for files larger than 10MB', async () => {
+    const actor = await requireSeededUser(E2E_USERS.KS_MEMBER);
+
+    const result = await createSignedUploadCore({
+      session: sessionFor(actor),
+      input: {
+        ...DEFAULT_UPLOAD,
+        fileSize: MAX_FILE_SIZE_BYTES + 1,
+      },
+      bucket: DEFAULT_BUCKET,
+    });
+
+    expect(result).toEqual({ ok: false, status: 413, error: 'File too large' });
+  });
+
+  test('createSignedUploadCore returns 415 for non-allowlisted file types', async () => {
+    const actor = await requireSeededUser(E2E_USERS.KS_MEMBER);
+
+    const result = await createSignedUploadCore({
+      session: sessionFor(actor),
+      input: {
+        ...DEFAULT_UPLOAD,
+        fileName: 'cross-tenant-proof.exe',
+        fileType: 'application/x-msdownload',
+      },
+      bucket: DEFAULT_BUCKET,
+    });
+
+    expect(result).toEqual({ ok: false, status: 415, error: 'File type not allowed' });
+  });
+
+  test('assertEvidenceStoragePath rejects a forged initial-upload actor path', () => {
+    const storagePath = buildEvidenceStoragePath({
+      actorId: 'member-a',
+      bucket: DEFAULT_BUCKET,
+      fileId: 'evidence-1',
+      fileName: 'proof.pdf',
+      shape: 'initial',
+      tenantId: E2E_USERS.KS_MEMBER.tenantId,
+    });
+
+    expect(() =>
+      assertEvidenceStoragePath({
+        actorId: 'member-b',
+        bucket: DEFAULT_BUCKET,
+        fileId: 'evidence-1',
+        shape: 'initial',
+        storagePath,
+        tenantId: E2E_USERS.KS_MEMBER.tenantId,
+      })
+    ).toThrow();
+  });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -34,7 +34,7 @@ const JUNIT_REPORT_FILE = path.join(TEST_RESULTS_DIR, 'junit.xml');
 const JSON_REPORT_FILE = path.join(TEST_RESULTS_DIR, 'report.json');
 
 const GATE_DEFAULT_MATCH = ['gate/**/*.spec.ts'];
-const GATE_SECURITY_MATCH = ['security/headers.spec.ts'];
+const GATE_SECURITY_MATCH = ['security/headers.spec.ts', 'security/upload-cross-tenant.spec.ts'];
 const PILOT_MATRIX_MATCH_GUARD = '/pilot/';
 const RUNNING_PILOT_MATRIX = process.argv.some(arg => arg.includes(PILOT_MATRIX_MATCH_GUARD));
 const GATE_KS_PILOT_MATCH = ['pilot/scenario-01-ks-e2e.spec.ts'];
@@ -43,9 +43,12 @@ const GATE_MK_PILOT_MATCH = [
   'pilot/c2-03-cross-tenant-write-isolation.spec.ts',
   'pilot/c2-04-cross-tenant-staff-member-write-isolation.spec.ts',
 ];
-const GATE_MK_CONTRACT_MATCH = ['gate/seed-contract.spec.ts', 'gate/tenant-resolution.spec.ts'];
+const GATE_MK_CONTRACT_MATCH = [
+  ...GATE_SECURITY_MATCH,
+  'gate/seed-contract.spec.ts',
+  'gate/tenant-resolution.spec.ts',
+];
 const GATE_AL_PILOT_MATCH = ['pilot/c2-03-cross-tenant-write-isolation.spec.ts'];
-const NOOP_TEST_MATCH = ['__never__/__none__.spec.ts'];
 
 const GATE_KS_TEST_MATCH = RUNNING_PILOT_MATRIX
   ? [...GATE_DEFAULT_MATCH, ...GATE_SECURITY_MATCH, ...GATE_KS_PILOT_MATCH]
@@ -53,7 +56,9 @@ const GATE_KS_TEST_MATCH = RUNNING_PILOT_MATRIX
 const GATE_MK_TEST_MATCH = RUNNING_PILOT_MATRIX
   ? [...GATE_DEFAULT_MATCH, ...GATE_SECURITY_MATCH, ...GATE_MK_PILOT_MATCH]
   : [...GATE_DEFAULT_MATCH, ...GATE_SECURITY_MATCH];
-const GATE_AL_TEST_MATCH = RUNNING_PILOT_MATRIX ? GATE_AL_PILOT_MATCH : NOOP_TEST_MATCH;
+const GATE_AL_TEST_MATCH = RUNNING_PILOT_MATRIX
+  ? [...GATE_SECURITY_MATCH, ...GATE_AL_PILOT_MATCH]
+  : [...GATE_SECURITY_MATCH];
 
 function requireState(statePath: string) {
   if (fs.existsSync(statePath)) return;

--- a/apps/web/src/app/api/uploads/_core.ts
+++ b/apps/web/src/app/api/uploads/_core.ts
@@ -118,7 +118,10 @@ export async function createSignedUploadCore(args: {
     }
   }
 
-  const evidenceId = nanoid();
+  const generatedEvidenceId = nanoid();
+  const evidenceId = /^[A-Za-z0-9]/.test(generatedEvidenceId)
+    ? generatedEvidenceId
+    : `e${generatedEvidenceId}`;
   const classification = DEFAULT_CLASSIFICATION;
   const pathResult = createEvidenceUploadPath({
     actorId: session.user.id,

--- a/scripts/check-e2e-contracts.mjs
+++ b/scripts/check-e2e-contracts.mjs
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { glob } from 'glob';
+import ts from 'typescript';
 
 const repoRoot = process.cwd();
 
@@ -23,6 +24,21 @@ const STRICT_TARGETS = new Set([
 const ALLOWLIST_PATHS = new Set([
   // Contract tests may intentionally reference cross-locale paths.
   'apps/web/e2e/gate/tenant-resolution.spec.ts',
+]);
+
+const PLAYWRIGHT_CONFIG_PATH = 'apps/web/playwright.config.ts';
+const UPLOAD_CROSS_TENANT_SPEC = 'security/upload-cross-tenant.spec.ts';
+const SECURITY_GATE_CONSUMERS = [
+  'GATE_KS_TEST_MATCH',
+  'GATE_MK_TEST_MATCH',
+  'GATE_AL_TEST_MATCH',
+  'GATE_MK_CONTRACT_MATCH',
+];
+const SECURITY_GATE_PROJECT_MATCHES = new Map([
+  ['gate-ks-sq', 'GATE_KS_TEST_MATCH'],
+  ['gate-mk-mk', 'GATE_MK_TEST_MATCH'],
+  ['gate-al-sq', 'GATE_AL_TEST_MATCH'],
+  ['gate-mk-contract', 'GATE_MK_CONTRACT_MATCH'],
 ]);
 
 const localeRules = [
@@ -98,10 +114,172 @@ function enforceProductionSpecStrictness(relPath, content) {
   return violations;
 }
 
+function propertyNameText(name) {
+  if (!name) return null;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+function getObjectProperty(objectLiteral, propertyName) {
+  return objectLiteral.properties.find(
+    property =>
+      ts.isPropertyAssignment(property) && propertyNameText(property.name) === propertyName
+  );
+}
+
+function getConstInitializer(sourceFile, constName) {
+  let initializer = null;
+
+  function visit(node) {
+    if (initializer) return;
+    if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name) && declaration.name.text === constName) {
+          initializer = declaration.initializer ?? null;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  if (!initializer) {
+    throw new Error(`${PLAYWRIGHT_CONFIG_PATH}: missing ${constName} declaration`);
+  }
+
+  return initializer;
+}
+
+function unwrapExpression(node) {
+  if (ts.isParenthesizedExpression(node)) return unwrapExpression(node.expression);
+  return node;
+}
+
+function arrayLiteralIncludesString(initializer, expectedValue) {
+  const expression = unwrapExpression(initializer);
+  return (
+    ts.isArrayLiteralExpression(expression) &&
+    expression.elements.some(
+      element => ts.isStringLiteral(element) && element.text === expectedValue
+    )
+  );
+}
+
+function matchListAlwaysIncludesSecuritySpread(initializer) {
+  const expression = unwrapExpression(initializer);
+
+  if (ts.isConditionalExpression(expression)) {
+    return (
+      matchListAlwaysIncludesSecuritySpread(expression.whenTrue) &&
+      matchListAlwaysIncludesSecuritySpread(expression.whenFalse)
+    );
+  }
+
+  return (
+    ts.isArrayLiteralExpression(expression) &&
+    expression.elements.some(
+      element =>
+        ts.isSpreadElement(element) &&
+        ts.isIdentifier(element.expression) &&
+        element.expression.text === 'GATE_SECURITY_MATCH'
+    )
+  );
+}
+
+function findProjectsArray(sourceFile) {
+  let projectsArray = null;
+
+  function visit(node) {
+    if (projectsArray) return;
+    if (ts.isObjectLiteralExpression(node)) {
+      const projects = getObjectProperty(node, 'projects');
+      if (projects && ts.isArrayLiteralExpression(unwrapExpression(projects.initializer))) {
+        projectsArray = unwrapExpression(projects.initializer);
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  if (!projectsArray) {
+    throw new Error(`${PLAYWRIGHT_CONFIG_PATH}: missing Playwright projects array`);
+  }
+
+  return projectsArray;
+}
+
+function collectProjectTestMatches(sourceFile) {
+  const projectsArray = findProjectsArray(sourceFile);
+  const projectMatches = new Map();
+
+  for (const element of projectsArray.elements) {
+    const project = unwrapExpression(element);
+    if (!ts.isObjectLiteralExpression(project)) continue;
+
+    const name = getObjectProperty(project, 'name');
+    const testMatch = getObjectProperty(project, 'testMatch');
+    if (!name || !testMatch || !ts.isStringLiteralLike(name.initializer)) continue;
+
+    projectMatches.set(name.initializer.text, testMatch.initializer);
+  }
+
+  return projectMatches;
+}
+
+function enforceSecurityGateWiring(playwrightConfig) {
+  const violations = [];
+  const sourceFile = ts.createSourceFile(
+    PLAYWRIGHT_CONFIG_PATH,
+    playwrightConfig,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const securityMatch = getConstInitializer(sourceFile, 'GATE_SECURITY_MATCH');
+
+  if (!arrayLiteralIncludesString(securityMatch, UPLOAD_CROSS_TENANT_SPEC)) {
+    violations.push(
+      `${PLAYWRIGHT_CONFIG_PATH}: GATE_SECURITY_MATCH must include '${UPLOAD_CROSS_TENANT_SPEC}'.`
+    );
+  }
+
+  for (const consumer of SECURITY_GATE_CONSUMERS) {
+    const initializer = getConstInitializer(sourceFile, consumer);
+    if (!matchListAlwaysIncludesSecuritySpread(initializer)) {
+      violations.push(`${PLAYWRIGHT_CONFIG_PATH}: ${consumer} must include GATE_SECURITY_MATCH.`);
+    }
+  }
+
+  const projectMatches = collectProjectTestMatches(sourceFile);
+  for (const [projectName, expectedMatch] of SECURITY_GATE_PROJECT_MATCHES) {
+    const actualMatch = projectMatches.get(projectName);
+    if (!actualMatch) {
+      violations.push(`${PLAYWRIGHT_CONFIG_PATH}: missing ${projectName} project testMatch.`);
+      continue;
+    }
+
+    if (!ts.isIdentifier(actualMatch) || actualMatch.text !== expectedMatch) {
+      violations.push(
+        `${PLAYWRIGHT_CONFIG_PATH}: ${projectName} testMatch must use ${expectedMatch}.`
+      );
+    }
+  }
+
+  return violations;
+}
+
 async function main() {
   const files = await glob(E2E_GLOBS, { cwd: repoRoot, nodir: true });
 
   const violations = [];
+  const playwrightConfig = await readFile(path.join(repoRoot, PLAYWRIGHT_CONFIG_PATH), 'utf8');
+  violations.push(...enforceSecurityGateWiring(playwrightConfig));
 
   for (const relPath of files) {
     const absPath = path.join(repoRoot, relPath);


### PR DESCRIPTION
## Summary
- Adds a focused API/core-level `@security` spec for upload cross-tenant authorization without browser navigation or a new gate project.
- Wires `security/upload-cross-tenant.spec.ts` into `GATE_SECURITY_MATCH` and includes the security match in both PR-gate lanes, including `gate-mk-contract`.
- Extends `pnpm check:e2e-contracts` with AST-backed guards so future Playwright config refactors cannot silently drop the security spec or disconnect security gate wiring.
- Keeps initial upload evidence IDs compatible with the landed storage-path invariant by prefixing generated IDs only when `nanoid()` starts with a non-alphanumeric character.

## Covered Cases
- Tenant A session with Tenant B `claimId` returns `404 Claim not found` through `createSignedUploadCore`.
- Tenant A session with Tenant B `claimId` returns `404` through `POST /api/uploads`.
- Same-tenant member uploading to a claim owned by another user returns `403 Forbidden`.
- No `claimId` plus forged `x-tenant-id` header and tenant cookie still produces an upload path scoped to the session tenant.
- File size above 10MB returns `413`.
- Non-allowlisted MIME type returns `415`.
- Extra landed-storage-path invariant case rejects a forged initial-upload actor path via `assertEvidenceStoragePath`.

## Verification
- `pnpm --filter @interdomestik/web exec playwright test e2e/security/upload-cross-tenant.spec.ts --project=gate-ks-sq` -> `7 passed (2.4m)` on corrected head.
- `pnpm --filter @interdomestik/web exec playwright test e2e/security/upload-cross-tenant.spec.ts --project=gate-mk-contract` -> `7 passed (2.6s)` on corrected head.
- `pnpm --filter @interdomestik/web test:unit --run src/app/api/uploads/route.test.ts` -> `12 passed` on corrected head.
- `pnpm check:e2e-contracts` -> passed on corrected head.
- `pnpm verify-slice -- --static` -> passed on corrected head.
- `pnpm verify-slice -- --required-gates` -> passed before the Sonar cleanup/safe-ID amend; final E2E gate result `118 passed, 4 skipped (2.8m)` and verifier selected `security_reviewer architect_reviewer qa_reviewer contracts_reviewer`.
- `git diff --check` -> passed.
- Interdomestik QA scope audit -> passed for the original intended files before the safe-ID amend.

## Regression Proof
Temporarily removed the tenant filter `eq(claims.tenantId, tenantId)` from `apps/web/src/app/api/uploads/_core.ts` and reran the focused spec. The new core cross-tenant case failed as intended: expected `404 Claim not found`, received `403`, with `1 failed, 6 passed`. The upload core tenant filter was restored before commit.

## Security Review
- Mandatory reviewer pool completed; maintainability and gate/test findings were fixed, and re-review found no remaining must-fix issues.
- Codex Security plugin MCP scan tool was not exposed by tool discovery in this runtime. I used the local Codex Security `security-scan` skill fallback for a diff-scoped scan.
- Codex Security fallback result: no plausible findings. Report saved at `/tmp/codex-security-scans/interdomestik-crystal-home/df2d2440_20260506T123405Z/report.md`.

## Scope Notes
- Did not promote the full `c2-02` pilot spec; it remains in the pilot matrix as the broader proof.
- Upload auth/tenancy logic is unchanged; the only upload-core runtime change normalizes generated evidence IDs when required by the existing storage-path invariant.
- No changes to `apps/web/src/proxy.ts`, canonical routes, auth architecture, tenancy architecture, schema, Stripe, README, AGENTS.md, architecture docs, or tracker docs.
- No new gate project, env vars, `@quarantine`, or `@smoke` tagging.
