### PR TITLE
Harden direct DB access guardrails

### DIFF
--- a/apps/web/e2e/gate/staff-support-handoffs.spec.ts
+++ b/apps/web/e2e/gate/staff-support-handoffs.spec.ts
@@ -451,6 +451,7 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
     const subject = `E2E CRM05 advisory ${testInfo.project.name} ${Date.now()}`;
     const secondSubject = `${subject} second`;
     const claimHelpPath = `${routes.memberHelp(testInfo)}?claimId=${encodeURIComponent(claimId)}`;
+    const currentMemberSurface = () => memberPage.getByTestId('member-page-ready').last();
 
     await cleanupHandoffBySubject(subject);
     await cleanupHandoffBySubject(secondSubject);
@@ -486,16 +487,21 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
       await gotoApp(memberPage, claimHelpPath, testInfo, {
         marker: 'member-page-ready',
       });
-      await expect(memberPage.getByTestId('member-support-handoff-advisory-claim')).toBeVisible({
-        timeout: 15000,
-      });
-      await expect(memberPage.getByTestId('member-support-handoff-claim')).toHaveValue(claimId);
+      const claimAdvisory = currentMemberSurface().getByTestId(
+        'member-support-handoff-advisory-claim'
+      );
+      await expect(claimAdvisory).toBeVisible({ timeout: 15000 });
+      await expect(currentMemberSurface().getByTestId('member-support-handoff-claim')).toHaveValue(
+        claimId
+      );
 
-      await memberPage.getByTestId('member-support-handoff-subject').fill(secondSubject);
-      await memberPage
+      await currentMemberSurface()
+        .getByTestId('member-support-handoff-subject')
+        .fill(secondSubject);
+      await currentMemberSurface()
         .getByTestId('member-support-handoff-message')
         .fill('Second advisory test handoff proving the advisory remains non-blocking.');
