### PR TITLE
P33-SEC08: Enforce Vercel TypeScript build errors

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -12,14 +12,8 @@ const bundleAnalyzer = withBundleAnalyzer({
 
 validateSupabaseDeploymentSeparation(process.env);
 
-const isVercelBuild = process.env.VERCEL === '1';
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  typescript: {
-    // CI runs full type-check gates; Vercel previews skip Next's duplicate TS pass.
-    ignoreBuildErrors: isVercelBuild,
-  },
   transpilePackages: [
     '@interdomestik/ui',
     '@interdomestik/database',

--- a/scripts/check-next-typescript-build-integrity.mjs
+++ b/scripts/check-next-typescript-build-integrity.mjs
@@ -25,7 +25,7 @@ export function findNextTypeScriptBuildIntegrityViolations(options = {}) {
   const source = fs.readFileSync(configPath, 'utf8');
   const findings = [];
 
-  for (const match of source.matchAll(/\bignoreBuildErrors\b/g)) {
+  for (const match of source.matchAll(/\bignoreBuildErrors\s*:/g)) {
     findings.push({
       file: NEXT_CONFIG_PATH,
       line: lineForIndex(source, match.index ?? 0),

--- a/scripts/check-next-typescript-build-integrity.mjs
+++ b/scripts/check-next-typescript-build-integrity.mjs
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const NEXT_CONFIG_PATH = 'apps/web/next.config.mjs';
+
+function lineForIndex(source, index) {
+  return source.slice(0, index).split('\n').length;
+}
+
+export function findNextTypeScriptBuildIntegrityViolations(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const configPath = path.join(root, NEXT_CONFIG_PATH);
+
+  if (!fs.existsSync(configPath)) {
+    return [
+      {
+        file: NEXT_CONFIG_PATH,
+        line: 1,
+        reason: 'Next.js config is missing, so TypeScript build enforcement cannot be verified',
+      },
+    ];
+  }
+
+  const source = fs.readFileSync(configPath, 'utf8');
+  const findings = [];
+
+  for (const match of source.matchAll(/\bignoreBuildErrors\b/g)) {
+    findings.push({
+      file: NEXT_CONFIG_PATH,
+      line: lineForIndex(source, match.index ?? 0),
+      reason:
+        'Next.js builds must fail on TypeScript errors; do not set typescript.ignoreBuildErrors',
+    });
+  }
+
+  return findings;
+}
+
+export function runNextTypeScriptBuildIntegrityGuard(options = {}) {
+  const findings = findNextTypeScriptBuildIntegrityViolations(options);
+
+  if (findings.length === 0) {
+    console.log('Next TypeScript build integrity guard passed: ignoreBuildErrors is not set.');
+    return 0;
+  }
+
+  console.error(
+    'Next TypeScript build integrity guard failed: production builds may skip type errors.'
+  );
+  for (const finding of findings) {
+    console.error(`- ${finding.file}:${finding.line} ${finding.reason}`);
+  }
+  return 1;
+}
+
+function parseArgs(args) {
+  const options = {};
+
+  for (const arg of args) {
+    if (arg === '--help' || arg === '-h') {
+      console.log('Usage: node scripts/check-next-typescript-build-integrity.mjs [--root=<repo>]');
+      process.exit(0);
+    }
+
+    if (arg.startsWith('--root=')) {
+      options.root = arg.slice('--root='.length);
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = runNextTypeScriptBuildIntegrityGuard(parseArgs(process.argv.slice(2)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/next-typescript-build-integrity.test.mjs
+++ b/scripts/ci/next-typescript-build-integrity.test.mjs
@@ -24,18 +24,20 @@ function runGuard(root) {
   });
 }
 
-test('Next TypeScript build integrity guard blocks ignoreBuildErrors', () => {
+test('Next TypeScript build integrity guard blocks ignoreBuildErrors', t => {
   const tempRoot = makeTempRepo(
     "export default { typescript: { ignoreBuildErrors: process.env.VERCEL === '1' } };\n"
   );
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 
   const failed = runGuard(tempRoot);
   assert.equal(failed.status, 1, failed.stderr);
   assert.match(failed.stderr, /do not set typescript\.ignoreBuildErrors/);
 });
 
-test('Next TypeScript build integrity guard permits enforced TypeScript builds', () => {
+test('Next TypeScript build integrity guard permits enforced TypeScript builds', t => {
   const tempRoot = makeTempRepo("export default { output: 'standalone' };\n");
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 
   const passed = runGuard(tempRoot);
   assert.equal(passed.status, 0, passed.stderr);

--- a/scripts/ci/next-typescript-build-integrity.test.mjs
+++ b/scripts/ci/next-typescript-build-integrity.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const guardScript = path.join(repoRoot, 'scripts/check-next-typescript-build-integrity.mjs');
+
+function makeTempRepo(configSource) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-next-ts-'));
+  const configPath = path.join(tempRoot, 'apps/web/next.config.mjs');
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, configSource, 'utf8');
+  return tempRoot;
+}
+
+function runGuard(root) {
+  return spawnSync(process.execPath, [guardScript, `--root=${root}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+test('Next TypeScript build integrity guard blocks ignoreBuildErrors', () => {
+  const tempRoot = makeTempRepo(
+    "export default { typescript: { ignoreBuildErrors: process.env.VERCEL === '1' } };\n"
+  );
+
+  const failed = runGuard(tempRoot);
+  assert.equal(failed.status, 1, failed.stderr);
+  assert.match(failed.stderr, /do not set typescript\.ignoreBuildErrors/);
+});
+
+test('Next TypeScript build integrity guard permits enforced TypeScript builds', () => {
+  const tempRoot = makeTempRepo("export default { output: 'standalone' };\n");
+
+  const passed = runGuard(tempRoot);
+  assert.equal(passed.status, 0, passed.stderr);
+  assert.match(passed.stdout, /ignoreBuildErrors is not set/);
+});

--- a/scripts/security-guard.mjs
+++ b/scripts/security-guard.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { runEvidenceStoragePathGuard } from './check-evidence-storage-paths.mjs';
+import { runNextTypeScriptBuildIntegrityGuard } from './check-next-typescript-build-integrity.mjs';
 import { runServiceRoleStorageBoundaryGuard } from './check-service-role-storage-boundary.mjs';
 import { runSignedUrlExposureGuard } from './check-signed-url-exposure.mjs';
 
@@ -103,6 +104,11 @@ async function runGuard() {
   const signedUrlExposureStatus = runSignedUrlExposureGuard();
   if (signedUrlExposureStatus !== 0) {
     process.exit(signedUrlExposureStatus);
+  }
+
+  const nextTypeScriptBuildIntegrityStatus = runNextTypeScriptBuildIntegrityGuard();
+  if (nextTypeScriptBuildIntegrityStatus !== 0) {
+    process.exit(nextTypeScriptBuildIntegrityStatus);
   }
 
   console.log('✅ Security Guard passed. All enforced versions are clean.');


### PR DESCRIPTION
## Summary

- Removes the Vercel-only `typescript.ignoreBuildErrors` suppression from `apps/web/next.config.mjs` so Next production builds use the default TypeScript failure behavior.
- Adds `scripts/check-next-typescript-build-integrity.mjs`, wired into `pnpm security:guard`, to block reintroducing `ignoreBuildErrors` in the web Next config.
- Adds a focused Node contract test covering the previous `process.env.VERCEL === '1'` suppression shape and the clean config case.

## Build-Failure Proof

Hosted Vercel deployment proof is impractical for this PR because the remote Vercel check reports `Canceled by Ignored Build Step`; the repo currently has an `apps/web/vercel.json` `ignoreCommand` that can skip preview builds. I therefore used a local Vercel-env Next build proof against the same web build command.

Synthetic local proof passed:

1. Temporarily added `apps/web/src/__sec08_next_build_type_error_proof.ts` with `const sec08TypeErrorProof: string = 1;`.
2. Ran `VERCEL=1 NEXT_PUBLIC_BILLING_TEST_MODE=1 node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/web run build:ci`.
3. Build failed in Next's TypeScript step with `Type 'number' is not assignable to type 'string'.`
4. Removed the temporary proof file before committing.

Named compensating static check: `Next TypeScript build integrity guard`, enforced by `pnpm security:guard`, fails if `ignoreBuildErrors` is present in `apps/web/next.config.mjs`.

## Verification

- `node --test scripts/ci/next-typescript-build-integrity.test.mjs`
- `node scripts/check-next-typescript-build-integrity.mjs`
- `pnpm exec prettier --check apps/web/next.config.mjs scripts/check-next-typescript-build-integrity.mjs scripts/security-guard.mjs scripts/ci/next-typescript-build-integrity.test.mjs`
- `pnpm security:guard`
- `VERCEL=1 NEXT_PUBLIC_BILLING_TEST_MODE=1 node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/web run build:ci`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates` at `tmp/multi-agent/verify-slice/verify-slice-20260509T112804Z-7e9922`
  - includes `pnpm pr:verify`
  - includes `pnpm security:guard`
  - includes standalone `pnpm e2e:gate` with `118 passed`, `4 skipped`

## Review Notes

- Pre-PR reviewer pool completed with no must-fix findings across security/auth/tenancy, performance/build-cost, maintainability/code-quality, and test/E2E/gate review.
- `tool_search` did not expose a callable Codex Security scan MCP tool for a diff-scoped scan; I performed a targeted diff-scoped security fallback over the four changed files. No reportable findings.
- No browser-specific validation was added because this slice changes build-time config and guard behavior, not user-visible runtime UI.

## Scope Guard

Untouched: `apps/web/src/proxy.ts`, canonical routes, auth, tenancy architecture, schema, Storage redesign, Stripe, README, AGENTS, and architecture docs.
