### PR TITLE
P33-SEC07 Signed URL Exposure Hardening

### DIFF
--- a/apps/web/src/actions/uploads/upload.ts
+++ b/apps/web/src/actions/uploads/upload.ts
@@ -7,6 +7,7 @@ import {
   createTenantSignedDownloadUrl,
   uploadTenantObject,
 } from '@/lib/storage/service-role';
+import { redactSignedUrlErrorDetails } from '@/lib/storage/signed-url-exposure';
 import { createInitialClaimUploadIntentToken } from '@/features/claims/upload/server/initial-claim-upload';
 import {
   assertEvidenceStoragePath,
@@ -260,7 +261,9 @@ async function uploadToStorage(params: {
         Bucket: bucketName,
         Key: fileName,
       });
-      const viewUrl = await getSignedUrl(signer, getCommand, { expiresIn: 60 * 10 });
+      const viewUrl = await getSignedUrl(signer, getCommand, {
+        expiresIn: VOICE_NOTE_PREVIEW_TTL_SECONDS,
+      });
 
       return {
         success: true,
@@ -273,7 +276,7 @@ async function uploadToStorage(params: {
         size: buffer.byteLength,
       };
     } catch (err) {
-      console.error('S3/MinIO upload error:', err);
+      console.error('S3/MinIO upload error:', redactSignedUrlErrorDetails(err));
       return { success: false, error: 'Upload failed (S3)' };
     }
   }
@@ -308,8 +311,10 @@ async function uploadToStorage(params: {
     });
 
     if (error) {
-      console.error('Supabase upload error:', error);
-      return { success: false, error: 'Upload failed: ' + error.message };
+      const details = redactSignedUrlErrorDetails(error);
+      const message = details.message;
+      console.error('Supabase upload error:', details);
+      return { success: false, error: 'Upload failed: ' + message };
     }
 
     const { data: signedData, error: signedError } = await createTenantSignedDownloadUrl({
@@ -317,6 +322,7 @@ async function uploadToStorage(params: {
       context: 'voice note preview',
       expiresInSeconds: VOICE_NOTE_PREVIEW_TTL_SECONDS,
       family: 'claims',
+      operation: 'voiceNotePreview',
       path: fileName,
       tenantId,
     });
@@ -345,7 +351,7 @@ async function uploadToStorage(params: {
       size: buffer.byteLength,
     };
   } catch (err) {
-    console.error('Unexpected upload error:', err);
+    console.error('Unexpected upload error:', redactSignedUrlErrorDetails(err));
     return { success: false, error: 'Unexpected error during upload' };
   }
 }

--- a/apps/web/src/app/api/documents/[id]/download/route.test.ts
+++ b/apps/web/src/app/api/documents/[id]/download/route.test.ts
@@ -168,6 +168,7 @@ describe('GET /api/documents/[id]/download', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('application/pdf');
     expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
 
     const contentDisposition = response.headers.get('Content-Disposition');
     expect(contentDisposition).toContain('attachment');

--- a/apps/web/src/app/api/documents/[id]/download/route.ts
+++ b/apps/web/src/app/api/documents/[id]/download/route.ts
@@ -2,6 +2,7 @@ import { logAuditEvent } from '@/lib/audit';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db.server';
 import { enforceRateLimit } from '@/lib/rate-limit';
+import { SIGNED_URL_REFERRER_POLICY } from '@/lib/storage/signed-url-exposure';
 import * as Sentry from '@sentry/nextjs';
 import { NextResponse } from 'next/server';
 import {
@@ -92,6 +93,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
           'Content-Type': 'text/plain',
           'Content-Disposition': `${disposition}; filename="dummy_seed.txt"`,
           'Cache-Control': 'private, no-store',
+          'Referrer-Policy': SIGNED_URL_REFERRER_POLICY,
         },
       });
     }
@@ -110,6 +112,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       'Content-Type': access.document.fileType || 'application/octet-stream',
       'Content-Disposition': buildContentDispositionHeader({ disposition, filename }),
       'Cache-Control': 'private, no-store',
+      'Referrer-Policy': SIGNED_URL_REFERRER_POLICY,
     },
   });
 }

