### PR TITLE
P33-SEC10 harden Paddle webhook tenant resolution

### DIFF
--- a/apps/web/src/app/api/webhooks/paddle/_core.test.ts
+++ b/apps/web/src/app/api/webhooks/paddle/_core.test.ts
@@ -2,6 +2,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   requestPasswordReset: vi.fn(),
+  dbUserFindFirst: vi.fn(),
+  findSubscriptionByProviderReference: vi.fn(),
+  handlePaddleEvent: vi.fn(),
+  insertWebhookEvent: vi.fn(),
+  markWebhookFailed: vi.fn(),
+  markWebhookProcessed: vi.fn(),
+  parsePaddleWebhookBody: vi.fn(),
+  persistInvalidSignatureAttempt: vi.fn(),
+  persistInvoiceAndLedgerInvariants: vi.fn(),
+  sha256Hex: vi.fn(),
+  verifyPaddleWebhook: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -12,7 +23,49 @@ vi.mock('@/lib/auth', () => ({
   },
 }));
 
-import { buildTenantPasswordResetRedirectUrl, requestPasswordResetOnboarding } from './_core';
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    query: {
+      user: {
+        findFirst: hoisted.dbUserFindFirst,
+      },
+    },
+  },
+}));
+
+vi.mock('@interdomestik/domain-membership-billing/subscription', () => ({
+  findSubscriptionByProviderReference: hoisted.findSubscriptionByProviderReference,
+}));
+
+vi.mock('@interdomestik/domain-membership-billing/paddle-webhooks', () => ({
+  handlePaddleEvent: hoisted.handlePaddleEvent,
+  insertWebhookEvent: hoisted.insertWebhookEvent,
+  markWebhookFailed: hoisted.markWebhookFailed,
+  markWebhookProcessed: hoisted.markWebhookProcessed,
+  parsePaddleWebhookBody: hoisted.parsePaddleWebhookBody,
+  persistInvalidSignatureAttempt: hoisted.persistInvalidSignatureAttempt,
+  persistInvoiceAndLedgerInvariants: hoisted.persistInvoiceAndLedgerInvariants,
+  sha256Hex: hoisted.sha256Hex,
+  verifyPaddleWebhook: hoisted.verifyPaddleWebhook,
+}));
+
+vi.mock('@/actions/thank-you-letter/send', () => ({
+  sendThankYouLetterCore: vi.fn(),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/email', () => ({
+  sendPaymentFailedEmail: vi.fn(),
+}));
+
+import {
+  buildTenantPasswordResetRedirectUrl,
+  handlePaddleWebhookCore,
+  requestPasswordResetOnboarding,
+} from './_core';
 
 describe('paddle webhook onboarding helpers', () => {
   const mutableEnv = process.env as Record<string, string | undefined>;
@@ -64,5 +117,90 @@ describe('paddle webhook onboarding helpers', () => {
         redirectTo: 'https://ks.example.test/sq/reset-password',
       },
     });
+  });
+});
+
+describe('handlePaddleWebhookCore tenant resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    hoisted.sha256Hex.mockReturnValue('payload_hash');
+    hoisted.parsePaddleWebhookBody.mockReturnValue({
+      parsedPayload: { data: {} },
+      eventTypeFromPayload: 'subscription.updated',
+      eventIdFromPayload: 'evt_payload',
+      eventTimestampFromPayload: null,
+    });
+    hoisted.verifyPaddleWebhook.mockResolvedValue({
+      eventData: {
+        eventType: 'subscription.updated',
+        eventId: 'evt_verified',
+        data: {
+          id: 'sub_provider_1',
+          customData: {
+            userId: 'user_from_custom_data',
+          },
+        },
+      },
+      signatureValid: true,
+      signatureBypassed: false,
+    });
+    hoisted.findSubscriptionByProviderReference.mockResolvedValue(null);
+    hoisted.dbUserFindFirst.mockResolvedValue({ tenantId: 'tenant_from_user' });
+    hoisted.insertWebhookEvent.mockResolvedValue({
+      inserted: true,
+      webhookEventRowId: 'webhook_event_1',
+    });
+    hoisted.persistInvoiceAndLedgerInvariants.mockResolvedValue(undefined);
+    hoisted.handlePaddleEvent.mockResolvedValue(undefined);
+    hoisted.markWebhookProcessed.mockResolvedValue(undefined);
+  });
+
+  async function callCore() {
+    return handlePaddleWebhookCore({
+      paddle: {} as never,
+      headers: new Headers(),
+      signature: 'paddle-signature',
+      secret: 'paddle-secret',
+      bodyText: '{"event":"payload"}',
+    });
+  }
+
+  it('prefers canonical subscription tenant over provider customData user fallback', async () => {
+    hoisted.findSubscriptionByProviderReference.mockResolvedValue({
+      id: 'sub_internal_1',
+      tenantId: 'tenant_from_subscription',
+      userId: 'canonical_user',
+    });
+
+    const result = await callCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.findSubscriptionByProviderReference).toHaveBeenCalledWith('sub_provider_1');
+    expect(hoisted.dbUserFindFirst).not.toHaveBeenCalled();
+    expect(hoisted.insertWebhookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant_from_subscription',
+        processingScopeKey: 'tenant:tenant_from_subscription',
+        dedupeKey: 'paddle:tenant:tenant_from_subscription:event:evt_verified',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('falls back to customData user tenant only when subscription lookup cannot resolve tenant', async () => {
+    const result = await callCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.findSubscriptionByProviderReference).toHaveBeenCalledWith('sub_provider_1');
+    expect(hoisted.dbUserFindFirst).toHaveBeenCalledTimes(1);
+    expect(hoisted.insertWebhookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant_from_user',
+        processingScopeKey: 'tenant:tenant_from_user',
+        dedupeKey: 'paddle:tenant:tenant_from_user:event:evt_verified',
+      }),
+      expect.any(Object)
+    );
   });
 });

