### PR TITLE
fix: enforce agent lead authorization

### DIFF
--- a/apps/web/src/app/[locale]/(agent)/agent/leads/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/_core.entry.test.tsx
@@ -1,12 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   headersMock: vi.fn(async () => new Headers()),
   redirectMock: vi.fn((url: string) => {
     throw new Error(`redirect:${url}`);
   }),
-  getSessionMock: vi.fn(async () => null),
+  notFoundMock: vi.fn(() => {
+    throw new Error('notFound');
+  }),
+  getSessionMock: vi.fn<() => Promise<unknown>>(async () => null),
   ensureTenantIdMock: vi.fn(),
+  findAgentSettingsMock: vi.fn(),
   getAgentLeadsCoreMock: vi.fn(),
 }));
 
@@ -15,7 +19,7 @@ vi.mock('next/headers', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  notFound: vi.fn(),
+  notFound: hoisted.notFoundMock,
   redirect: hoisted.redirectMock,
 }));
 
@@ -35,7 +39,7 @@ vi.mock('@interdomestik/database/db', () => ({
   db: {
     query: {
       agentSettings: {
-        findFirst: vi.fn(),
+        findFirst: hoisted.findAgentSettingsMock,
       },
     },
   },
@@ -59,12 +63,103 @@ vi.mock('./_core', () => ({
 
 import AgentLeadsEntry from './_core.entry';
 
+function mockEntrySession(user: Record<string, string | undefined> | null) {
+  hoisted.getSessionMock.mockResolvedValue(user ? { user } : null);
+}
+
+function expectEntryNotFound() {
+  return expect(
+    AgentLeadsEntry({
+      params: Promise.resolve({ locale: 'en' }),
+    })
+  ).rejects.toThrow('notFound');
+}
+
+function expectNoLeadEntryDataAccess() {
+  expect(hoisted.ensureTenantIdMock).not.toHaveBeenCalled();
+  expect(hoisted.findAgentSettingsMock).not.toHaveBeenCalled();
+  expect(hoisted.getAgentLeadsCoreMock).not.toHaveBeenCalled();
+}
+
 describe('AgentLeadsEntry auth redirect', () => {
+  beforeEach(() => {
+    hoisted.headersMock.mockClear();
+    hoisted.redirectMock.mockClear();
+    hoisted.notFoundMock.mockClear();
+    hoisted.getSessionMock.mockReset();
+    hoisted.ensureTenantIdMock.mockReset();
+    hoisted.findAgentSettingsMock.mockReset();
+    hoisted.getAgentLeadsCoreMock.mockReset();
+  });
+
   it('redirects unauthenticated users to the locale login path', async () => {
+    mockEntrySession(null);
+
     await expect(
       AgentLeadsEntry({
         params: Promise.resolve({ locale: 'en' }),
       })
     ).rejects.toThrow('redirect:/en/login');
+  });
+
+  it('renders notFound for a member session even with pro agent settings', async () => {
+    mockEntrySession({
+      id: 'member-1',
+      role: 'member',
+      tenantId: 'tenant-1',
+    });
+    hoisted.findAgentSettingsMock.mockResolvedValue({ tier: 'pro' });
+
+    await expectEntryNotFound();
+    expectNoLeadEntryDataAccess();
+  });
+
+  it('renders notFound for a standard-tier agent', async () => {
+    mockEntrySession({
+      id: 'agent-1',
+      role: 'agent',
+      tenantId: 'tenant-1',
+      branchId: 'branch-1',
+    });
+    hoisted.ensureTenantIdMock.mockReturnValue('tenant-1');
+    hoisted.findAgentSettingsMock.mockResolvedValue({ tier: 'standard' });
+
+    await expectEntryNotFound();
+
+    expect(hoisted.getAgentLeadsCoreMock).not.toHaveBeenCalled();
+  });
+
+  it('renders notFound for an agent session without branch scope', async () => {
+    mockEntrySession({
+      id: 'agent-1',
+      role: 'agent',
+      tenantId: 'tenant-1',
+    });
+
+    await expectEntryNotFound();
+    expectNoLeadEntryDataAccess();
+  });
+
+  it('loads leads for a pro agent session', async () => {
+    mockEntrySession({
+      id: 'agent-1',
+      role: 'agent',
+      tenantId: 'tenant-1',
+      branchId: 'branch-1',
+    });
+    hoisted.ensureTenantIdMock.mockReturnValue('tenant-1');
+    hoisted.findAgentSettingsMock.mockResolvedValue({ tier: 'pro' });
+    hoisted.getAgentLeadsCoreMock.mockResolvedValue([{ id: 'lead-1' }]);
+
+    await expect(
+      AgentLeadsEntry({
+        params: Promise.resolve({ locale: 'en' }),
+      })
+    ).resolves.toBeDefined();
+
+    expect(hoisted.getAgentLeadsCoreMock).toHaveBeenCalledWith(
+      { tenantId: 'tenant-1', agentId: 'agent-1', branchId: 'branch-1' },
+      expect.any(Object)
+    );
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/_core.entry.tsx
@@ -22,6 +22,14 @@ export default async function AgentLeadsEntry({ params }: Readonly<Props>) {
     redirect(`/${locale}/login`);
   }
 
+  if (session.user.role !== 'agent') {
+    notFound();
+  }
+
+  if (!session.user.branchId) {
+    notFound();
+  }
+
   const tenantId = ensureTenantId(session);
 
   // Tier Gating (Strict)
@@ -35,7 +43,10 @@ export default async function AgentLeadsEntry({ params }: Readonly<Props>) {
     notFound();
   }
 
-  const leadsData = await getAgentLeadsCore({ tenantId, agentId: session.user.id }, { db });
+  const leadsData = await getAgentLeadsCore(
+    { tenantId, agentId: session.user.id, branchId: session.user.branchId },
+    { db }
+  );
 
   return <AgentLeadsProPage leads={leadsData} />;
 }

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/_core.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { getAgentLeadsCore } from './_core';
 
 describe('getAgentLeadsCore', () => {
+  const whereEq = vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right }));
+  const whereAnd = vi.fn((...args: unknown[]) => ({ op: 'and', args }));
+  const orderDesc = vi.fn((column: unknown) => ({ op: 'desc', column }));
   const mockDb = {
     query: {
       memberLeads: {
@@ -12,17 +15,46 @@ describe('getAgentLeadsCore', () => {
 
   const services = { db: mockDb as never };
 
-  it('fetches leads with branch relation for a tenant', async () => {
+  it('fetches leads with branch relation for the tenant, agent, and branch', async () => {
     const mockData = [{ id: 'l1', branch: { name: 'Branch A' } }];
     mockDb.query.memberLeads.findMany.mockResolvedValue(mockData);
 
-    const result = await getAgentLeadsCore({ tenantId: 't1' }, services);
+    const result = await getAgentLeadsCore(
+      { tenantId: 't1', agentId: 'agent-1', branchId: 'branch-1' },
+      services
+    );
 
     expect(result).toEqual(mockData);
     expect(mockDb.query.memberLeads.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        where: expect.any(Function),
         with: { branch: true },
       })
     );
+
+    const queryArgs = mockDb.query.memberLeads.findMany.mock.calls[0]?.[0];
+    const where = queryArgs?.where(
+      {
+        tenantId: 'member_leads.tenant_id',
+        agentId: 'member_leads.agent_id',
+        branchId: 'member_leads.branch_id',
+      },
+      { and: whereAnd, eq: whereEq }
+    );
+
+    expect(where).toEqual({
+      op: 'and',
+      args: [
+        { op: 'eq', left: 'member_leads.tenant_id', right: 't1' },
+        { op: 'eq', left: 'member_leads.agent_id', right: 'agent-1' },
+        { op: 'eq', left: 'member_leads.branch_id', right: 'branch-1' },
+      ],
+    });
+
+    const orderBy = queryArgs?.orderBy(
+      { createdAt: 'member_leads.created_at' },
+      { desc: orderDesc }
+    );
+    expect(orderBy).toEqual([{ op: 'desc', column: 'member_leads.created_at' }]);
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/_core.ts
@@ -11,23 +11,22 @@ export interface AgentLeadsServices {
 
 /**
  * Pure core logic for the Agent Leads page.
- * Fetches leads for a tenant with branch relations.
+ * Fetches leads for the signed-in agent within their tenant and branch.
  */
 export async function getAgentLeadsCore(
   params: {
     tenantId: string;
-    agentId?: string; // Optional: can be used for further isolation if needed
+    agentId: string;
+    branchId: string;
   },
   services: AgentLeadsServices
 ): Promise<MemberLeadRow[]> {
-  const { tenantId } = params;
+  const { tenantId, agentId, branchId } = params;
   const { db } = services;
 
-  // Use the query builder to keep the "with branch" logic clean as per original route
-  // Note: Original route ONLY filtered by tenantId, not agentId.
-  // We keep this behavior but allow agentId for future refinement.
   return db.query.memberLeads.findMany({
-    where: (leads, { eq }) => eq(leads.tenantId, tenantId),
+    where: (leads, { and, eq }) =>
+      and(eq(leads.tenantId, tenantId), eq(leads.agentId, agentId), eq(leads.branchId, branchId)),
     orderBy: (leads, { desc }) => [desc(leads.createdAt)],
     with: {
       branch: true,

--- a/apps/web/src/features/agent/leads/actions.test.ts
+++ b/apps/web/src/features/agent/leads/actions.test.ts
@@ -33,6 +33,9 @@ vi.mock('next/headers', () => ({
 }));
 
 vi.mock('@interdomestik/shared-auth', () => ({
+  ROLES: {
+    agent: 'agent',
+  },
   ensureTenantId: mocks.ensureTenantId,
 }));
 
@@ -63,140 +66,182 @@ vi.mock('@interdomestik/database', () => ({
   eq: mocks.eq,
 }));
 
-import { convertLeadToClient } from './actions';
+import { convertLeadToClient, updateLeadStatus } from './actions';
+
+function resetActionMocks() {
+  mocks.authGetSession.mockReset();
+  mocks.headers.mockReset();
+  mocks.ensureTenantId.mockReset();
+  mocks.findLead.mockReset();
+  mocks.update.mockClear();
+  mocks.set.mockClear();
+  mocks.where.mockClear();
+  mocks.startPayment.mockReset();
+  mocks.revalidatePath.mockReset();
+
+  mocks.headers.mockResolvedValue(new Headers());
+  mockSession();
+  mocks.ensureTenantId.mockReturnValue('tenant-1');
+}
+
+function mockSession(
+  user: Record<string, string | undefined> = {
+    id: 'agent-1',
+    role: 'agent',
+    tenantId: 'tenant-1',
+    branchId: 'branch-1',
+  }
+) {
+  mocks.authGetSession.mockResolvedValue({ user });
+}
+
+function mockLead(id: string) {
+  mocks.findLead.mockResolvedValue({
+    id,
+    tenantId: 'tenant-1',
+    branchId: 'branch-1',
+    agentId: 'agent-1',
+  });
+}
+
+function expectNoMutation() {
+  expect(mocks.update).not.toHaveBeenCalled();
+  expect(mocks.startPayment).not.toHaveBeenCalled();
+}
+
+function expectNoLookupOrMutation() {
+  expect(mocks.findLead).not.toHaveBeenCalled();
+  expectNoMutation();
+}
+
+function scopedWhereForLead(leadId: string) {
+  return expect.objectContaining({
+    op: 'and',
+    args: expect.arrayContaining([
+      expect.objectContaining({ op: 'eq', left: 'member_leads.id', right: leadId }),
+      expect.objectContaining({
+        op: 'eq',
+        left: 'member_leads.tenant_id',
+        right: 'tenant-1',
+      }),
+      expect.objectContaining({ op: 'eq', left: 'member_leads.agent_id', right: 'agent-1' }),
+      expect.objectContaining({
+        op: 'eq',
+        left: 'member_leads.branch_id',
+        right: 'branch-1',
+      }),
+    ]),
+  });
+}
+
+beforeEach(resetActionMocks);
 
 describe('convertLeadToClient', () => {
-  beforeEach(() => {
-    mocks.authGetSession.mockReset();
-    mocks.headers.mockReset();
-    mocks.ensureTenantId.mockReset();
-    mocks.findLead.mockReset();
-    mocks.update.mockClear();
-    mocks.set.mockClear();
-    mocks.where.mockClear();
-    mocks.startPayment.mockReset();
-    mocks.revalidatePath.mockReset();
-
-    mocks.headers.mockResolvedValue(new Headers());
-    mocks.authGetSession.mockResolvedValue({
-      user: {
-        id: 'agent-1',
-        tenantId: 'tenant-1',
-        branchId: 'branch-1',
-      },
-    });
-    mocks.ensureTenantId.mockReturnValue('tenant-1');
-  });
-
   it('denies conversion when scoped lead is not found and performs no mutation', async () => {
     mocks.findLead.mockResolvedValue(null);
 
     await expect(convertLeadToClient('lead-1')).rejects.toThrow(/not found or access denied/i);
-    expect(mocks.update).not.toHaveBeenCalled();
-    expect(mocks.startPayment).not.toHaveBeenCalled();
+    expectNoMutation();
   });
 
   it('applies tenant + agent + branch scope constraints when session has branchId', async () => {
-    mocks.findLead.mockResolvedValue({
-      id: 'lead-2',
-      tenantId: 'tenant-1',
-      branchId: 'branch-1',
-      agentId: 'agent-1',
-    });
+    mockLead('lead-2');
 
     await expect(convertLeadToClient('lead-2')).resolves.toEqual({ success: true });
 
-    expect(mocks.findLead).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: 'and',
-        args: expect.arrayContaining([
-          expect.objectContaining({ op: 'eq', left: 'member_leads.id', right: 'lead-2' }),
-          expect.objectContaining({
-            op: 'eq',
-            left: 'member_leads.tenant_id',
-            right: 'tenant-1',
-          }),
-          expect.objectContaining({ op: 'eq', left: 'member_leads.agent_id', right: 'agent-1' }),
-          expect.objectContaining({
-            op: 'eq',
-            left: 'member_leads.branch_id',
-            right: 'branch-1',
-          }),
-        ]),
-      }),
-    });
-    expect(mocks.where).toHaveBeenCalledWith(
-      expect.objectContaining({
-        op: 'and',
-        args: expect.arrayContaining([
-          expect.objectContaining({ op: 'eq', left: 'member_leads.id', right: 'lead-2' }),
-          expect.objectContaining({
-            op: 'eq',
-            left: 'member_leads.tenant_id',
-            right: 'tenant-1',
-          }),
-          expect.objectContaining({ op: 'eq', left: 'member_leads.agent_id', right: 'agent-1' }),
-          expect.objectContaining({
-            op: 'eq',
-            left: 'member_leads.branch_id',
-            right: 'branch-1',
-          }),
-        ]),
-      })
-    );
+    const scopedWhere = scopedWhereForLead('lead-2');
+    expect(mocks.findLead).toHaveBeenCalledWith({ where: scopedWhere });
+    expect(mocks.where).toHaveBeenCalledWith(scopedWhere);
     expect(mocks.startPayment).not.toHaveBeenCalled();
   });
 
-  it('allows conversion when session has no branchId and lead matches tenant + agent', async () => {
-    mocks.authGetSession.mockResolvedValue({
-      user: {
-        id: 'agent-1',
-        tenantId: 'tenant-1',
-      },
-    });
-    mocks.findLead.mockResolvedValue({
-      id: 'lead-4',
-      tenantId: 'tenant-1',
-      branchId: 'branch-2',
-      agentId: 'agent-1',
-    });
+  it('rejects conversion when agent session has no branchId and performs no lookup or mutation', async () => {
+    mockSession({ id: 'agent-1', role: 'agent', tenantId: 'tenant-1' });
 
-    await expect(convertLeadToClient('lead-4')).resolves.toEqual({ success: true });
-    expect(mocks.findLead).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: 'and',
-        args: expect.arrayContaining([
-          expect.objectContaining({ op: 'eq', left: 'member_leads.id', right: 'lead-4' }),
-          expect.objectContaining({
-            op: 'eq',
-            left: 'member_leads.tenant_id',
-            right: 'tenant-1',
-          }),
-          expect.objectContaining({ op: 'eq', left: 'member_leads.agent_id', right: 'agent-1' }),
-        ]),
-      }),
-    });
-    const findWhereArgs = (mocks.findLead.mock.calls.at(-1)?.[0]?.where as { args?: unknown[] })
-      ?.args;
-    expect(findWhereArgs).toBeDefined();
-    expect(findWhereArgs).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          op: 'eq',
-          left: 'member_leads.branch_id',
-        }),
-      ])
-    );
-    expect(mocks.update).toHaveBeenCalled();
-    expect(mocks.startPayment).not.toHaveBeenCalled();
+    await expect(convertLeadToClient('lead-4')).rejects.toThrow(/not found or access denied/i);
+    expectNoLookupOrMutation();
   });
 
   it('rejects when unauthenticated and performs no mutation', async () => {
     mocks.authGetSession.mockResolvedValue(null);
 
     await expect(convertLeadToClient('lead-5')).rejects.toThrow(/unauthorized/i);
-    expect(mocks.findLead).not.toHaveBeenCalled();
-    expect(mocks.update).not.toHaveBeenCalled();
+    expectNoLookupOrMutation();
+  });
+});
+
+describe('updateLeadStatus', () => {
+  it('rejects unauthenticated calls and performs no mutation', async () => {
+    mocks.authGetSession.mockResolvedValue(null);
+
+    await expect(updateLeadStatus('lead-1', 'contacted')).rejects.toThrow(/unauthorized/i);
+    expectNoLookupOrMutation();
+  });
+
+  it('rejects when scoped lead is not found and performs no mutation', async () => {
+    mocks.ensureTenantId.mockReturnValue('tenant-2');
+    mocks.findLead.mockResolvedValue(null);
+
+    await expect(updateLeadStatus('lead-1', 'contacted')).rejects.toThrow(
+      /not found or access denied/i
+    );
+    expectNoMutation();
+  });
+
+  it('rejects payment_pending from a non-agent session before lookup or payment', async () => {
+    mockSession({ id: 'member-1', role: 'member', tenantId: 'tenant-1', branchId: 'branch-1' });
+
+    await expect(updateLeadStatus('lead-1', 'payment_pending')).rejects.toThrow(
+      /not found or access denied/i
+    );
+    expectNoLookupOrMutation();
+  });
+
+  it('does not start payment when payment_pending lead lookup fails', async () => {
+    mocks.findLead.mockResolvedValue(null);
+
+    await expect(updateLeadStatus('lead-1', 'payment_pending')).rejects.toThrow(
+      /not found or access denied/i
+    );
+    expectNoMutation();
+  });
+
+  it('requires branch scope for agent status updates', async () => {
+    mockSession({ id: 'agent-1', role: 'agent', tenantId: 'tenant-1' });
+
+    await expect(updateLeadStatus('lead-1', 'contacted')).rejects.toThrow(
+      /not found or access denied/i
+    );
+    expectNoLookupOrMutation();
+  });
+
+  it('applies tenant + agent + branch scope constraints before updating status', async () => {
+    mockLead('lead-2');
+
+    await expect(updateLeadStatus('lead-2', 'contacted')).resolves.toEqual({ success: true });
+
+    const scopedWhere = scopedWhereForLead('lead-2');
+    expect(mocks.findLead).toHaveBeenCalledWith({ where: scopedWhere });
+    expect(mocks.where).toHaveBeenCalledWith(scopedWhere);
     expect(mocks.startPayment).not.toHaveBeenCalled();
+  });
+
+  it('starts payment only after the agent-scoped lead lookup succeeds', async () => {
+    mockLead('lead-3');
+
+    await expect(updateLeadStatus('lead-3', 'payment_pending')).resolves.toEqual({
+      success: true,
+    });
+
+    expect(mocks.startPayment).toHaveBeenCalledWith(
+      { tenantId: 'tenant-1' },
+      {
+        leadId: 'lead-3',
+        method: 'cash',
+        amountCents: 15000,
+        priceId: 'default_membership',
+      }
+    );
+    expect(mocks.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/agent/leads/actions.ts
+++ b/apps/web/src/features/agent/leads/actions.ts
@@ -3,7 +3,7 @@
 import { auth } from '@/lib/auth';
 import { and, db, eq, memberLeads } from '@interdomestik/database';
 import { startPayment } from '@interdomestik/domain-leads';
-import { ensureTenantId } from '@interdomestik/shared-auth';
+import { ROLES, ensureTenantId } from '@interdomestik/shared-auth';
 import type { SQL } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
@@ -50,10 +50,11 @@ async function resolveLeadAccess(params: {
   ];
 
   if (params.scope === 'agent') {
-    conditions.push(eq(memberLeads.agentId, session.user.id));
-    if (session.user.branchId) {
-      conditions.push(eq(memberLeads.branchId, session.user.branchId));
+    if (session.user.role !== ROLES.agent || !session.user.branchId) {
+      throw new Error('Lead not found or access denied');
     }
+    conditions.push(eq(memberLeads.agentId, session.user.id));
+    conditions.push(eq(memberLeads.branchId, session.user.branchId));
   }
 
   const scopedWhere = and(...conditions);
@@ -108,10 +109,10 @@ async function updateLeadStatusCore(params: {
 
 /**
  * Updates the status of a lead.
- * strictly enforces tenant isolation.
+ * strictly enforces tenant, agent, and branch isolation.
  */
 export async function updateLeadStatus(leadId: string, status: string) {
-  const { tenantId, scopedWhere } = await resolveLeadAccess({ leadId, scope: 'tenant' });
+  const { tenantId, scopedWhere } = await resolveLeadAccess({ leadId, scope: 'agent' });
   return updateLeadStatusCore({ leadId, status: assertLeadStatus(status), tenantId, scopedWhere });
 }
 


### PR DESCRIPTION
## Summary
- require agent role and branch scope before lead mutations can update status or trigger payment
- scope the agent leads page and lead list by tenant, agent, and branch
- add unit coverage for unauthorized status updates, payment_pending, branchless agents, and page entry guards

## Verification
- pnpm --filter @interdomestik/web test:unit --run src/features/agent/leads/actions.test.ts
- pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(agent)/agent/leads/_core.entry.test.tsx'
- pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(agent)/agent/leads/_core.test.ts'
- pnpm --filter @interdomestik/web lint
- pnpm -w type-check
- pnpm check:db-access
- pnpm security:guard
- pnpm e2e:gate:pr:fast (69 passed, 1 skipped)

## Notes
- apps/web/src/proxy.ts and docs were not changed.
- Existing local script changes were left unstaged and are not part of this branch.