--- a/apps/web/src/app/api/documents/[id]/route.test.ts
+++ b/apps/web/src/app/api/documents/[id]/route.test.ts
@@ -160,6 +160,8 @@ describe('GET /api/documents/[id]', () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store, max-age=0');
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
     expect(data).toEqual({
       url: 'https://signed.example.com/file',
       name: 'file.pdf',

--- a/apps/web/src/app/api/documents/[id]/route.ts
+++ b/apps/web/src/app/api/documents/[id]/route.ts
@@ -2,6 +2,7 @@ import { logAuditEvent } from '@/lib/audit';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db.server';
 import { enforceRateLimit } from '@/lib/rate-limit';
+import { signedUrlResponseInit } from '@/lib/storage/signed-url-exposure';
 import { NextResponse } from 'next/server';
 import {
   DOCUMENT_ACCESS_STATUS_BY_CODE,
@@ -74,11 +75,14 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     return NextResponse.json({ error: 'Failed to generate download URL' }, { status: 500 });
   }
 
-  return NextResponse.json({
-    url: urlResult.signedUrl,
-    name: access.document.name,
-    type: access.document.fileType,
-    size: access.document.fileSize,
-    expiresIn: 300,
-  });
+  return NextResponse.json(
+    {
+      url: urlResult.signedUrl,
+      name: access.document.name,
+      type: access.document.fileType,
+      size: access.document.fileSize,
+      expiresIn: 300,
+    },
+    signedUrlResponseInit()
+  );
 }

--- a/apps/web/src/app/api/documents/storage-service.server.ts
+++ b/apps/web/src/app/api/documents/storage-service.server.ts
@@ -12,6 +12,7 @@ export function createDocumentSignedUrlStorageService(): DocumentStorageService 
         context: 'document signed URL',
         expiresInSeconds: expiresIn,
         family: options.family,
+        operation: 'documentDownload',
         path,
         tenantId: options.tenantId,
       });

