### PR TITLE
test: disambiguate free start completion selector

### DIFF
--- a/apps/web/src/app/[locale]/components/home/free-start-intake-shell.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/free-start-intake-shell.test.tsx
@@ -311,7 +311,7 @@ describe('FreeStartIntakeShell', () => {
 
     await completeFreeStartIntake(user, 'en');
 
-    expect(screen.getByTestId('free-start-complete')).toBeInTheDocument();
+    expect(screen.getByTestId('free-start-complete-pending-pack')).toBeInTheDocument();
     expect(screen.getByTestId('free-start-confidence-level')).toHaveTextContent(
       enFreeStartMessages.freeStart.completion.confidence.levels.high.label
     );
@@ -408,7 +408,7 @@ describe('FreeStartIntakeShell', () => {
       },
     });
 
-    expect(await screen.findByTestId('free-start-complete')).toBeInTheDocument();
+    expect(await screen.findByTestId('free-start-complete-pending-pack')).toBeInTheDocument();
   });
 
   it('renders the generated claim pack when the pack action succeeds', async () => {
@@ -608,5 +608,6 @@ describe('FreeStartIntakeShell', () => {
       'Please try again. If the problem persists, contact support.'
     );
     expect(screen.queryByTestId('free-start-complete')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('free-start-complete-pending-pack')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/[locale]/components/home/free-start-intake-shell/sidebar.tsx
+++ b/apps/web/src/app/[locale]/components/home/free-start-intake-shell/sidebar.tsx
@@ -150,7 +150,7 @@ export function FreeStartSidebar({
 
     return (
       <div className="space-y-4">
-        <div data-testid="free-start-complete" className="space-y-4">
+        <div data-testid="free-start-complete-pending-pack" className="space-y-4">
           <div className="inline-flex items-center gap-2 rounded-full border border-emerald-300/40 bg-emerald-300/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-emerald-100">
             <CheckCircle2 className="h-3.5 w-3.5" />
             {t('completion.badge')}


### PR DESCRIPTION
## Summary
- Rename the pending-pack completion sidebar test id to `free-start-complete-pending-pack`.
- Update the free-start intake shell unit tests to assert the pending and generated-pack completion states separately.
- Keep child components under the existing parent client boundary to avoid adding new client-boundary serialization constraints for callback props.

## Verification
- `git diff --check`
- `mcp__interdomestik_qa__.scope_audit` for the free-start intake shell paths, with `apps/web/src/proxy.ts`, README, AGENTS.md, and docs as forbidden paths
- `pnpm --filter @interdomestik/web test:unit --run src/app/[locale]/components/home/free-start-intake-shell.test.tsx`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates` (local Sentry upload env filtered during the run and restored afterward; no repo env files changed)

## Review
- Slice-runner reviewer pool rechecked security/auth/tenancy, maintainability, QA/test contracts, product/UX, and performance.
- Codex Security diff scan reported no findings.

## Rollback
- Revert commit `3666b184` to restore the prior shared `free-start-complete` selector contract.