-      await memberPage.getByTestId('member-support-handoff-submit').click();
+      await currentMemberSurface().getByTestId('member-support-handoff-submit').click();
 
       await expect(memberPage).toHaveURL(/\/member\/help\?support=created$/, {
         timeout: 15000,

--- a/apps/web/src/actions/leads/payment.test.ts
+++ b/apps/web/src/actions/leads/payment.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  runAuthenticatedAction: vi.fn(),
+  startPayment: vi.fn(),
+}));
+
+vi.mock('@/lib/safe-action', () => ({
+  runAuthenticatedAction: hoisted.runAuthenticatedAction,
+}));
+
+vi.mock('@interdomestik/domain-leads', () => ({
+  startPayment: hoisted.startPayment,
+  startPaymentSchema: {
+    parse: (input: unknown) => input,
+  },
+}));
+
+import { startPaymentAction } from './payment';
+
+const agentSession = {
+  user: {
+    id: 'agent-1',
+    role: 'agent',
+    tenantId: 'tenant-1',
+  },
+};
+
+function paymentContextWithBranch(branchId: string | null) {
+  return {
+    scope: {
+      actorAgentId: 'agent-1',
+      attributedAgentId: null,
+      branchId,
+    },
+    session: agentSession,
+    tenantId: 'tenant-1',
+    userRole: 'agent',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.runAuthenticatedAction.mockImplementation(async callback =>
+    callback(paymentContextWithBranch('branch-1'))
+  );
+  hoisted.startPayment.mockResolvedValue({
+    attemptId: 'pay_attempt_1',
+    method: 'cash',
+    status: 'pending',
+  });
+});
+
+describe('startPaymentAction', () => {
+  it('passes tenant, agent, and branch scope into payment creation', async () => {
+    await expect(
+      startPaymentAction({
+        amountCents: 15000,
+        leadId: 'lead-1',
+        method: 'cash',
+        priceId: 'default_membership',
+      })
+    ).resolves.toEqual({
+      attemptId: 'pay_attempt_1',
+      method: 'cash',
+      status: 'pending',
+    });
+
+    expect(hoisted.startPayment).toHaveBeenCalledWith(
+      {
+        agentId: 'agent-1',
+        branchId: 'branch-1',
+        tenantId: 'tenant-1',
+      },
+      expect.objectContaining({ leadId: 'lead-1' })
+    );
+  });
+
+  it('rejects callers without agent branch scope before payment creation', async () => {
+    hoisted.runAuthenticatedAction.mockImplementationOnce(async callback =>
+      callback(paymentContextWithBranch(null))
+    );
+
+    await expect(
+      startPaymentAction({
+        amountCents: 15000,
+        leadId: 'lead-1',
+        method: 'cash',
+        priceId: 'default_membership',
+      })
+    ).rejects.toThrow(/unauthorized/i);
+    expect(hoisted.startPayment).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/actions/leads/payment.ts
+++ b/apps/web/src/actions/leads/payment.ts
@@ -1,14 +1,22 @@
 'use server';
 
 import { runAuthenticatedAction } from '@/lib/safe-action';
+import { ROLE_AGENT } from '@/lib/roles.core';
 import { startPayment, startPaymentSchema } from '@interdomestik/domain-leads';
 
 export async function startPaymentAction(input: unknown) {
   return runAuthenticatedAction(async ctx => {
     const data = startPaymentSchema.parse(input);
+    const { actorAgentId, branchId } = ctx.scope;
+    if (ctx.userRole !== ROLE_AGENT || !actorAgentId || !branchId) {
+      throw new Error('Unauthorized');
+    }
+
     return await startPayment(
       {
-        tenantId: ctx.session.user.tenantId,
+        agentId: actorAgentId,
+        branchId,
+        tenantId: ctx.tenantId,
       },
       data
     );

--- a/apps/web/src/actions/leads/update.test.ts
+++ b/apps/web/src/actions/leads/update.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  runAuthenticatedAction: vi.fn(),
+  updateScopedAgentLeadStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/safe-action', () => ({
+  runAuthenticatedAction: hoisted.runAuthenticatedAction,
+}));
+
+vi.mock('@/features/agent/leads/server/lead-actions', () => ({
+  updateScopedAgentLeadStatus: hoisted.updateScopedAgentLeadStatus,
+}));
+
+import { updateLeadStatusAction } from './update';
+
+function updateActionContext(options: { branchId?: string | null } = {}) {
+  const branchId = options.branchId === undefined ? 'branch-1' : options.branchId;
+
+  return {
+    tenantId: 'tenant-1',
+    userRole: 'agent',
+    scope: {
+      actorAgentId: 'agent-1',
+      attributedAgentId: null,
+      branchId,
+    },
+    session: {
+      user: {
+        tenantId: 'tenant-1',
+        role: 'agent',
+        id: 'agent-1',
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.runAuthenticatedAction.mockImplementation(async callback =>
+    callback(updateActionContext())
+  );
+  hoisted.updateScopedAgentLeadStatus.mockResolvedValue({ success: true });
+});
+
+describe('updateLeadStatusAction', () => {
+  it('passes tenant, agent, and branch scope into the lead status update', async () => {
+    await expect(
+      updateLeadStatusAction({
+        leadId: 'lead-1',
+        notes: 'left voicemail',
+        status: 'contacted',
+      })
+    ).resolves.toEqual({ success: true });
+
+    expect(hoisted.updateScopedAgentLeadStatus).toHaveBeenCalledWith({
+      notes: 'left voicemail',
+      scope: {
+        agentId: 'agent-1',
+        branchId: 'branch-1',
+        leadId: 'lead-1',
+        tenantId: 'tenant-1',
+      },
+      status: 'contacted',
+    });
+  });
+
+  it('rejects callers without agent branch scope before lead mutation', async () => {
+    hoisted.runAuthenticatedAction.mockImplementationOnce(async callback =>
+      callback(updateActionContext({ branchId: null }))
+    );
+
+    await expect(
+      updateLeadStatusAction({
+        leadId: 'lead-1',
+        status: 'contacted',
+      })
+    ).rejects.toThrow(/unauthorized/i);
+    expect(hoisted.updateScopedAgentLeadStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/actions/leads/update.ts
+++ b/apps/web/src/actions/leads/update.ts
@@ -1,9 +1,8 @@
 'use server';
 
+import { updateScopedAgentLeadStatus } from '@/features/agent/leads/server/lead-actions';
+import { ROLE_AGENT } from '@/lib/roles.core';
 import { runAuthenticatedAction } from '@/lib/safe-action';
-import { db } from '@interdomestik/database';
-import { memberLeads } from '@interdomestik/database/schema';
-import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 const updateLeadStatusSchema = z.object({
@@ -25,28 +24,23 @@ export async function updateLeadStatusAction(input: unknown) {
   return runAuthenticatedAction(async ctx => {
     const data = updateLeadStatusSchema.parse(input);
     const { leadId, status, notes } = data;
-    const { tenantId, session, userRole } = ctx;
-    const { user } = session;
+    const { tenantId, userRole } = ctx;
+    const { actorAgentId, branchId } = ctx.scope;
 
-    // Verify ownership or permission
-    const lead = await db.query.memberLeads.findFirst({
-      where: (l, { eq, and }) => and(eq(l.id, leadId), eq(l.tenantId, tenantId)),
-    });
-
-    if (!lead) throw new Error('Lead not found');
-
-    if (userRole === 'agent' && lead.agentId !== user.id) {
+    if (userRole !== ROLE_AGENT || !actorAgentId || !branchId) {
       throw new Error('Unauthorized');
     }
 
-    await db
-      .update(memberLeads)
-      .set({
-        status,
-        notes: notes ? `${lead.notes ? lead.notes + '\n' : ''}${notes}` : lead.notes,
-        updatedAt: new Date(),
-      })
-      .where(eq(memberLeads.id, leadId));
+    await updateScopedAgentLeadStatus({
+      notes,
+      scope: {
+        agentId: actorAgentId,
+        branchId,
+        leadId,
+        tenantId,
+      },
+      status,
+    });
 
     return { success: true };
   });

--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -1,6 +1,6 @@
 import { logAuditEvent } from '@/lib/audit';
 import { auth } from '@/lib/auth';
-import { coerceTenantId } from '@/lib/tenant/tenant-hosts';
+import { lookupUserTenantByEmail } from '@/lib/auth/tenant-lookup';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { toNextJsHandler } from 'better-auth/next-js';
 
@@ -98,19 +98,7 @@ export async function POST(req: Request) {
       url: req.url,
       headers: req.headers,
       body: signInBody,
-      lookupUserTenantByEmail: async email => {
-        const [{ db }, { user: userTable }, drizzle] = await Promise.all([
-          import('@interdomestik/database/db'),
-          import('@interdomestik/database/schema'),
-          import('drizzle-orm'),
-        ]);
-        const rows = await db
-          .select({ tenantId: userTable.tenantId })
-          .from(userTable)
-          .where(drizzle.eq(userTable.email, email))
-          .limit(1);
-        return coerceTenantId(rows[0]?.tenantId ?? undefined);
-      },
+      lookupUserTenantByEmail,
     });
 
     if (tenantGuard?.decision === 'deny') {

--- a/apps/web/src/app/api/claims/evidence-upload/route.test.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.test.ts
@@ -12,6 +12,7 @@ const hoisted = vi.hoisted(() => ({
   confirmUpload: vi.fn(),
   createClaimUploadIntentToken: vi.fn(),
   captureMessage: vi.fn(),
+  findOwnedMemberUploadClaim: vi.fn(),
   and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
   eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
 }));
@@ -43,6 +44,7 @@ vi.mock('@/features/member/claims/actions', () => ({
 }));
 vi.mock('@/features/claims/upload/server/access', () => ({
   findAccessibleAdminUploadClaim: hoisted.findAccessibleAdminUploadClaim,
+  findOwnedMemberUploadClaim: hoisted.findOwnedMemberUploadClaim,
 }));
 vi.mock('@/features/claims/upload/server/shared-upload', () => ({
   createClaimUploadIntentToken: hoisted.createClaimUploadIntentToken,
@@ -84,6 +86,7 @@ describe('POST /api/claims/evidence-upload', () => {
       branchId: 'branch-1',
       staffId: 'staff-1',
     });
+    hoisted.findOwnedMemberUploadClaim.mockResolvedValue({ id: 'claim-1' });
     hoisted.upload.mockResolvedValue({ error: null });
     hoisted.createAdminClient.mockReturnValue({
       storage: {
@@ -107,6 +110,26 @@ describe('POST /api/claims/evidence-upload', () => {
     expect(data).toEqual({ error: 'Claim not found' });
     expect(hoisted.upload).not.toHaveBeenCalled();
     expect(hoisted.confirmAdminUpload).not.toHaveBeenCalled();
+  });
+
+  it('denies member uploads for claims outside member ownership before storage upload', async () => {
+    hoisted.getSession.mockResolvedValueOnce({
+      user: { id: 'member-2', role: 'member', tenantId: 'tenant-1' },
+    });
+    hoisted.findOwnedMemberUploadClaim.mockResolvedValueOnce(null);
+
+    const response = await POST(createEvidenceUploadRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toEqual({ error: 'Claim not found' });
+    expect(hoisted.findOwnedMemberUploadClaim).toHaveBeenCalledWith({
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      userId: 'member-2',
+    });
+    expect(hoisted.upload).not.toHaveBeenCalled();
+    expect(hoisted.confirmUpload).not.toHaveBeenCalled();
   });
 
   it('captures orphan-upload telemetry when metadata confirmation fails after storage upload', async () => {

--- a/apps/web/src/app/api/claims/evidence-upload/route.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/route.ts
@@ -8,17 +8,19 @@ import {
   assertEvidenceStoragePath,
   buildEvidenceStoragePath,
 } from '@/features/claims/upload/server/storage-path';
-import { findAccessibleAdminUploadClaim } from '@/features/claims/upload/server/access';
+import {
+  findAccessibleAdminUploadClaim,
+  findOwnedMemberUploadClaim,
+} from '@/features/claims/upload/server/access';
 import { confirmUpload } from '@/features/member/claims/actions';
 import { LOCALES } from '@/i18n/locales';
 import { auth } from '@/lib/auth';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
 import { resolveTenantFromHost } from '@/lib/tenant/tenant-hosts';
-import { claims, createAdminClient, db } from '@interdomestik/database';
+import { createAdminClient } from '@interdomestik/database';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import * as Sentry from '@sentry/nextjs';
 import { randomUUID } from 'crypto';
-import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 const ADMIN_UPLOAD_ROLES = new Set([
@@ -73,11 +75,10 @@ async function validateClaimAccess(params: {
     return claim ? { success: true, isAdminSurface } : { success: false, status: 404 };
   }
 
-  const claim = await db.query.claims.findFirst({
-    where: and(eq(claims.id, claimId), eq(claims.tenantId, tenantId), eq(claims.userId, userId)),
-    columns: {
-      id: true,
-    },
+  const claim = await findOwnedMemberUploadClaim({
+    claimId,
+    tenantId,
+    userId,
   });
 
   if (!claim) {

--- a/apps/web/src/features/agent/activation/actions.test.ts
+++ b/apps/web/src/features/agent/activation/actions.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  activateAgentUserProfile: vi.fn(),
+  authGetSession: vi.fn(),
+  ensureTenantId: vi.fn(),
+  headers: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: hoisted.authGetSession,
+    },
+  },
+}));
+
+vi.mock('@/features/agent/activation/server/activate-agent-profile', () => ({
+  activateAgentUserProfile: hoisted.activateAgentUserProfile,
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: hoisted.ensureTenantId,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: hoisted.revalidatePath,
+}));
+
+vi.mock('next/headers', () => ({
+  headers: hoisted.headers,
+}));
+
+import { activateAgentProfile } from './actions';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.headers.mockResolvedValue(new Headers());
+  hoisted.authGetSession.mockResolvedValue({
+    user: {
+      id: 'member-1',
+      name: 'Arben Lila',
+      role: 'member',
+      tenantId: 'tenant-1',
+    },
+  });
+  hoisted.ensureTenantId.mockReturnValue('tenant-1');
+  hoisted.activateAgentUserProfile.mockResolvedValue(undefined);
+});
+
+describe('activateAgentProfile', () => {
+  it('rejects unauthenticated activation before mutation', async () => {
+    hoisted.authGetSession.mockResolvedValueOnce(null);
+
+    await expect(activateAgentProfile()).resolves.toEqual({
+      success: false,
+      error: 'Unauthorized',
+    });
+
+    expect(hoisted.activateAgentUserProfile).not.toHaveBeenCalled();
+    expect(hoisted.revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('updates only the authenticated user profile', async () => {
+    await expect(activateAgentProfile()).resolves.toEqual({
+      success: true,
+      referralCode: expect.stringMatching(/^ARBEN-[0-9A-F]{4}$/),
+    });
+
+    expect(hoisted.activateAgentUserProfile).toHaveBeenCalledWith({
+      currentRole: 'member',
+      referralCode: expect.stringMatching(/^ARBEN-[0-9A-F]{4}$/),
+      tenantId: 'tenant-1',
+      userId: 'member-1',
+    });
+    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/', 'layout');
+  });
+
+  it('is idempotent for an existing agent and performs no mutation', async () => {
+    hoisted.authGetSession.mockResolvedValueOnce({
+      user: {
+        id: 'agent-1',
+        name: 'Existing Agent',
+        role: 'agent',
+        referralCode: 'EXISTING-1234',
+      },
+    });
+
+    await expect(activateAgentProfile()).resolves.toEqual({
+      success: true,
+      referralCode: 'EXISTING-1234',
+      alreadyActive: true,
+    });
+
+    expect(hoisted.activateAgentUserProfile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/agent/activation/actions.ts
+++ b/apps/web/src/features/agent/activation/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
+import { activateAgentUserProfile } from '@/features/agent/activation/server/activate-agent-profile';
 import { auth } from '@/lib/auth';
-import { db } from '@interdomestik/database/db';
-import { user } from '@interdomestik/database/schema';
-import { eq } from 'drizzle-orm';
+import { ensureTenantId } from '@interdomestik/shared-auth';
 import { randomBytes } from 'crypto';
 import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
@@ -38,18 +37,17 @@ export async function activateAgentProfile() {
   const code = `${baseName}-${suffix}`;
 
   try {
+    const tenantId = ensureTenantId(session);
     // Transactional safety: In a real scenario with high concurrency,
     // we might want a loop to handle code collision (unique constraint),
     // but with 4 chars hex suffix (65k combinations per name), collision is rare enough for now.
 
-    await db
-      .update(user)
-      .set({
-        role: 'agent',
-        referralCode: code,
-        updatedAt: new Date(),
-      })
-      .where(eq(user.id, session.user.id));
+    await activateAgentUserProfile({
+      currentRole: session.user.role,
+      referralCode: code,
+      tenantId,
+      userId: session.user.id,
+    });
 
     revalidatePath('/', 'layout'); // Revalidate everything to update sidebar/nav
 

--- a/apps/web/src/features/agent/activation/server/activate-agent-profile.test.ts
+++ b/apps/web/src/features/agent/activation/server/activate-agent-profile.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  returning: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+  where: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database/db', () => ({
+  db: {
+    update: hoisted.update,
+  },
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  user: {
+    id: 'user.id',
+    tenantId: 'user.tenant_id',
+    role: 'user.role',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: hoisted.and,
+  eq: hoisted.eq,
+}));
+
+import { activateAgentUserProfile } from './activate-agent-profile';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.update.mockReturnValue({ set: hoisted.set });
+  hoisted.set.mockReturnValue({ where: hoisted.where });
+  hoisted.where.mockReturnValue({ returning: hoisted.returning });
+  hoisted.returning.mockResolvedValue([{ id: 'member-1' }]);
+});
+
+describe('activateAgentUserProfile', () => {
+  it('scopes the role update to the authenticated user, tenant, and current role', async () => {
+    await expect(
+      activateAgentUserProfile({
+        currentRole: 'member',
+        referralCode: 'ARBEN-1234',
+        tenantId: 'tenant-1',
+        userId: 'member-1',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(hoisted.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'agent',
+        referralCode: 'ARBEN-1234',
+        updatedAt: expect.any(Date),
+      })
+    );
+    expect(hoisted.where).toHaveBeenCalledWith({
+      op: 'and',
+      args: [
+        { op: 'eq', left: 'user.id', right: 'member-1' },
+        { op: 'eq', left: 'user.tenant_id', right: 'tenant-1' },
+        { op: 'eq', left: 'user.role', right: 'member' },
+      ],
+    });
+    expect(hoisted.returning).toHaveBeenCalledWith({ id: 'user.id' });
+  });
+
+  it('fails closed when the authenticated scope no longer matches a user row', async () => {
+    hoisted.returning.mockResolvedValueOnce([]);
+
+    await expect(
+      activateAgentUserProfile({
+        currentRole: 'member',
+        referralCode: 'ARBEN-1234',
+        tenantId: 'tenant-1',
+        userId: 'member-1',
+      })
+    ).rejects.toThrow(/scope no longer matches/i);
+  });
+});

--- a/apps/web/src/features/agent/activation/server/activate-agent-profile.ts
+++ b/apps/web/src/features/agent/activation/server/activate-agent-profile.ts
@@ -1,0 +1,30 @@
+import { db } from '@interdomestik/database/db';
+import { user } from '@interdomestik/database/schema';
+import { and, eq } from 'drizzle-orm';
+
+export async function activateAgentUserProfile(params: {
+  currentRole: string;
+  referralCode: string;
+  tenantId: string;
+  userId: string;
+}): Promise<void> {
+  const updatedRows = await db
+    .update(user)
+    .set({
+      role: 'agent',
+      referralCode: params.referralCode,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(user.id, params.userId),
+        eq(user.tenantId, params.tenantId),
+        eq(user.role, params.currentRole)
+      )
+    )
+    .returning({ id: user.id });
+
+  if (updatedRows.length === 0) {
+    throw new Error('Agent activation scope no longer matches the authenticated session');
+  }
+}

--- a/apps/web/src/features/agent/leads/actions.test.ts
+++ b/apps/web/src/features/agent/leads/actions.test.ts
@@ -234,7 +234,7 @@ describe('updateLeadStatus', () => {
     });
 
     expect(mocks.startPayment).toHaveBeenCalledWith(
-      { tenantId: 'tenant-1' },
+      { agentId: 'agent-1', branchId: 'branch-1', tenantId: 'tenant-1' },
       {
         leadId: 'lead-3',
         method: 'cash',

--- a/apps/web/src/features/agent/leads/actions.ts
+++ b/apps/web/src/features/agent/leads/actions.ts
@@ -1,15 +1,12 @@
 'use server';
 
 import { auth } from '@/lib/auth';
-import { and, db, eq, memberLeads } from '@interdomestik/database';
-import { startPayment } from '@interdomestik/domain-leads';
+import { updateScopedAgentLeadStatus, type AgentLeadScope } from './server/lead-actions';
+import { memberLeads } from '@interdomestik/database';
 import { ROLES, ensureTenantId } from '@interdomestik/shared-auth';
-import type { SQL } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
 
-type LeadScope = 'tenant' | 'agent';
-type LeadScopeCondition = SQL<unknown>;
 type LeadStatus = typeof memberLeads.$inferInsert.status;
 
 const LEAD_STATUSES = [
@@ -31,10 +28,7 @@ function assertLeadStatus(status: string): LeadStatus {
   throw new Error('Invalid lead status');
 }
 
-async function resolveLeadAccess(params: {
-  leadId: string;
-  scope: LeadScope;
-}): Promise<{ tenantId: string; scopedWhere: LeadScopeCondition }> {
+async function resolveAgentLeadScope(leadId: string): Promise<AgentLeadScope> {
   const session = await auth.api.getSession({
     headers: await headers(),
   });
@@ -44,67 +38,16 @@ async function resolveLeadAccess(params: {
   }
 
   const tenantId = ensureTenantId(session);
-  const conditions: LeadScopeCondition[] = [
-    eq(memberLeads.id, params.leadId),
-    eq(memberLeads.tenantId, tenantId),
-  ];
-
-  if (params.scope === 'agent') {
-    if (session.user.role !== ROLES.agent || !session.user.branchId) {
-      throw new Error('Lead not found or access denied');
-    }
-    conditions.push(eq(memberLeads.agentId, session.user.id));
-    conditions.push(eq(memberLeads.branchId, session.user.branchId));
-  }
-
-  const scopedWhere = and(...conditions);
-  if (!scopedWhere) {
+  if (session.user.role !== ROLES.agent || !session.user.branchId) {
     throw new Error('Lead not found or access denied');
   }
 
-  const lead = await db.query.memberLeads.findFirst({
-    where: scopedWhere,
-  });
-
-  if (!lead) {
-    throw new Error('Lead not found or access denied');
-  }
-
-  return { tenantId, scopedWhere };
-}
-
-async function updateLeadStatusCore(params: {
-  leadId: string;
-  status: LeadStatus;
-  tenantId: string;
-  scopedWhere: LeadScopeCondition;
-}) {
-  const { leadId, status, tenantId, scopedWhere } = params;
-
-  // If requesting payment, we MUST create a payment attempt record
-  if (status === 'payment_pending') {
-    // Default to Cash 150 EUR for Ops Flow MVP
-    await startPayment(
-      { tenantId },
-      {
-        leadId,
-        method: 'cash',
-        amountCents: 15000,
-        priceId: 'default_membership',
-      }
-    );
-  } else {
-    await db
-      .update(memberLeads)
-      .set({
-        status,
-        updatedAt: new Date(),
-      })
-      .where(scopedWhere);
-  }
-
-  revalidatePath('/[locale]/(app)/agent/leads');
-  return { success: true };
+  return {
+    agentId: session.user.id,
+    branchId: session.user.branchId,
+    leadId,
+    tenantId,
+  };
 }
 
 /**
@@ -112,8 +55,12 @@ async function updateLeadStatusCore(params: {
  * strictly enforces tenant, agent, and branch isolation.
  */
 export async function updateLeadStatus(leadId: string, status: string) {
-  const { tenantId, scopedWhere } = await resolveLeadAccess({ leadId, scope: 'agent' });
-  return updateLeadStatusCore({ leadId, status: assertLeadStatus(status), tenantId, scopedWhere });
+  const result = await updateScopedAgentLeadStatus({
+    scope: await resolveAgentLeadScope(leadId),
+    status: assertLeadStatus(status),
+  });
+  revalidatePath('/[locale]/(app)/agent/leads');
+  return result;
 }
 
 /**
@@ -122,6 +69,10 @@ export async function updateLeadStatus(leadId: string, status: string) {
  * or would trigger a complex flow. MVP: Status -> 'converted'.
  */
 export async function convertLeadToClient(leadId: string) {
-  const { tenantId, scopedWhere } = await resolveLeadAccess({ leadId, scope: 'agent' });
-  return updateLeadStatusCore({ leadId, status: 'converted', tenantId, scopedWhere });
+  const result = await updateScopedAgentLeadStatus({
+    scope: await resolveAgentLeadScope(leadId),
+    status: 'converted',
+  });
+  revalidatePath('/[locale]/(app)/agent/leads');
+  return result;
 }

--- a/apps/web/src/features/agent/leads/server/lead-actions.ts
+++ b/apps/web/src/features/agent/leads/server/lead-actions.ts
@@ -1,0 +1,72 @@
+import { and, db, eq, memberLeads } from '@interdomestik/database';
+import { startPayment } from '@interdomestik/domain-leads';
+import type { SQL } from 'drizzle-orm';
+
+type LeadScopeCondition = SQL<unknown>;
+type LeadStatus = typeof memberLeads.$inferInsert.status;
+
+export type AgentLeadScope = {
+  agentId: string;
+  branchId: string;
+  leadId: string;
+  tenantId: string;
+};
+
+function buildAgentLeadWhere(scope: AgentLeadScope): LeadScopeCondition {
+  const scopedWhere = and(
+    eq(memberLeads.id, scope.leadId),
+    eq(memberLeads.tenantId, scope.tenantId),
+    eq(memberLeads.agentId, scope.agentId),
+    eq(memberLeads.branchId, scope.branchId)
+  );
+
+  if (!scopedWhere) {
+    throw new Error('Lead not found or access denied');
+  }
+
+  return scopedWhere;
+}
+
+export async function updateScopedAgentLeadStatus(params: {
+  notes?: string;
+  scope: AgentLeadScope;
+  status: LeadStatus;
+}) {
+  const { notes, scope, status } = params;
+  const scopedWhere = buildAgentLeadWhere(scope);
+  const lead = await db.query.memberLeads.findFirst({
+    where: scopedWhere,
+  });
+
+  if (!lead) {
+    throw new Error('Lead not found or access denied');
+  }
+
+  if (status === 'payment_pending') {
+    await startPayment(
+      {
+        agentId: scope.agentId,
+        branchId: scope.branchId,
+        tenantId: scope.tenantId,
+      },
+      {
+        leadId: scope.leadId,
+        method: 'cash',
+        amountCents: 15000,
+        priceId: 'default_membership',
+      }
+    );
+    return { success: true };
+  }
+
+  await db
+    .update(memberLeads)
+    .set({
+      notes: notes ? `${lead.notes ? `${lead.notes}\n` : ''}${notes}` : lead.notes,
+      status,
+      updatedAt: new Date(),
+    })
+    .where(scopedWhere);
+
+  return { success: true };
+}

--- a/apps/web/src/features/claims/upload/server/access.test.ts
+++ b/apps/web/src/features/claims/upload/server/access.test.ts
@@ -1,6 +1,36 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { canAccessClaimFromAdminUploadSurface } from './access';
+const hoisted = vi.hoisted(() => ({
+  findClaimFirst: vi.fn(),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    query: {
+      claims: {
+        findFirst: hoisted.findClaimFirst,
+      },
+    },
+  },
+  claims: {
+    id: 'claims.id',
+    tenantId: 'claims.tenant_id',
+    userId: 'claims.user_id',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: hoisted.and,
+  eq: hoisted.eq,
+}));
+
+import { canAccessClaimFromAdminUploadSurface, findOwnedMemberUploadClaim } from './access';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('canAccessClaimFromAdminUploadSurface', () => {
   it('allows assigned staff even when the claim branch differs', () => {
@@ -12,5 +42,51 @@ describe('canAccessClaimFromAdminUploadSurface', () => {
         userId: 'staff-2',
       })
     ).toBe(true);
+  });
+
+  it('denies staff outside both branch and assignment scope', () => {
+    expect(
+      canAccessClaimFromAdminUploadSurface({
+        branchId: 'branch-2',
+        claim: { branchId: 'branch-1', staffId: 'staff-1' },
+        role: 'staff',
+        userId: 'staff-2',
+      })
+    ).toBe(false);
+  });
+
+  it('denies branch managers outside their branch scope', () => {
+    expect(
+      canAccessClaimFromAdminUploadSurface({
+        branchId: 'branch-2',
+        claim: { branchId: 'branch-1', staffId: null },
+        role: 'branch_manager',
+        userId: 'manager-1',
+      })
+    ).toBe(false);
+  });
+
+  it('scopes member upload lookup to claim, tenant, and owning member', async () => {
+    hoisted.findClaimFirst.mockResolvedValueOnce({ id: 'claim-1' });
+
+    await expect(
+      findOwnedMemberUploadClaim({
+        claimId: 'claim-1',
+        tenantId: 'tenant-1',
+        userId: 'member-1',
+      })
+    ).resolves.toEqual({ id: 'claim-1' });
+
+    expect(hoisted.findClaimFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        op: 'and',
+        args: expect.arrayContaining([
+          expect.objectContaining({ op: 'eq', left: 'claims.id', right: 'claim-1' }),
+          expect.objectContaining({ op: 'eq', left: 'claims.tenant_id', right: 'tenant-1' }),
+          expect.objectContaining({ op: 'eq', left: 'claims.user_id', right: 'member-1' }),
+        ]),
+      }),
+      columns: { id: true },
+    });
   });
 });

--- a/apps/web/src/features/claims/upload/server/access.ts
+++ b/apps/web/src/features/claims/upload/server/access.ts
@@ -6,6 +6,10 @@ type ClaimScopeRecord = {
   staffId?: string | null;
 };
 
+type MemberClaimOwnershipRecord = {
+  id: string;
+};
+
 const FULL_TENANT_CLAIMS_ROLES = new Set(['admin', 'tenant_admin', 'super_admin']);
 
 export function canAccessClaimFromAdminUploadSurface(args: {
@@ -68,4 +72,23 @@ export async function findAccessibleAdminUploadClaim(args: {
   }
 
   return claim;
+}
+
+export async function findOwnedMemberUploadClaim(args: {
+  claimId: string;
+  tenantId: string;
+  userId: string;
+}): Promise<MemberClaimOwnershipRecord | null> {
+  const claim = await db.query.claims.findFirst({
+    where: and(
+      eq(claims.id, args.claimId),
+      eq(claims.tenantId, args.tenantId),
+      eq(claims.userId, args.userId)
+    ),
+    columns: {
+      id: true,
+    },
+  });
+
+  return claim ?? null;
 }

--- a/apps/web/src/features/member/claims/actions.test.ts
+++ b/apps/web/src/features/member/claims/actions.test.ts
@@ -9,7 +9,7 @@ const hoisted = vi.hoisted(() => {
     headers: vi.fn(),
     ensureTenantId: vi.fn(),
     resolveEvidenceBucketName: vi.fn(),
-    findClaimFirst: vi.fn(),
+    findOwnedMemberUploadClaim: vi.fn(),
     createSignedUploadUrl: vi.fn(),
     listStorageObjects: vi.fn(),
     storageFrom: vi.fn(),
@@ -45,20 +45,14 @@ vi.mock('@/lib/storage/evidence-bucket', () => ({
   resolveEvidenceBucketName: hoisted.resolveEvidenceBucketName,
 }));
 
+vi.mock('@/features/claims/upload/server/access', () => ({
+  findOwnedMemberUploadClaim: hoisted.findOwnedMemberUploadClaim,
+}));
+
 vi.mock('@interdomestik/database', () => ({
   db: {
-    query: {
-      claims: {
-        findFirst: hoisted.findClaimFirst,
-      },
-    },
     insert: hoisted.insert,
     transaction: hoisted.transaction,
-  },
-  claims: {
-    id: 'claims.id',
-    tenantId: 'claims.tenant_id',
-    userId: 'claims.user_id',
   },
   claimDocuments: 'claim_documents',
 }));
@@ -141,7 +135,7 @@ describe('member claim upload actions', () => {
     });
     hoisted.ensureTenantId.mockReturnValue('tenant-1');
     hoisted.resolveEvidenceBucketName.mockReturnValue('claim-evidence');
-    hoisted.findClaimFirst.mockResolvedValue({ id: 'claim-1', userId: 'member-1' });
+    hoisted.findOwnedMemberUploadClaim.mockResolvedValue({ id: 'claim-1' });
     hoisted.storageFrom.mockReturnValue({
       createSignedUploadUrl: hoisted.createSignedUploadUrl,
       list: hoisted.listStorageObjects,
@@ -256,36 +250,30 @@ describe('member claim upload actions', () => {
   });
 
   it('denies signed URL issuance for same-tenant claims owned by another member', async () => {
-    hoisted.findClaimFirst.mockResolvedValue(null);
+    hoisted.findOwnedMemberUploadClaim.mockResolvedValue(null);
 
     const result = await generateUploadUrl('claim-1', 'evidence.pdf', 'application/pdf', 1024);
 
     expect(result).toEqual({ success: false, error: 'Claim not found', status: 404 });
     expect(hoisted.createSignedUploadUrl).not.toHaveBeenCalled();
-    expect(hoisted.findClaimFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: 'and',
-        args: expect.arrayContaining([
-          expect.objectContaining({ op: 'eq', left: 'claims.user_id', right: 'member-1' }),
-        ]),
-      }),
+    expect(hoisted.findOwnedMemberUploadClaim).toHaveBeenCalledWith({
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      userId: 'member-1',
     });
   });
 
   it('denies confirmUpload when claim is not owned by the member', async () => {
-    hoisted.findClaimFirst.mockResolvedValue(null);
+    hoisted.findOwnedMemberUploadClaim.mockResolvedValue(null);
 
     const result = await confirmUpload(createConfirmUploadParams());
 
     expect(result).toEqual({ success: false, error: 'Claim not found', status: 404 });
     expect(hoisted.insert).not.toHaveBeenCalled();
-    expect(hoisted.findClaimFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        op: 'and',
-        args: expect.arrayContaining([
-          expect.objectContaining({ op: 'eq', left: 'claims.user_id', right: 'member-1' }),
-        ]),
-      }),
+    expect(hoisted.findOwnedMemberUploadClaim).toHaveBeenCalledWith({
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      userId: 'member-1',
     });
   });
 

--- a/apps/web/src/features/member/claims/actions.ts
+++ b/apps/web/src/features/member/claims/actions.ts
@@ -7,10 +7,9 @@ import {
   revalidatePathForAllLocales,
   validateConfirmedClaimUpload,
 } from '@/features/claims/upload/server/shared-upload';
+import { findOwnedMemberUploadClaim } from '@/features/claims/upload/server/access';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
-import { claims, db } from '@interdomestik/database';
 import { ensureTenantId } from '@interdomestik/shared-auth';
-import { and, eq } from 'drizzle-orm';
 import { headers } from 'next/headers';
 
 export type GenerateUploadUrlResult =
@@ -53,13 +52,10 @@ export async function generateUploadUrl(
     return { success: false, error: message, status: 500 };
   }
 
-  // Authorization: fail-closed to claims owned by the current member and tenant.
-  const claim = await db.query.claims.findFirst({
-    where: and(
-      eq(claims.id, claimId),
-      eq(claims.tenantId, tenantId),
-      eq(claims.userId, session.user.id)
-    ),
+  const claim = await findOwnedMemberUploadClaim({
+    claimId,
+    tenantId,
+    userId: session.user.id,
   });
 
   if (!claim) {
@@ -148,13 +144,10 @@ export async function confirmUpload(params: ConfirmUploadParams): Promise<Confir
   }
   const { session, tenantId, resolvedBucket } = uploadContext;
 
-  // Authorization: fail-closed to claims owned by the current member and tenant.
-  const claim = await db.query.claims.findFirst({
-    where: and(
-      eq(claims.id, claimId),
-      eq(claims.tenantId, tenantId),
-      eq(claims.userId, session.user.id)
-    ),
+  const claim = await findOwnedMemberUploadClaim({
+    claimId,
+    tenantId,
+    userId: session.user.id,
   });
 
   if (!claim) {

--- a/apps/web/src/lib/auth/tenant-lookup.ts
+++ b/apps/web/src/lib/auth/tenant-lookup.ts
@@ -1,0 +1,15 @@
+import { db } from '@interdomestik/database/db';
+import { user as userTable } from '@interdomestik/database/schema';
+import { eq } from 'drizzle-orm';
+
+import { coerceTenantId, type TenantId } from '@/lib/tenant/tenant-hosts';
+
+export async function lookupUserTenantByEmail(email: string): Promise<TenantId | null> {
+  const rows = await db
+    .select({ tenantId: userTable.tenantId })
+    .from(userTable)
+    .where(eq(userTable.email, email))
+    .limit(1);
+
+  return coerceTenantId(rows[0]?.tenantId ?? undefined);
+}

--- a/packages/domain-leads/src/payment.test.ts
+++ b/packages/domain-leads/src/payment.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  findLead: vi.fn(),
+  insert: vi.fn(),
+  insertValues: vi.fn(),
+  nanoid: vi.fn(),
+  ne: vi.fn((left: unknown, right: unknown) => ({ op: 'ne', left, right })),
+  returning: vi.fn(),
+  set: vi.fn(),
+  transaction: vi.fn(),
+  update: vi.fn(),
+  where: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    query: {
+      memberLeads: {
+        findFirst: mocks.findLead,
+      },
+    },
+    transaction: mocks.transaction,
+  },
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  leadPaymentAttempts: 'lead_payment_attempts',
+  memberLeads: {
+    id: 'member_leads.id',
+    tenantId: 'member_leads.tenant_id',
+    agentId: 'member_leads.agent_id',
+    branchId: 'member_leads.branch_id',
+    status: 'member_leads.status',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: mocks.and,
+  eq: mocks.eq,
+  ne: mocks.ne,
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: mocks.nanoid,
+}));
+
+import { startPayment } from './payment';
+
+function installTransactionHarness(updatedRows: Array<{ id: string }> = [{ id: 'lead-1' }]) {
+  const tx = {
+    insert: mocks.insert,
+    update: mocks.update,
+  };
+  mocks.update.mockReturnValue({ set: mocks.set });
+  mocks.set.mockReturnValue({ where: mocks.where });
+  mocks.where.mockReturnValue({ returning: mocks.returning });
+  mocks.returning.mockResolvedValue(updatedRows);
+  mocks.insert.mockReturnValue({ values: mocks.insertValues });
+  mocks.insertValues.mockResolvedValue(undefined);
+  mocks.transaction.mockImplementation(async (callback: (txArg: typeof tx) => Promise<unknown>) =>
+    callback(tx)
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.findLead.mockResolvedValue({
+    id: 'lead-1',
+    status: 'new',
+  });
+  mocks.nanoid.mockReturnValue('attempt-1');
+  installTransactionHarness();
+});
+
+describe('startPayment', () => {
+  it('carries optional agent and branch scope through payment validation and status update', async () => {
+    await expect(
+      startPayment(
+        {
+          agentId: 'agent-1',
+          branchId: 'branch-1',
+          tenantId: 'tenant-1',
+        },
+        {
+          amountCents: 15000,
+          leadId: 'lead-1',
+          method: 'cash',
+          priceId: 'default_membership',
+        }
+      )
+    ).resolves.toEqual({
+      attemptId: 'pay_attempt_attempt-1',
+      method: 'cash',
+      status: 'pending',
+    });
+
+    const scopedWhere = {
+      op: 'and',
+      args: [
+        { op: 'eq', left: 'member_leads.id', right: 'lead-1' },
+        { op: 'eq', left: 'member_leads.tenant_id', right: 'tenant-1' },
+        { op: 'eq', left: 'member_leads.agent_id', right: 'agent-1' },
+        { op: 'eq', left: 'member_leads.branch_id', right: 'branch-1' },
+      ],
+    };
+    expect(mocks.findLead).toHaveBeenCalledWith({ where: scopedWhere });
+    expect(mocks.where).toHaveBeenCalledWith({
+      op: 'and',
+      args: [scopedWhere, { op: 'ne', left: 'member_leads.status', right: 'converted' }],
+    });
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leadId: 'lead-1',
+        tenantId: 'tenant-1',
+      })
+    );
+  });
+
+  it('does not insert a payment attempt when the scoped status update no longer matches', async () => {
+    installTransactionHarness([]);
+
+    await expect(
+      startPayment(
+        {
+          agentId: 'agent-1',
+          branchId: 'branch-1',
+          tenantId: 'tenant-1',
+        },
+        {
+          amountCents: 15000,
+          leadId: 'lead-1',
+          method: 'cash',
+          priceId: 'default_membership',
+        }
+      )
+    ).rejects.toThrow(/lead not found/i);
+
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-leads/src/payment.ts
+++ b/packages/domain-leads/src/payment.ts
@@ -1,6 +1,6 @@
 import { db } from '@interdomestik/database';
 import { leadPaymentAttempts, memberLeads } from '@interdomestik/database/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq, ne } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 // We might need to import paddle helper if we generate a transaction server-side
@@ -15,12 +15,62 @@ export const startPaymentSchema = z.object({
 
 export type StartPaymentInput = z.infer<typeof startPaymentSchema>;
 
-export async function startPayment(ctx: { tenantId: string }, input: StartPaymentInput) {
-  const { leadId, method, priceId, amountCents } = input;
+type StartPaymentContext =
+  | { tenantId: string }
+  | { tenantId: string; agentId: string; branchId: string };
+
+function buildLeadPaymentScope(ctx: StartPaymentContext, leadId: string) {
+  const conditions = [eq(memberLeads.id, leadId), eq(memberLeads.tenantId, ctx.tenantId)];
+
+  if ('agentId' in ctx) {
+    conditions.push(eq(memberLeads.agentId, ctx.agentId));
+    conditions.push(eq(memberLeads.branchId, ctx.branchId));
+  }
+
+  const scopedWhere = and(...conditions);
+  if (!scopedWhere) {
+    throw new Error('Lead not found');
+  }
+
+  return scopedWhere;
+}
+
+async function markLeadPaymentPending(
+  ctx: StartPaymentContext,
+  input: StartPaymentInput,
+  attemptId: string,
+  scopedWhere: NonNullable<ReturnType<typeof buildLeadPaymentScope>>
+) {
+  await db.transaction(async tx => {
+    const updatedRows = await tx
+      .update(memberLeads)
+      .set({ status: 'payment_pending' })
+      .where(and(scopedWhere, ne(memberLeads.status, 'converted')))
+      .returning({ id: memberLeads.id });
+
+    if (updatedRows.length === 0) {
+      throw new Error('Lead not found');
+    }
+
+    await tx.insert(leadPaymentAttempts).values({
+      id: attemptId,
+      tenantId: ctx.tenantId,
+      leadId: input.leadId,
+      method: input.method,
+      status: 'pending',
+      amount: input.amountCents,
+      currency: 'EUR',
+    });
+  });
+}
+
+export async function startPayment(ctx: StartPaymentContext, input: StartPaymentInput) {
+  const { leadId, method } = input;
+  const scopedWhere = buildLeadPaymentScope(ctx, leadId);
 
   // 1. Validate Lead
   const lead = await db.query.memberLeads.findFirst({
-    where: (leads, { eq, and }) => and(eq(leads.id, leadId), eq(leads.tenantId, ctx.tenantId)),
+    where: scopedWhere,
   });
 
   if (!lead) throw new Error('Lead not found');
@@ -28,55 +78,7 @@ export async function startPayment(ctx: { tenantId: string }, input: StartPaymen
 
   const attemptId = `pay_attempt_${nanoid()}`;
 
-  // 2. Handle Cash
-  if (method === 'cash') {
-    await db.transaction(async tx => {
-      await tx.insert(leadPaymentAttempts).values({
-        id: attemptId,
-        tenantId: ctx.tenantId,
-        leadId,
-        method: 'cash',
-        status: 'pending',
-        amount: amountCents,
-        currency: 'EUR',
-      });
+  await markLeadPaymentPending(ctx, input, attemptId, scopedWhere);
 
-      await tx
-        .update(memberLeads)
-        .set({ status: 'payment_pending' })
-        .where(eq(memberLeads.id, leadId));
-    });
-
-    return { attemptId, status: 'pending', method: 'cash' };
-  }
-
-  // 3. Handle Card (Paddle)
-  // For now, we just record the intent. The actual Transaction object is created by client or server-side SDK.
-  // If we need to create a Paddle Transaction here, we would use the Paddle SDK.
-  // Let's assume the Client initiates the transaction with Paddle using priceId,
-  // and we pass `custom_data: { leadId }` to Paddle.
-  // So strictly speaking, we might not strictly NEED a DB record for "intent" unless we want to track it.
-  // But verifying says we should.
-
-  await db.transaction(async tx => {
-    await tx.insert(leadPaymentAttempts).values({
-      id: attemptId,
-      tenantId: ctx.tenantId,
-      leadId,
-      method: 'card',
-      status: 'pending',
-      amount: amountCents,
-      currency: 'EUR',
-      // We can create a paddle transaction here if we want server-side generated checkout
-    });
-
-    // We don't necessarily move lead to 'payment_pending' yet, or maybe we do?
-    // Let's set it to payment_pending to indicate active checkout.
-    await tx
-      .update(memberLeads)
-      .set({ status: 'payment_pending' })
-      .where(eq(memberLeads.id, leadId));
-  });
-
-  return { attemptId, status: 'pending', method: 'card' };
+  return { attemptId, status: 'pending', method };
 }

--- a/scripts/check-db-access-guard.mjs
+++ b/scripts/check-db-access-guard.mjs
@@ -18,6 +18,13 @@ const DIRECT_DB_METHODS = [
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts']);
 
 const APPROVED_WRAPPER_PATTERNS = [/^packages\/database\//u];
+const EXPLICIT_CLASSIFICATION_RISKS = new Set(['server-action', 'high-risk-route']);
+const EXPLICIT_CLASSIFICATION_PATH_PATTERNS = [
+  /^apps\/web\/src\/features\/agent\/activation\/server\/activate-agent-profile\.ts$/u,
+  /^apps\/web\/src\/features\/agent\/leads\/server\/lead-actions\.ts$/u,
+  /^apps\/web\/src\/features\/claims\/upload\/server\/access\.ts$/u,
+  /^apps\/web\/src\/lib\/auth\/tenant-lookup\.ts$/u,
+];
 
 const EXCLUDED_PATH_PATTERNS = [
   /(^|\/)__tests__(\/|$)/u,
@@ -242,6 +249,23 @@ function createEntryKey(entry) {
   return `${entry.file}|${entry.method}|${entry.source}`;
 }
 
+function hasExplicitClassification(entry) {
+  return typeof entry.classification === 'string' && entry.classification.trim().length > 0;
+}
+
+function findUnclassifiedRiskyBaselineEntries(entries) {
+  return entries.filter(
+    entry => requiresExplicitClassification(entry) && !hasExplicitClassification(entry)
+  );
+}
+
+function requiresExplicitClassification(entry) {
+  return (
+    EXPLICIT_CLASSIFICATION_RISKS.has(entry.risk) ||
+    EXPLICIT_CLASSIFICATION_PATH_PATTERNS.some(pattern => pattern.test(entry.file))
+  );
+}
+
 function classifyRisk(relativePath) {
   if (/^packages\/domain-[^/]+\/src\//u.test(relativePath)) return 'domain-wrapper';
   if (/\/route\.[cm]?[jt]sx?$/u.test(relativePath)) return 'high-risk-route';
@@ -391,7 +415,23 @@ function diffAgainstBaseline(currentEntries, baselineEntries) {
   return { newEntries, removedEntries };
 }
 
-function buildBaseline({ entries, scanRoots }) {
+function createClassificationLookup(entries) {
+  const lookup = new Map();
+  for (const entry of entries) {
+    if (hasExplicitClassification(entry)) {
+      lookup.set(createEntryKey(entry), entry.classification);
+    }
+  }
+  return lookup;
+}
+
+function buildBaseline({ entries, scanRoots, existingEntries = [] }) {
+  const classificationLookup = createClassificationLookup(existingEntries);
+  const classifiedEntries = entries.map(entry => {
+    const classification = classificationLookup.get(createEntryKey(entry));
+    return classification ? { ...entry, classification } : entry;
+  });
+
   return {
     version: 1,
     generatedAt: new Date().toISOString(),
@@ -400,7 +440,7 @@ function buildBaseline({ entries, scanRoots }) {
     scanRoots,
     approvedWrapperPatterns: APPROVED_WRAPPER_PATTERNS.map(pattern => pattern.source),
     methods: DIRECT_DB_METHODS,
-    entries,
+    entries: classifiedEntries,
   };
 }
 
@@ -429,10 +469,17 @@ function main() {
   const findings = collectFindings({ repoRoot, scanRoots: options.scanRoots });
 
   if (options.writeBaseline) {
+    const existingEntries = fs.existsSync(baselinePath)
+      ? (readJson(baselinePath).entries ?? [])
+      : [];
     ensureDirForFile(baselinePath);
     fs.writeFileSync(
       baselinePath,
-      `${JSON.stringify(buildBaseline({ entries: findings, scanRoots: options.scanRoots }), null, 2)}\n`
+      `${JSON.stringify(
+        buildBaseline({ entries: findings, existingEntries, scanRoots: options.scanRoots }),
+        null,
+        2
+      )}\n`
     );
     console.log(`Updated DB access baseline: ${options.baselinePath} (${findings.length} entries)`);
     return;
@@ -449,19 +496,36 @@ function main() {
     throw new Error(`Invalid baseline ${options.baselinePath}: missing entries array.`);
   }
 
+  const unclassifiedRiskyBaselineEntries = findUnclassifiedRiskyBaselineEntries(baseline.entries);
   const { newEntries, removedEntries } = diffAgainstBaseline(findings, baseline.entries);
   const report = {
-    status: newEntries.length === 0 ? 'pass' : 'fail',
+    status:
+      newEntries.length === 0 && unclassifiedRiskyBaselineEntries.length === 0 ? 'pass' : 'fail',
     baselinePath: options.baselinePath,
     scannedCount: findings.length,
     baselineCount: baseline.entries.length,
     newCount: newEntries.length,
     removedCount: removedEntries.length,
+    unclassifiedRiskyBaselineCount: unclassifiedRiskyBaselineEntries.length,
     newEntries,
     removedEntries,
+    unclassifiedRiskyBaselineEntries,
   };
 
   writeReport(reportPath, report);
+
+  if (unclassifiedRiskyBaselineEntries.length > 0) {
+    console.error(
+      'DB access guard failed: risky server-action/high-risk-route entries and extracted boundary wrapper paths require explicit classification.'
+    );
+    printEntries('Unclassified risky baseline entries:', unclassifiedRiskyBaselineEntries);
+    console.error('');
+    console.error(
+      'Move the access behind an approved domain/database wrapper, or add classification metadata only after focused authorization review.'
+    );
+    console.error(`Report: ${options.reportPath}`);
+    process.exit(1);
+  }
 
   if (newEntries.length > 0) {
     console.error(

--- a/scripts/ci/db-access-baseline.json
+++ b/scripts/ci/db-access-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-05T21:59:12.445Z",
+  "generatedAt": "2026-05-08T15:55:32.243Z",
   "policy": "Baseline for direct db.* calls outside approved database package internals. New app-layer and domain-package direct database access must move behind an approved wrapper or intentionally update this baseline.",
   "scanRoots": ["apps/web/src", "packages"],
   "approvedWrapperPatterns": ["^packages\\/database\\/"],
@@ -273,20 +273,6 @@
       "source": "const leads = await db.query.memberLeads.findMany({"
     },
     {
-      "file": "apps/web/src/actions/leads/update.ts",
-      "line": 32,
-      "method": "query",
-      "risk": "app-layer",
-      "source": "const lead = await db.query.memberLeads.findFirst({"
-    },
-    {
-      "file": "apps/web/src/actions/leads/update.ts",
-      "line": 42,
-      "method": "update",
-      "risk": "app-layer",
-      "source": "await db .update(memberLeads)"
-    },
-    {
       "file": "apps/web/src/actions/member-notes/create.core.ts",
       "line": 51,
       "method": "insert",
@@ -540,14 +526,14 @@
     },
     {
       "file": "apps/web/src/app/[locale]/(agent)/agent/leads/_core.entry.tsx",
-      "line": 28,
+      "line": 36,
       "method": "query",
       "risk": "app-layer",
       "source": "const settings = await db.query.agentSettings.findFirst({"
     },
     {
       "file": "apps/web/src/app/[locale]/(agent)/agent/leads/_core.ts",
-      "line": 29,
+      "line": 27,
       "method": "query",
       "risk": "app-layer",
       "source": "return db.query.memberLeads.findMany({"
@@ -938,20 +924,6 @@
       "source": "await tx .update(documentExtractions)"
     },
     {
-      "file": "apps/web/src/app/api/auth/[...all]/route.ts",
-      "line": 107,
-      "method": "select",
-      "risk": "high-risk-route",
-      "source": "const rows = await db .select({ tenantId: userTable.tenantId })"
-    },
-    {
-      "file": "apps/web/src/app/api/claims/evidence-upload/route.ts",
-      "line": 75,
-      "method": "query",
-      "risk": "high-risk-route",
-      "source": "const claim = await db.query.claims.findFirst({"
-    },
-    {
       "file": "apps/web/src/app/api/cron/dunning/_core.ts",
       "line": 39,
       "method": "query",
@@ -1303,7 +1275,7 @@
     },
     {
       "file": "apps/web/src/app/api/uploads/_core.ts",
-      "line": 93,
+      "line": 98,
       "method": "query",
       "risk": "app-layer",
       "source": "const claim = await db.query.claims.findFirst({"
@@ -1799,11 +1771,12 @@
       "source": "let queryBuilder = db .select({"
     },
     {
-      "file": "apps/web/src/features/agent/activation/actions.ts",
-      "line": 45,
+      "file": "apps/web/src/features/agent/activation/server/activate-agent-profile.ts",
+      "line": 11,
       "method": "update",
-      "risk": "server-action",
-      "source": "await db .update(user)"
+      "risk": "app-layer",
+      "source": "const updatedRows = await db .update(user)",
+      "classification": "extracted-server-action-wrapper: authenticated tenant/user/current-role scope is explicit in helper input and covered by negative scope tests"
     },
     {
       "file": "apps/web/src/features/agent/dashboard/components/AgentDashboardV2Page.tsx",
@@ -1841,18 +1814,20 @@
       "source": "const [slaBreaches] = await db .select({ count: count() })"
     },
     {
-      "file": "apps/web/src/features/agent/leads/actions.ts",
-      "line": 64,
+      "file": "apps/web/src/features/agent/leads/server/lead-actions.ts",
+      "line": 37,
       "method": "query",
-      "risk": "server-action",
-      "source": "const lead = await db.query.memberLeads.findFirst({"
+      "risk": "app-layer",
+      "source": "const lead = await db.query.memberLeads.findFirst({",
+      "classification": "extracted-server-action-wrapper: authenticated tenant/agent/branch lead scope is explicit in helper input and covered by negative authorization tests"
     },
     {
-      "file": "apps/web/src/features/agent/leads/actions.ts",
-      "line": 96,
+      "file": "apps/web/src/features/agent/leads/server/lead-actions.ts",
+      "line": 62,
       "method": "update",
-      "risk": "server-action",
-      "source": "await db .update(memberLeads)"
+      "risk": "app-layer",
+      "source": "await db .update(memberLeads)",
+      "classification": "extracted-server-action-wrapper: authenticated tenant/agent/branch lead scope is explicit in helper input and covered by negative authorization tests"
     },
     {
       "file": "apps/web/src/features/claims/timeline/server/getClaimTimeline.ts",
@@ -1940,28 +1915,37 @@
     },
     {
       "file": "apps/web/src/features/claims/upload/server/access.ts",
-      "line": 50,
+      "line": 54,
       "method": "query",
       "risk": "app-layer",
-      "source": "const claim = await db.query.claims.findFirst({"
+      "source": "const claim = await db.query.claims.findFirst({",
+      "classification": "extracted-upload-boundary-wrapper: tenant plus admin-role branch/staff or member-owner scope is explicit and covered by negative authorization tests"
+    },
+    {
+      "file": "apps/web/src/features/claims/upload/server/access.ts",
+      "line": 82,
+      "method": "query",
+      "risk": "app-layer",
+      "source": "const claim = await db.query.claims.findFirst({",
+      "classification": "extracted-upload-boundary-wrapper: tenant plus admin-role branch/staff or member-owner scope is explicit and covered by negative authorization tests"
     },
     {
       "file": "apps/web/src/features/claims/upload/server/shared-upload.ts",
-      "line": 501,
+      "line": 531,
       "method": "transaction",
       "risk": "app-layer",
       "source": "await db.transaction(async tx => {"
     },
     {
       "file": "apps/web/src/features/claims/upload/server/shared-upload.ts",
-      "line": 502,
+      "line": 532,
       "method": "insert",
       "risk": "app-layer",
       "source": "await tx.insert(claimDocuments).values({"
     },
     {
       "file": "apps/web/src/features/claims/upload/server/shared-upload.ts",
-      "line": 517,
+      "line": 547,
       "method": "transaction",
       "risk": "app-layer",
       "source": "const queuedRuns = await db.transaction(async tx =>"
@@ -1972,20 +1956,6 @@
       "method": "select",
       "risk": "app-layer",
       "source": "await db.select({ id: user.id }).from(user).limit(1);"
-    },
-    {
-      "file": "apps/web/src/features/member/claims/actions.ts",
-      "line": 57,
-      "method": "query",
-      "risk": "server-action",
-      "source": "const claim = await db.query.claims.findFirst({"
-    },
-    {
-      "file": "apps/web/src/features/member/claims/actions.ts",
-      "line": 152,
-      "method": "query",
-      "risk": "server-action",
-      "source": "const claim = await db.query.claims.findFirst({"
     },
     {
       "file": "apps/web/src/features/share-pack/share-pack.service.ts",
@@ -2126,6 +2096,14 @@
       "method": "select",
       "risk": "app-layer",
       "source": "const existing = await db .select({"
+    },
+    {
+      "file": "apps/web/src/lib/auth/tenant-lookup.ts",
+      "line": 8,
+      "method": "select",
+      "risk": "app-layer",
+      "source": "const rows = await db .select({ tenantId: userTable.tenantId })",
+      "classification": "extracted-high-risk-route-wrapper: email sign-in tenant lookup returns tenant id only and is consumed by tenant guard tests"
     },
     {
       "file": "apps/web/src/lib/business-leads/resolve-business-lead-owner.ts",
@@ -3403,52 +3381,31 @@
     },
     {
       "file": "packages/domain-leads/src/payment.ts",
-      "line": 22,
+      "line": 44,
+      "method": "transaction",
+      "risk": "domain-wrapper",
+      "source": "await db.transaction(async tx => {"
+    },
+    {
+      "file": "packages/domain-leads/src/payment.ts",
+      "line": 45,
+      "method": "update",
+      "risk": "domain-wrapper",
+      "source": "const updatedRows = await tx .update(memberLeads)"
+    },
+    {
+      "file": "packages/domain-leads/src/payment.ts",
+      "line": 55,
+      "method": "insert",
+      "risk": "domain-wrapper",
+      "source": "await tx.insert(leadPaymentAttempts).values({"
+    },
+    {
+      "file": "packages/domain-leads/src/payment.ts",
+      "line": 72,
       "method": "query",
       "risk": "domain-wrapper",
       "source": "const lead = await db.query.memberLeads.findFirst({"
-    },
-    {
-      "file": "packages/domain-leads/src/payment.ts",
-      "line": 33,
-      "method": "transaction",
-      "risk": "domain-wrapper",
-      "source": "await db.transaction(async tx => {"
-    },
-    {
-      "file": "packages/domain-leads/src/payment.ts",
-      "line": 34,
-      "method": "insert",
-      "risk": "domain-wrapper",
-      "source": "await tx.insert(leadPaymentAttempts).values({"
-    },
-    {
-      "file": "packages/domain-leads/src/payment.ts",
-      "line": 44,
-      "method": "update",
-      "risk": "domain-wrapper",
-      "source": "await tx .update(memberLeads)"
-    },
-    {
-      "file": "packages/domain-leads/src/payment.ts",
-      "line": 61,
-      "method": "transaction",
-      "risk": "domain-wrapper",
-      "source": "await db.transaction(async tx => {"
-    },
-    {
-      "file": "packages/domain-leads/src/payment.ts",
-      "line": 62,
-      "method": "insert",
-      "risk": "domain-wrapper",
-      "source": "await tx.insert(leadPaymentAttempts).values({"
-    },
-    {
-      "file": "packages/domain-leads/src/payment.ts",
-      "line": 75,
-      "method": "update",
-      "risk": "domain-wrapper",
-      "source": "await tx .update(memberLeads)"
     },
     {
       "file": "packages/domain-leads/src/verify.ts",

--- a/scripts/ci/db-access-guard.test.mjs
+++ b/scripts/ci/db-access-guard.test.mjs
@@ -87,6 +87,123 @@ test('db access guard fails only when direct db access is added beyond the basel
   assert.match(failingResult.stdout, /new\.ts:3 select/u);
 });
 
+test('db access guard requires explicit classification for risky baseline entries', () => {
+  const tempRoot = createTempRepo();
+  const actionFixturePath = 'apps/web/src/features/example/actions.ts';
+  const routeFixturePath = 'apps/web/src/app/api/example/route.ts';
+  const actionBaselineEntry = {
+    file: actionFixturePath,
+    line: 3,
+    method: 'query',
+    risk: 'server-action',
+    source: 'return db.query.user.findFirst({});',
+  };
+  const routeBaselineEntry = {
+    file: routeFixturePath,
+    line: 3,
+    method: 'select',
+    risk: 'high-risk-route',
+    source: 'return db.select().from(user);',
+  };
+
+  writeFixture(tempRoot, actionFixturePath, [
+    "import { db } from '@interdomestik/database';",
+    'export async function action() {',
+    '  return db.query.user.findFirst({});',
+    '}',
+  ]);
+  writeFixture(tempRoot, routeFixturePath, [
+    "import { db } from '@interdomestik/database';",
+    'export async function GET() {',
+    '  return db.select().from(user);',
+    '}',
+  ]);
+  fs.writeFileSync(
+    path.join(tempRoot, 'db-access-baseline.json'),
+    JSON.stringify({ version: 1, entries: [actionBaselineEntry, routeBaselineEntry] }, null, 2)
+  );
+
+  const failingResult = runAppGuard(tempRoot);
+  assert.equal(failingResult.status, 1);
+  assert.match(failingResult.stderr, /require explicit classification/u);
+  assert.match(failingResult.stderr, /server-action\/high-risk-route/u);
+
+  fs.writeFileSync(
+    path.join(tempRoot, 'db-access-baseline.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        entries: [
+          {
+            ...actionBaselineEntry,
+            classification: 'negative-authorization-test-covered',
+          },
+          {
+            ...routeBaselineEntry,
+            classification: 'negative-authorization-test-covered',
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+
+  const passingResult = runAppGuard(tempRoot);
+  assert.equal(passingResult.status, 0, passingResult.stderr);
+});
+
+test('db access guard requires classification for extracted boundary wrappers', () => {
+  const tempRoot = createTempRepo();
+  const fixturePath = 'apps/web/src/features/agent/activation/server/activate-agent-profile.ts';
+  const baselineEntry = {
+    file: fixturePath,
+    line: 3,
+    method: 'update',
+    risk: 'app-layer',
+    source: 'return db.update(user);',
+  };
+
+  writeFixture(tempRoot, fixturePath, [
+    "import { db } from '@interdomestik/database';",
+    'export async function activate() {',
+    '  return db.update(user);',
+    '}',
+  ]);
+  fs.writeFileSync(
+    path.join(tempRoot, 'db-access-baseline.json'),
+    JSON.stringify({ version: 1, entries: [baselineEntry] }, null, 2)
+  );
+
+  const failingResult = runAppGuard(tempRoot);
+  assert.equal(failingResult.status, 1);
+  assert.match(failingResult.stderr, /require explicit classification/u);
+  assert.match(failingResult.stderr, /extracted boundary wrapper paths/u);
+
+  fs.writeFileSync(
+    path.join(tempRoot, 'db-access-baseline.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        entries: [
+          {
+            ...baselineEntry,
+            classification: 'extracted-server-action-wrapper: tenant and role scoped helper',
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+
+  const writeResult = runAppGuard(tempRoot, ['--write-baseline']);
+  assert.equal(writeResult.status, 0, writeResult.stderr);
+
+  const passingResult = runAppGuard(tempRoot);
+  assert.equal(passingResult.status, 0, passingResult.stderr);
+});
+
 test('db access guard catches multiline chains and new domain-package direct access', () => {
   const tempRoot = createTempRepo();
   writeEmptyBaseline(tempRoot);


### PR DESCRIPTION
## Summary
- remove all `server-action` and `high-risk-route` entries from the direct DB access baseline
- move high-risk direct DB access behind explicit auth/scope wrappers for auth tenant lookup, claims uploads, member claims, agent activation, agent leads, and legacy lead payment/status actions
- require classifications for risky or extracted boundary DB access in `check:db-access`
- add focused negative authorization coverage and stabilize the staff support handoff gate locator

## Verification
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate`
- `pnpm check:db-access`
- `node --test scripts/ci/db-access-guard.test.mjs`
- `pnpm --filter @interdomestik/domain-leads test:unit --run src/payment.test.ts`
- `pnpm --filter @interdomestik/web test:unit --run src/actions/leads/payment.test.ts src/actions/leads/update.test.ts src/features/agent/activation/actions.test.ts src/features/agent/activation/server/activate-agent-profile.test.ts src/features/agent/leads/actions.test.ts src/features/claims/upload/server/access.test.ts src/features/member/claims/actions.test.ts src/app/api/claims/evidence-upload/route.test.ts`
