### PR TITLE
security: assert RLS connection role

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -25,7 +25,7 @@
     "push": "drizzle-kit push",
     "studio": "drizzle-kit studio",
     "type-check": "tsc --noEmit",
-    "test:rls": "tsx --test test/critical-rls-tables.test.ts test/rls-engaged.test.ts test/no-domain-db-admin-import.test.ts test/rls-coverage.test.ts test/seed-cleanup.test.ts",
+    "test:rls": "tsx --test test/critical-rls-tables.test.ts test/rls-engaged.test.ts test/rls-role-assertion.test.ts test/no-domain-db-admin-import.test.ts test/rls-coverage.test.ts test/seed-cleanup.test.ts",
     "seed:golden": "tsx src/seed.ts golden",
     "seed:workload": "tsx src/seed.ts workload",
     "seed:full": "tsx src/seed.ts full",

--- a/packages/database/src/db.ts
+++ b/packages/database/src/db.ts
@@ -1,6 +1,11 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 
+import {
+  assertRlsConnectionRole,
+  type RlsConnectionRoleAssertionResult,
+  type RlsConnectionRolePosture,
+} from './rls-role-assertion';
 import * as schema from './schema';
 
 const globalQueryClients = global as unknown as {
@@ -14,6 +19,20 @@ const isVercelRuntime = process.env.VERCEL === '1';
 function parseEnvInt(value: string | undefined, fallback: number): number {
   const parsed = Number.parseInt(value ?? '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isLocalDatabaseUrl(databaseUrl: string): boolean {
+  try {
+    const hostname = new URL(databaseUrl).hostname;
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1' ||
+      hostname === '[::1]'
+    );
+  } catch {
+    return false;
+  }
 }
 
 if (!process.env.DATABASE_URL) {
@@ -44,6 +63,15 @@ if (isProduction && !process.env.DATABASE_URL_RLS) {
 }
 
 const rlsDatabaseUrl = process.env.DATABASE_URL_RLS ?? adminDatabaseUrl;
+const shouldRequireProductionRlsConnection = isProduction && !isLocalDatabaseUrl(rlsDatabaseUrl);
+const shouldAssertRlsConnectionRole =
+  shouldRequireProductionRlsConnection || process.env.REQUIRE_RLS_INTEGRATION === '1';
+const rlsConnectionUrlFailure =
+  shouldRequireProductionRlsConnection && rlsDatabaseUrl === adminDatabaseUrl
+    ? new Error(
+        'DATABASE_URL_RLS is identical to DATABASE_URL; configure a separate NOBYPASSRLS role for tenant-scoped queries.'
+      )
+    : null;
 
 const adminQueryClient =
   globalQueryClients.queryClientAdmin ?? createQueryClient(adminDatabaseUrl, 'admin');
@@ -56,8 +84,241 @@ const rlsQueryClient =
 globalQueryClients.queryClientAdmin = adminQueryClient;
 globalQueryClients.queryClientRls = rlsQueryClient;
 
+async function queryRlsConnectionRolePosture(
+  roleName?: string
+): Promise<RlsConnectionRolePosture[]> {
+  if (roleName) {
+    return rlsQueryClient<RlsConnectionRolePosture[]>`
+      select
+        current_user as "currentUser",
+        rolname as "roleName",
+        rolbypassrls as "roleBypassesRls",
+        rolsuper as "roleIsSuperuser"
+      from pg_roles
+      where rolname = ${roleName}
+      limit 1
+    `;
+  }
+
+  return rlsQueryClient<RlsConnectionRolePosture[]>`
+      select
+        current_user as "currentUser",
+        rolname as "roleName",
+        rolbypassrls as "roleBypassesRls",
+        rolsuper as "roleIsSuperuser"
+      from pg_roles
+      where rolname = current_user
+      limit 1
+    `;
+}
+
+type RlsConnectionRoleAssertionState = 'not_required' | 'pending' | 'passed' | 'failed';
+
+function getInitialRlsConnectionRoleAssertionState(): RlsConnectionRoleAssertionState {
+  if (shouldAssertRlsConnectionRole && rlsConnectionUrlFailure) {
+    return 'failed';
+  }
+
+  if (shouldAssertRlsConnectionRole) {
+    return 'pending';
+  }
+
+  return 'not_required';
+}
+
+let rlsConnectionRoleAssertionState: RlsConnectionRoleAssertionState =
+  getInitialRlsConnectionRoleAssertionState();
+let rlsConnectionRoleAssertionFailure: unknown = rlsConnectionUrlFailure;
+
+type OptionalSentry = {
+  addBreadcrumb?: (breadcrumb: {
+    category?: string;
+    level?: 'info' | 'error';
+    message?: string;
+    data?: Record<string, unknown>;
+  }) => void;
+  captureException?: (error: unknown, options?: Record<string, unknown>) => void;
+  captureMessage?: (message: string, options?: Record<string, unknown>) => void;
+};
+
+let rlsConnectionRoleAssertionTelemetryReported = false;
+
+async function loadOptionalSentry(): Promise<OptionalSentry | null> {
+  try {
+    const importOptionalModule = new Function('specifier', 'return import(specifier)') as (
+      specifier: string
+    ) => Promise<unknown>;
+    return (await importOptionalModule('@sentry/nextjs')) as OptionalSentry;
+  } catch {
+    return null;
+  }
+}
+
+function reportRlsConnectionRoleAssertion(
+  result: RlsConnectionRoleAssertionResult,
+  error?: unknown
+): void {
+  if (rlsConnectionRoleAssertionTelemetryReported) {
+    return;
+  }
+  rlsConnectionRoleAssertionTelemetryReported = true;
+
+  const event = `database.rls.role_assertion.${result.ok ? 'passed' : 'failed'}`;
+  const data = {
+    currentUser: result.currentUser,
+    configuredDbRole: result.configuredDbRole,
+    reason: result.ok ? undefined : result.reason,
+    checkedRole: result.ok ? undefined : result.checkedRole,
+  };
+
+  if (result.ok) {
+    console.info(`[database:rls] ${event}`, data);
+  } else {
+    console.error(`[database:rls] ${event}`, error ?? data);
+  }
+
+  void loadOptionalSentry()
+    .then(sentry => {
+      if (!sentry) {
+        return;
+      }
+
+      try {
+        sentry.addBreadcrumb?.({
+          category: 'database.rls',
+          level: result.ok ? 'info' : 'error',
+          message: event,
+          data,
+        });
+
+        if (result.ok) {
+          sentry.captureMessage?.(event, {
+            level: 'info',
+            tags: {
+              component: 'database',
+              check: 'rls_role_assertion',
+            },
+            extra: data,
+          });
+          return;
+        }
+
+        sentry.captureException?.(error, {
+          fingerprint: ['database.rls.role_assertion.failed'],
+          tags: {
+            component: 'database',
+            check: 'rls_role_assertion',
+          },
+          extra: data,
+        });
+      } catch (telemetryError) {
+        if (isProduction) {
+          console.warn('[database:rls] optional Sentry telemetry failed:', telemetryError);
+        }
+      }
+    })
+    .catch(telemetryError => {
+      if (isProduction) {
+        console.warn('[database:rls] optional Sentry telemetry failed:', telemetryError);
+      }
+    });
+}
+
+function resultFromRlsConnectionRoleAssertionError(
+  error: unknown
+): RlsConnectionRoleAssertionResult {
+  if (error instanceof Error && 'result' in error) {
+    return error.result as RlsConnectionRoleAssertionResult;
+  }
+
+  return {
+    ok: false,
+    reason: 'query_failed',
+    cause: error,
+  };
+}
+
+// One pg_roles check per process/isolate cold start, plus one more when DB_RLS_ROLE is set.
+// withTenantContext awaits the same module-scoped promise; this is not a per-request query.
+function startRlsConnectionRoleAssertion(): Promise<RlsConnectionRoleAssertionResult | undefined> {
+  if (!shouldAssertRlsConnectionRole) {
+    return Promise.resolve(undefined);
+  }
+
+  if (rlsConnectionUrlFailure) {
+    reportRlsConnectionRoleAssertion(
+      {
+        ok: false,
+        reason: 'query_failed',
+        cause: rlsConnectionUrlFailure,
+      },
+      rlsConnectionUrlFailure
+    );
+    return Promise.resolve(undefined);
+  }
+
+  return assertRlsConnectionRole({
+    isProduction: shouldAssertRlsConnectionRole,
+    configuredDbRole: process.env.DB_RLS_ROLE,
+    queryRolePosture: queryRlsConnectionRolePosture,
+  })
+    .then(result => {
+      rlsConnectionRoleAssertionState = 'passed';
+      reportRlsConnectionRoleAssertion(result);
+      return result;
+    })
+    .catch(error => {
+      rlsConnectionRoleAssertionState = 'failed';
+      rlsConnectionRoleAssertionFailure = error;
+      reportRlsConnectionRoleAssertion(resultFromRlsConnectionRoleAssertionError(error), error);
+      return undefined;
+    });
+}
+
+const rlsConnectionRoleAssertion = startRlsConnectionRoleAssertion();
+
+function assertRlsDatabaseClientReady(): void {
+  if (!shouldAssertRlsConnectionRole || rlsConnectionRoleAssertionState === 'passed') {
+    return;
+  }
+
+  if (rlsConnectionRoleAssertionState === 'failed') {
+    throw rlsConnectionRoleAssertionFailure instanceof Error
+      ? rlsConnectionRoleAssertionFailure
+      : new Error('DATABASE_URL_RLS role assertion failed');
+  }
+
+  throw new Error(
+    'DATABASE_URL_RLS role assertion has not completed; await assertRlsConnectionRoleReady() before using dbRls or db'
+  );
+}
+
+function createAssertedRlsDatabaseClient<TClient extends object>(client: TClient): TClient {
+  if (!shouldAssertRlsConnectionRole) {
+    return client;
+  }
+
+  return new Proxy(client, {
+    get(target, property, receiver) {
+      assertRlsDatabaseClientReady();
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+export async function assertRlsConnectionRoleReady(): Promise<void> {
+  await rlsConnectionRoleAssertion;
+  if (rlsConnectionRoleAssertionState === 'failed') {
+    throw rlsConnectionRoleAssertionFailure instanceof Error
+      ? rlsConnectionRoleAssertionFailure
+      : new Error('DATABASE_URL_RLS role assertion failed');
+  }
+}
+
 export const dbAdmin = drizzle(adminQueryClient, { schema });
-export const dbRls = drizzle(rlsQueryClient, { schema });
+const dbRlsClient = drizzle(rlsQueryClient, { schema });
+export const dbRls = createAssertedRlsDatabaseClient(dbRlsClient);
 
 /**
  * Backward-compatible alias. Prefer explicit dbRls or dbAdmin.

--- a/packages/database/src/rls-role-assertion.ts
+++ b/packages/database/src/rls-role-assertion.ts
@@ -1,0 +1,235 @@
+/**
+ * Verifies only the RLS connection and optional configured SET ROLE target.
+ * The admin connection is intentionally privileged and may bypass RLS by design;
+ * do not extend this assertion to dbAdmin.
+ */
+export type RlsConnectionRolePosture = {
+  currentUser: string | null;
+  roleName?: string | null;
+  roleBypassesRls: boolean | null;
+  roleIsSuperuser: boolean | null;
+};
+
+export type RlsConnectionRoleAssertionOptions = {
+  isProduction: boolean;
+  configuredDbRole?: string | null;
+  queryRolePosture: (roleName?: string) => Promise<RlsConnectionRolePosture[]>;
+  timeoutMs?: number;
+};
+
+export type RlsConnectionRoleAssertionResult =
+  | {
+      ok: true;
+      currentUser: string;
+      configuredDbRole?: string;
+      roleBypassesRls: false;
+      roleIsSuperuser: false;
+    }
+  | {
+      ok: false;
+      reason:
+        | 'invalid_configured_role'
+        | 'missing_role_posture'
+        | 'role_bypasses_rls'
+        | 'query_failed';
+      checkedRole?: 'connection' | 'configuredDbRole';
+      currentUser?: string;
+      configuredDbRole?: string;
+      cause?: unknown;
+    };
+
+export class RlsConnectionRoleAssertionError extends Error {
+  readonly result: RlsConnectionRoleAssertionResult;
+
+  constructor(result: RlsConnectionRoleAssertionResult) {
+    super(formatRlsConnectionRoleAssertionFailure(result));
+    this.name = 'RlsConnectionRoleAssertionError';
+    this.result = result;
+  }
+}
+
+export function evaluateRlsConnectionRolePosture(
+  rows: RlsConnectionRolePosture[],
+  checkedRole: 'connection' | 'configuredDbRole' = 'connection',
+  expectedRoleName?: string
+): RlsConnectionRoleAssertionResult {
+  const posture = rows[0];
+  const currentUser =
+    expectedRoleName ?? posture?.roleName?.trim() ?? posture?.currentUser?.trim() ?? undefined;
+
+  if (
+    !currentUser ||
+    typeof posture?.roleBypassesRls !== 'boolean' ||
+    typeof posture?.roleIsSuperuser !== 'boolean'
+  ) {
+    return {
+      ok: false,
+      reason: 'missing_role_posture',
+      checkedRole,
+      currentUser,
+    };
+  }
+
+  if (posture.roleBypassesRls || posture.roleIsSuperuser) {
+    return {
+      ok: false,
+      reason: 'role_bypasses_rls',
+      checkedRole,
+      currentUser,
+    };
+  }
+
+  return {
+    ok: true,
+    currentUser,
+    roleBypassesRls: false,
+    roleIsSuperuser: false,
+  };
+}
+
+export function formatRlsConnectionRoleAssertionFailure(
+  result: RlsConnectionRoleAssertionResult
+): string {
+  if (result.ok) {
+    return `DATABASE_URL_RLS role ${result.currentUser} cannot bypass RLS`;
+  }
+
+  if (result.reason === 'role_bypasses_rls') {
+    const label = result.checkedRole === 'configuredDbRole' ? 'DB_RLS_ROLE target' : 'role';
+    return `DATABASE_URL_RLS ${label} ${result.currentUser ?? 'unknown'} can bypass row-level security; refusing startup`;
+  }
+
+  if (result.reason === 'invalid_configured_role') {
+    return `DB_RLS_ROLE contains an invalid PostgreSQL role identifier; refusing startup`;
+  }
+
+  if (result.reason === 'query_failed') {
+    return `DATABASE_URL_RLS role posture could not be verified; refusing startup`;
+  }
+
+  return `DATABASE_URL_RLS role posture was missing or malformed; refusing startup`;
+}
+
+export function assertRlsRoleIdentifier(role: string): string {
+  const normalized = role.trim();
+  if (!/^[a-zA-Z_]\w*$/u.test(normalized)) {
+    throw new Error(`Invalid DB role for RLS context: ${role}`);
+  }
+  return normalized;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`DATABASE_URL_RLS role posture query timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function handleNonOkRoleAssertionResult(
+  result: RlsConnectionRoleAssertionResult,
+  isProduction: boolean
+): RlsConnectionRoleAssertionResult {
+  if (isProduction) {
+    throw new RlsConnectionRoleAssertionError(result);
+  }
+
+  return result;
+}
+
+function getConfiguredDbRole(
+  configuredDbRole: string | null | undefined,
+  isProduction: boolean
+): string | RlsConnectionRoleAssertionResult | undefined {
+  if (!configuredDbRole?.trim()) {
+    return undefined;
+  }
+
+  try {
+    return assertRlsRoleIdentifier(configuredDbRole);
+  } catch (cause) {
+    return handleNonOkRoleAssertionResult(
+      {
+        ok: false,
+        reason: 'invalid_configured_role',
+        configuredDbRole,
+        cause,
+      },
+      isProduction
+    );
+  }
+}
+
+async function evaluateQueriedRolePosture(
+  options: RlsConnectionRoleAssertionOptions,
+  roleName: string | undefined,
+  checkedRole: 'connection' | 'configuredDbRole'
+): Promise<RlsConnectionRoleAssertionResult> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const rows = await withTimeout(options.queryRolePosture(roleName), timeoutMs);
+  const result = evaluateRlsConnectionRolePosture(rows, checkedRole, roleName);
+
+  if (!result.ok && checkedRole === 'configuredDbRole') {
+    result.configuredDbRole = roleName;
+  }
+
+  return result;
+}
+
+export async function assertRlsConnectionRole(
+  options: RlsConnectionRoleAssertionOptions
+): Promise<RlsConnectionRoleAssertionResult> {
+  const configuredDbRole = getConfiguredDbRole(options.configuredDbRole, options.isProduction);
+  if (typeof configuredDbRole === 'object') {
+    return configuredDbRole;
+  }
+
+  try {
+    const connectionResult = await evaluateQueriedRolePosture(options, undefined, 'connection');
+    if (!connectionResult.ok) {
+      return handleNonOkRoleAssertionResult(connectionResult, options.isProduction);
+    }
+
+    if (!configuredDbRole) {
+      return connectionResult;
+    }
+
+    const configuredRoleResult = await evaluateQueriedRolePosture(
+      options,
+      configuredDbRole,
+      'configuredDbRole'
+    );
+    if (!configuredRoleResult.ok) {
+      return handleNonOkRoleAssertionResult(configuredRoleResult, options.isProduction);
+    }
+
+    return {
+      ...connectionResult,
+      configuredDbRole,
+    };
+  } catch (cause) {
+    if (cause instanceof RlsConnectionRoleAssertionError) {
+      throw cause;
+    }
+
+    const result: RlsConnectionRoleAssertionResult = {
+      ok: false,
+      reason: 'query_failed',
+      cause,
+    };
+    if (options.isProduction) {
+      throw new RlsConnectionRoleAssertionError(result);
+    }
+    return result;
+  }
+}

--- a/packages/database/src/tenant.ts
+++ b/packages/database/src/tenant.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 
-import { dbRls } from './db';
+import { assertRlsConnectionRoleReady, dbRls } from './db';
+import { assertRlsRoleIdentifier } from './rls-role-assertion';
 
 export type TenantContext = {
   tenantId: string;
@@ -24,16 +25,8 @@ function assertTenantId(tenantId: string): string {
   return normalized;
 }
 
-function assertRoleIdentifier(role: string): string {
-  const normalized = role.trim();
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/u.test(normalized)) {
-    throw new Error(`Invalid DB role for RLS context: ${role}`);
-  }
-  return normalized;
-}
-
 function setLocalRoleSql(role: string) {
-  const safeRole = assertRoleIdentifier(role);
+  const safeRole = assertRlsRoleIdentifier(role);
   return sql.raw(`set local role "${safeRole}"`);
 }
 
@@ -43,6 +36,8 @@ export async function withTenantContext<T>(
 ): Promise<T> {
   const tenantId = assertTenantId(context.tenantId);
   const effectiveDbRole = context.dbRole?.trim() || CONFIGURED_RLS_ROLE;
+
+  await assertRlsConnectionRoleReady();
 
   return dbRls.transaction(async tx => {
     if (effectiveDbRole) {

--- a/packages/database/test/rls-role-assertion.test.ts
+++ b/packages/database/test/rls-role-assertion.test.ts
@@ -1,0 +1,304 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  assertRlsRoleIdentifier,
+  assertRlsConnectionRole,
+  evaluateRlsConnectionRolePosture,
+  RlsConnectionRoleAssertionError,
+} from '../src/rls-role-assertion';
+
+test('RLS role assertion accepts a role that cannot bypass row-level security', async () => {
+  const result = await assertRlsConnectionRole({
+    isProduction: true,
+    queryRolePosture: async () => [
+      {
+        currentUser: 'interdomestik_rls',
+        roleBypassesRls: false,
+        roleIsSuperuser: false,
+      },
+    ],
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    currentUser: 'interdomestik_rls',
+    roleBypassesRls: false,
+    roleIsSuperuser: false,
+  });
+});
+
+test('RLS role assertion rejects a production role that can bypass row-level security', async () => {
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        queryRolePosture: async () => [
+          {
+            currentUser: 'postgres',
+            roleBypassesRls: true,
+            roleIsSuperuser: false,
+          },
+        ],
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match(
+        (error as Error).message,
+        /DATABASE_URL_RLS role postgres can bypass row-level security; refusing startup/u
+      );
+      return true;
+    }
+  );
+});
+
+test('RLS role assertion rejects a production superuser role', async () => {
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        queryRolePosture: async () => [
+          {
+            currentUser: 'postgres',
+            roleBypassesRls: false,
+            roleIsSuperuser: true,
+          },
+        ],
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match(
+        (error as Error).message,
+        /DATABASE_URL_RLS role postgres can bypass row-level security; refusing startup/u
+      );
+      return true;
+    }
+  );
+});
+
+test('RLS role assertion rejects production when the role posture is missing', async () => {
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        queryRolePosture: async () => [],
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match(
+        (error as Error).message,
+        /DATABASE_URL_RLS role posture was missing or malformed/u
+      );
+      return true;
+    }
+  );
+});
+
+test('RLS role assertion rejects production when posture verification fails', async () => {
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        queryRolePosture: async () => {
+          throw new Error('database unavailable');
+        },
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match((error as Error).message, /could not be verified/u);
+      return true;
+    }
+  );
+});
+
+test('RLS role assertion rejects production when posture verification times out', async () => {
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        timeoutMs: 1,
+        queryRolePosture: () => new Promise(() => undefined),
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match((error as Error).message, /could not be verified/u);
+      return true;
+    }
+  );
+});
+
+test('RLS role assertion checks DB_RLS_ROLE when configured', async () => {
+  const checkedRoles: Array<string | undefined> = [];
+  const result = await assertRlsConnectionRole({
+    isProduction: true,
+    configuredDbRole: 'interdomestik_runtime_rls',
+    queryRolePosture: async roleName => {
+      checkedRoles.push(roleName);
+      return [
+        {
+          currentUser: 'interdomestik_app',
+          roleName: roleName ?? 'interdomestik_app',
+          roleBypassesRls: false,
+          roleIsSuperuser: false,
+        },
+      ];
+    },
+  });
+
+  assert.deepEqual(checkedRoles, [undefined, 'interdomestik_runtime_rls']);
+  assert.deepEqual(result, {
+    ok: true,
+    currentUser: 'interdomestik_app',
+    configuredDbRole: 'interdomestik_runtime_rls',
+    roleBypassesRls: false,
+    roleIsSuperuser: false,
+  });
+});
+
+test('RLS role assertion rejects production when DB_RLS_ROLE can bypass row-level security', async () => {
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        configuredDbRole: 'postgres',
+        queryRolePosture: async roleName => [
+          {
+            currentUser: 'interdomestik_app',
+            roleName: roleName ?? 'interdomestik_app',
+            roleBypassesRls: roleName === 'postgres',
+            roleIsSuperuser: false,
+          },
+        ],
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match(
+        (error as Error).message,
+        /DATABASE_URL_RLS DB_RLS_ROLE target postgres can bypass row-level security/u
+      );
+      return true;
+    }
+  );
+});
+
+test('RLS role assertion rejects production when DB_RLS_ROLE is a superuser', async () => {
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        configuredDbRole: 'postgres',
+        queryRolePosture: async roleName => [
+          {
+            currentUser: 'interdomestik_app',
+            roleName: roleName ?? 'interdomestik_app',
+            roleBypassesRls: false,
+            roleIsSuperuser: roleName === 'postgres',
+          },
+        ],
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match(
+        (error as Error).message,
+        /DATABASE_URL_RLS DB_RLS_ROLE target postgres can bypass row-level security/u
+      );
+      return true;
+    }
+  );
+});
+
+test('RLS role assertion rejects production when DB_RLS_ROLE is missing from pg_roles', async () => {
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        configuredDbRole: 'missing_role',
+        queryRolePosture: async roleName =>
+          roleName
+            ? []
+            : [
+                {
+                  currentUser: 'interdomestik_app',
+                  roleName: 'interdomestik_app',
+                  roleBypassesRls: false,
+                  roleIsSuperuser: false,
+                },
+              ],
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match(
+        (error as Error).message,
+        /DATABASE_URL_RLS role posture was missing or malformed/u
+      );
+      return true;
+    }
+  );
+});
+
+test('RLS role assertion rejects invalid DB_RLS_ROLE before querying', async () => {
+  let queryCount = 0;
+
+  await assert.rejects(
+    () =>
+      assertRlsConnectionRole({
+        isProduction: true,
+        configuredDbRole: 'postgres; drop table claim',
+        queryRolePosture: async () => {
+          queryCount += 1;
+          return [];
+        },
+      }),
+    error => {
+      assert.equal(error instanceof RlsConnectionRoleAssertionError, true);
+      assert.match((error as Error).message, /DB_RLS_ROLE contains an invalid/u);
+      return true;
+    }
+  );
+
+  assert.equal(queryCount, 0);
+});
+
+test('RLS role assertion checks only the connection role when DB_RLS_ROLE is unset', async () => {
+  const checkedRoles: Array<string | undefined> = [];
+
+  await assertRlsConnectionRole({
+    isProduction: true,
+    queryRolePosture: async roleName => {
+      checkedRoles.push(roleName);
+      return [
+        {
+          currentUser: 'interdomestik_app',
+          roleBypassesRls: false,
+          roleIsSuperuser: false,
+        },
+      ];
+    },
+  });
+
+  assert.deepEqual(checkedRoles, [undefined]);
+});
+
+test('assertRlsRoleIdentifier rejects unsafe role names', () => {
+  assert.throws(
+    () => assertRlsRoleIdentifier('postgres; drop table claim'),
+    /Invalid DB role for RLS context/u
+  );
+});
+
+test('RLS role posture evaluation treats malformed rows as unverifiable', () => {
+  const result = evaluateRlsConnectionRolePosture([
+    {
+      currentUser: 'interdomestik_rls',
+      roleBypassesRls: null,
+      roleIsSuperuser: null,
+    },
+  ]);
+
+  assert.deepEqual(result, {
+    ok: false,
+    reason: 'missing_role_posture',
+    checkedRole: 'connection',
+    currentUser: 'interdomestik_rls',
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a fail-closed startup assertion for the tenant-scoped RLS database connection in deployed production and when `REQUIRE_RLS_INTEGRATION=1` is set.
- Verifies both the connection role and optional `DB_RLS_ROLE` target are present and are neither `BYPASSRLS` nor superuser before `withTenantContext` can run.
- Guards raw `dbRls` / `db` access until the assertion passes, while keeping `dbAdmin` intentionally privileged and unchanged.
- Keeps local loopback production-mode builds/E2E viable when `DATABASE_URL_RLS` defaults to the same local URL as `DATABASE_URL`; non-local production still fails if both URLs resolve to the same connection.

## Scope

- No schema or migration changes.
- No admin connection role posture or query path changes.
- No new environment variables; this only reads existing `DB_RLS_ROLE` and `REQUIRE_RLS_INTEGRATION`.
- No build guard for direct `db.*` callsites; that remains the next planned slice.
- No proxy, routing, auth, product UX, Stripe, or architecture changes.

## Verification

- `pnpm --filter @interdomestik/database exec tsx --test test/rls-role-assertion.test.ts` passed.
- `pnpm --filter @interdomestik/database type-check` passed.
- `pnpm db:rls:test:required` passed: 23 tests, `RLS_COVERAGE total=54 enabled=54 missing=0 pct=100.00`, runtime receipt with `row_security=on`.
- `pnpm verify-slice -- --static` passed.
- `VITEST_MAX_WORKERS=1 pnpm check:fast` passed.
- `VITEST_MAX_WORKERS=1 pnpm coverage:gate` passed: repo line coverage 80.97% vs 60% gate.
- `KS_HOST=ks.localhost:3000 MK_HOST=mk.localhost:3000 node scripts/run-with-default-db-url.mjs pnpm e2e:gate` passed: 118 passed, 4 skipped.
- Earlier combined `VITEST_MAX_WORKERS=1 pnpm verify-slice -- --required-gates` reached green `pr:verify` and `security:guard`, then hit unrelated local E2E flakes; focused reruns passed and the final host-routed full E2E gate above passed.
- Diff-scoped Codex Security plugin scan was unavailable because `tool_search` did not expose a callable scan tool; local fallback diff-scoped security review found no reportable findings.
- Mandatory reviewer pool completed; no must-fix findings remained after re-review.

## Operational Notes

- The assertion is module-scoped: one `pg_roles` check per process/isolate cold start, plus one additional check when `DB_RLS_ROLE` is set.
- Failures are reported once through logs and optional Sentry telemetry under `database.rls.role_assertion.{passed,failed}`.
- Rollback is a normal revert; the change is code-only and does not alter persisted data.