### PR TITLE
fix: clean up db access guard hardening

### DIFF
--- a/apps/web/src/features/agent/leads/server/lead-actions.ts
+++ b/apps/web/src/features/agent/leads/server/lead-actions.ts
@@ -59,10 +59,12 @@ export async function updateScopedAgentLeadStatus(params: {
     return { success: true };
   }
 
+  const updatedNotes = notes ? [lead.notes, notes].filter(Boolean).join('\n') : lead.notes;
+
   await db
     .update(memberLeads)
     .set({
-      notes: notes ? `${lead.notes ? `${lead.notes}\n` : ''}${notes}` : lead.notes,
+      notes: updatedNotes,
       status,
       updatedAt: new Date(),
     })

--- a/packages/domain-leads/src/payment.ts
+++ b/packages/domain-leads/src/payment.ts
@@ -20,12 +20,15 @@ type StartPaymentContext =
   | { tenantId: string; agentId: string; branchId: string };
 
 function buildLeadPaymentScope(ctx: StartPaymentContext, leadId: string) {
-  const conditions = [eq(memberLeads.id, leadId), eq(memberLeads.tenantId, ctx.tenantId)];
-
-  if ('agentId' in ctx) {
-    conditions.push(eq(memberLeads.agentId, ctx.agentId));
-    conditions.push(eq(memberLeads.branchId, ctx.branchId));
-  }
+  const agentScopeConditions =
+    'agentId' in ctx
+      ? [eq(memberLeads.agentId, ctx.agentId), eq(memberLeads.branchId, ctx.branchId)]
+      : [];
+  const conditions = [
+    eq(memberLeads.id, leadId),
+    eq(memberLeads.tenantId, ctx.tenantId),
+    ...agentScopeConditions,
+  ];
 
   const scopedWhere = and(...conditions);
   if (!scopedWhere) {

--- a/scripts/check-db-access-guard.mjs
+++ b/scripts/check-db-access-guard.mjs
@@ -25,6 +25,8 @@ const EXPLICIT_CLASSIFICATION_PATH_PATTERNS = [
   /^apps\/web\/src\/features\/claims\/upload\/server\/access\.ts$/u,
   /^apps\/web\/src\/lib\/auth\/tenant-lookup\.ts$/u,
 ];
+const EXPLICIT_CLASSIFICATION_REASON =
+  'server-action risk, high-risk-route risk, or configured extracted boundary wrapper path';
 
 const EXCLUDED_PATH_PATTERNS = [
   /(^|\/)__tests__(\/|$)/u,
@@ -516,8 +518,9 @@ function main() {
 
   if (unclassifiedRiskyBaselineEntries.length > 0) {
     console.error(
-      'DB access guard failed: risky server-action/high-risk-route entries and extracted boundary wrapper paths require explicit classification.'
+      'DB access guard failed: baseline entries matching the explicit classification policy require classification metadata.'
     );
+    console.error(`Policy triggers: ${EXPLICIT_CLASSIFICATION_REASON}.`);
     printEntries('Unclassified risky baseline entries:', unclassifiedRiskyBaselineEntries);
     console.error('');
     console.error(

--- a/scripts/ci/db-access-guard.test.mjs
+++ b/scripts/ci/db-access-guard.test.mjs
@@ -125,8 +125,8 @@ test('db access guard requires explicit classification for risky baseline entrie
 
   const failingResult = runAppGuard(tempRoot);
   assert.equal(failingResult.status, 1);
-  assert.match(failingResult.stderr, /require explicit classification/u);
-  assert.match(failingResult.stderr, /server-action\/high-risk-route/u);
+  assert.match(failingResult.stderr, /require classification metadata/u);
+  assert.match(failingResult.stderr, /server-action risk, high-risk-route risk/u);
 
   fs.writeFileSync(
     path.join(tempRoot, 'db-access-baseline.json'),
@@ -177,8 +177,8 @@ test('db access guard requires classification for extracted boundary wrappers', 
 
   const failingResult = runAppGuard(tempRoot);
   assert.equal(failingResult.status, 1);
-  assert.match(failingResult.stderr, /require explicit classification/u);
-  assert.match(failingResult.stderr, /extracted boundary wrapper paths/u);
+  assert.match(failingResult.stderr, /require classification metadata/u);
+  assert.match(failingResult.stderr, /configured extracted boundary wrapper path/u);
 
   fs.writeFileSync(
     path.join(tempRoot, 'db-access-baseline.json'),


### PR DESCRIPTION
## Summary

Follow-up cleanup for #683.

- clarifies the direct DB access guard failure message so path-pattern classification failures are actionable
- removes Sonar noise in agent lead note appending without changing behavior
- removes Sonar noise in lead payment scope construction without changing the query shape
- confirms the merged guard already points at `apps/web/src/lib/auth/tenant-lookup.ts`; the stale `apps/web/src/app/api/auth/[...all]/tenant-lookup.ts` pattern reported by Copilot is not present on `main`

## Verification

- `node --test scripts/ci/db-access-guard.test.mjs`
- `pnpm --filter @interdomestik/domain-leads test:unit --run src/payment.test.ts`
- `pnpm --filter @interdomestik/web test:unit --run src/features/agent/leads/actions.test.ts`
- `git diff --check`
- `pnpm check:db-access`
- `pnpm exec prettier --check scripts/check-db-access-guard.mjs scripts/ci/db-access-guard.test.mjs apps/web/src/features/agent/leads/server/lead-actions.ts packages/domain-leads/src/payment.ts`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`

## Notes

- Global `pnpm format:check` still reports pre-existing unrelated formatting warnings in six files outside this branch; changed files pass Prettier.
- Local Next builds warn because this worktree lives nested under the main repo and Next sees two workspace lockfiles. CI will not have that nested worktree layout.