--- a/apps/web/src/app/api/webhooks/paddle/_core.ts
+++ b/apps/web/src/app/api/webhooks/paddle/_core.ts
@@ -113,10 +113,16 @@ export async function requestPasswordResetOnboarding(params: {
 async function resolveWebhookTenantId(data: unknown): Promise<string | null> {
   const payload = (data ?? {}) as PaddleWebhookData;
   const customData = payload.customData || payload.custom_data;
-  const userId = customData?.userId;
+  const subscriptionId = payload.id || payload.subscriptionId || payload.subscription_id;
 
+  if (subscriptionId) {
+    const subscription = await findSubscriptionByProviderReference(subscriptionId);
+    if (subscription?.tenantId) return subscription.tenantId;
+  }
+
+  const userId = customData?.userId;
   if (userId) {
-    // db-access-guard: tenant-scoped -- reason: userId comes from verified Paddle webhook custom data
+    // db-access-guard: system-exempt -- reason: Paddle customData userId is a fallback only after canonical subscription lookup cannot resolve tenant
     const userRecord = await db.query.user.findFirst({
       where: (users, { eq }) => eq(users.id, userId),
       columns: { tenantId: true },
@@ -124,11 +130,7 @@ async function resolveWebhookTenantId(data: unknown): Promise<string | null> {
     if (userRecord?.tenantId) return userRecord.tenantId;
   }
 
-  const subscriptionId = payload.id || payload.subscriptionId || payload.subscription_id;
-  if (!subscriptionId) return null;
-
-  const subscription = await findSubscriptionByProviderReference(subscriptionId);
-  return subscription?.tenantId ?? null;
+  return null;
 }
 
 export async function handlePaddleWebhookCore(args: {

--- a/docs/plans/2026-05-09-p33-sec10-billing-webhook-tenant-resolution-hardening.md
+++ b/docs/plans/2026-05-09-p33-sec10-billing-webhook-tenant-resolution-hardening.md
@@ -40,10 +40,10 @@ architecture docs unchanged.
 | Tenant posture     | Count |
 | ------------------ | ----: |
 | `tenant-context`   |     5 |
-| `tenant-scoped`    |   165 |
+| `tenant-scoped`    |   162 |
 | `tenant-predicate` |   353 |
 | `admin-privileged` |     0 |
-| `system-exempt`    |    25 |
+| `system-exempt`    |    28 |
 | `unclassified`     |    67 |
 
 DG14 inventoried `14` billing webhook/provider-event hard cases, targeting `80 -> 66`.

--- a/docs/plans/2026-05-09-p33-sec10-billing-webhook-tenant-resolution-hardening.md
+++ b/docs/plans/2026-05-09-p33-sec10-billing-webhook-tenant-resolution-hardening.md
@@ -1,0 +1,79 @@
+---
+status: implementation
+date: 2026-05-09
+slice: P33-SEC10
+title: Billing Webhook Tenant Resolution Hardening
+owner: platform + security + qa
+phase: Phase C
+---
+
+# P33-SEC10 Billing Webhook Tenant Resolution Hardening
+
+## Summary
+
+P33-SEC10 implements the DG14-promoted Paddle billing webhook tenant-resolution hardening
+slice. The implementation keeps `apps/web/src/proxy.ts`, canonical routes, auth/session
+architecture, tenancy architecture, schema/migrations, Storage, Stripe, README, AGENTS, and
+architecture docs unchanged.
+
+## Implementation
+
+- Paddle subscription context now treats persisted subscription and user records as canonical
+  and rejects conflicting provider `customData.userId` or `customData.tenantId` before
+  subscription writes.
+- The app webhook tenant resolver now checks canonical subscription state before using
+  provider `customData.userId` as a fallback and classifies that fallback as `system-exempt`.
+- Subscription upserts now constrain fallback lookups and updates with canonical tenant context.
+- Past-due/dunning handling now resolves through canonical subscription/user state, rejects
+  provider user or tenant conflicts, and keeps dunning writes tenant-scoped.
+- Transaction audit context now skips tenant-scoped audit writes when provider tenant or user
+  metadata conflicts with canonical subscription/user state.
+- Checkout-user reconciliation now detects conflicting subscription-vs-transaction custom data
+  before member creation or update and reloads the final user with the reconciled tenant.
+- Invalid-signature and duplicate webhook receipt persistence remain best-effort audit paths and
+  preserve nullable `tenantId` when safe tenant resolution is unavailable.
+
+## DB Access Posture Result
+
+`pnpm check:db-access` passes with `615` scanned entries and posture counts:
+
+| Tenant posture     | Count |
+| ------------------ | ----: |
+| `tenant-context`   |     5 |
+| `tenant-scoped`    |   165 |
+| `tenant-predicate` |   353 |
+| `admin-privileged` |     0 |
+| `system-exempt`    |    25 |
+| `unclassified`     |    67 |
+
+DG14 inventoried `14` billing webhook/provider-event hard cases, targeting `80 -> 66`.
+The synced implementation baseline at `f34d0b48ba1b822facff5ee231b5f993f7070174` contained
+`13` unclassified entries under `packages/domain-membership-billing/src/paddle-webhooks/**`.
+P33-SEC10 resolves all `13`; there are now `0` unclassified entries under that package path.
+The remaining `1` `packages/domain-membership-billing/src` unclassified entry is
+`packages/domain-membership-billing/src/commissions/create.ts`, outside the DG14-authorized
+Paddle webhook scope.
+
+## DG15 Residual
+
+The Paddle lead conversion block in `apps/web/src/app/api/webhooks/paddle/_core.ts` remains a
+named DG15 residual and was not changed by SEC10. It still needs a design decision for null
+tenant handling before lead conversion, validation of provider `customData.leadId`, and completion
+or removal of the incomplete TODO-marked lead payment logic.
+
+## Verification Plan
+
+- Focused Paddle webhook unit tests for subscription context, subscription upsert, dunning,
+  transaction audit, checkout-user reconciliation, and webhook receipt persistence.
+- `pnpm check:db-access`.
+- `pnpm security:guard`.
+- `pnpm verify-slice -- --static`.
+- `pnpm verify-slice -- --required-gates`.
+- Mandatory implementation reviewer pool and diff-scoped Codex Security scan before required
+  gates.
+
+## Rollback
+
+Rollback is a normal revert of the package hardening changes and DB access posture receipts. The
+failure mode after rollback would be a return to pre-SEC10 provider-event tenant fallback behavior;
+invalid-signature and duplicate webhook audit persistence remain compatible in either direction.

--- a/docs/security/db-access-posture-baseline.md
+++ b/docs/security/db-access-posture-baseline.md
@@ -3,7 +3,7 @@ plan_role: input
 status: archived
 source_of_truth: false
 owner: platform + security + qa
-last_reviewed: 2026-05-08
+last_reviewed: 2026-05-09
 ---
 
 # DB Access Posture Baseline
@@ -11,8 +11,8 @@ last_reviewed: 2026-05-08
 > Status: Archived implementation receipt. The authoritative execution state remains in
 > `docs/plans/current-program.md` and `docs/plans/current-tracker.md`.
 
-Generated from `scripts/ci/db-access-baseline.json` on 2026-05-08 after the v2 posture
-classifier upgrade and SEC04B burn-down pass.
+Generated from `scripts/ci/db-access-baseline.json` on 2026-05-09 after P33-SEC10
+cleared the Paddle billing webhook/provider-event tenant-resolution cluster.
 
 ## Summary
 
@@ -20,23 +20,25 @@ classifier upgrade and SEC04B burn-down pass.
 | --------------------------- | ---------: |
 | Baseline version            |          2 |
 | Baseline entries            |        615 |
-| Guard runtime sample        |      1.13s |
+| Guard runtime sample        |      1.00s |
 | Pre-SEC04 runtime reference |      0.69s |
-| Baseline JSON size          | 6378 lines |
+| Baseline JSON size          | 6390 lines |
 
 SEC04B reduced the v2 classifier's unclassified entries from `262` to `80`, meeting the
-DG05 target without classifying the remaining hard cases.
+DG05 target without classifying the remaining hard cases. P33-SEC10 then reduced the
+canonical baseline from `80` to `67` by resolving every current unclassified Paddle
+webhook entry under `packages/domain-membership-billing/src/paddle-webhooks/**`.
 
 ## Counts By Posture
 
 | Tenant posture     | Count |
 | ------------------ | ----: |
 | `tenant-context`   |     5 |
-| `tenant-scoped`    |   158 |
-| `tenant-predicate` |   352 |
+| `tenant-scoped`    |   165 |
+| `tenant-predicate` |   353 |
 | `admin-privileged` |     0 |
-| `system-exempt`    |    20 |
-| `unclassified`     |    80 |
+| `system-exempt`    |    25 |
+| `unclassified`     |    67 |
 
 ## Counts By Risk
 
@@ -50,22 +52,22 @@ DG05 target without classifying the remaining hard cases.
 | Count | Tenant posture     | Risk             | File prefix                              |
 | ----: | ------------------ | ---------------- | ---------------------------------------- |
 |   165 | `tenant-predicate` | `app-layer`      | `apps/web/src`                           |
-|    88 | `tenant-scoped`    | `app-layer`      | `apps/web/src`                           |
+|    87 | `tenant-scoped`    | `app-layer`      | `apps/web/src`                           |
 |    56 | `tenant-predicate` | `domain-wrapper` | `packages/domain-claims/src`             |
 |    52 | `unclassified`     | `app-layer`      | `apps/web/src`                           |
 |    48 | `tenant-predicate` | `domain-wrapper` | `packages/domain-users/src`              |
 |    27 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-claims/src`             |
-|    25 | `tenant-predicate` | `domain-wrapper` | `packages/domain-membership-billing/src` |
+|    26 | `tenant-predicate` | `domain-wrapper` | `packages/domain-membership-billing/src` |
+|    22 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |    19 | `tenant-predicate` | `domain-wrapper` | `packages/domain-communications/src`     |
 |    14 | `tenant-predicate` | `domain-wrapper` | `packages/domain-analytics/src`          |
 |    14 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-leads/src`              |
-|    14 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
-|    14 | `unclassified`     | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |    13 | `system-exempt`    | `domain-wrapper` | `packages/domain-analytics/src`          |
 |    12 | `tenant-predicate` | `domain-wrapper` | `packages/domain-referrals/src`          |
 |     7 | `unclassified`     | `domain-wrapper` | `packages/domain-communications/src`     |
 |     5 | `tenant-context`   | `app-layer`      | `apps/web/src`                           |
-|     4 | `system-exempt`    | `app-layer`      | `apps/web/src`                           |
+|     5 | `system-exempt`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
+|     5 | `system-exempt`    | `app-layer`      | `apps/web/src`                           |
 |     4 | `tenant-predicate` | `domain-wrapper` | `packages/domain-activities/src`         |
 |     4 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-activities/src`         |
 |     4 | `unclassified`     | `domain-wrapper` | `packages/domain-claims/src`             |
@@ -77,18 +79,25 @@ DG05 target without classifying the remaining hard cases.
 |     2 | `tenant-predicate` | `domain-wrapper` | `packages/domain-leads/src`              |
 |     2 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-documents/src`          |
 |     2 | `unclassified`     | `domain-wrapper` | `packages/domain-users/src`              |
-|     1 | `system-exempt`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |     1 | `tenant-predicate` | `domain-wrapper` | `packages/domain-ai/src`                 |
 |     1 | `tenant-predicate` | `domain-wrapper` | `packages/domain-member/src`             |
 |     1 | `tenant-scoped`    | `app-layer`      | `packages/shared-utils/src`              |
 |     1 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-member/src`             |
 |     1 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-referrals/src`          |
+|     1 | `unclassified`     | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |     1 | `unclassified`     | `domain-wrapper` | `packages/domain-referrals/src`          |
 
 ## Remaining Review Input
 
-The remaining `80` unclassified entries are intentionally left as hard cases. The largest
-clusters are commercial action idempotency, legacy agent dashboard reads, billing webhook
-handlers, campaign execution, NPS/engagement cron residue, and admin/branch cross-tenant
-lookups. Those entries should not be mass-stamped; they need either callsite migration,
-helper-level tenant proof, or a fresh design review.
+The remaining `67` unclassified entries are intentionally left as hard cases. The largest
+clusters are commercial action idempotency, legacy agent dashboard reads, campaign execution,
+NPS/engagement cron residue, admin/branch cross-tenant lookups, and smaller one-off
+application/domain paths. Those entries should not be mass-stamped; they need either callsite
+migration, helper-level tenant proof, or a fresh design review.
+
+P33-SEC10 note: DG14 inventoried `14` billing webhook/provider-event entries, but the synced
+implementation baseline at `f34d0b48ba1b822facff5ee231b5f993f7070174` contained `13`
+unclassified entries under the authorized Paddle webhook package path. All `13` are resolved;
+the remaining `1` unclassified `packages/domain-membership-billing/src` entry is
+`packages/domain-membership-billing/src/commissions/create.ts` and is outside the SEC10 billing
+webhook scope.

--- a/docs/security/db-access-posture-baseline.md
+++ b/docs/security/db-access-posture-baseline.md
@@ -34,10 +34,10 @@ webhook entry under `packages/domain-membership-billing/src/paddle-webhooks/**`.
 | Tenant posture     | Count |
 | ------------------ | ----: |
 | `tenant-context`   |     5 |
-| `tenant-scoped`    |   165 |
+| `tenant-scoped`    |   162 |
 | `tenant-predicate` |   353 |
 | `admin-privileged` |     0 |
-| `system-exempt`    |    25 |
+| `system-exempt`    |    28 |
 | `unclassified`     |    67 |
 
 ## Counts By Risk
@@ -58,15 +58,15 @@ webhook entry under `packages/domain-membership-billing/src/paddle-webhooks/**`.
 |    48 | `tenant-predicate` | `domain-wrapper` | `packages/domain-users/src`              |
 |    27 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-claims/src`             |
 |    26 | `tenant-predicate` | `domain-wrapper` | `packages/domain-membership-billing/src` |
-|    22 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
+|    19 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |    19 | `tenant-predicate` | `domain-wrapper` | `packages/domain-communications/src`     |
 |    14 | `tenant-predicate` | `domain-wrapper` | `packages/domain-analytics/src`          |
 |    14 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-leads/src`              |
 |    13 | `system-exempt`    | `domain-wrapper` | `packages/domain-analytics/src`          |
 |    12 | `tenant-predicate` | `domain-wrapper` | `packages/domain-referrals/src`          |
+|     8 | `system-exempt`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |     7 | `unclassified`     | `domain-wrapper` | `packages/domain-communications/src`     |
 |     5 | `tenant-context`   | `app-layer`      | `apps/web/src`                           |
-|     5 | `system-exempt`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |     5 | `system-exempt`    | `app-layer`      | `apps/web/src`                           |
 |     4 | `tenant-predicate` | `domain-wrapper` | `packages/domain-activities/src`         |
 |     4 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-activities/src`         |

--- a/docs/security/db-access-posture-burndown.md
+++ b/docs/security/db-access-posture-burndown.md
@@ -23,8 +23,8 @@ baseline to `67` by resolving the current Paddle billing webhook/provider-event 
 | SEC04B unclassified baseline    |    80 |
 | P33-SEC10 unclassified baseline |    67 |
 | Entries removed from scan       |     4 |
-| Reviewed `tenant-scoped` calls  |   165 |
-| Reviewed `system-exempt` calls  |    25 |
+| Reviewed `tenant-scoped` calls  |   162 |
+| Reviewed `system-exempt` calls  |    28 |
 
 ## Classification Rules Used
 
@@ -48,6 +48,8 @@ system analytics:
   tenant ownership before a tenant-scoped boundary exists.
 - Paddle webhook `customData.userId` fallback lookup after canonical subscription lookup cannot
   resolve tenant ownership.
+- Paddle webhook userId bootstrap lookups that resolve canonical tenant context before later
+  subscription, dunning, or transaction audit writes are tenant-scoped.
 - Paddle webhook receipt and invalid-signature audit rows that must persist before handler-level
   tenant resolution is safe.
 - Checkout email ownership probes that intentionally detect cross-tenant conflicts before

--- a/docs/security/db-access-posture-burndown.md
+++ b/docs/security/db-access-posture-burndown.md
@@ -3,7 +3,7 @@ plan_role: input
 status: archived
 source_of_truth: false
 owner: platform + security + qa
-last_reviewed: 2026-05-08
+last_reviewed: 2026-05-09
 ---
 
 # DB Access Posture Burn-Down
@@ -12,17 +12,19 @@ last_reviewed: 2026-05-08
 > `docs/plans/current-program.md` and `docs/plans/current-tracker.md`.
 
 SEC04B reduced the DB access posture baseline from `262` unclassified entries to `80`.
-Classification stopped when the `<= 80` target was reached.
+Classification stopped when the `<= 80` target was reached. P33-SEC10 later reduced the
+baseline to `67` by resolving the current Paddle billing webhook/provider-event cluster.
 
 ## Burn-Down Summary
 
-| Metric                         | Count |
-| ------------------------------ | ----: |
-| SEC04A unclassified baseline   |   262 |
-| SEC04B unclassified baseline   |    80 |
-| Entries removed from scan      |     4 |
-| Reviewed `tenant-scoped` calls |   158 |
-| Reviewed `system-exempt` calls |    20 |
+| Metric                          | Count |
+| ------------------------------- | ----: |
+| SEC04A unclassified baseline    |   262 |
+| SEC04B unclassified baseline    |    80 |
+| P33-SEC10 unclassified baseline |    67 |
+| Entries removed from scan       |     4 |
+| Reviewed `tenant-scoped` calls  |   165 |
+| Reviewed `system-exempt` calls  |    25 |
 
 ## Classification Rules Used
 
@@ -44,25 +46,35 @@ system analytics:
 - Privacy deletion audit trail writes.
 - Login, push endpoint, and provider-reference bootstrap lookups that intentionally resolve
   tenant ownership before a tenant-scoped boundary exists.
+- Paddle webhook `customData.userId` fallback lookup after canonical subscription lookup cannot
+  resolve tenant ownership.
+- Paddle webhook receipt and invalid-signature audit rows that must persist before handler-level
+  tenant resolution is safe.
+- Checkout email ownership probes that intentionally detect cross-tenant conflicts before
+  creating or updating a tenant-scoped member.
 
 The e2e-only branch setup API was removed from the production posture baseline scan rather than
 classified.
 
 ## Remaining Evidence Set
 
-The remaining `80` entries are intentionally not classified in SEC04B. They include clusters that
-need migration or a narrower design decision:
+The remaining `67` entries are intentionally not classified. They include clusters that need
+migration or a narrower design decision:
 
 | Count | Cluster                                                                                           |
 | ----: | ------------------------------------------------------------------------------------------------- |
 |     5 | Commercial action idempotency records with optional tenant identity.                              |
 |     5 | Legacy agent dashboard reads without current tenant proof.                                        |
-|    14 | Billing webhook handlers and persistence paths that derive tenant identity from provider events.  |
 |     7 | Campaign execution and communication paths that batch across users or campaigns.                  |
 |     8 | Cron and public NPS/engagement residue that needs per-tenant job modeling or narrower predicates. |
 |     4 | Admin and branch dashboard cross-tenant lookup paths.                                             |
+|     1 | Non-Paddle membership billing commission ownership probe outside the SEC10 webhook scope.         |
 |    37 | Smaller one-off application/domain paths requiring callsite-specific migration review.            |
 
-Those entries should not be mass-stamped. The next action, if further burn-down is needed, is a
-targeted design review for webhook/provider-event tenancy, commercial idempotency scoping, and
-legacy agent dashboard ownership.
+Those entries should not be mass-stamped. P33-SEC10 resolved all current unclassified entries
+under `packages/domain-membership-billing/src/paddle-webhooks/**`. DG14 had inventoried `14`
+billing webhook/provider-event entries, but the synced implementation baseline contained `13`
+under that package path; the remaining membership-billing unclassified entry is the non-Paddle
+commission ownership probe listed above. The next action, if further burn-down is needed, is a
+targeted design review for commercial idempotency scoping, legacy agent dashboard ownership,
+campaign/cron/public-token tenancy, or the remaining one-off paths.

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.test.ts
@@ -77,6 +77,123 @@ describe('handleSubscriptionPastDue', () => {
     expect(sendPaymentFailedEmail).not.toHaveBeenCalled();
   });
 
+  it('uses existing subscription user when past-due customData omits userId', async () => {
+    const sendPaymentFailedEmail = vi.fn().mockResolvedValue(undefined);
+
+    hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+      id: 'sub_existing',
+      tenantId: 'tenant_abc',
+      userId: 'user_canonical',
+      dunningAttemptCount: 0,
+    });
+    hoisted.db.query.user.findFirst.mockResolvedValue({
+      id: 'user_canonical',
+      email: 'canonical@example.com',
+      name: 'Canonical',
+      tenantId: 'tenant_abc',
+    });
+
+    await handleSubscriptionPastDue(
+      {
+        data: {
+          id: 'sub_paddle_456',
+          status: 'past_due',
+          customData: { tenantId: 'tenant_abc' },
+          items: [
+            {
+              price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
+            },
+          ],
+          currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
+        },
+      },
+      { sendPaymentFailedEmail }
+    );
+
+    expect(sendPaymentFailedEmail).toHaveBeenCalledWith(
+      'canonical@example.com',
+      expect.objectContaining({ memberName: 'Canonical' })
+    );
+  });
+
+  it('skips dunning writes when provider tenant metadata conflicts with canonical tenant', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const sendPaymentFailedEmail = vi.fn().mockResolvedValue(undefined);
+
+    hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+      id: 'sub_existing',
+      tenantId: 'tenant_real',
+      userId: 'user_123',
+      dunningAttemptCount: 0,
+    });
+    hoisted.db.query.user.findFirst.mockResolvedValue({
+      id: 'user_123',
+      email: 'test@example.com',
+      name: 'Member',
+      tenantId: 'tenant_real',
+    });
+
+    await handleSubscriptionPastDue(
+      {
+        data: {
+          id: 'sub_paddle_456',
+          status: 'past_due',
+          customData: { userId: 'user_123', tenantId: 'tenant_bad' },
+          items: [
+            {
+              price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
+            },
+          ],
+          currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
+        },
+      },
+      { sendPaymentFailedEmail }
+    );
+
+    expect(hoisted.db.insert).not.toHaveBeenCalled();
+    expect(hoisted.db.update).not.toHaveBeenCalled();
+    expect(sendPaymentFailedEmail).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('customData tenant=tenant_bad'));
+
+    warnSpy.mockRestore();
+  });
+
+  it('skips dunning writes when provider user metadata conflicts with existing subscription user', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+      id: 'sub_existing',
+      tenantId: 'tenant_abc',
+      userId: 'user_real',
+      dunningAttemptCount: 0,
+    });
+
+    await handleSubscriptionPastDue({
+      data: {
+        id: 'sub_paddle_456',
+        status: 'past_due',
+        customData: { userId: 'user_bad', tenantId: 'tenant_abc' },
+        items: [
+          {
+            price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
+          },
+        ],
+        currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
+      },
+    });
+
+    expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
+    expect(hoisted.db.insert).not.toHaveBeenCalled();
+    expect(hoisted.db.update).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'customData user=user_bad conflicts with existing subscription user=user_real'
+      )
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it('retries as an update when a raced insert hits a unique constraint', async () => {
     const { mockSet, mockWhere } = mockRacedSubscriptionInsert(hoisted);
 

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts
@@ -176,7 +176,7 @@ function resolvePastDueUserId(sub: SubscriptionEventData): string | null {
 }
 
 async function findPastDueUserRecord(userId: string): Promise<PastDueUserRecord | null> {
-  // db-access-guard: tenant-scoped -- reason: userId is reconciled against canonical subscription or webhook user identity before tenant-scoped writes
+  // db-access-guard: system-exempt -- reason: Paddle userId lookup bootstraps dunning tenant context before tenant-scoped writes
   const userRecord = await db.query.user.findFirst({
     where: (users, { eq }) => eq(users.id, userId),
     columns: { id: true, email: true, name: true, tenantId: true },

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts
@@ -1,4 +1,4 @@
-import { db, eq, subscriptions } from '@interdomestik/database';
+import { and, db, eq, subscriptions } from '@interdomestik/database';
 import { findSubscriptionByProviderReference } from '../../subscription';
 import {
   createCanonicalMembershipPlanState,
@@ -17,6 +17,8 @@ type PastDueUserRecord = {
 };
 type ExistingSubscriptionRecord = {
   id: string;
+  tenantId: string;
+  userId: string;
   dunningAttemptCount?: number | null;
   pastDueAt?: Date | null;
   gracePeriodEndsAt?: Date | null;
@@ -57,37 +59,30 @@ export async function handleSubscriptionPastDue(
     return;
   }
 
-  const userId = resolvePastDueUserId(sub);
-  if (!userId) {
-    console.warn(`[Webhook] No userId found in customData for past_due subscription ${sub.id}`);
+  const context = await resolvePastDueContext(sub);
+  if (!context) {
     return;
   }
 
-  const userRecord = await findPastDueUserRecord(userId);
-  if (!userRecord) {
-    console.warn(`[Webhook] User not found: ${userId}`);
-    return;
-  }
-
-  const existingSub = await findExistingPastDueSubscription(sub.id, userId);
   const priceId = sub.items?.[0]?.price?.id || sub.items?.[0]?.priceId || 'unknown';
   const canonicalPlanState = await resolveCanonicalMembershipPlanState({
-    tenantId: userRecord.tenantId,
+    tenantId: context.userRecord.tenantId,
     planId: priceId,
   });
   const pastDueState = buildPastDueState({
     sub,
-    userId,
-    userRecord,
-    existingSub,
+    userId: context.userRecord.id,
+    userRecord: context.userRecord,
+    existingSub: context.existingSub,
     now: new Date(),
     planState: canonicalPlanState,
   });
 
   await persistPastDueSubscription({
     subscriptionId: sub.id,
-    userId,
-    existingSub,
+    userId: context.userRecord.id,
+    tenantId: context.userRecord.tenantId,
+    existingSub: context.existingSub,
     values: pastDueState.values,
   });
 
@@ -99,14 +94,14 @@ export async function handleSubscriptionPastDue(
   await logPastDueAuditEvent({
     deps,
     subscriptionId: sub.id,
-    tenantId: userRecord.tenantId,
+    tenantId: context.userRecord.tenantId,
     newDunningCount: pastDueState.newDunningCount,
     gracePeriodEnd: pastDueState.gracePeriodEnd,
   });
   await sendInitialPaymentFailedEmail({
     deps,
-    userId,
-    userRecord,
+    userId: context.userRecord.id,
+    userRecord: context.userRecord,
     sub,
     newDunningCount: pastDueState.newDunningCount,
     gracePeriodEnd: pastDueState.gracePeriodEnd,
@@ -123,30 +118,87 @@ function parsePastDueSubscription(data: unknown): SubscriptionEventData | null {
   return parseResult.data;
 }
 
+async function resolvePastDueContext(sub: SubscriptionEventData): Promise<{
+  userRecord: PastDueUserRecord;
+  existingSub: ExistingSubscriptionRecord;
+} | null> {
+  const customDataUserId = resolvePastDueUserId(sub);
+  const customDataTenantId = normalizeText((sub.customData || sub.custom_data)?.tenantId);
+  const existingSub = await findExistingPastDueSubscriptionByProvider(sub.id);
+  const existingUserId = normalizeText(existingSub?.userId);
+  const existingTenantId = normalizeText(existingSub?.tenantId);
+  const userId = existingUserId ?? customDataUserId;
+
+  if (!userId) {
+    console.warn(`[Webhook] No canonical userId found for past_due subscription ${sub.id}`);
+    return null;
+  }
+
+  if (existingUserId && customDataUserId && customDataUserId !== existingUserId) {
+    console.warn(
+      `[Webhook] Cannot resolve past_due subscription ${sub.id}; customData user=${customDataUserId} conflicts with existing subscription user=${existingUserId}`
+    );
+    return null;
+  }
+
+  const userRecord = await findPastDueUserRecord(userId);
+  if (!userRecord) {
+    console.warn(`[Webhook] User not found: ${userId}`);
+    return null;
+  }
+
+  if (existingTenantId && existingTenantId !== userRecord.tenantId) {
+    console.warn(
+      `[Webhook] Cannot resolve past_due subscription ${sub.id}; existing subscription tenant=${existingTenantId} conflicts with user tenant=${userRecord.tenantId}`
+    );
+    return null;
+  }
+
+  if (customDataTenantId && customDataTenantId !== userRecord.tenantId) {
+    console.warn(
+      `[Webhook] Cannot resolve past_due subscription ${sub.id}; customData tenant=${customDataTenantId} conflicts with canonical tenant=${userRecord.tenantId}`
+    );
+    return null;
+  }
+
+  const tenantScopedExistingSub =
+    existingSub ?? (await findExistingPastDueSubscriptionForUser(userRecord));
+
+  return {
+    userRecord,
+    existingSub: tenantScopedExistingSub,
+  };
+}
+
 function resolvePastDueUserId(sub: SubscriptionEventData): string | null {
   const customData = sub.customData || sub.custom_data;
-  return customData?.userId ?? null;
+  return normalizeText(customData?.userId);
 }
 
 async function findPastDueUserRecord(userId: string): Promise<PastDueUserRecord | null> {
-  return (
-    (await db.query.user.findFirst({
-      where: (users, { eq }) => eq(users.id, userId),
-      columns: { id: true, email: true, name: true, tenantId: true },
-    })) ?? null
-  );
+  // db-access-guard: tenant-scoped -- reason: userId is reconciled against canonical subscription or webhook user identity before tenant-scoped writes
+  const userRecord = await db.query.user.findFirst({
+    where: (users, { eq }) => eq(users.id, userId),
+    columns: { id: true, email: true, name: true, tenantId: true },
+  });
+  return userRecord ?? null;
 }
 
-async function findExistingPastDueSubscription(
-  subscriptionId: string,
-  userId: string
+async function findExistingPastDueSubscriptionByProvider(
+  subscriptionId: string
 ): Promise<ExistingSubscriptionRecord> {
+  return (await findSubscriptionByProviderReference(subscriptionId)) ?? null;
+}
+
+async function findExistingPastDueSubscriptionForUser(
+  userRecord: PastDueUserRecord
+): Promise<ExistingSubscriptionRecord> {
+  // db-access-guard: tenant-scoped -- reason: tenantId from canonical user record constrains fallback subscription lookup
   return (
-    (await findSubscriptionByProviderReference(subscriptionId)) ??
     (await db.query.subscriptions.findFirst({
-      where: (subs, { eq }) => eq(subs.userId, userId),
-    })) ??
-    null
+      where: (subs, { and, eq }) =>
+        and(eq(subs.userId, userRecord.id), eq(subs.tenantId, userRecord.tenantId)),
+    })) ?? null
   );
 }
 
@@ -205,18 +257,23 @@ function resolveBillingPeriodDate(primary?: string | null, fallback?: string | n
 async function persistPastDueSubscription(args: {
   subscriptionId: string;
   userId: string;
+  tenantId: string;
   existingSub: ExistingSubscriptionRecord;
   values: PastDueValues;
 }) {
   if (args.existingSub) {
+    // db-access-guard: tenant-scoped -- reason: tenantId from canonical user/subscription context constrains dunning update
     await db
       .update(subscriptions)
       .set(args.values)
-      .where(eq(subscriptions.id, args.existingSub.id));
+      .where(
+        and(eq(subscriptions.id, args.existingSub.id), eq(subscriptions.tenantId, args.tenantId))
+      );
     return;
   }
 
   try {
+    // db-access-guard: tenant-scoped -- reason: tenantId from canonical user context is included in dunning insert values
     await db.insert(subscriptions).values({
       id: args.subscriptionId,
       ...args.values,
@@ -226,10 +283,12 @@ async function persistPastDueSubscription(args: {
       throw error;
     }
 
-    const racedSubscription = await findExistingPastDueSubscription(
-      args.subscriptionId,
-      args.userId
-    );
+    const racedSubscription = await findExistingPastDueSubscriptionForUser({
+      id: args.userId,
+      tenantId: args.tenantId,
+      email: null,
+      name: null,
+    });
     if (!racedSubscription) {
       throw error;
     }
@@ -238,8 +297,16 @@ async function persistPastDueSubscription(args: {
     await db
       .update(subscriptions)
       .set(args.values)
-      .where(eq(subscriptions.id, racedSubscription.id));
+      .where(
+        and(eq(subscriptions.id, racedSubscription.id), eq(subscriptions.tenantId, args.tenantId))
+      );
   }
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
 }
 
 async function logPastDueAuditEvent(args: {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.test.ts
@@ -175,6 +175,129 @@ describe('handleSubscriptionChanged', () => {
     expect(logAuditEvent).not.toHaveBeenCalled();
   });
 
+  it('fails closed when provider tenant metadata conflicts with canonical subscription tenant', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+      id: 'sub_existing',
+      tenantId: 'tenant_real',
+      userId: 'user_123',
+    });
+    hoisted.db.query.user.findFirst.mockResolvedValue({
+      id: 'user_123',
+      email: 'test@example.com',
+      tenantId: 'tenant_real',
+    });
+
+    await expect(
+      handleSubscriptionChanged(
+        {
+          eventType: 'subscription.updated',
+          data: {
+            id: 'sub_existing',
+            status: 'active',
+            customData: { userId: 'user_123', tenantId: 'tenant_bad' },
+            items: [
+              {
+                price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
+              },
+            ],
+            currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
+          },
+        },
+        { logAuditEvent }
+      )
+    ).rejects.toThrow('customData tenant=tenant_bad conflicts with canonical tenant=tenant_real');
+
+    expect(hoisted.db.insert).not.toHaveBeenCalled();
+    expect(hoisted.db.update).not.toHaveBeenCalled();
+    expect(logAuditEvent).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not fall back to checkout reconciliation for subscription.created tenant conflicts', async () => {
+    hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+      id: 'sub_existing',
+      tenantId: 'tenant_real',
+      userId: 'user_123',
+    });
+    hoisted.db.query.user.findFirst.mockResolvedValue({
+      id: 'user_123',
+      email: 'test@example.com',
+      tenantId: 'tenant_real',
+    });
+
+    await expect(
+      handleSubscriptionChanged(
+        {
+          eventType: 'subscription.created',
+          data: {
+            id: 'sub_existing',
+            status: 'active',
+            transactionId: 'txn_existing',
+            customData: { userId: 'user_123', tenantId: 'tenant_bad' },
+            items: [
+              {
+                price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
+              },
+            ],
+            currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
+          },
+        },
+        { logAuditEvent }
+      )
+    ).rejects.toThrow('customData tenant=tenant_bad conflicts with canonical tenant=tenant_real');
+
+    expect(hoisted.db.query.webhookEvents.findFirst).not.toHaveBeenCalled();
+    expect(hoisted.db.insert).not.toHaveBeenCalled();
+    expect(logAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it('uses existing subscription canonical user when provider customData omits userId', async () => {
+    const mockWhere = vi.fn().mockResolvedValue(undefined);
+    const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+    hoisted.db.update.mockReturnValue({ set: mockSet });
+
+    hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+      id: 'sub_existing',
+      tenantId: 'tenant_abc',
+      userId: 'user_canonical',
+    });
+    hoisted.db.query.user.findFirst.mockResolvedValue({
+      id: 'user_canonical',
+      email: 'test@example.com',
+      tenantId: 'tenant_abc',
+    });
+
+    await handleSubscriptionChanged(
+      {
+        eventType: 'subscription.updated',
+        data: {
+          id: 'sub_existing',
+          status: 'active',
+          customData: { tenantId: 'tenant_abc' },
+          items: [
+            {
+              price: { id: 'pri_123', unitPrice: { amount: '1000', currencyCode: 'USD' } },
+            },
+          ],
+          currentBillingPeriod: { startsAt: '2023-01-01', endsAt: '2024-01-01' },
+        },
+      },
+      { logAuditEvent }
+    );
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant_abc',
+        userId: 'user_canonical',
+      })
+    );
+    expect(mockWhere).toHaveBeenCalled();
+  });
+
   it('updates an existing user-scoped subscription row instead of inserting a second row', async () => {
     const mockWhere = vi.fn().mockResolvedValue(undefined);
     const mockSet = vi.fn().mockReturnValue({ where: mockWhere });

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
@@ -1,4 +1,4 @@
-import { db, eq, subscriptions } from '@interdomestik/database';
+import { and, db, eq, subscriptions } from '@interdomestik/database';
 import { findSubscriptionByProviderReference } from '../../subscription';
 import {
   createCanonicalMembershipPlanState,
@@ -26,14 +26,14 @@ export async function handleSubscriptionChanged(
 
   // 1. Resolve Context (User, Tenant, Branch)
   let context = await resolveSubscriptionContext(sub);
-  if (!context && params.eventType === 'subscription.created') {
+  if (!context && params.eventType === 'subscription.created' && canReconcileCheckoutUser(sub)) {
     context = await reconcileCheckoutUser(sub, deps);
   }
   if (!context) {
     throw new Error(`Unable to resolve subscription context for ${sub.id}`);
   }
 
-  const { userId, tenantId, branchId, customData, userRecord } = context;
+  const { userId, tenantId, branchId, customData, userRecord, existingSub } = context;
   const canonicalUserRecord = userRecord ?? null;
   const resolvedAgentId = resolveSubscriptionAgentId({
     userRecord: canonicalUserRecord,
@@ -54,6 +54,7 @@ export async function handleSubscriptionChanged(
     userId,
     agentId: resolvedAgentId,
     branchId,
+    existingSub,
     mappedStatus,
     planState: canonicalPlanState,
   });
@@ -100,18 +101,21 @@ async function upsertSubscription(args: {
   userId: string;
   agentId?: string | null;
   branchId?: string;
+  existingSub?: { id: string; tenantId?: string | null; userId?: string | null } | null;
   mappedStatus: InternalSubscriptionStatus;
   planState: {
     planId: string;
     planKey: string | null;
   };
 }) {
-  const { sub, tenantId, userId, agentId, branchId, mappedStatus, planState } = args;
+  const { sub, tenantId, userId, agentId, branchId, existingSub, mappedStatus, planState } = args;
   const values = mapToSubscriptionValues(sub, mappedStatus, planState);
-  const existingSubscription = await findExistingSubscription(sub.id, userId);
+  const existingSubscription =
+    existingSub ?? (await findExistingSubscriptionForUser(userId, tenantId));
 
   if (existingSubscription) {
-    await updateSubscription(existingSubscription.id, {
+    assertSubscriptionMatchesContext(existingSubscription, { subId: sub.id, tenantId, userId });
+    await updateSubscription(existingSubscription.id, tenantId, {
       tenantId,
       userId,
       agentId,
@@ -134,18 +138,20 @@ async function upsertSubscription(args: {
   };
 
   try {
+    // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle subscription context is included in insert values
     await db.insert(subscriptions).values(insertValues);
   } catch (error) {
     if (!isUniqueViolation(error)) {
       throw error;
     }
 
-    const racedSubscription = await findExistingSubscription(sub.id, userId);
+    const racedSubscription = await findExistingSubscription(sub.id, userId, tenantId);
     if (!racedSubscription) {
       throw error;
     }
 
-    await updateSubscription(racedSubscription.id, {
+    assertSubscriptionMatchesContext(racedSubscription, { subId: sub.id, tenantId, userId });
+    await updateSubscription(racedSubscription.id, tenantId, {
       tenantId,
       userId,
       agentId,
@@ -160,18 +166,50 @@ async function upsertSubscription(args: {
   return sub.id as string;
 }
 
-async function findExistingSubscription(subId: string, userId: string) {
+async function findExistingSubscription(subId: string, userId: string, tenantId: string) {
   return (
     (await findSubscriptionByProviderReference(subId)) ??
-    (await db.query.subscriptions.findFirst({
-      where: (subs, { eq }) => eq(subs.userId, userId),
-      columns: { id: true, tenantId: true, userId: true },
-    }))
+    (await findExistingSubscriptionForUser(userId, tenantId))
   );
 }
 
-async function updateSubscription(subscriptionId: string, values: Record<string, unknown>) {
-  await db.update(subscriptions).set(values).where(eq(subscriptions.id, subscriptionId));
+async function findExistingSubscriptionForUser(userId: string, tenantId: string) {
+  return (
+    // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle subscription context constrains fallback user lookup
+    await db.query.subscriptions.findFirst({
+      where: (subs, { and, eq }) => and(eq(subs.userId, userId), eq(subs.tenantId, tenantId)),
+      columns: { id: true, tenantId: true, userId: true },
+    })
+  );
+}
+
+async function updateSubscription(
+  subscriptionId: string,
+  tenantId: string,
+  values: Record<string, unknown>
+) {
+  // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle subscription context constrains subscription update
+  await db
+    .update(subscriptions)
+    .set(values)
+    .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.tenantId, tenantId)));
+}
+
+function assertSubscriptionMatchesContext(
+  subscription: { id: string; tenantId?: string | null; userId?: string | null },
+  context: { subId: string; tenantId: string; userId: string }
+) {
+  if (subscription.tenantId && subscription.tenantId !== context.tenantId) {
+    throw new Error(
+      `Paddle subscription ${context.subId} tenant conflict: existing=${subscription.tenantId} resolved=${context.tenantId}`
+    );
+  }
+
+  if (subscription.userId && subscription.userId !== context.userId) {
+    throw new Error(
+      `Paddle subscription ${context.subId} user conflict: existing=${subscription.userId} resolved=${context.userId}`
+    );
+  }
 }
 
 function normalizeAgentId(agentId: string | null | undefined): string | null {
@@ -244,4 +282,24 @@ function isUniqueViolation(error: unknown): error is { code: string } {
     typeof (error as { code?: unknown }).code === 'string' &&
     (error as { code: string }).code === '23505'
   );
+}
+
+function canReconcileCheckoutUser(sub: {
+  transactionId?: string | null;
+  transaction_id?: string | null;
+  customData?: { userId?: string };
+  custom_data?: { userId?: string };
+}) {
+  const transactionId = sub.transactionId || sub.transaction_id;
+  const customData = sub.customData || sub.custom_data;
+  return Boolean(transactionId && !normalizeText(customData?.userId));
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
 }

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/test-support.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/test-support.ts
@@ -241,6 +241,13 @@ export function resetPaddleHandlerMocks(
 ) {
   vi.clearAllMocks();
   hoisted.selectResults.length = 0;
+  hoisted.db.query.user.findFirst.mockReset();
+  hoisted.db.query.account.findFirst.mockReset();
+  hoisted.db.query.subscriptions.findFirst.mockReset();
+  hoisted.db.query.tenantSettings.findFirst.mockReset();
+  hoisted.db.query.webhookEvents.findFirst.mockReset();
+  hoisted.db.query.agentClients.findFirst.mockReset();
+  hoisted.db.query.membershipPlans.findFirst.mockReset();
   hoisted.db.select.mockImplementation(() => ({
     from: createQueuedFromMock(vi.fn, hoisted.selectResults),
   }));

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.test.ts
@@ -60,7 +60,7 @@ describe('handleTransactionCompleted', () => {
     );
   });
 
-  it('uses customData tenant and attribution metadata for anonymous transactions', async () => {
+  it('skips tenant-scoped audit for anonymous transactions with only provider customData tenant', async () => {
     hoisted.db.query.subscriptions.findFirst.mockResolvedValue(undefined);
 
     const payload = {
@@ -81,22 +81,7 @@ describe('handleTransactionCompleted', () => {
 
     await handleTransactionCompleted({ data: payload }, { logAuditEvent });
 
-    expect(logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: 'payment.processed',
-        entityId: 'tx_anon',
-        tenantId: 'tenant_mk',
-        metadata: expect.objectContaining({
-          acquisitionSource: 'self_serve_web',
-          agentId: 'agent_9',
-          customerEmail: 'buyer@example.com',
-          customerId: 'ctm_123',
-          subscriptionId: 'sub_anon',
-          utmSource: 'google',
-          utmCampaign: 'diaspora',
-        }),
-      })
-    );
+    expect(logAuditEvent).not.toHaveBeenCalled();
     expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
   });
 
@@ -111,7 +96,7 @@ describe('handleTransactionCompleted', () => {
       status: 'completed',
       subscriptionId: 'sub_existing_owner',
       customData: {
-        tenantId: 'tenant_bad',
+        tenantId: 'tenant_real',
         agentId: 'agent_stale',
       },
       details: { totals: { total: '2000', currencyCode: 'EUR' } },
@@ -161,7 +146,9 @@ describe('handleTransactionCompleted', () => {
     );
   });
 
-  it('prefers persisted subscription tenant over client-provided tenant metadata', async () => {
+  it('skips transaction audit when provider tenant metadata conflicts with persisted subscription', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
     hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
       tenantId: 'tenant_real',
     });
@@ -179,12 +166,46 @@ describe('handleTransactionCompleted', () => {
 
     await handleTransactionCompleted({ data: payload }, { logAuditEvent });
 
-    expect(logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tenantId: 'tenant_real',
-      })
+    expect(logAuditEvent).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('canonical tenant=tenant_real customData tenant=tenant_bad')
     );
     expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('skips transaction audit when provider user metadata conflicts with persisted subscription user', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+      tenantId: 'tenant_real',
+      userId: 'user_real',
+    });
+
+    await handleTransactionCompleted(
+      {
+        data: {
+          id: 'tx_user_conflict',
+          status: 'completed',
+          subscriptionId: 'sub_existing',
+          customData: {
+            userId: 'user_bad',
+            tenantId: 'tenant_real',
+          },
+          details: { totals: { total: '2000', currencyCode: 'EUR' } },
+        },
+      },
+      { logAuditEvent }
+    );
+
+    expect(logAuditEvent).not.toHaveBeenCalled();
+    expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subscription user=user_real customData user=user_bad')
+    );
+
+    warnSpy.mockRestore();
   });
 
   it('resolves transaction tenant from provider subscription id lookups', async () => {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
@@ -26,47 +26,33 @@ export async function handleTransactionCompleted(
   const subscriptionId = tx.subscriptionId || tx.subscription_id;
   const customerId = tx.customerId || tx.customer_id;
   const customerEmail = tx.customerEmail || tx.customer_email;
-  let tenantId: string | null = null;
-  let canonicalAgentId: string | null | undefined;
+  const context = await resolveTransactionTenantContext({
+    subscriptionId,
+    userId,
+    tenantIdFromCustomData,
+    agentIdFromCustomData: customData?.agentId,
+    transactionId: tx.id,
+  });
 
-  if (subscriptionId) {
-    const subscription = await findSubscriptionByProviderReference(subscriptionId);
-    tenantId = subscription?.tenantId ?? null;
-    if (subscription) {
-      canonicalAgentId = normalizeAgentId(subscription.agentId);
-    }
+  if (!context) {
+    console.warn(`[Webhook] Skipping transaction audit for ${tx.id}; tenant context unresolved`);
+    return;
   }
 
-  if (userId) {
-    const user = await db.query.user.findFirst({
-      where: (t, { eq }) => eq(t.id, userId),
-      columns: { tenantId: true, agentId: true },
-    });
-    tenantId = user?.tenantId ?? tenantId;
-    if (user) {
-      canonicalAgentId = normalizeAgentId(user.agentId);
-    }
-  }
-
-  tenantId ??= tenantIdFromCustomData ?? null;
-  if (canonicalAgentId === undefined) {
-    canonicalAgentId = normalizeAgentId(customData?.agentId);
-  }
-
-  if (deps.logAuditEvent && tenantId) {
+  if (deps.logAuditEvent) {
     await deps.logAuditEvent({
       actorRole: 'system',
       action: 'payment.processed',
       entityType: 'transaction',
       entityId: tx.id,
-      tenantId,
+      tenantId: context.tenantId,
       metadata: {
         subscriptionId,
         status: tx.status,
         currency: tx.details?.totals?.currencyCode,
         amount: tx.details?.totals?.total,
         acquisitionSource: customData?.acquisitionSource,
-        agentId: canonicalAgentId,
+        agentId: context.agentId,
         customerEmail,
         customerId,
         userId: userId ?? null,
@@ -77,4 +63,83 @@ export async function handleTransactionCompleted(
       },
     });
   }
+}
+
+async function resolveTransactionTenantContext(args: {
+  subscriptionId?: string | null;
+  userId?: string | null;
+  tenantIdFromCustomData?: string | null;
+  agentIdFromCustomData?: string | null;
+  transactionId: string;
+}): Promise<{ tenantId: string; agentId: string | null } | null> {
+  const customDataTenantId = normalizeText(args.tenantIdFromCustomData);
+  const userId = normalizeText(args.userId);
+  const subscriptionId = normalizeText(args.subscriptionId);
+  let canonicalTenantId: string | null = null;
+  let canonicalAgentId: string | null | undefined;
+
+  if (subscriptionId) {
+    const subscription = await findSubscriptionByProviderReference(subscriptionId);
+    if (subscription) {
+      canonicalTenantId = normalizeText(subscription.tenantId);
+      canonicalAgentId = normalizeAgentId(subscription.agentId);
+
+      const subscriptionUserId = normalizeText(subscription.userId);
+      if (subscriptionUserId && userId && subscriptionUserId !== userId) {
+        console.warn(
+          `[Webhook] Transaction ${args.transactionId} user conflict: subscription user=${subscriptionUserId} customData user=${userId}`
+        );
+        return null;
+      }
+    }
+  }
+
+  if (userId) {
+    // db-access-guard: tenant-scoped -- reason: userId from verified Paddle event is reconciled before tenant-scoped audit writes
+    const user = await db.query.user.findFirst({
+      where: (t, { eq }) => eq(t.id, userId),
+      columns: { tenantId: true, agentId: true },
+    });
+
+    if (!user) {
+      console.warn(`[Webhook] Transaction ${args.transactionId} user ${userId} was not found`);
+      return null;
+    }
+
+    const userTenantId = normalizeText(user.tenantId);
+    if (canonicalTenantId && userTenantId && userTenantId !== canonicalTenantId) {
+      console.warn(
+        `[Webhook] Transaction ${args.transactionId} tenant conflict: subscription tenant=${canonicalTenantId} user tenant=${userTenantId}`
+      );
+      return null;
+    }
+
+    canonicalTenantId = userTenantId ?? canonicalTenantId;
+    canonicalAgentId = normalizeAgentId(user.agentId);
+  }
+
+  if (canonicalTenantId && customDataTenantId && customDataTenantId !== canonicalTenantId) {
+    console.warn(
+      `[Webhook] Transaction ${args.transactionId} tenant conflict: canonical tenant=${canonicalTenantId} customData tenant=${customDataTenantId}`
+    );
+    return null;
+  }
+
+  if (!canonicalTenantId) {
+    return null;
+  }
+
+  return {
+    tenantId: canonicalTenantId,
+    agentId:
+      canonicalAgentId !== undefined
+        ? canonicalAgentId
+        : normalizeAgentId(args.agentIdFromCustomData),
+  };
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
 }

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts
@@ -95,7 +95,7 @@ async function resolveTransactionTenantContext(args: {
   }
 
   if (userId) {
-    // db-access-guard: tenant-scoped -- reason: userId from verified Paddle event is reconciled before tenant-scoped audit writes
+    // db-access-guard: system-exempt -- reason: Paddle userId lookup bootstraps transaction tenant context before tenant-scoped audit writes
     const user = await db.query.user.findFirst({
       where: (t, { eq }) => eq(t.id, userId),
       columns: { tenantId: true, agentId: true },

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.test.ts
@@ -115,7 +115,9 @@ describe('context utils', () => {
       (db.query.subscriptions.findFirst as any).mockImplementation(
         mockDbResponse({ tenantId: 'tn_ex', userId: 'u_1' })
       );
-      (db.query.user.findFirst as any).mockImplementation(mockDbResponse({ email: 'e@mail.com' }));
+      (db.query.user.findFirst as any).mockImplementation(
+        mockDbResponse({ tenantId: 'tn_ex', email: 'e@mail.com' })
+      );
       (db.query.tenantSettings.findFirst as any).mockImplementation(
         mockDbResponse({ value: { branchId: 'br_def' } })
       );
@@ -167,7 +169,7 @@ describe('context utils', () => {
       );
     });
 
-    it('should prefer canonical tenant over mismatched customData tenant', async () => {
+    it('should reject mismatched customData tenant before writes', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const sub = { id: 's_existing', customData: { userId: 'u_1', tenantId: 'tenant_bad' } };
 
@@ -181,14 +183,39 @@ describe('context utils', () => {
         mockDbResponse({ value: { branchId: 'br_def' } })
       );
 
-      const result = await resolveSubscriptionContext(sub);
-
-      expect(result?.tenantId).toBe('tenant_real');
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Ignoring mismatched customData.tenantId')
+      await expect(resolveSubscriptionContext(sub)).rejects.toThrow(
+        'customData tenant=tenant_bad conflicts with canonical tenant=tenant_real'
       );
+      expect(warnSpy).not.toHaveBeenCalled();
 
       warnSpy.mockRestore();
+    });
+
+    it('should reject mismatched customData user when an existing subscription has canonical user', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const sub = { id: 's_existing', customData: { userId: 'u_bad', tenantId: 'tenant_real' } };
+
+      (db.query.subscriptions.findFirst as any).mockImplementation(
+        mockDbResponse({ tenantId: 'tenant_real', userId: 'u_real' })
+      );
+
+      await expect(resolveSubscriptionContext(sub)).rejects.toThrow(
+        'customData user=u_bad conflicts with existing subscription user=u_real'
+      );
+      expect(db.query.user.findFirst).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it('should not use customData tenant when canonical user lookup fails', async () => {
+      const sub = { id: 's_bad', customData: { userId: 'u_missing', tenantId: 'tenant_provider' } };
+      (db.query.subscriptions.findFirst as any).mockImplementation(mockDbResponse(undefined));
+      (db.query.user.findFirst as any).mockImplementation(mockDbResponse(undefined));
+
+      const result = await resolveSubscriptionContext(sub);
+
+      expect(result).toBeNull();
     });
 
     it('should return null if tenant cannot be resolved', async () => {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
@@ -1,6 +1,13 @@
 import { db } from '@interdomestik/database';
 import { findSubscriptionByProviderReference } from '../../../subscription';
 
+export class PaddleSubscriptionContextConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PaddleSubscriptionContextConflictError';
+  }
+}
+
 export async function resolveBranchId(args: {
   customData: { agentId?: string } | undefined;
   tenantId: string;
@@ -55,25 +62,47 @@ export async function resolveSubscriptionContext(sub: any) {
     | undefined;
 
   const existingSub = await findSubscriptionByProviderReference(sub.id);
-  const userId = customData?.userId ?? existingSub?.userId;
+  const customDataUserId = normalizeText(customData?.userId);
+  const customDataTenantId = normalizeText(customData?.tenantId);
+  const existingUserId = normalizeText(existingSub?.userId);
+  const existingTenantId = normalizeText(existingSub?.tenantId);
+  const userId = existingUserId ?? customDataUserId;
 
   if (!userId) {
     console.warn(`[Webhook] No userId found in customData for subscription ${sub.id}`);
     return null;
   }
 
-  // db-access-guard: tenant-scoped -- reason: tenantId resolved into local variable before this DB call
+  if (existingUserId && customDataUserId && customDataUserId !== existingUserId) {
+    throw new PaddleSubscriptionContextConflictError(
+      `Cannot resolve subscription ${sub.id}; customData user=${customDataUserId} conflicts with existing subscription user=${existingUserId}`
+    );
+  }
+
+  // db-access-guard: tenant-scoped -- reason: userId resolved from canonical subscription or verified user lookup boundary
   const userRecord = await db.query.user.findFirst({
     where: (users, { eq }) => eq(users.id, userId),
     columns: { tenantId: true, email: true, name: true, memberNumber: true, agentId: true },
   });
 
-  const canonicalTenantId = existingSub?.tenantId ?? userRecord?.tenantId;
-  const tenantId = canonicalTenantId ?? customData?.tenantId;
-
-  if (canonicalTenantId && customData?.tenantId && customData.tenantId !== canonicalTenantId) {
+  if (!userRecord) {
     console.warn(
-      `[Webhook] Ignoring mismatched customData.tenantId for subscription ${sub.id} userId=${userId}; canonical tenant=${canonicalTenantId} customData tenant=${customData.tenantId}`
+      `[Webhook] Cannot resolve subscription ${sub.id}; canonical user ${userId} was not found`
+    );
+    return null;
+  }
+
+  if (existingTenantId && userRecord.tenantId !== existingTenantId) {
+    throw new PaddleSubscriptionContextConflictError(
+      `Cannot resolve subscription ${sub.id}; existing subscription tenant=${existingTenantId} conflicts with user tenant=${userRecord.tenantId}`
+    );
+  }
+
+  const tenantId = existingTenantId ?? userRecord.tenantId;
+
+  if (customDataTenantId && customDataTenantId !== tenantId) {
+    throw new PaddleSubscriptionContextConflictError(
+      `Cannot resolve subscription ${sub.id}; customData tenant=${customDataTenantId} conflicts with canonical tenant=${tenantId}`
     );
   }
 
@@ -91,4 +120,13 @@ export async function resolveSubscriptionContext(sub: any) {
   });
 
   return { userId, tenantId, branchId, customData, userRecord, existingSub };
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
 }

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts
@@ -79,7 +79,7 @@ export async function resolveSubscriptionContext(sub: any) {
     );
   }
 
-  // db-access-guard: tenant-scoped -- reason: userId resolved from canonical subscription or verified user lookup boundary
+  // db-access-guard: system-exempt -- reason: Paddle userId lookup bootstraps tenant context before tenant-scoped subscription writes
   const userRecord = await db.query.user.findFirst({
     where: (users, { eq }) => eq(users.id, userId),
     columns: { tenantId: true, email: true, name: true, memberNumber: true, agentId: true },

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts
@@ -260,6 +260,120 @@ describe('reconcileCheckoutUser', () => {
     warnSpy.mockRestore();
   });
 
+  it('returns null when subscription customData conflicts with stored transaction tenant', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    hoisted.db.query.webhookEvents.findFirst.mockResolvedValue({
+      payload: {
+        data: {
+          customerEmail: 'buyer@example.com',
+          customData: {
+            tenantId: 'tenant_mk',
+          },
+        },
+      },
+    });
+
+    const result = await reconcileCheckoutUser(
+      {
+        id: 'sub_conflict',
+        transactionId: 'txn_conflict',
+        customData: {
+          tenantId: 'tenant_bad',
+        },
+      },
+      { requestPasswordResetOnboarding }
+    );
+
+    expect(result).toBeNull();
+    expect(hoisted.db.query.user.findFirst).not.toHaveBeenCalled();
+    expect(hoisted.db.transaction).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subscription customData conflicts with stored transaction')
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('returns null when customData user does not match the canonical email user', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    hoisted.db.query.webhookEvents.findFirst.mockResolvedValue({
+      payload: {
+        data: {
+          customerEmail: 'existing@example.com',
+          customData: {
+            tenantId: 'tenant_ks',
+            userId: 'user_stale',
+          },
+        },
+      },
+    });
+    hoisted.db.query.user.findFirst.mockResolvedValue({
+      id: 'user_existing',
+      tenantId: 'tenant_ks',
+      email: 'existing@example.com',
+      name: 'Existing Member',
+      memberNumber: 'MEM-2026-000001',
+      role: 'member',
+    });
+
+    const result = await reconcileCheckoutUser(
+      {
+        id: 'sub_user_conflict',
+        transactionId: 'txn_user_conflict',
+      },
+      { requestPasswordResetOnboarding }
+    );
+
+    expect(result).toBeNull();
+    expect(hoisted.db.transaction).not.toHaveBeenCalled();
+    expect(requestPasswordResetOnboarding).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'customData user=user_stale does not match canonical email user=user_existing'
+      )
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('returns null instead of creating a member when customData asserts a missing user', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    hoisted.db.query.webhookEvents.findFirst.mockResolvedValue({
+      payload: {
+        data: {
+          customerEmail: 'new@example.com',
+          customData: {
+            tenantId: 'tenant_mk',
+            userId: 'user_missing',
+          },
+        },
+      },
+    });
+    hoisted.db.query.user.findFirst.mockResolvedValue(null);
+
+    const result = await reconcileCheckoutUser(
+      {
+        id: 'sub_missing_user',
+        transactionId: 'txn_missing_user',
+      },
+      { requestPasswordResetOnboarding }
+    );
+
+    expect(result).toBeNull();
+    expect(hoisted.db.transaction).not.toHaveBeenCalled();
+    expect(requestPasswordResetOnboarding).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'customData user=user_missing does not match canonical email user=none'
+      )
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it('keeps the reconciled user context when onboarding email delivery fails', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     requestPasswordResetOnboarding.mockRejectedValueOnce(new Error('email offline'));

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts
@@ -69,6 +69,16 @@ function toCustomData(
   return { ...fallback, ...value };
 }
 
+function hasCustomDataConflict(
+  field: 'tenantId' | 'userId',
+  value: CheckoutCustomData | undefined,
+  fallback: CheckoutCustomData | undefined
+): boolean {
+  const current = normalizeText(value?.[field]);
+  const previous = normalizeText(fallback?.[field]);
+  return Boolean(current && previous && current !== previous);
+}
+
 function shouldPromoteRole(role: string | null | undefined): boolean {
   return !role || role === 'user' || role === 'member';
 }
@@ -84,23 +94,23 @@ function isUniqueViolation(error: unknown): error is { code: string } {
 }
 
 async function findUserByEmail(email: string): Promise<ReconciledUserRecord | null> {
-  return (
-    (await db.query.user.findFirst({
-      where: (users, { eq }) => eq(users.email, email),
-      columns: {
-        id: true,
-        tenantId: true,
-        branchId: true,
-        email: true,
-        name: true,
-        role: true,
-        memberNumber: true,
-        agentId: true,
-        createdBy: true,
-        assistedByAgentId: true,
-      },
-    })) ?? null
-  );
+  // db-access-guard: system-exempt -- reason: checkout reconciliation probes global email ownership before tenant-scoped user writes
+  const userRecord = await db.query.user.findFirst({
+    where: (users, { eq }) => eq(users.email, email),
+    columns: {
+      id: true,
+      tenantId: true,
+      branchId: true,
+      email: true,
+      name: true,
+      role: true,
+      memberNumber: true,
+      agentId: true,
+      createdBy: true,
+      assistedByAgentId: true,
+    },
+  });
+  return userRecord ?? null;
 }
 
 export async function reconcileCheckoutUser(
@@ -115,7 +125,7 @@ export async function reconcileCheckoutUser(
     return null;
   }
 
-  // db-access-guard: tenant-scoped -- reason: tenantId resolved into local variable before this DB call
+  // db-access-guard: system-exempt -- reason: provider transaction lookup bootstraps checkout reconciliation before tenant context exists
   const webhookEvent = await db.query.webhookEvents.findFirst({
     where: (events, { eq }) => eq(events.providerTransactionId, transactionId),
     columns: { payload: true },
@@ -130,10 +140,19 @@ export async function reconcileCheckoutUser(
     return null;
   }
 
-  const mergedCustomData = toCustomData(
-    sub.customData || sub.custom_data,
-    transactionData.customData || transactionData.custom_data
-  );
+  const subscriptionCustomData = sub.customData || sub.custom_data;
+  const transactionCustomData = transactionData.customData || transactionData.custom_data;
+  if (
+    hasCustomDataConflict('tenantId', subscriptionCustomData, transactionCustomData) ||
+    hasCustomDataConflict('userId', subscriptionCustomData, transactionCustomData)
+  ) {
+    console.warn(
+      `[Webhook] Cannot reconcile checkout user for subscription ${sub.id}; subscription customData conflicts with stored transaction ${transactionId}`
+    );
+    return null;
+  }
+
+  const mergedCustomData = toCustomData(subscriptionCustomData, transactionCustomData);
   const tenantId = normalizeText(mergedCustomData?.tenantId);
   const customerEmail = normalizeText(
     transactionData.customerEmail || transactionData.customer_email
@@ -147,10 +166,18 @@ export async function reconcileCheckoutUser(
   }
 
   let existingUser = await findUserByEmail(customerEmail);
+  const customDataUserId = normalizeText(mergedCustomData?.userId);
 
   if (existingUser && existingUser.tenantId !== tenantId) {
     console.warn(
       `[Webhook] Cannot reconcile checkout user for subscription ${sub.id}; tenant mismatch for ${customerEmail}: existing=${existingUser.tenantId} payload=${tenantId}`
+    );
+    return null;
+  }
+
+  if (customDataUserId && existingUser?.id !== customDataUserId) {
+    console.warn(
+      `[Webhook] Cannot reconcile checkout user for subscription ${sub.id}; customData user=${customDataUserId} does not match canonical email user=${existingUser?.id ?? 'none'}`
     );
     return null;
   }
@@ -210,13 +237,16 @@ export async function reconcileCheckoutUser(
     }
   }
 
-  const credentialAccount = userId
-    ? await db.query.account.findFirst({
-        where: (accounts, { and, eq }) =>
-          and(eq(accounts.userId, userId), eq(accounts.providerId, 'credential')),
-        columns: { id: true, providerId: true },
-      })
-    : null;
+  let credentialAccount: { id: string; providerId: string } | null = null;
+  if (userId) {
+    // db-access-guard: tenant-scoped -- reason: userId belongs to same-tenant checkout user before credential lookup
+    const accountRecord = await db.query.account.findFirst({
+      where: (accounts, { and, eq }) =>
+        and(eq(accounts.userId, userId), eq(accounts.providerId, 'credential')),
+      columns: { id: true, providerId: true },
+    });
+    credentialAccount = accountRecord ?? null;
+  }
 
   if (
     existingUser &&
@@ -258,8 +288,10 @@ export async function reconcileCheckoutUser(
     shouldRequestOnboarding = !credentialAccount;
   }
 
+  // db-access-guard: tenant-scoped -- reason: tenantId from reconciled checkout context constrains final user reload
   const finalUser = await db.query.user.findFirst({
-    where: (users, { eq }) => eq(users.email, customerEmail),
+    where: (users, { and, eq }) =>
+      and(eq(users.email, customerEmail), eq(users.tenantId, tenantId)),
     columns: {
       id: true,
       tenantId: true,

--- a/packages/domain-membership-billing/src/paddle-webhooks/persist.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/persist.test.ts
@@ -59,6 +59,27 @@ describe('webhook persistence idempotency', () => {
     expect(hoisted.onConflictDoNothing).toHaveBeenCalledWith();
   });
 
+  it('preserves nullable tenant persistence for invalid signatures when tenant is unsafe', async () => {
+    await persistInvalidSignatureAttempt({
+      headers: new Headers(),
+      processingScopeKey: 'entity:unknown',
+      dedupeKey: 'paddle:entity:unknown:hash:hash_unsafe',
+      eventType: 'transaction.completed',
+      eventId: undefined,
+      eventTimestamp: null,
+      payloadHash: 'hash_unsafe',
+      parsedPayload: { ok: false },
+      tenantId: null,
+    });
+
+    expect(hoisted.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: null,
+        processingScopeKey: 'entity:unknown',
+      })
+    );
+  });
+
   it('returns duplicate=false when DB unique linkage blocks a replayed transaction identity', async () => {
     hoisted.returning.mockResolvedValueOnce([{ id: 'we_tx_1' }]).mockResolvedValueOnce([]);
 
@@ -103,6 +124,41 @@ describe('webhook persistence idempotency', () => {
         metadata: expect.objectContaining({
           processingScopeKey: 'tenant:tenant_ks',
           providerTransactionId: 'txn_1',
+        }),
+      })
+    );
+  });
+
+  it('preserves duplicate webhook audit behavior when tenantId is nullable', async () => {
+    hoisted.returning.mockResolvedValueOnce([]);
+    const deps = { logAuditEvent: vi.fn() };
+
+    const result = await insertWebhookEvent(
+      {
+        headers: new Headers(),
+        processingScopeKey: 'entity:unknown',
+        dedupeKey: 'paddle:entity:unknown:event:evt_dup',
+        eventType: 'transaction.completed',
+        eventId: 'evt_dup',
+        eventTimestamp: new Date('2026-02-23T00:00:00.000Z'),
+        payloadHash: 'hash_dup',
+        parsedPayload: { data: { id: 'txn_dup' } },
+        signatureValid: true,
+        signatureBypassed: false,
+        tenantId: null,
+        providerTransactionId: 'txn_dup',
+      },
+      deps
+    );
+
+    expect(result).toEqual({ inserted: false, webhookEventRowId: null });
+    expect(hoisted.insertValues).toHaveBeenCalledWith(expect.objectContaining({ tenantId: null }));
+    expect(deps.logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'webhook.duplicate',
+        metadata: expect.objectContaining({
+          processingScopeKey: 'entity:unknown',
+          providerTransactionId: 'txn_dup',
         }),
       })
     );

--- a/packages/domain-membership-billing/src/paddle-webhooks/persist.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/persist.ts
@@ -18,6 +18,7 @@ export async function persistInvalidSignatureAttempt(
   },
   deps: PaddleWebhookAuditDeps = {}
 ) {
+  // db-access-guard: system-exempt -- reason: Paddle invalid-signature audit must persist before safe tenant resolution and allows tenantId null
   await db
     .insert(webhookEvents)
     .values({
@@ -68,6 +69,7 @@ export async function insertWebhookEvent(
   },
   deps: PaddleWebhookAuditDeps = {}
 ) {
+  // db-access-guard: system-exempt -- reason: Paddle webhook receipt audit preserves duplicate detection before handler-level tenant writes
   const inserted = await db
     .insert(webhookEvents)
     .values({

--- a/scripts/ci/db-access-baseline.json
+++ b/scripts/ci/db-access-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-05-08T19:53:07.580Z",
+  "generatedAt": "2026-05-09T15:16:36.539Z",
   "policy": "see docs/dev/db-access-guard.md",
   "scanRoots": ["apps/web/src", "packages"],
   "approvedDatabaseInternalPatterns": [
@@ -27,11 +27,11 @@
     },
     "byTenantPosture": {
       "tenant-context": 5,
-      "tenant-scoped": 158,
-      "tenant-predicate": 352,
+      "tenant-scoped": 165,
+      "tenant-predicate": 353,
       "admin-privileged": 0,
-      "system-exempt": 20,
-      "unclassified": 80
+      "system-exempt": 25,
+      "unclassified": 67
     }
   },
   "entries": [
@@ -1196,7 +1196,7 @@
     },
     {
       "file": "apps/web/src/app/[locale]/admin/claims/[id]/_core.ts",
-      "line": 36,
+      "line": 37,
       "callee": "db.query",
       "method": "query",
       "risk": "app-layer",
@@ -1206,7 +1206,7 @@
     },
     {
       "file": "apps/web/src/app/[locale]/admin/claims/[id]/_core.ts",
-      "line": 45,
+      "line": 46,
       "callee": "db.select",
       "method": "select",
       "risk": "app-layer",
@@ -1578,7 +1578,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 134,
+      "line": 138,
       "callee": "db.transaction",
       "method": "transaction",
       "risk": "app-layer",
@@ -1589,7 +1589,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 141,
+      "line": 145,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -1600,7 +1600,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 155,
+      "line": 159,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -1611,7 +1611,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 171,
+      "line": 175,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -1622,7 +1622,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 211,
+      "line": 215,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
@@ -1633,7 +1633,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 252,
+      "line": 261,
       "callee": "db.select",
       "method": "select",
       "risk": "app-layer",
@@ -1644,7 +1644,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 297,
+      "line": 306,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
@@ -1655,7 +1655,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 341,
+      "line": 350,
       "callee": "db.transaction",
       "method": "transaction",
       "risk": "app-layer",
@@ -1666,7 +1666,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 343,
+      "line": 352,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -1677,7 +1677,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 353,
+      "line": 362,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -1688,7 +1688,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 373,
+      "line": 382,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -1699,7 +1699,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 401,
+      "line": 410,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
@@ -1864,13 +1864,13 @@
     },
     {
       "file": "apps/web/src/app/api/webhooks/paddle/_core.ts",
-      "line": 120,
+      "line": 126,
       "callee": "db.query",
       "method": "query",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "userId comes from verified Paddle webhook custom data",
+      "tenantPosture": "system-exempt",
+      "tenantPostureReason": "system-exempt: directive",
+      "tenantPostureDetail": "Paddle customData userId is a fallback only after canonical subscription lookup cannot resolve tenant",
       "source": "const userRecord = await db.query.user.findFirst({"
     },
     {
@@ -2858,7 +2858,7 @@
     },
     {
       "file": "apps/web/src/features/claims/upload/server/shared-upload.ts",
-      "line": 532,
+      "line": 521,
       "callee": "db.transaction",
       "method": "transaction",
       "risk": "app-layer",
@@ -2869,7 +2869,7 @@
     },
     {
       "file": "apps/web/src/features/claims/upload/server/shared-upload.ts",
-      "line": 534,
+      "line": 523,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -2880,7 +2880,7 @@
     },
     {
       "file": "apps/web/src/features/claims/upload/server/shared-upload.ts",
-      "line": 550,
+      "line": 539,
       "callee": "db.transaction",
       "method": "transaction",
       "risk": "app-layer",
@@ -3017,7 +3017,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 101,
+      "line": 110,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
@@ -3028,7 +3028,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 125,
+      "line": 134,
       "callee": "db.select",
       "method": "select",
       "risk": "app-layer",
@@ -3038,7 +3038,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 173,
+      "line": 182,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
@@ -3049,7 +3049,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 243,
+      "line": 256,
       "callee": "db.transaction",
       "method": "transaction",
       "risk": "app-layer",
@@ -3060,7 +3060,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 245,
+      "line": 258,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -3071,7 +3071,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 251,
+      "line": 264,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -3082,7 +3082,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 279,
+      "line": 292,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
@@ -5306,47 +5306,50 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts",
-      "line": 133,
+      "line": 180,
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
-      "source": "(await db.query.user.findFirst({"
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "userId is reconciled against canonical subscription or webhook user identity before tenant-scoped writes",
+      "source": "const userRecord = await db.query.user.findFirst({"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts",
-      "line": 146,
+      "line": 198,
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-predicate",
+      "tenantPostureReason": "tenant-predicate: in-where-clause",
       "source": "(await db.query.subscriptions.findFirst({"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts",
-      "line": 212,
+      "line": 266,
       "callee": "db.update",
       "method": "update",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "tenantId from canonical user/subscription context constrains dunning update",
       "source": "await db .update(subscriptions)"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts",
-      "line": 220,
+      "line": 277,
       "callee": "db.insert",
       "method": "insert",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "tenantId from canonical user context is included in dunning insert values",
       "source": "await db.insert(subscriptions).values({"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/dunning.ts",
-      "line": 238,
+      "line": 297,
       "callee": "db.update",
       "method": "update",
       "risk": "domain-wrapper",
@@ -5357,53 +5360,57 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts",
-      "line": 137,
+      "line": 142,
       "callee": "db.insert",
       "method": "insert",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "tenantId from canonical Paddle subscription context is included in insert values",
       "source": "await db.insert(subscriptions).values(insertValues);"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts",
-      "line": 166,
-      "callee": "db.query",
-      "method": "query",
-      "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
-      "source": "(await db.query.subscriptions.findFirst({"
-    },
-    {
-      "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts",
-      "line": 174,
-      "callee": "db.update",
-      "method": "update",
-      "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
-      "source": "await db.update(subscriptions).set(values).where(eq(subscriptions.id, subscriptionId));"
-    },
-    {
-      "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts",
-      "line": 41,
-      "callee": "db.query",
-      "method": "query",
-      "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
-      "source": "const user = await db.query.user.findFirst({"
-    },
-    {
-      "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts",
-      "line": 66,
+      "line": 179,
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
       "tenantPosture": "tenant-scoped",
       "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId resolved into local variable before this DB call",
+      "tenantPostureDetail": "tenantId from canonical Paddle subscription context constrains fallback user lookup",
+      "source": "await db.query.subscriptions.findFirst({"
+    },
+    {
+      "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts",
+      "line": 192,
+      "callee": "db.update",
+      "method": "update",
+      "risk": "domain-wrapper",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "tenantId from canonical Paddle subscription context constrains subscription update",
+      "source": "await db .update(subscriptions)"
+    },
+    {
+      "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/transaction.ts",
+      "line": 99,
+      "callee": "db.query",
+      "method": "query",
+      "risk": "domain-wrapper",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "userId from verified Paddle event is reconciled before tenant-scoped audit writes",
+      "source": "const user = await db.query.user.findFirst({"
+    },
+    {
+      "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/context.ts",
+      "line": 83,
+      "callee": "db.query",
+      "method": "query",
+      "risk": "domain-wrapper",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "userId resolved from canonical subscription or verified user lookup boundary",
       "source": "const userRecord = await db.query.user.findFirst({"
     },
     {
@@ -5439,28 +5446,29 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts",
-      "line": 88,
+      "line": 98,
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
-      "source": "(await db.query.user.findFirst({"
+      "tenantPosture": "system-exempt",
+      "tenantPostureReason": "system-exempt: directive",
+      "tenantPostureDetail": "checkout reconciliation probes global email ownership before tenant-scoped user writes",
+      "source": "const userRecord = await db.query.user.findFirst({"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts",
-      "line": 119,
+      "line": 129,
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId resolved into local variable before this DB call",
+      "tenantPosture": "system-exempt",
+      "tenantPostureReason": "system-exempt: directive",
+      "tenantPostureDetail": "provider transaction lookup bootstraps checkout reconciliation before tenant context exists",
       "source": "const webhookEvent = await db.query.webhookEvents.findFirst({"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts",
-      "line": 169,
+      "line": 196,
       "callee": "db.transaction",
       "method": "transaction",
       "risk": "domain-wrapper",
@@ -5471,7 +5479,7 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts",
-      "line": 171,
+      "line": 198,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "domain-wrapper",
@@ -5482,17 +5490,18 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts",
-      "line": 214,
+      "line": 243,
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
-      "source": "? await db.query.account.findFirst({"
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "userId belongs to same-tenant checkout user before credential lookup",
+      "source": "const accountRecord = await db.query.account.findFirst({"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts",
-      "line": 229,
+      "line": 259,
       "callee": "db.transaction",
       "method": "transaction",
       "risk": "domain-wrapper",
@@ -5503,7 +5512,7 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts",
-      "line": 231,
+      "line": 261,
       "callee": "tx.update",
       "method": "update",
       "risk": "domain-wrapper",
@@ -5514,12 +5523,13 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/reconcile-checkout-user.ts",
-      "line": 261,
+      "line": 292,
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "tenantId from reconciled checkout context constrains final user reload",
       "source": "const finalUser = await db.query.user.findFirst({"
     },
     {
@@ -5557,27 +5567,29 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/persist.ts",
-      "line": 21,
+      "line": 22,
       "callee": "db.insert",
       "method": "insert",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "system-exempt",
+      "tenantPostureReason": "system-exempt: directive",
+      "tenantPostureDetail": "Paddle invalid-signature audit must persist before safe tenant resolution and allows tenantId null",
       "source": "await db .insert(webhookEvents)"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/persist.ts",
-      "line": 71,
+      "line": 73,
       "callee": "db.insert",
       "method": "insert",
       "risk": "domain-wrapper",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "system-exempt",
+      "tenantPostureReason": "system-exempt: directive",
+      "tenantPostureDetail": "Paddle webhook receipt audit preserves duplicate detection before handler-level tenant writes",
       "source": "const inserted = await db .insert(webhookEvents)"
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/persist.ts",
-      "line": 147,
+      "line": 149,
       "callee": "db.update",
       "method": "update",
       "risk": "domain-wrapper",
@@ -5588,7 +5600,7 @@
     },
     {
       "file": "packages/domain-membership-billing/src/paddle-webhooks/persist.ts",
-      "line": 188,
+      "line": 190,
       "callee": "db.update",
       "method": "update",
       "risk": "domain-wrapper",

--- a/scripts/ci/db-access-baseline.json
+++ b/scripts/ci/db-access-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-05-09T15:16:36.539Z",
+  "generatedAt": "2026-05-09T15:49:15.294Z",
   "policy": "see docs/dev/db-access-guard.md",
   "scanRoots": ["apps/web/src", "packages"],
   "approvedDatabaseInternalPatterns": [
@@ -27,10 +27,10 @@
     },
     "byTenantPosture": {
       "tenant-context": 5,
-      "tenant-scoped": 165,
+      "tenant-scoped": 162,
       "tenant-predicate": 353,
       "admin-privileged": 0,
-      "system-exempt": 25,
+      "system-exempt": 28,
       "unclassified": 67
     }
   },
@@ -5310,9 +5310,9 @@
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "userId is reconciled against canonical subscription or webhook user identity before tenant-scoped writes",
+      "tenantPosture": "system-exempt",
+      "tenantPostureReason": "system-exempt: directive",
+      "tenantPostureDetail": "Paddle userId lookup bootstraps dunning tenant context before tenant-scoped writes",
       "source": "const userRecord = await db.query.user.findFirst({"
     },
     {
@@ -5397,9 +5397,9 @@
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "userId from verified Paddle event is reconciled before tenant-scoped audit writes",
+      "tenantPosture": "system-exempt",
+      "tenantPostureReason": "system-exempt: directive",
+      "tenantPostureDetail": "Paddle userId lookup bootstraps transaction tenant context before tenant-scoped audit writes",
       "source": "const user = await db.query.user.findFirst({"
     },
     {
@@ -5408,9 +5408,9 @@
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "userId resolved from canonical subscription or verified user lookup boundary",
+      "tenantPosture": "system-exempt",
+      "tenantPostureReason": "system-exempt: directive",
+      "tenantPostureDetail": "Paddle userId lookup bootstraps tenant context before tenant-scoped subscription writes",
       "source": "const userRecord = await db.query.user.findFirst({"
     },
     {


### PR DESCRIPTION
## Summary
- Harden Paddle webhook tenant resolution to prefer canonical subscription/user state over provider `customData`.
- Fail closed on tenant/user conflicts before subscription, dunning, transaction audit, and checkout reconciliation writes.
- Update Paddle receipt/audit DB access posture and document the DG15 residual for the unchanged lead conversion block.

## Scope
- Package hardening under `packages/domain-membership-billing/src/paddle-webhooks/**`.
- Explicitly authorized route-core resolver update in `apps/web/src/app/api/webhooks/paddle/_core.ts` plus focused tests.
- DB access baseline and security posture receipts.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/app/api/webhooks/paddle/_core.test.ts`
- `pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/paddle-webhooks/handlers/utils/context.test.ts src/paddle-webhooks/handlers/subscriptions.test.ts src/paddle-webhooks/handlers/dunning.test.ts src/paddle-webhooks/handlers/transaction.test.ts src/paddle-webhooks/handlers/utils/reconcile-checkout-user.test.ts src/paddle-webhooks/persist.test.ts`
- `pnpm check:db-access`
- `pnpm security:guard`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates`

## Security Scan
Diff-scoped Codex Security scan completed with no diff-introduced reportable findings.
Report: `/tmp/codex-security-scans/interdomestik-crystal-home/f34d0b48_20260509T151923Z/report.md`

## DG15 Residual
The lead conversion block in `apps/web/src/app/api/webhooks/paddle/_core.ts` is intentionally unchanged and documented as a DG15 residual: null tenant fallback to `unknown`, unvalidated provider `customData.leadId`, and incomplete TODO-marked lead payment logic.
