### PR TITLE
P33-SEC03: Tag first-party CSP reports

### DIFF
--- a/apps/web/src/lib/security/csp-report.test.ts
+++ b/apps/web/src/lib/security/csp-report.test.ts
@@ -73,9 +73,47 @@ describe('csp-report', () => {
         'csp.disposition': 'report',
         'csp.blocked_host': 'tracker.example',
         'csp.document_host': 'app.example',
+        'csp.first_party': 'false',
       },
       fingerprint: ['csp-violation', 'script-src-elem', 'tracker.example'],
       extra: report,
     });
+  });
+
+  it('tags inline and same-host reports as first-party', () => {
+    const reports = normalizeCspReportBody([
+      {
+        type: 'csp-violation',
+        body: {
+          blockedURL: 'inline',
+          documentURL: 'https://app.example/sq',
+          effectiveDirective: 'script-src',
+        },
+      },
+      {
+        type: 'csp-violation',
+        body: {
+          blockedURL: 'https://app.example/_next/static/chunks/app.js',
+          documentURL: 'https://app.example/sq',
+          effectiveDirective: 'script-src-elem',
+        },
+      },
+      {
+        type: 'csp-violation',
+        body: {
+          blockedURL: 'chrome-extension://example/script.js',
+          documentURL: 'https://app.example/sq',
+          effectiveDirective: 'script-src-elem',
+        },
+      },
+    ]);
+
+    captureCspReports(reports);
+
+    expect(hoisted.captureMessage.mock.calls.map(call => call[1].tags['csp.first_party'])).toEqual([
+      'true',
+      'true',
+      'false',
+    ]);
   });
 });

--- a/apps/web/src/lib/security/csp-report.ts
+++ b/apps/web/src/lib/security/csp-report.ts
@@ -89,6 +89,12 @@ function optionalNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
+function isFirstPartyReport(report: NormalizedCspReport): boolean {
+  if (report.blockedUri === 'inline') return true;
+  if (report.blockedHost === 'none' || report.blockedHost === 'opaque') return false;
+  return report.blockedHost === report.documentHost;
+}
+
 function normalizeReportPayload(payload: Record<string, unknown>): NormalizedCspReport {
   const blockedUri = stripQueryString(payload['blocked-uri'] ?? payload.blockedURL);
   const documentUri = stripQueryString(payload['document-uri'] ?? payload.documentURL);
@@ -143,6 +149,7 @@ export function captureCspReports(reports: NormalizedCspReport[]): void {
         'csp.disposition': report.disposition,
         'csp.blocked_host': report.blockedHost,
         'csp.document_host': report.documentHost,
+        'csp.first_party': String(isFirstPartyReport(report)),
       },
       fingerprint: ['csp-violation', report.violatedDirective, report.blockedHost],
       extra: report,

--- a/docs/security/csp-nonce-migration.md
+++ b/docs/security/csp-nonce-migration.md
@@ -308,6 +308,16 @@ were skipped because Sentry event query tooling was unavailable, Playwright MCP 
 and no authenticated storage-state setup was available for the local fallback probe. The
 missing flows remain required `P33-SEC03` follow-up evidence before Phase 1 promotion.
 
+SEC03 implementation probe on 2026-05-08 confirmed an additional constraint: Next.js 16.2.4
+and a patch probe on 16.2.6 did not apply nonce attributes to App Router framework/static
+scripts in the standalone report-only path, even though the proxy emitted
+`x-middleware-request-content-security-policy`, the response emitted a matching
+`Content-Security-Policy-Report-Only`, and the root-layout canary script carried the
+response `x-nonce`. A `NextResponse.rewrite(..., { request: { headers } })` probe broke
+normal page readiness and was rejected. Until a supported Next.js hook or framework fix is
+identified, SEC03 must not claim framework nonce coverage as fixed; it should at minimum
+pin first-party CSP classification and keep Phase 1 blocked.
+
 DG04 outcomes:
 
 - H1 - Next framework scripts: confirmed.


### PR DESCRIPTION
## Summary
- adds the `csp.first_party` Sentry tag for CSP reports so inline and same-host script violations can be separated from extension/opaque/third-party noise
- pins the first-party classification rules with focused unit coverage
- records the SEC03 implementation probe result in `docs/security/csp-nonce-migration.md`: Next.js 16.2.4 and a 16.2.6 patch probe did not nonce App Router framework/static scripts in the standalone report-only path, so Phase 1 enforcement remains blocked

## Scope
- No change to `apps/web/src/proxy.ts`, `proxy-logic.ts`, auth, tenancy, schema, routes, Stripe, or product UX
- No CSP enforcement promotion
- No dependency changes

## Verification
- `pnpm --filter @interdomestik/web exec vitest run src/lib/security/csp-report.test.ts src/app/api/csp-report/route.test.ts --reporter=verbose`
- `git diff --check`
- `pnpm docs:verify`
- `pnpm purity:audit`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates` (final e2e gate: 118 passed, 4 skipped; wrapper PASS)
- `interdomestik_qa.scope_audit` passed with changes limited to `apps/web/src/lib/security/` and `docs/security/`

## Notes
- Reviewer-pool subagents are blocked in this runtime by the active policy requiring explicit user delegation. Local fallback verification and required gates were run.
- Diff-scoped Codex Security plugin scan tooling was not exposed by `tool_search`; fallback repo `security:guard` passed inside required gates.
- Remote push reported one existing Dependabot vulnerability on the default branch; this PR does not touch dependencies.