### PR TITLE
feat: add CSP nonce report-only phase zero

### DIFF
--- a/apps/web/e2e/security/headers.spec.ts
+++ b/apps/web/e2e/security/headers.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from '@playwright/test';
 import { gotoApp } from '../utils/navigation';
 
 test.describe('Security Headers', () => {
+  const cspNonceMode = process.env.CSP_NONCE_MODE ?? 'off';
+
   async function expectSecurityHeaders(
     page: Parameters<typeof gotoApp>[0],
     path: string,
@@ -22,6 +24,29 @@ test.describe('Security Headers', () => {
     expect(headers['x-frame-options']).toBe('DENY');
     expect(headers['x-content-type-options']).toBe('nosniff');
     expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+
+    if (cspNonceMode === 'report') {
+      const reportOnlyCsp = headers['content-security-policy-report-only'];
+      const nonce = headers['x-nonce'];
+      expect(reportOnlyCsp).toBeDefined();
+      expect(reportOnlyCsp).toContain("'nonce-");
+      expect(reportOnlyCsp).toContain("'strict-dynamic'");
+      expect(reportOnlyCsp).toContain('report-uri /api/csp-report');
+      expect(reportOnlyCsp).toContain('report-to csp-endpoint');
+      expect(headers['report-to']).toContain('"group":"csp-endpoint"');
+      expect(nonce).toMatch(/^[A-Za-z0-9_-]{22}$/);
+      const scriptNonces = await page
+        .locator('script')
+        .evaluateAll(scripts =>
+          scripts.map(script => (script as HTMLScriptElement).nonce).filter(Boolean)
+        );
+      expect(scriptNonces).toContain(nonce);
+      return { headers, nonce };
+    }
+
+    expect(headers['content-security-policy-report-only']).toBeUndefined();
+    expect(headers['x-nonce']).toBeUndefined();
+    return { headers, nonce: undefined };
   }
 
   test('should have security headers on static public pages', async ({ page }, testInfo) => {
@@ -30,5 +55,21 @@ test.describe('Security Headers', () => {
 
   test('should have security headers on dynamic public pages', async ({ page }, testInfo) => {
     await expectSecurityHeaders(page, '/pricing', 'pricing-page-ready', testInfo);
+  });
+
+  test('should use fresh CSP report-only nonces when report mode is enabled', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      cspNonceMode !== 'report',
+      'CSP nonce report-mode proof runs with CSP_NONCE_MODE=report'
+    );
+
+    const first = await expectSecurityHeaders(page, '/', 'landing-page-ready', testInfo);
+    const second = await expectSecurityHeaders(page, '/pricing', 'pricing-page-ready', testInfo);
+
+    expect(first.nonce).toBeDefined();
+    expect(second.nonce).toBeDefined();
+    expect(first.nonce).not.toBe(second.nonce);
   });
 });

--- a/apps/web/scripts/stamp-standalone.mjs
+++ b/apps/web/scripts/stamp-standalone.mjs
@@ -26,6 +26,11 @@ function normalizeBillingTestMode(value) {
   return value?.trim() === '1' ? '1' : '0';
 }
 
+function normalizeCspNonceMode(value) {
+  if (value === undefined || value === 'off') return 'off';
+  return value;
+}
+
 function stripRouteGroups(relativePath) {
   return relativePath
     .split(path.sep)
@@ -105,11 +110,15 @@ function syncClientReferenceManifests(sourceRoot, targetRoot) {
 
 const gitSha = resolveGitSha();
 const billingTestMode = normalizeBillingTestMode(process.env.NEXT_PUBLIC_BILLING_TEST_MODE);
+const cspNonceMode = normalizeCspNonceMode(process.env.CSP_NONCE_MODE);
 const stamp = {
   gitSha,
   builtAt: new Date().toISOString(),
   publicEnv: {
     NEXT_PUBLIC_BILLING_TEST_MODE: billingTestMode,
+  },
+  buildEnv: {
+    CSP_NONCE_MODE: cspNonceMode,
   },
 };
 const outDir = path.resolve('.next/standalone');
@@ -132,7 +141,9 @@ const aliasCount = serverRoots.reduce(
 fs.mkdirSync(outDir, { recursive: true });
 fs.writeFileSync(outFile, `${JSON.stringify(stamp, null, 2)}\n`);
 
-console.log(`[build-stamp] ${outFile} (${gitSha}, billingTestMode=${billingTestMode})`);
+console.log(
+  `[build-stamp] ${outFile} (${gitSha}, billingTestMode=${billingTestMode}, cspNonceMode=${cspNonceMode})`
+);
 if (syncCount > 0) {
   console.log(`[build-stamp] standalone client reference manifests synced=${syncCount}`);
 }

--- a/apps/web/src/app/[locale]/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/_core.entry.tsx
@@ -8,9 +8,12 @@ import { PostHogProvider } from '@/components/providers/posthog-provider';
 import { QueryProvider } from '@/components/providers/query-provider';
 import { BASE_NAMESPACES, pickMessages } from '@/i18n/messages';
 import { routing } from '@/i18n/routing';
+import { isCspNonceActive } from '@/lib/security/csp-nonce';
 import '@interdomestik/ui/globals.css';
 import type { Metadata } from 'next';
 import { Inter, Space_Grotesk } from 'next/font/google';
+import { headers } from 'next/headers';
+import { connection } from 'next/server';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
@@ -95,6 +98,11 @@ export default async function RootLayout({ children, params }: Props) {
   // Fetch messages for the locale
   const allMessages = await getMessages();
   const messages = pickMessages(allMessages, BASE_NAMESPACES);
+  let cspNonce: string | null = null;
+  if (isCspNonceActive()) {
+    await connection();
+    cspNonce = (await headers()).get('x-nonce');
+  }
 
   return (
     <html lang={locale} suppressHydrationWarning>
@@ -115,6 +123,7 @@ export default async function RootLayout({ children, params }: Props) {
             zIndex: -1,
           }}
         />
+        {cspNonce ? <script data-csp-nonce-probe="" nonce={cspNonce} /> : null}
         {process.env.NODE_ENV === 'development' && enableDevtoolsScript && (
           <script src="http://localhost:8097" async></script>
         )}
@@ -139,7 +148,7 @@ export default async function RootLayout({ children, params }: Props) {
                 {enableAxe ? <AxeProvider /> : null}
                 <ReferralTracker />
                 <PwaRegistrar />
-                <AnalyticsScripts />
+                <AnalyticsScripts nonce={cspNonce ?? undefined} />
                 <CookieConsentBanner />
               </QueryProvider>
             </NextIntlClientProvider>

--- a/apps/web/src/app/api/csp-report/route.test.ts
+++ b/apps/web/src/app/api/csp-report/route.test.ts
@@ -128,6 +128,25 @@ describe('/api/csp-report', () => {
     expect(hoisted.captureMessage).not.toHaveBeenCalled();
   });
 
+  it('preserves fail-closed rate-limit outages without returning a shared body', async () => {
+    hoisted.enforceRateLimit.mockResolvedValueOnce(
+      new Response('unavailable', { status: 503, headers: { 'Retry-After': '60' } })
+    );
+
+    const response = await POST(
+      makeRequest({
+        contentType: 'application/csp-report',
+        body: { invalid: true },
+      })
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('60');
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(await response.text()).toBe('');
+    expect(hoisted.captureMessage).not.toHaveBeenCalled();
+  });
+
   it('bounds oversized report bodies without capture', async () => {
     const response = await POST(
       makeRequest({

--- a/apps/web/src/app/api/csp-report/route.test.ts
+++ b/apps/web/src/app/api/csp-report/route.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  captureMessage: vi.fn(),
+  enforceRateLimit: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: hoisted.captureMessage,
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  enforceRateLimit: hoisted.enforceRateLimit,
+}));
+
+import { GET, POST } from './route';
+
+function makeRequest(init?: { contentType?: string; body?: unknown; cookie?: string }): Request {
+  const headers = new Headers();
+  if (init?.contentType) headers.set('content-type', init.contentType);
+  if (init?.cookie) headers.set('cookie', init.cookie);
+
+  return new Request('http://localhost:3000/api/csp-report', {
+    method: 'POST',
+    headers,
+    body: init?.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+}
+
+describe('/api/csp-report', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.enforceRateLimit.mockResolvedValue(null);
+  });
+
+  it('rejects GET with 405', async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('allow')).toBe('POST');
+  });
+
+  it('rejects unsupported content types with 415', async () => {
+    const response = await POST(makeRequest({ contentType: 'application/json', body: {} }));
+
+    expect(response.status).toBe(415);
+    expect(hoisted.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns 204 for legacy CSP reports and strips sensitive fields before Sentry capture', async () => {
+    const response = await POST(
+      makeRequest({
+        contentType: 'application/csp-report',
+        cookie: 'better-auth.session_token=secret',
+        body: {
+          'csp-report': {
+            'blocked-uri': 'https://cdn.example/script.js?token=secret',
+            'document-uri': 'https://app.example/member/help?otp=secret',
+            disposition: 'report',
+            'script-sample': 'inline secret',
+            'violated-directive': 'script-src https:',
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe('');
+    expect(response.headers.get('set-cookie')).toBeNull();
+    expect(hoisted.captureMessage).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(hoisted.captureMessage.mock.calls[0])).not.toContain('better-auth');
+    expect(JSON.stringify(hoisted.captureMessage.mock.calls[0])).not.toContain('secret');
+  });
+
+  it('accepts Reporting API reports with modern Chrome field names', async () => {
+    const response = await POST(
+      makeRequest({
+        contentType: 'application/reports+json',
+        body: [
+          {
+            type: 'csp-violation',
+            body: {
+              blockedURL: 'https://cdn.example/script.js?token=secret',
+              documentURL: 'https://app.example/sq?otp=secret',
+              disposition: 'enforce',
+              effectiveDirective: 'script-src-elem',
+              originalPolicy: 'x'.repeat(700),
+              sourceFile: 'https://cdn.example/source.js?session=secret',
+            },
+          },
+        ],
+      })
+    );
+
+    expect(response.status).toBe(204);
+    expect(hoisted.captureMessage).toHaveBeenCalledTimes(1);
+    expect(hoisted.captureMessage).toHaveBeenCalledWith(
+      'csp.violation',
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          'csp.directive': 'script-src-elem',
+          'csp.disposition': 'report',
+          'csp.blocked_host': 'cdn.example',
+          'csp.document_host': 'app.example',
+        }),
+        extra: expect.objectContaining({
+          blockedUri: 'https://cdn.example/script.js',
+          documentUri: 'https://app.example/sq',
+          sourceFile: 'https://cdn.example/source.js',
+        }),
+      })
+    );
+    expect(JSON.stringify(hoisted.captureMessage.mock.calls[0])).not.toContain('secret');
+  });
+
+  it('returns 204 without parsing reports when rate-limited', async () => {
+    hoisted.enforceRateLimit.mockResolvedValueOnce(new Response('limited', { status: 429 }));
+
+    const response = await POST(
+      makeRequest({
+        contentType: 'application/csp-report',
+        body: { invalid: true },
+      })
+    );
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe('');
+    expect(hoisted.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('bounds oversized report bodies without capture', async () => {
+    const response = await POST(
+      makeRequest({
+        contentType: 'application/csp-report',
+        body: { 'csp-report': { 'blocked-uri': 'x'.repeat(20_000) } },
+      })
+    );
+
+    expect(response.status).toBe(204);
+    expect(hoisted.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('caps Reporting API events per request', async () => {
+    const reports = Array.from({ length: 12 }, (_, index) => ({
+      type: 'csp-violation',
+      body: {
+        blockedURL: `https://cdn${index}.example/script.js`,
+        documentURL: 'https://app.example/sq',
+        effectiveDirective: 'script-src',
+      },
+    }));
+
+    const response = await POST(
+      makeRequest({
+        contentType: 'application/reports+json',
+        body: reports,
+      })
+    );
+
+    expect(response.status).toBe(204);
+    expect(hoisted.captureMessage).toHaveBeenCalledTimes(10);
+  });
+
+  it('marks the rate-limit call production sensitive', async () => {
+    await POST(
+      makeRequest({
+        contentType: 'application/csp-report',
+        body: {},
+      })
+    );
+
+    expect(hoisted.enforceRateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'api/csp-report',
+        limit: 60,
+        windowSeconds: 60,
+        productionSensitive: true,
+      })
+    );
+  });
+});

--- a/apps/web/src/app/api/csp-report/route.ts
+++ b/apps/web/src/app/api/csp-report/route.ts
@@ -1,0 +1,49 @@
+import {
+  captureCspReports,
+  isAcceptedCspReportContentType,
+  normalizeCspReportBody,
+  readCspReportBody,
+} from '@/lib/security/csp-report';
+import { enforceRateLimit } from '@/lib/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+function noContent(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function GET(): Promise<Response> {
+  return new Response(null, { status: 405, headers: { Allow: 'POST' } });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const limited = await enforceRateLimit({
+    name: 'api/csp-report',
+    limit: 60,
+    windowSeconds: 60,
+    headers: request.headers,
+    productionSensitive: true,
+  });
+  if (limited) return noContent();
+
+  if (!isAcceptedCspReportContentType(request.headers.get('content-type'))) {
+    return new Response(null, { status: 415 });
+  }
+
+  try {
+    const body = await readCspReportBody(request);
+    if (body === null) return noContent();
+
+    const reports = normalizeCspReportBody(JSON.parse(body));
+    captureCspReports(reports);
+  } catch {
+    // Malformed browser reports should not turn report delivery into a user-visible failure.
+  }
+
+  return noContent();
+}

--- a/apps/web/src/app/api/csp-report/route.ts
+++ b/apps/web/src/app/api/csp-report/route.ts
@@ -17,6 +17,18 @@ function noContent(): Response {
   });
 }
 
+function rateLimitResponse(response: Response): Response {
+  if (response.status === 503) {
+    const retryAfter = response.headers.get('retry-after');
+    const headers = new Headers({ 'Cache-Control': 'no-store' });
+    if (retryAfter) headers.set('Retry-After', retryAfter);
+
+    return new Response(null, { status: 503, headers });
+  }
+
+  return noContent();
+}
+
 export async function GET(): Promise<Response> {
   return new Response(null, { status: 405, headers: { Allow: 'POST' } });
 }
@@ -29,7 +41,7 @@ export async function POST(request: Request): Promise<Response> {
     headers: request.headers,
     productionSensitive: true,
   });
-  if (limited) return noContent();
+  if (limited) return rateLimitResponse(limited);
 
   if (!isAcceptedCspReportContentType(request.headers.get('content-type'))) {
     return new Response(null, { status: 415 });

--- a/apps/web/src/components/analytics/analytics-scripts.test.tsx
+++ b/apps/web/src/components/analytics/analytics-scripts.test.tsx
@@ -8,14 +8,24 @@ vi.mock('@/lib/cookie-consent', () => ({
 }));
 
 vi.mock('next/script', () => ({
-  default: ({ id, src, onLoad }: { id: string; src?: string; onLoad?: () => void }) => {
+  default: ({
+    id,
+    nonce,
+    src,
+    onLoad,
+  }: {
+    id: string;
+    nonce?: string;
+    src?: string;
+    onLoad?: () => void;
+  }) => {
     if (id === 'google-tag-manager-src' && !(globalThis as { dataLayer?: unknown }).dataLayer) {
       throw new Error('GTM rendered before dataLayer initialization');
     }
 
     onLoad?.();
 
-    return <div data-testid={id} data-src={src} />;
+    return <div data-testid={id} data-nonce={nonce} data-src={src} />;
   },
 }));
 
@@ -45,12 +55,16 @@ describe('AnalyticsScripts', () => {
   });
 
   it('initializes dataLayer before rendering the GTM script', async () => {
-    render(<AnalyticsScripts />);
+    render(<AnalyticsScripts nonce="nonce-test" />);
 
     await waitFor(() => {
       expect(screen.getByTestId('google-tag-manager-src')).toBeInTheDocument();
     });
 
+    expect(screen.getByTestId('google-tag-manager-src')).toHaveAttribute(
+      'data-nonce',
+      'nonce-test'
+    );
     expect((globalThis as { dataLayer?: Array<Record<string, unknown>> }).dataLayer).toEqual(
       expect.arrayContaining([expect.objectContaining({ event: 'gtm.js' })])
     );

--- a/apps/web/src/components/analytics/analytics-scripts.tsx
+++ b/apps/web/src/components/analytics/analytics-scripts.tsx
@@ -18,7 +18,7 @@ type AnalyticsWindow = Window & {
   _fbq?: MetaPixelFunction;
 };
 
-export function AnalyticsScripts() {
+export function AnalyticsScripts({ nonce }: { nonce?: string }) {
   const { consent } = useCookieConsent();
   const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
   const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID;
@@ -86,6 +86,7 @@ export function AnalyticsScripts() {
           id="google-tag-manager-src"
           src={`https://www.googletagmanager.com/gtm.js?id=${GTM_ID}`}
           strategy="afterInteractive"
+          nonce={nonce}
         />
       )}
 
@@ -94,6 +95,7 @@ export function AnalyticsScripts() {
           id="meta-pixel-src"
           src="https://connect.facebook.net/en_US/fbevents.js"
           strategy="afterInteractive"
+          nonce={nonce}
           onLoad={() => {
             const analyticsWindow = globalThis as typeof globalThis & AnalyticsWindow;
             analyticsWindow.fbq?.('init', META_PIXEL_ID);

--- a/apps/web/src/lib/proxy-logic.csp-nonce.test.ts
+++ b/apps/web/src/lib/proxy-logic.csp-nonce.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const ORIGINAL_MODE = process.env.CSP_NONCE_MODE;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const mutableEnv = process.env as Record<string, string | undefined>;
+
+vi.mock('@/i18n/routing', () => ({
+  routing: {
+    locales: ['sq', 'en', 'sr', 'mk', 'de', 'hr'],
+  },
+}));
+
+vi.mock('@/lib/feature-flags', () => ({
+  isStaffAuthTolerantTenant: () => false,
+}));
+
+vi.mock('@/lib/telemetry', () => ({
+  emitAuthTelemetryEvent: vi.fn(),
+}));
+
+function makeRequest(pathname: string): NextRequest {
+  return new NextRequest(`https://ks.localhost:3000${pathname}`, {
+    headers: {
+      host: 'ks.localhost:3000',
+      'x-forwarded-proto': 'https',
+    },
+  });
+}
+
+async function importProxy() {
+  vi.resetModules();
+  return import('./proxy-logic');
+}
+
+describe('proxy CSP nonce Phase 0', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mutableEnv.CSP_NONCE_MODE = ORIGINAL_MODE;
+    mutableEnv.NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  it('keeps off mode on the current enforced CSP only', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.CSP_NONCE_MODE = 'off';
+    const { proxy } = await importProxy();
+
+    const response = await proxy(makeRequest('/sq'));
+
+    expect(response.headers.get('content-security-policy')).toContain(
+      "script-src 'self' 'unsafe-inline'"
+    );
+    expect(response.headers.get('content-security-policy-report-only')).toBeNull();
+    expect(response.headers.get('report-to')).toBeNull();
+    expect(response.headers.get('x-nonce')).toBeNull();
+  });
+
+  it('keeps the enforced CSP byte-identical in report mode', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.CSP_NONCE_MODE = 'off';
+    const offProxy = (await importProxy()).proxy;
+    const offResponse = await offProxy(makeRequest('/sq'));
+    const offCsp = offResponse.headers.get('content-security-policy');
+
+    mutableEnv.CSP_NONCE_MODE = 'report';
+    const reportProxy = (await importProxy()).proxy;
+    const reportResponse = await reportProxy(makeRequest('/sq'));
+
+    expect(reportResponse.headers.get('content-security-policy')).toBe(offCsp);
+    expect(reportResponse.headers.get('content-security-policy-report-only')).toContain("'nonce-");
+    expect(reportResponse.headers.get('content-security-policy-report-only')).toContain(
+      "'strict-dynamic'"
+    );
+    expect(reportResponse.headers.get('content-security-policy-report-only')).toContain(
+      'report-uri /api/csp-report'
+    );
+    expect(reportResponse.headers.get('content-security-policy-report-only')).toContain(
+      'report-to csp-endpoint'
+    );
+    expect(reportResponse.headers.get('report-to')).toBe(
+      '{"group":"csp-endpoint","max_age":86400,"endpoints":[{"url":"/api/csp-report"}]}'
+    );
+    expect(reportResponse.headers.get('x-nonce')).toMatch(/^[A-Za-z0-9_-]{22}$/);
+  });
+
+  it('uses different nonces for consecutive report-mode requests', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.CSP_NONCE_MODE = 'report';
+    const { proxy } = await importProxy();
+
+    const first = await proxy(makeRequest('/sq'));
+    const second = await proxy(makeRequest('/sq/pricing'));
+
+    expect(first.headers.get('x-nonce')).toMatch(/^[A-Za-z0-9_-]{22}$/);
+    expect(second.headers.get('x-nonce')).toMatch(/^[A-Za-z0-9_-]{22}$/);
+    expect(first.headers.get('x-nonce')).not.toBe(second.headers.get('x-nonce'));
+  });
+
+  it('adds report-only nonce headers to protected redirects without changing auth behavior', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.CSP_NONCE_MODE = 'report';
+    const { proxy } = await importProxy();
+
+    const response = await proxy(makeRequest('/sq/member'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://ks.localhost:3000/sq/login');
+    expect(response.headers.get('x-auth-guard')).toBe('middleware-redirect');
+    expect(response.headers.get('content-security-policy-report-only')).toContain("'nonce-");
+    expect(response.headers.get('x-nonce')).toMatch(/^[A-Za-z0-9_-]{22}$/);
+  });
+});

--- a/apps/web/src/lib/proxy-logic.csp-nonce.test.ts
+++ b/apps/web/src/lib/proxy-logic.csp-nonce.test.ts
@@ -7,7 +7,7 @@ const mutableEnv = process.env as Record<string, string | undefined>;
 
 vi.mock('@/i18n/routing', () => ({
   routing: {
-    locales: ['sq', 'en', 'sr', 'mk', 'de', 'hr'],
+    locales: ['sq', 'en', 'sr', 'mk'],
   },
 }));
 

--- a/apps/web/src/lib/proxy-logic.ts
+++ b/apps/web/src/lib/proxy-logic.ts
@@ -5,6 +5,12 @@ import { emitAuthTelemetryEvent } from '@/lib/telemetry';
 import { applyTenantCookie } from '@/lib/tenant/tenant-cookie';
 import { resolveTenantFromHost as resolveTenantFromCanonicalHost } from '@/lib/tenant/tenant-hosts';
 import { NextRequest, NextResponse } from 'next/server';
+import {
+  buildReportOnlyCsp,
+  buildReportToHeader,
+  generateCspNonce,
+  isCspNonceActive,
+} from '@/lib/security/csp-nonce';
 
 const PROTECTED_TOP_LEVEL = new Set(['member', 'admin', 'staff', 'agent']);
 const SESSION_COOKIE_NAMES = [
@@ -17,6 +23,7 @@ const ACTIVE_SESSION_CACHE_MAX_ENTRIES = 100;
 const activeSessionCache = new Map<string, number>();
 
 type SecurityHeaders = {
+  requestHeaders?: Headers;
   responseHeaders: Headers;
 };
 
@@ -53,6 +60,7 @@ function buildContentSecurityPolicy(request: NextRequest): string {
 function createSecurityHeaders(request: NextRequest): SecurityHeaders {
   const csp = buildContentSecurityPolicy(request);
   const responseHeaders = new Headers();
+  const isProductionHttps = isProductionDeployment() && isHttpsRequest(request);
 
   responseHeaders.set('Content-Security-Policy', csp);
   responseHeaders.set('X-Frame-Options', 'DENY');
@@ -60,11 +68,26 @@ function createSecurityHeaders(request: NextRequest): SecurityHeaders {
   responseHeaders.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   responseHeaders.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=()');
 
-  if (isProductionDeployment() && isHttpsRequest(request)) {
+  let requestHeaders: Headers | undefined;
+  if (isCspNonceActive()) {
+    const nonce = generateCspNonce();
+    const reportOnlyCsp = buildReportOnlyCsp({ nonce, isProductionHttps });
+
+    requestHeaders = new Headers(request.headers);
+    requestHeaders.set('x-nonce', nonce);
+    requestHeaders.set('Content-Security-Policy', reportOnlyCsp);
+    requestHeaders.set('Content-Security-Policy-Report-Only', reportOnlyCsp);
+
+    responseHeaders.set('Content-Security-Policy-Report-Only', reportOnlyCsp);
+    responseHeaders.set('Report-To', buildReportToHeader());
+    responseHeaders.set('x-nonce', nonce);
+  }
+
+  if (isProductionHttps) {
     responseHeaders.set('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
   }
 
-  return { responseHeaders };
+  return { requestHeaders, responseHeaders };
 }
 
 function applyResponseHardening(
@@ -463,7 +486,9 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   }
 
   // 3. Tenant Resolution
-  const response = NextResponse.next();
+  const response = securityHeaders.requestHeaders
+    ? NextResponse.next({ request: { headers: securityHeaders.requestHeaders } })
+    : NextResponse.next();
 
   if (isE2EDiagnosticsEnabled()) {
     response.headers.set('x-e2e-tenant', tenant ?? 'none');

--- a/apps/web/src/lib/security/csp-nonce.test.ts
+++ b/apps/web/src/lib/security/csp-nonce.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const ORIGINAL_MODE = process.env.CSP_NONCE_MODE;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const mutableEnv = process.env as Record<string, string | undefined>;
+
+async function importCspNonceModule() {
+  vi.resetModules();
+  return import('./csp-nonce');
+}
+
+describe('csp-nonce', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mutableEnv.CSP_NONCE_MODE = ORIGINAL_MODE;
+    mutableEnv.NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  it.each([
+    { raw: '', expected: 'off' },
+    { raw: ' report ', expected: 'off' },
+    { raw: 'Report', expected: 'off' },
+    { raw: 'enforce ', expected: 'off' },
+    { raw: 'junk', expected: 'off' },
+  ])('falls back to off with a warning for invalid non-production mode "$raw"', async row => {
+    mutableEnv.NODE_ENV = 'test';
+    mutableEnv.CSP_NONCE_MODE = row.raw;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const cspNonce = await importCspNonceModule();
+
+    expect(cspNonce.CSP_NONCE_MODE).toBe(row.expected);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Falling back to "off"'));
+  });
+
+  it('throws on unknown production mode values', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.CSP_NONCE_MODE = 'repor';
+
+    await expect(importCspNonceModule()).rejects.toThrow('Invalid CSP_NONCE_MODE "repor"');
+  });
+
+  it('throws on explicitly empty production mode values', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.CSP_NONCE_MODE = '';
+
+    await expect(importCspNonceModule()).rejects.toThrow('Invalid CSP_NONCE_MODE ""');
+  });
+
+  it('rejects enforce mode during Phase 0', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.CSP_NONCE_MODE = 'enforce';
+
+    await expect(importCspNonceModule()).rejects.toThrow(
+      'CSP_NONCE_MODE=enforce is not supported in Phase 0'
+    );
+  });
+
+  it('generates base64url 16-byte nonces', async () => {
+    mutableEnv.NODE_ENV = 'test';
+    delete mutableEnv.CSP_NONCE_MODE;
+    const { generateCspNonce } = await importCspNonceModule();
+    const nonces = Array.from({ length: 1000 }, () => generateCspNonce());
+
+    expect(new Set(nonces).size).toBe(1000);
+    expect(nonces.every(nonce => /^[A-Za-z0-9_-]{22}$/.test(nonce))).toBe(true);
+  });
+
+  it('builds the Phase 0 report-only CSP with strict-dynamic and report directives', async () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.CSP_NONCE_MODE = 'report';
+    const { buildReportOnlyCsp } = await importCspNonceModule();
+    const request = new NextRequest('https://ks.example.test/sq');
+
+    const csp = buildReportOnlyCsp({ nonce: 'abc123', isProductionHttps: true });
+
+    expect(request.nextUrl.pathname).toBe('/sq');
+    expect(csp).toContain("script-src 'self' 'nonce-abc123' 'strict-dynamic' https:");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain('report-uri /api/csp-report');
+    expect(csp).toContain('report-to csp-endpoint');
+    expect(csp).toContain('upgrade-insecure-requests');
+  });
+});

--- a/apps/web/src/lib/security/csp-nonce.ts
+++ b/apps/web/src/lib/security/csp-nonce.ts
@@ -1,0 +1,73 @@
+export type CspNonceMode = 'off' | 'report';
+
+const PHASE_0_ENFORCE_MESSAGE =
+  'CSP_NONCE_MODE=enforce is not supported in Phase 0; use Phase 1 once Report-Only observation is complete.';
+
+function parseCspNonceMode(rawMode = process.env.CSP_NONCE_MODE): CspNonceMode {
+  if (rawMode === undefined) return 'off';
+
+  if (rawMode === 'enforce') {
+    throw new Error(PHASE_0_ENFORCE_MESSAGE);
+  }
+
+  if (rawMode === 'off' || rawMode === 'report') {
+    return rawMode;
+  }
+
+  const message = `Invalid CSP_NONCE_MODE "${rawMode}". Expected "off", "report", or "enforce".`;
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(message);
+  }
+
+  console.warn(`${message} Falling back to "off" outside production.`);
+  return 'off';
+}
+
+export const CSP_NONCE_MODE = parseCspNonceMode();
+
+export function isCspNonceActive(): boolean {
+  return CSP_NONCE_MODE === 'report';
+}
+
+export function generateCspNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export function buildReportToHeader(): string {
+  return JSON.stringify({
+    group: 'csp-endpoint',
+    max_age: 86400,
+    endpoints: [{ url: '/api/csp-report' }],
+  });
+}
+
+export function buildReportOnlyCsp(params: { nonce: string; isProductionHttps: boolean }): string {
+  const { nonce, isProductionHttps } = params;
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https: ${isDevelopment ? "'unsafe-eval'" : ''}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https://*.supabase.co https://www.facebook.com",
+    "font-src 'self' data:",
+    "connect-src 'self' https://*.supabase.co https://*.posthog.com https://*.sentry.io https://*.ingest.sentry.io https://api.paddle.com https://*.paddle.com https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://connect.facebook.net https://graph.facebook.com",
+    "frame-src 'self' https://*.paddle.com https://buy.paddle.com",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    'report-uri /api/csp-report',
+    'report-to csp-endpoint',
+    isProductionHttps ? 'upgrade-insecure-requests' : '',
+  ].filter(Boolean);
+
+  return directives
+    .join('; ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}

--- a/apps/web/src/lib/security/csp-nonce.ts
+++ b/apps/web/src/lib/security/csp-nonce.ts
@@ -32,10 +32,19 @@ export function isCspNonceActive(): boolean {
 export function generateCspNonce(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return btoa(String.fromCharCode(...bytes))
+  const nonce = btoa(String.fromCharCode(...bytes))
     .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+    .replace(/\//g, '_');
+
+  if (nonce.endsWith('==')) {
+    return nonce.slice(0, -2);
+  }
+
+  if (nonce.endsWith('=')) {
+    return nonce.slice(0, -1);
+  }
+
+  return nonce;
 }
 
 export function buildReportToHeader(): string {

--- a/apps/web/src/lib/security/csp-report.test.ts
+++ b/apps/web/src/lib/security/csp-report.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: hoisted.captureMessage,
+}));
+
+import {
+  captureCspReports,
+  isAcceptedCspReportContentType,
+  normalizeCspReportBody,
+} from './csp-report';
+
+describe('csp-report', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts CSP report content types only', () => {
+    expect(isAcceptedCspReportContentType('application/csp-report')).toBe(true);
+    expect(isAcceptedCspReportContentType('application/reports+json; charset=utf-8')).toBe(true);
+    expect(isAcceptedCspReportContentType('application/json')).toBe(false);
+    expect(isAcceptedCspReportContentType(null)).toBe(false);
+  });
+
+  it('normalizes legacy reports without query strings or script samples', () => {
+    const [report] = normalizeCspReportBody({
+      'csp-report': {
+        'blocked-uri': 'https://tracker.example/script.js?token=secret',
+        'document-uri': 'https://app.example/member/help?otp=123',
+        disposition: 'report',
+        referrer: 'https://ref.example/path?session=secret',
+        'script-sample': 'secret inline script',
+        'source-file': 'https://cdn.example/source.js?token=secret',
+        'violated-directive': 'script-src-elem https:',
+        'original-policy': 'x'.repeat(700),
+      },
+    });
+
+    expect(report).toMatchObject({
+      blockedHost: 'tracker.example',
+      blockedUri: 'https://tracker.example/script.js',
+      documentHost: 'app.example',
+      documentUri: 'https://app.example/member/help',
+      referrer: 'https://ref.example/path',
+      sourceFile: 'https://cdn.example/source.js',
+      violatedDirective: 'script-src-elem',
+    });
+    expect(report.originalPolicy).toHaveLength(512);
+    expect(JSON.stringify(report)).not.toContain('script-sample');
+    expect(JSON.stringify(report)).not.toContain('secret');
+  });
+
+  it('captures warning events with stable CSP tags and fingerprint', () => {
+    const [report] = normalizeCspReportBody({
+      'csp-report': {
+        'blocked-uri': 'https://tracker.example/script.js',
+        'document-uri': 'https://app.example/member/help',
+        disposition: 'report',
+        'violated-directive': 'script-src-elem https:',
+      },
+    });
+
+    captureCspReports([report]);
+
+    expect(hoisted.captureMessage).toHaveBeenCalledWith('csp.violation', {
+      level: 'warning',
+      tags: {
+        'csp.directive': 'script-src-elem',
+        'csp.disposition': 'report',
+        'csp.blocked_host': 'tracker.example',
+        'csp.document_host': 'app.example',
+      },
+      fingerprint: ['csp-violation', 'script-src-elem', 'tracker.example'],
+      extra: report,
+    });
+  });
+});

--- a/apps/web/src/lib/security/csp-report.ts
+++ b/apps/web/src/lib/security/csp-report.ts
@@ -1,0 +1,151 @@
+import * as Sentry from '@sentry/nextjs';
+
+const MAX_ORIGINAL_POLICY_LENGTH = 512;
+export const MAX_CSP_REPORT_BODY_BYTES = 16 * 1024;
+export const MAX_CSP_REPORTS_PER_REQUEST = 10;
+
+const ACCEPTED_CONTENT_TYPES = new Set(['application/csp-report', 'application/reports+json']);
+
+type CspReportBody = {
+  'csp-report'?: Record<string, unknown>;
+};
+
+type ReportingApiBody = Array<{
+  type?: unknown;
+  body?: Record<string, unknown>;
+}>;
+
+type NormalizedCspReport = {
+  blockedHost: string;
+  blockedUri: string;
+  disposition: string;
+  documentHost: string;
+  documentUri: string;
+  lineNumber?: number;
+  originalPolicy?: string;
+  referrer?: string;
+  sourceFile?: string;
+  violatedDirective: string;
+};
+
+export function isAcceptedCspReportContentType(contentType: string | null): boolean {
+  if (!contentType) return false;
+  return ACCEPTED_CONTENT_TYPES.has(contentType.split(';')[0].trim().toLowerCase());
+}
+
+export async function readCspReportBody(request: Request): Promise<string | null> {
+  const contentLength = request.headers.get('content-length');
+  if (contentLength && Number(contentLength) > MAX_CSP_REPORT_BODY_BYTES) return null;
+
+  if (!request.body) return '';
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_CSP_REPORT_BODY_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(body);
+}
+
+function stripQueryString(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) return '';
+
+  try {
+    const parsed = new URL(value);
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return value.split('?')[0].split('#')[0];
+  }
+}
+
+function hostFromUri(value: string): string {
+  try {
+    return new URL(value).host || 'none';
+  } catch {
+    return value === '' ? 'none' : 'opaque';
+  }
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeReportPayload(payload: Record<string, unknown>): NormalizedCspReport {
+  const blockedUri = stripQueryString(payload['blocked-uri'] ?? payload.blockedURL);
+  const documentUri = stripQueryString(payload['document-uri'] ?? payload.documentURL);
+  const originalPolicy =
+    typeof (payload['original-policy'] ?? payload.originalPolicy) === 'string'
+      ? String(payload['original-policy'] ?? payload.originalPolicy).slice(
+          0,
+          MAX_ORIGINAL_POLICY_LENGTH
+        )
+      : undefined;
+  const violatedDirective = payload['violated-directive'] ?? payload.effectiveDirective;
+
+  return {
+    blockedHost: hostFromUri(blockedUri),
+    blockedUri,
+    disposition: 'report',
+    documentHost: hostFromUri(documentUri),
+    documentUri,
+    lineNumber: optionalNumber(payload['line-number']),
+    originalPolicy,
+    referrer: stripQueryString(payload.referrer),
+    sourceFile: stripQueryString(payload['source-file'] ?? payload.sourceFile),
+    violatedDirective:
+      typeof violatedDirective === 'string' ? violatedDirective.split(/\s+/)[0] : 'unknown',
+  };
+}
+
+export function normalizeCspReportBody(body: unknown): NormalizedCspReport[] {
+  if (Array.isArray(body)) {
+    return (body as ReportingApiBody)
+      .filter(item => item?.type === 'csp-violation' && item.body)
+      .slice(0, MAX_CSP_REPORTS_PER_REQUEST)
+      .map(item => normalizeReportPayload(item.body as Record<string, unknown>));
+  }
+
+  if (body && typeof body === 'object') {
+    const payload = (body as CspReportBody)['csp-report'] ?? body;
+    if (payload && typeof payload === 'object') {
+      return [normalizeReportPayload(payload as Record<string, unknown>)];
+    }
+  }
+
+  return [];
+}
+
+export function captureCspReports(reports: NormalizedCspReport[]): void {
+  for (const report of reports) {
+    Sentry.captureMessage('csp.violation', {
+      level: 'warning',
+      tags: {
+        'csp.directive': report.violatedDirective,
+        'csp.disposition': report.disposition,
+        'csp.blocked_host': report.blockedHost,
+        'csp.document_host': report.documentHost,
+      },
+      fingerprint: ['csp-violation', report.violatedDirective, report.blockedHost],
+      extra: report,
+    });
+  }
+}

--- a/scripts/ci/e2e-standalone-contracts.test.mjs
+++ b/scripts/ci/e2e-standalone-contracts.test.mjs
@@ -21,9 +21,12 @@ test('e2e launchers resolve standalone server artifacts dynamically for worktree
   assert.match(webServerScript, /resolve_standalone_server\(\)/);
   assert.match(webServerScript, /resolve_standalone_app_root\(\)/);
   assert.match(webServerScript, /normalize_billing_test_mode\(\)/);
+  assert.match(webServerScript, /normalize_csp_nonce_mode\(\)/);
   assert.match(webServerScript, /stamp\.publicEnv\?\.NEXT_PUBLIC_BILLING_TEST_MODE/);
+  assert.match(webServerScript, /stamp\.buildEnv\?\.CSP_NONCE_MODE/);
   assert.match(webServerScript, /STAMP_STATUS_REASON="stale-stamp-env"/);
   assert.match(webServerScript, /requested billingTestMode:/);
+  assert.match(webServerScript, /requested cspNonceMode:/);
   assert.match(
     webServerScript,
     /find "\$\{STANDALONE_ROOT\}" -path '\*\/node_modules\/\*' -prune -o -type f -name server\.js -print/
@@ -42,8 +45,11 @@ test('e2e launchers resolve standalone server artifacts dynamically for worktree
   assert.match(gateScript, /if ! resolve_standalone_server >\/dev\/null; then/);
 
   assert.match(stampScript, /NEXT_PUBLIC_BILLING_TEST_MODE/);
+  assert.match(stampScript, /CSP_NONCE_MODE/);
   assert.match(stampScript, /publicEnv/);
+  assert.match(stampScript, /buildEnv/);
   assert.match(stampScript, /billingTestMode=/);
+  assert.match(stampScript, /cspNonceMode=/);
   assert.match(stampScript, /syncClientReferenceManifests/);
   assert.match(stampScript, /standalone client reference manifests synced=/);
   assert.match(stampScript, /aliasRouteGroupClientReferenceManifests/);
@@ -78,6 +84,7 @@ test('standalone stamp copies and aliases route-group client reference manifests
       ...process.env,
       COMMIT_SHA: 'fixture-sha',
       NEXT_PUBLIC_BILLING_TEST_MODE: '1',
+      CSP_NONCE_MODE: 'report',
     },
     encoding: 'utf8',
   });
@@ -108,5 +115,9 @@ test('standalone stamp copies and aliases route-group client reference manifests
   assert.match(
     fs.readFileSync(path.join(tempDir, '.next/standalone/.build-stamp.json'), 'utf8'),
     /"NEXT_PUBLIC_BILLING_TEST_MODE": "1"/
+  );
+  assert.match(
+    fs.readFileSync(path.join(tempDir, '.next/standalone/.build-stamp.json'), 'utf8'),
+    /"CSP_NONCE_MODE": "report"/
   );
 });

--- a/scripts/e2e-webserver.sh
+++ b/scripts/e2e-webserver.sh
@@ -230,6 +230,8 @@ CURRENT_GIT_SHA=""
 STAMP_GIT_SHA=""
 CURRENT_BILLING_TEST_MODE=""
 STAMP_BILLING_TEST_MODE=""
+CURRENT_CSP_NONCE_MODE=""
+STAMP_CSP_NONCE_MODE=""
 STAMP_STATUS_REASON=""
 
 link_static_dir() {
@@ -306,12 +308,24 @@ normalize_billing_test_mode() {
 	printf '%s' "0"
 }
 
+normalize_csp_nonce_mode() {
+	local value="${1-__unset__}"
+	if [[ "${value}" == "__unset__" || "${value}" == "off" ]]; then
+		printf '%s' "off"
+		return 0
+	fi
+
+	printf '%s' "${value}"
+}
+
 refresh_stamp_status() {
 	STAMP_STATUS_REASON=""
 	STAMP_GIT_SHA=""
 	STAMP_BILLING_TEST_MODE=""
+	STAMP_CSP_NONCE_MODE=""
 	CURRENT_GIT_SHA="$(resolve_current_git_sha)"
 	CURRENT_BILLING_TEST_MODE="$(normalize_billing_test_mode "${NEXT_PUBLIC_BILLING_TEST_MODE:-}")"
+	CURRENT_CSP_NONCE_MODE="$(normalize_csp_nonce_mode "${CSP_NONCE_MODE-__unset__}")"
 
 	if [[ ! -f "${STANDALONE_STAMP_FILE}" ]]; then
 		STAMP_STATUS_REASON="missing-stamp"
@@ -336,12 +350,26 @@ refresh_stamp_status() {
 		return 1
 	fi
 
+	STAMP_CSP_NONCE_MODE="$(
+		node -e "const fs=require('node:fs');const stamp=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.stdout.write(stamp.buildEnv?.CSP_NONCE_MODE ?? 'off');" "${STANDALONE_STAMP_FILE}" 2>/dev/null || true
+	)"
+
+	if [[ -z "${STAMP_CSP_NONCE_MODE}" ]]; then
+		STAMP_STATUS_REASON="stale-stamp-env"
+		return 1
+	fi
+
 	if [[ "${CURRENT_GIT_SHA}" != "unknown" && "${STAMP_GIT_SHA}" != "unknown" && "${CURRENT_GIT_SHA}" != "${STAMP_GIT_SHA}" ]]; then
 		STAMP_STATUS_REASON="stale-stamp"
 		return 1
 	fi
 
 	if [[ "${CURRENT_BILLING_TEST_MODE}" != "${STAMP_BILLING_TEST_MODE}" ]]; then
+		STAMP_STATUS_REASON="stale-stamp-env"
+		return 1
+	fi
+
+	if [[ "${CURRENT_CSP_NONCE_MODE}" != "${STAMP_CSP_NONCE_MODE}" ]]; then
 		STAMP_STATUS_REASON="stale-stamp-env"
 		return 1
 	fi
@@ -381,6 +409,8 @@ rebuild_standalone_once() {
 	echo "   current HEAD: ${CURRENT_GIT_SHA:-<missing>}" >&2
 	echo "   stamp billingTestMode: ${STAMP_BILLING_TEST_MODE:-<missing>}" >&2
 	echo "   requested billingTestMode: ${CURRENT_BILLING_TEST_MODE:-<missing>}" >&2
+	echo "   stamp cspNonceMode: ${STAMP_CSP_NONCE_MODE:-<missing>}" >&2
+	echo "   requested cspNonceMode: ${CURRENT_CSP_NONCE_MODE:-<missing>}" >&2
 	rm -rf "${WEB_DIR}/.next"
 	env -u PLAYWRIGHT -u INTERDOMESTIK_AUTOMATED pnpm --filter @interdomestik/web run build:ci
 	link_standalone_static_assets
@@ -396,6 +426,8 @@ if ! refresh_stamp_status; then
 			echo "   current HEAD: ${CURRENT_GIT_SHA:-<missing>}" >&2
 			echo "   stamp billingTestMode: ${STAMP_BILLING_TEST_MODE:-<missing>}" >&2
 			echo "   requested billingTestMode: ${CURRENT_BILLING_TEST_MODE:-<missing>}" >&2
+			echo "   stamp cspNonceMode: ${STAMP_CSP_NONCE_MODE:-<missing>}" >&2
+			echo "   requested cspNonceMode: ${CURRENT_CSP_NONCE_MODE:-<missing>}" >&2
 			echo "   Try: pnpm --filter @interdomestik/web run build:ci" >&2
 			exit 1
 		fi
@@ -409,6 +441,8 @@ if ! refresh_stamp_status; then
 		echo "   current HEAD: ${CURRENT_GIT_SHA:-<missing>}" >&2
 		echo "   stamp billingTestMode: ${STAMP_BILLING_TEST_MODE:-<missing>}" >&2
 		echo "   requested billingTestMode: ${CURRENT_BILLING_TEST_MODE:-<missing>}" >&2
+		echo "   stamp cspNonceMode: ${STAMP_CSP_NONCE_MODE:-<missing>}" >&2
+		echo "   requested cspNonceMode: ${CURRENT_CSP_NONCE_MODE:-<missing>}" >&2
 		echo "   Rebuild with: pnpm --filter @interdomestik/web run build:ci" >&2
 		echo "   Override: STANDALONE_AUTOREBUILD=true to auto-rebuild once" >&2
 		exit 1


### PR DESCRIPTION
## Summary

Implements CSP nonce Phase 0 in report-only mode without changing the enforced CSP shape.

- Adds strict `CSP_NONCE_MODE` parsing with Phase 0 `enforce` guard and an Edge-safe 16-byte base64url nonce primitive.
- Adds report-only CSP in `report` mode with `'nonce-{N}'`, `'strict-dynamic'`, `https:`, `report-uri`, `report-to`, `Report-To`, and observable `x-nonce` propagation.
- Adds `/api/csp-report` as an intentionally unauthenticated POST endpoint with content-type checks, 60/min/IP rate limiting, 16 KiB body cap, 10-report cap, sanitization, and Sentry warning tags/fingerprints.
- Wires root layout/analytics to consume nonce only when CSP nonce mode is active.
- Extends header E2E coverage and standalone build stamping so off/report builds cannot be mixed.

## Scope Guardrails

- No change to enforced CSP shape in any mode.
- No removal of `'unsafe-inline'` from any directive.
- No `style-src` nonce.
- No persistence for CSP reports.
- No new dependencies.
- No `apps/web/src/proxy.ts`, route authority, auth, tenancy, schema, architecture, README, AGENTS, or Stripe changes.
- `CSP_NONCE_MODE=enforce` is explicitly gated as not supported in Phase 0.
- `/api/csp-report` is intentionally unauthenticated.
- No analytics or Paddle SDK rewrites.

## Phase 1 Promotion Criterion

Phase 0 success = 14 consecutive days with zero CSP violations of severity >= medium attributable to first-party code in the report-only stream. Third-party violations such as GTM custom HTML tags or browser extensions are triaged separately and do not block promotion.

Current local smoke found first-party `script-src` report-only violations, so Phase 1 enforcement is blocked until framework/inline script nonce coverage is solved and re-verified.

## Reviewer Pool

Pre-PR reviewers covered security/privacy, performance, maintainability, test/gates, and product/workflow. Must-fixes from the pool were incorporated:

- Bounded report body and report count to avoid unauthenticated flood amplification.
- Made rate limiting production-sensitive and returned local 204 on limit hits.
- Rejected empty/whitespace/case-mutated CSP nonce modes in production.
- Made `csp.disposition` server-owned instead of report-controlled.
- Added Chrome Reporting API field-name support.

## Codex Security Scan

Diff-scoped Codex Security scan completed with no reportable findings.

Report: `/tmp/codex-security-scans/interdomestik-crystal-home/35f1ec05_20260508T085617Z_csp-nonce-phase-0/report.md`

## Build / Dynamic Route Receipt

Captured route-table comparisons for main, slice default/off, and slice report mode under `tmp/p33-sec02-build-receipts/`.

- `CSP_NONCE_MODE=off`: enforced CSP remains byte-identical and localized static route behavior is preserved, with only the new `/api/csp-report` dynamic endpoint added.
- `CSP_NONCE_MODE=report`: nonce propagation through the root layout uses `headers()/connection()`, so localized app routes become dynamic in report mode. This is the expected temporary Phase 0 performance cost and does not affect default/off mode.

## Browser / Analytics Smoke

Report-mode Playwright MCP smoke against production server:

- `connect-src`: 0 violations observed.
- `frame-src`: 0 violations observed.
- `style-src`: 0 violations observed.
- `script-src`: 148 total report-only console reports across sampled pages, including 89 inline and 59 external script reports.

Local env has no `NEXT_PUBLIC_GTM_ID` or `NEXT_PUBLIC_META_PIXEL_ID`, so GTM/Pixel runtime loading was not exercised locally. This confirms no connect/frame noise in the sampled app path, but Phase 1 must not proceed until first-party script nonce coverage is resolved.

## Verification

Passed locally:

- `git diff --check`
- `pnpm --filter @interdomestik/web lint`
- `pnpm --filter @interdomestik/web type-check`
- Focused unit tests for CSP nonce, proxy, report route, report sanitization, layout, and analytics scripts: 57 passed.
- `node --test scripts/ci/e2e-standalone-contracts.test.mjs`
- `CSP_NONCE_MODE=report NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web run build:ci`
- `CSP_NONCE_MODE=report NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web exec playwright test e2e/security/headers.spec.ts --project=gate-ks-sq --project=gate-mk-contract --workers=1`
- `CSP_NONCE_MODE=off NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web run build:ci && pnpm --filter @interdomestik/web exec playwright test e2e/security/headers.spec.ts --project=gate-ks-sq --project=gate-mk-contract --workers=1`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates`
- `interdomestik_qa.security_guard`
- `interdomestik_qa.scope_audit` for allowed paths and protected no-change paths

Required gate receipt: `/Users/arbenlila/development/interdomestik-crystal-home/tmp/multi-agent/verify-slice/verify-slice-20260508T085731Z-e690d5`

## Rollback

Set `CSP_NONCE_MODE=off` or remove the variable. Default/off mode emits no report-only header and no nonce; enforced CSP stays on the existing production path.