--- a/apps/web/src/app/api/uploads/route.test.ts
+++ b/apps/web/src/app/api/uploads/route.test.ts
@@ -296,6 +296,8 @@ describe('POST /api/uploads', () => {
     const data = await res.json();
 
     expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store, max-age=0');
+    expect(res.headers.get('Referrer-Policy')).toBe('no-referrer');
     expect(data).toEqual(
       expect.objectContaining({
         upload: expect.objectContaining({

--- a/apps/web/src/app/api/uploads/route.ts
+++ b/apps/web/src/app/api/uploads/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
+import { signedUrlResponseInit } from '@/lib/storage/signed-url-exposure';
 import { NextResponse } from 'next/server';
 
 import { createSignedUploadCore, uploadRequestSchema } from './_core';
@@ -56,5 +57,5 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: result.error }, { status: result.status });
   }
 
-  return NextResponse.json(result.body, { status: result.status });
+  return NextResponse.json(result.body, signedUrlResponseInit({ status: result.status }));
 }

--- a/apps/web/src/features/claims/upload/server/shared-upload.ts
+++ b/apps/web/src/features/claims/upload/server/shared-upload.ts
@@ -3,6 +3,7 @@ import {
   markClaimAiRunDispatchFailedService,
 } from '@/lib/ai/claim-workflows';
 import { LOCALES } from '@/i18n/locales';
+import { redactSignedUrlErrorDetails } from '@/lib/storage/signed-url-exposure';
 import { claimDocuments, db } from '@interdomestik/database';
 import { queueClaimDocumentAiWorkflows } from '@interdomestik/domain-claims/claims/ai-workflows';
 import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
@@ -455,7 +456,8 @@ export async function createSignedUploadUrl(params: {
         };
       }
 
-      const detail = error?.message ?? 'Unknown storage error';
+      const details = redactSignedUrlErrorDetails(error ?? 'Unknown storage error');
+      const detail = details.message;
       const retryable = shouldRetrySignedUpload(detail);
       const hasAttemptsLeft = attempt < SIGNED_UPLOAD_MAX_ATTEMPTS;
 
@@ -463,10 +465,10 @@ export async function createSignedUploadUrl(params: {
         bucket,
         path,
         detail,
-        error,
         attempt,
         maxAttempts: SIGNED_UPLOAD_MAX_ATTEMPTS,
         retryable,
+        error: details,
       });
 
       if (retryable && hasAttemptsLeft) {
@@ -483,7 +485,7 @@ export async function createSignedUploadUrl(params: {
       status: 500,
     };
   } catch (error) {
-    console.error(`${logPrefix} generate upload URL error`, error);
+    console.error(`${logPrefix} generate upload URL error`, redactSignedUrlErrorDetails(error));
     return { success: false, error: 'Unexpected error', status: 500 };
   }
 }

--- a/apps/web/src/lib/storage/service-role.test.ts
+++ b/apps/web/src/lib/storage/service-role.test.ts
@@ -62,6 +62,44 @@ describe('service-role storage boundary', () => {
     );
   });
 
+  it('rejects signed download TTLs above the operation cap', async () => {
+    const { createTenantSignedDownloadUrl } = await import('./service-role');
+
+    await expect(
+      createTenantSignedDownloadUrl({
+        bucket: 'policies',
+        expiresInSeconds: 301,
+        family: 'policies',
+        operation: 'documentDownload',
+        path: 'pii/tenants/tenant-a/policies/user-1/file.pdf',
+        tenantId: 'tenant-a',
+      })
+    ).rejects.toThrow(/exceeds documentDownload cap 300s/);
+
+    expect(createAdminClient).not.toHaveBeenCalled();
+    expect(createSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('allows voice-note previews to use the reviewed ten-minute TTL cap', async () => {
+    const { VOICE_NOTE_PREVIEW_TTL_SECONDS, createTenantSignedDownloadUrl } =
+      await import('./service-role');
+    createSignedUrl.mockResolvedValue({ data: { signedUrl: 'https://signed.example' } });
+
+    await createTenantSignedDownloadUrl({
+      bucket: 'claim-evidence',
+      expiresInSeconds: VOICE_NOTE_PREVIEW_TTL_SECONDS,
+      family: 'claims',
+      operation: 'voiceNotePreview',
+      path: 'pii/tenants/tenant-a/claims/user-1/unassigned/voice.webm',
+      tenantId: 'tenant-a',
+    });
+
+    expect(createSignedUrl).toHaveBeenCalledWith(
+      'pii/tenants/tenant-a/claims/user-1/unassigned/voice.webm',
+      VOICE_NOTE_PREVIEW_TTL_SECONDS
+    );
+  });
+
   it('supports upload, download, and single-file list operations after path assertion', async () => {
     const { downloadTenantObject, listTenantObjectsForSingleFile, uploadTenantObject } =
       await import('./service-role');

--- a/apps/web/src/lib/storage/service-role.ts
+++ b/apps/web/src/lib/storage/service-role.ts
@@ -7,9 +7,14 @@ import {
   assertTenantStoragePath,
   splitStorageFolderAndName,
 } from './tenant-prefix';
+import {
+  SIGNED_DOWNLOAD_TTL_CAPS_SECONDS,
+  type SignedDownloadOperation,
+  resolveSignedDownloadTtlSeconds,
+} from './signed-url-exposure';
 
-export const SIGNED_DOWNLOAD_TTL_SECONDS = 5 * 60;
-export const VOICE_NOTE_PREVIEW_TTL_SECONDS = 10 * 60;
+export const SIGNED_DOWNLOAD_TTL_SECONDS = SIGNED_DOWNLOAD_TTL_CAPS_SECONDS.default;
+export const VOICE_NOTE_PREVIEW_TTL_SECONDS = SIGNED_DOWNLOAD_TTL_CAPS_SECONDS.voiceNotePreview;
 export const SIGNED_UPLOAD_INTENT_TTL_SECONDS = 15 * 60;
 
 type TenantStorageTarget = {
@@ -37,13 +42,18 @@ export async function createTenantSignedUploadUrl(
 }
 
 export async function createTenantSignedDownloadUrl(
-  args: TenantStorageTarget & { expiresInSeconds?: number }
+  args: TenantStorageTarget & {
+    expiresInSeconds?: number;
+    operation?: SignedDownloadOperation;
+  }
 ) {
   assertTenantStoragePath(args);
+  const expiresInSeconds = resolveSignedDownloadTtlSeconds({
+    operation: args.operation,
+    requestedSeconds: args.expiresInSeconds,
+  });
 
-  return createAdminClient()
-    .storage.from(args.bucket)
-    .createSignedUrl(args.path, args.expiresInSeconds ?? SIGNED_DOWNLOAD_TTL_SECONDS);
+  return createAdminClient().storage.from(args.bucket).createSignedUrl(args.path, expiresInSeconds);
 }
 
 export async function uploadTenantObject(args: UploadTarget) {

--- a/apps/web/src/lib/storage/signed-url-exposure.test.ts
+++ b/apps/web/src/lib/storage/signed-url-exposure.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SIGNED_URL_NO_STORE_CACHE_CONTROL,
+  SIGNED_URL_REFERRER_POLICY,
+  redactSignedUrlErrorDetails,
+  redactSignedUrlText,
+  signedUrlResponseInit,
+} from './signed-url-exposure';
+
+describe('signed URL exposure controls', () => {
+  it('sets no-store and no-referrer response headers', () => {
+    const init = signedUrlResponseInit({ status: 200 });
+    const headers = new Headers(init.headers);
+
+    expect(init.status).toBe(200);
+    expect(headers.get('Cache-Control')).toBe(SIGNED_URL_NO_STORE_CACHE_CONTROL);
+    expect(headers.get('Referrer-Policy')).toBe(SIGNED_URL_REFERRER_POLICY);
+  });
+
+  it('redacts signed URL-shaped values from log messages', () => {
+    const message = redactSignedUrlText(
+      new Error('failed https://storage.example/object/sign/file.pdf?token=secret-token')
+    );
+
+    expect(message).toBe(
+      'failed https://storage.example/object/sign/file.pdf?[signed-url-redacted]'
+    );
+    expect(message).not.toContain('secret-token');
+  });
+
+  it('preserves redacted error debugging details', () => {
+    const error = new Error(
+      'failed https://storage.example/object/sign/file.pdf?token=secret-token'
+    );
+    error.stack =
+      'Error: failed\n    at https://storage.example/object/sign/file.pdf?token=stack-token';
+
+    const details = redactSignedUrlErrorDetails(error);
+
+    expect(details).toMatchObject({
+      name: 'Error',
+      message: 'failed https://storage.example/object/sign/file.pdf?[signed-url-redacted]',
+    });
+    expect(details.stack).toContain('https://storage.example/object/sign/file.pdf?');
+    expect(details.stack).not.toContain('stack-token');
+  });
+});

--- a/apps/web/src/lib/storage/signed-url-exposure.ts
+++ b/apps/web/src/lib/storage/signed-url-exposure.ts
@@ -1,0 +1,120 @@
+export const SIGNED_URL_NO_STORE_CACHE_CONTROL = 'private, no-store, max-age=0';
+export const SIGNED_URL_REFERRER_POLICY = 'no-referrer';
+
+export const SIGNED_URL_RESPONSE_HEADERS = {
+  'Cache-Control': SIGNED_URL_NO_STORE_CACHE_CONTROL,
+  'Referrer-Policy': SIGNED_URL_REFERRER_POLICY,
+} as const;
+
+export const SIGNED_DOWNLOAD_TTL_CAPS_SECONDS = {
+  default: 5 * 60,
+  documentDownload: 5 * 60,
+  voiceNotePreview: 10 * 60,
+} as const;
+
+export type SignedDownloadOperation = keyof typeof SIGNED_DOWNLOAD_TTL_CAPS_SECONDS;
+
+export function signedUrlResponseInit(init: ResponseInit = {}): ResponseInit {
+  const headers = new Headers(init.headers);
+  headers.set('Cache-Control', SIGNED_URL_NO_STORE_CACHE_CONTROL);
+  headers.set('Referrer-Policy', SIGNED_URL_REFERRER_POLICY);
+
+  return {
+    ...init,
+    headers,
+  };
+}
+
+export function resolveSignedDownloadTtlSeconds(args: {
+  operation?: SignedDownloadOperation;
+  requestedSeconds?: number;
+}): number {
+  const operation = args.operation ?? 'default';
+  const cap = SIGNED_DOWNLOAD_TTL_CAPS_SECONDS[operation];
+  const requested = args.requestedSeconds ?? cap;
+
+  if (!Number.isSafeInteger(requested) || requested <= 0) {
+    throw new RangeError(`Invalid signed download URL TTL: ${String(requested)}`);
+  }
+
+  if (requested > cap) {
+    throw new RangeError(`Signed download URL TTL ${requested}s exceeds ${operation} cap ${cap}s`);
+  }
+
+  return requested;
+}
+
+function formatLogMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (
+    value &&
+    typeof value === 'object' &&
+    'message' in value &&
+    typeof value.message === 'string'
+  ) {
+    return value.message;
+  }
+
+  return String(value ?? 'unknown');
+}
+
+export function redactSignedUrlText(value: unknown): string {
+  const text = formatLogMessage(value);
+
+  return text.replace(/https?:\/\/[^\s"'<>]*(?:token|signature|signed)[^\s"'<>]*/gi, match => {
+    try {
+      const parsed = new URL(match);
+      return `${parsed.origin}${parsed.pathname}?[signed-url-redacted]`;
+    } catch {
+      return '[signed-url-redacted]';
+    }
+  });
+}
+
+function readRecordField(record: Record<string, unknown>, key: string): unknown {
+  return Object.prototype.hasOwnProperty.call(record, key) ? record[key] : undefined;
+}
+
+function readRedactedStringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = readRecordField(record, key);
+  return typeof value === 'string' ? redactSignedUrlText(value) : undefined;
+}
+
+function readPrimitiveField(
+  record: Record<string, unknown>,
+  key: string
+): string | number | undefined {
+  const value = readRecordField(record, key);
+  return typeof value === 'string' || typeof value === 'number' ? value : undefined;
+}
+
+export type RedactedSignedUrlErrorDetails = {
+  message: string;
+  name?: string;
+  stack?: string;
+  code?: string | number;
+  status?: string | number;
+  statusCode?: string | number;
+};
+
+export function redactSignedUrlErrorDetails(value: unknown): RedactedSignedUrlErrorDetails {
+  const details: RedactedSignedUrlErrorDetails = {
+    message: redactSignedUrlText(value),
+  };
+
+  if (value instanceof Error) {
+    details.name = value.name;
+    if (value.stack) details.stack = redactSignedUrlText(value.stack);
+  }
+
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    details.name = readRedactedStringField(record, 'name') ?? details.name;
+    details.stack = readRedactedStringField(record, 'stack') ?? details.stack;
+    details.code = readPrimitiveField(record, 'code');
+    details.status = readPrimitiveField(record, 'status');
+    details.statusCode = readPrimitiveField(record, 'statusCode');
+  }
+
+  return details;
+}

--- a/docs/security/storage-access-baseline.md
+++ b/docs/security/storage-access-baseline.md
@@ -182,3 +182,51 @@ exfiltration or service-role key compromise risk; it reduces the app-side blast
 radius by rejecting untenant-prefixed paths before service-role Storage calls and
 keeps CSP enforce-mode dependency tracked separately under the blocked CSP
 migration line.
+
+## P33-SEC07 Implementation Receipt
+
+SEC07 implements the DG09 signed URL exposure-hardening follow-up without
+changing Storage architecture, auth/session shape, proxy behavior, canonical
+routes, schema, Stripe, README, AGENTS, or architecture docs.
+
+Signed download TTLs are now enforced at the service-role Storage boundary with
+operation-specific caps:
+
+| Operation             | Cap       | Notes                                                                 |
+| --------------------- | --------- | --------------------------------------------------------------------- |
+| Default download      | `300` sec | Used by admin/ops document signed links unless a narrower cap is set. |
+| Document download API | `300` sec | Used by `/api/documents/[id]` signed URL issuance.                    |
+| Voice-note preview    | `600` sec | Preserves the reviewed immediate playback preview bound.              |
+
+Requests above the selected cap fail before Supabase Storage is invoked. Signed
+upload URL token lifetime remains SDK-managed by Supabase; no route accepts a
+caller-provided upload-token TTL, and app-level upload intent tokens remain
+bounded at 15 minutes.
+
+Signed URL API responses that contain bearer URLs or upload tokens now use
+`Cache-Control: private, no-store, max-age=0` and
+`Referrer-Policy: no-referrer`. Direct document download responses keep
+`private, no-store` and also emit `Referrer-Policy: no-referrer` because the
+download target is sensitive even though it no longer returns a signed URL in
+the body.
+
+Known rendered anchors that can carry Storage signed URLs already used
+`noreferrer` semantics:
+
+- `apps/web/src/components/ops/OpsDocumentsPanel.tsx`;
+- `apps/web/src/features/member/policies/components/MemberPoliciesV2Page.tsx`.
+
+SEC07 keeps those semantics and adds `scripts/check-signed-url-exposure.mjs` to
+`pnpm security:guard`. The guard currently enforces three practical static
+checks under `apps/web/src`:
+
+1. no console logging blocks may include `signedUrl` values;
+2. known signed URL API routes must use the shared no-store/no-referrer response
+   helper;
+3. URL-bearing anchors must include `noreferrer`.
+
+The guard shape was assessed as practical for logs, known route responses, and
+anchor referrer suppression. It intentionally does not attempt full data-flow
+proof across every server action or arbitrary object property named `url`
+because that would create high false-positive risk; the bounded route inventory
+and focused tests cover the signed URL paths promoted by DG09.

--- a/scripts/check-signed-url-exposure.mjs
+++ b/scripts/check-signed-url-exposure.mjs
@@ -1,0 +1,140 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  DEFAULT_SCAN_ROOTS,
+  lineForIndex,
+  parseScanArgs,
+  toPosixRelative,
+  walkSourceFiles,
+} from './lib/source-scan.mjs';
+
+const SIGNED_URL_RESPONSE_HELPER = 'signedUrlResponseInit';
+const SIGNED_URL_RESPONSE_ROUTES = new Set([
+  'apps/web/src/app/api/documents/[id]/route.ts',
+  'apps/web/src/app/api/uploads/route.ts',
+]);
+
+function findConsoleBlocks(source) {
+  const blocks = [];
+  const consoleCallPattern = /console\.(?:error|warn|info|log)\s*\(/g;
+  let match;
+
+  while ((match = consoleCallPattern.exec(source))) {
+    let depth = 0;
+    let end = match.index;
+
+    for (let index = match.index; index < source.length; index += 1) {
+      const char = source[index];
+      if (char === '(') depth += 1;
+      if (char === ')') {
+        depth -= 1;
+        if (depth === 0) {
+          end = index + 1;
+          break;
+        }
+      }
+    }
+
+    blocks.push({ index: match.index, text: source.slice(match.index, end) });
+  }
+
+  return blocks;
+}
+
+function findAnchorBlocks(source) {
+  return Array.from(source.matchAll(/<a\b[^>]*>/g)).map(match => ({
+    index: match.index ?? 0,
+    text: match[0],
+  }));
+}
+
+export function findSignedUrlExposureViolations(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const scanRoots = options.scanRoots ?? DEFAULT_SCAN_ROOTS;
+  const findings = [];
+
+  for (const scanRoot of scanRoots) {
+    const absoluteScanRoot = path.resolve(root, scanRoot);
+    for (const filePath of walkSourceFiles(absoluteScanRoot)) {
+      const relPath = toPosixRelative(root, filePath);
+      if (/\.(test|spec)\.[tj]sx?$/.test(relPath)) continue;
+
+      const source = fs.readFileSync(filePath, 'utf8');
+
+      for (const block of findConsoleBlocks(source)) {
+        if (/\bsignedUrl\b|\.signedUrl\b|\btoken\b.*\bsignedUrl\b/s.test(block.text)) {
+          findings.push({
+            file: relPath,
+            line: lineForIndex(source, block.index),
+            reason: 'signed URL value may be logged',
+          });
+        }
+      }
+
+      if (SIGNED_URL_RESPONSE_ROUTES.has(relPath) && !source.includes(SIGNED_URL_RESPONSE_HELPER)) {
+        findings.push({
+          file: relPath,
+          line: 1,
+          reason: 'signed URL API response must use no-store and no-referrer headers',
+        });
+      }
+
+      if (
+        SIGNED_URL_RESPONSE_ROUTES.has(relPath) &&
+        /Cache-Control['"]?\s*:\s*['"]public/i.test(source)
+      ) {
+        findings.push({
+          file: relPath,
+          line: lineForIndex(source, source.search(/Cache-Control/i)),
+          reason: 'signed URL API response must not be public-cacheable',
+        });
+      }
+
+      for (const block of findAnchorBlocks(source)) {
+        if (
+          /href=\{[^}]*\burl\b[^}]*\}/.test(block.text) &&
+          !/\brel=["'][^"']*noreferrer/.test(block.text)
+        ) {
+          findings.push({
+            file: relPath,
+            line: lineForIndex(source, block.index),
+            reason: 'anchor with URL-bearing href must use noreferrer semantics',
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+export function runSignedUrlExposureGuard(options = {}) {
+  const findings = findSignedUrlExposureViolations(options);
+
+  if (findings.length === 0) {
+    console.log('Signed URL exposure guard passed: headers, logs, and anchors are bounded.');
+    return 0;
+  }
+
+  console.error('Signed URL exposure guard failed: signed URL exposure controls are incomplete.');
+  for (const finding of findings) {
+    console.error(`- ${finding.file}:${finding.line} ${finding.reason}`);
+  }
+  return 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = runSignedUrlExposureGuard(
+      parseScanArgs(
+        process.argv.slice(2),
+        'Usage: node scripts/check-signed-url-exposure.mjs [--root=<repo>] [--scan-root=<path,...>]'
+      )
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/signed-url-exposure-guard.test.mjs
+++ b/scripts/ci/signed-url-exposure-guard.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const guardScript = path.join(repoRoot, 'scripts/check-signed-url-exposure.mjs');
+
+function makeTempRepo() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-signed-url-'));
+  fs.mkdirSync(path.join(tempRoot, 'apps/web/src/app/api/documents/[id]'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(tempRoot, 'apps/web/src/app/api/uploads'), { recursive: true });
+  return tempRoot;
+}
+
+function runGuard(root) {
+  return spawnSync(process.execPath, [guardScript, `--root=${root}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+test('signed URL exposure guard blocks signed URL logging', () => {
+  const tempRoot = makeTempRepo();
+  const routePath = path.join(tempRoot, 'apps/web/src/app/api/documents/[id]/route.ts');
+  fs.writeFileSync(routePath, 'console.error("failed", { signedUrl: data.signedUrl });\n', 'utf8');
+
+  const failed = runGuard(tempRoot);
+  assert.equal(failed.status, 1, failed.stderr);
+  assert.match(failed.stderr, /signed URL value may be logged/);
+});
+
+test('signed URL exposure guard requires signed URL response headers on known routes', () => {
+  const tempRoot = makeTempRepo();
+  const routePath = path.join(tempRoot, 'apps/web/src/app/api/uploads/route.ts');
+  fs.writeFileSync(
+    routePath,
+    'export function POST() { return NextResponse.json(result.body); }\n',
+    'utf8'
+  );
+
+  const failed = runGuard(tempRoot);
+  assert.equal(failed.status, 1, failed.stderr);
+  assert.match(failed.stderr, /no-store and no-referrer/);
+});
+
+test('signed URL exposure guard blocks URL-bearing anchors without noreferrer', () => {
+  const tempRoot = makeTempRepo();
+  const componentPath = path.join(tempRoot, 'apps/web/src/components/Documents.tsx');
+  fs.mkdirSync(path.dirname(componentPath), { recursive: true });
+  fs.writeFileSync(componentPath, '<a href={doc.url} target="_blank">View</a>\n', 'utf8');
+
+  const failed = runGuard(tempRoot);
+  assert.equal(failed.status, 1, failed.stderr);
+  assert.match(failed.stderr, /noreferrer semantics/);
+});
+
+test('signed URL exposure guard permits bounded headers and noreferrer links', () => {
+  const tempRoot = makeTempRepo();
+  fs.writeFileSync(
+    path.join(tempRoot, 'apps/web/src/app/api/documents/[id]/route.ts'),
+    "import { signedUrlResponseInit } from '@/lib/storage/signed-url-exposure';\n" +
+      'export function GET() { return NextResponse.json(body, signedUrlResponseInit()); }\n',
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(tempRoot, 'apps/web/src/app/api/uploads/route.ts'),
+    "import { signedUrlResponseInit } from '@/lib/storage/signed-url-exposure';\n" +
+      'export function POST() { return NextResponse.json(result.body, signedUrlResponseInit()); }\n',
+    'utf8'
+  );
+  const componentPath = path.join(tempRoot, 'apps/web/src/components/Documents.tsx');
+  fs.mkdirSync(path.dirname(componentPath), { recursive: true });
+  fs.writeFileSync(
+    componentPath,
+    '<a href={doc.url} target="_blank" rel="noopener noreferrer">View</a>\n',
+    'utf8'
+  );
+
+  const passed = runGuard(tempRoot);
+  assert.equal(passed.status, 0, passed.stderr);
+  assert.match(passed.stdout, /Signed URL exposure guard passed/);
+});

--- a/scripts/security-guard.mjs
+++ b/scripts/security-guard.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { runEvidenceStoragePathGuard } from './check-evidence-storage-paths.mjs';
 import { runServiceRoleStorageBoundaryGuard } from './check-service-role-storage-boundary.mjs';
+import { runSignedUrlExposureGuard } from './check-signed-url-exposure.mjs';
 
 const LOCKFILE_PATH = path.join(process.cwd(), 'pnpm-lock.yaml');
 
@@ -97,6 +98,11 @@ async function runGuard() {
   const serviceRoleStorageBoundaryStatus = runServiceRoleStorageBoundaryGuard();
   if (serviceRoleStorageBoundaryStatus !== 0) {
     process.exit(serviceRoleStorageBoundaryStatus);
+  }
+
+  const signedUrlExposureStatus = runSignedUrlExposureGuard();
+  if (signedUrlExposureStatus !== 0) {
+    process.exit(signedUrlExposureStatus);
   }
 
   console.log('✅ Security Guard passed. All enforced versions are clean.');


### PR DESCRIPTION
## Summary

- Implements `P33-SEC07 Signed URL Exposure Hardening`, the implementation slice promoted by merged DG09.
- Adds a shared signed URL exposure helper for no-store/no-referrer response headers, signed download TTL caps, and signed URL redaction.
- Applies hardening to document signed URL responses, upload signed URL responses, direct document download responses, service-role signed download TTL resolution, voice-note preview TTL usage, and upload error logging.
- Wires `scripts/check-signed-url-exposure.mjs` into `pnpm security:guard` and records the SEC07 implementation receipt in `docs/security/storage-access-baseline.md`.

## Review focus

- Primary review surface: `apps/web/src/lib/storage/signed-url-exposure.ts`, `apps/web/src/lib/storage/service-role.ts`, signed URL API route headers, upload error redaction, and `scripts/check-signed-url-exposure.mjs`.
- Primary contracts or risks to verify: signed URL bearer responses are `private, no-store, max-age=0` plus `Referrer-Policy: no-referrer`; signed download TTLs fail before Supabase when over cap; logs do not emit raw signed URL-bearing errors; the static guard is bounded and documented.
- Ignore unless behavior changed: proxy/routing, canonical route names, auth/session layering, tenancy architecture, schema/migrations, Stripe, README, AGENTS, and architecture docs.

## Acceptance

- [x] Slice criteria are explicit and complete.
- [x] No behavior changed outside slice scope.

## Evidence (mandatory before merge)

- PR status: `PASS`
- Summary JSON: not generated for this slice-runner path; local `verify-slice` run roots below are the canonical local evidence.
- Closure note: not generated for this slice-runner path; SEC07 implementation receipt is in `docs/security/storage-access-baseline.md`.
- Gates:
  - `pnpm --filter @interdomestik/web test:unit --run src/lib/storage/signed-url-exposure.test.ts src/lib/storage/service-role.test.ts 'src/app/api/documents/[id]/route.test.ts' 'src/app/api/documents/[id]/download/route.test.ts' src/app/api/uploads/route.test.ts` (exit: `0`, 28 tests)
  - `node --test scripts/ci/signed-url-exposure-guard.test.mjs` (exit: `0`, 4 tests)
  - `pnpm test:ci:contracts` (exit: `0`, 125 tests)
  - `pnpm security:guard` (exit: `0`)
  - `git diff --check` / staged `git diff --cached --check` (exit: `0`)
  - `pnpm docs:verify` (exit: `0`)
  - `pnpm verify-slice -- --static` (exit: `0`), run root: `/Users/arbenlila/development/interdomestik-crystal-home/tmp/multi-agent/verify-slice/verify-slice-20260509T094716Z-39bfce`
  - `pnpm verify-slice -- --required-gates` (exit: `0`), run root: `/Users/arbenlila/development/interdomestik-crystal-home/tmp/multi-agent/verify-slice/verify-slice-20260509T095409Z-294fc3`; included `pnpm pr:verify`, `pnpm security:guard`, fast PR E2E `69 passed, 1 skipped`, smoke E2E `13 passed, 1 skipped`, and full `pnpm e2e:gate` `118 passed, 4 skipped`.
- Logs: `tmp/multi-agent/verify-slice/verify-slice-20260509T094716Z-39bfce`, `tmp/multi-agent/verify-slice/verify-slice-20260509T095409Z-294fc3`
- Screenshots: not applicable; no UI rendering changes.
- Runbooks: not applicable; implementation receipt is in `docs/security/storage-access-baseline.md`.

## Security review notes

- Diff-scoped Codex Security scan completed with no technically plausible reportable findings.
- Artifact path: `/tmp/codex-security-scans/interdomestik-crystal-home/3af925a9_20260509T094639Z_p33-sec07`.
- Reviewer-pool fallback: runtime policy only allows subagents when explicitly requested. No subagents were spawned; local review plus `verify-slice` selected-reviewer gate coverage and Codex Security scan were used instead.
- Residual risk: Supabase signed upload token lifetime remains SDK-managed because the route does not accept a caller TTL; the static guard intentionally covers practical route/log/anchor patterns rather than full arbitrary data-flow proof.

## Pilot guardrails

- [x] No changes to auth, routing, proxy, or API body contracts were made.
- [x] Explicitly allowed exceptions documented:
  - `apps/web/src/proxy.ts` — reason: untouched.
  - `apps/web/src/app/api/**/route.ts` — reason: bounded signed URL exposure hardening only: no-store/no-referrer headers on bearer URL/token responses and direct sensitive downloads; no route identity, authorization, request shape, or response body contract changes.
  - `packages/**/src/api/**` — reason: untouched.
  - `packages/**/src/**/auth*` — reason: untouched.

## Merge readiness

- [ ] All GitHub review threads resolved.
- [ ] Copilot or bot findings were either fixed or explicitly closed with technical reasoning.
- [ ] Required checks green (`CI / static`, `CI / unit`, `CI / audit`, `CI / e2e-gate`, `Pilot Gate / pilot-gate`, `Security / pnpm-audit`, `Security / gitleaks`).
- [x] Evidence artifact paths are present and complete.
