### PR TITLE
P33-SEC11 Paddle lead conversion tenant guard hardening

### DIFF
--- a/apps/web/src/app/api/webhooks/paddle/_core.test.ts
+++ b/apps/web/src/app/api/webhooks/paddle/_core.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const hoisted = vi.hoisted(() => ({
   requestPasswordReset: vi.fn(),
   dbUserFindFirst: vi.fn(),
+  convertLeadToMember: vi.fn(),
+  hasTenantLeadForConversion: vi.fn(),
   findSubscriptionByProviderReference: vi.fn(),
   handlePaddleEvent: vi.fn(),
   insertWebhookEvent: vi.fn(),
@@ -49,6 +51,11 @@ vi.mock('@interdomestik/domain-membership-billing/paddle-webhooks', () => ({
   verifyPaddleWebhook: hoisted.verifyPaddleWebhook,
 }));
 
+vi.mock('@interdomestik/domain-leads', () => ({
+  convertLeadToMember: hoisted.convertLeadToMember,
+  hasTenantLeadForConversion: hoisted.hasTenantLeadForConversion,
+}));
+
 vi.mock('@/actions/thank-you-letter/send', () => ({
   sendThankYouLetterCore: vi.fn(),
 }));
@@ -66,6 +73,16 @@ import {
   handlePaddleWebhookCore,
   requestPasswordResetOnboarding,
 } from './_core';
+
+async function callPaddleWebhookCore() {
+  return handlePaddleWebhookCore({
+    paddle: {} as never,
+    headers: new Headers(),
+    signature: 'paddle-signature',
+    secret: 'paddle-secret',
+    bodyText: '{"event":"payload"}',
+  });
+}
 
 describe('paddle webhook onboarding helpers', () => {
   const mutableEnv = process.env as Record<string, string | undefined>;
@@ -156,16 +173,6 @@ describe('handlePaddleWebhookCore tenant resolution', () => {
     hoisted.markWebhookProcessed.mockResolvedValue(undefined);
   });
 
-  async function callCore() {
-    return handlePaddleWebhookCore({
-      paddle: {} as never,
-      headers: new Headers(),
-      signature: 'paddle-signature',
-      secret: 'paddle-secret',
-      bodyText: '{"event":"payload"}',
-    });
-  }
-
   it('prefers canonical subscription tenant over provider customData user fallback', async () => {
     hoisted.findSubscriptionByProviderReference.mockResolvedValue({
       id: 'sub_internal_1',
@@ -173,7 +180,7 @@ describe('handlePaddleWebhookCore tenant resolution', () => {
       userId: 'canonical_user',
     });
 
-    const result = await callCore();
+    const result = await callPaddleWebhookCore();
 
     expect(result).toEqual({ status: 200, body: { success: true } });
     expect(hoisted.findSubscriptionByProviderReference).toHaveBeenCalledWith('sub_provider_1');
@@ -189,7 +196,7 @@ describe('handlePaddleWebhookCore tenant resolution', () => {
   });
 
   it('falls back to customData user tenant only when subscription lookup cannot resolve tenant', async () => {
-    const result = await callCore();
+    const result = await callPaddleWebhookCore();
 
     expect(result).toEqual({ status: 200, body: { success: true } });
     expect(hoisted.findSubscriptionByProviderReference).toHaveBeenCalledWith('sub_provider_1');
@@ -202,5 +209,331 @@ describe('handlePaddleWebhookCore tenant resolution', () => {
       }),
       expect.any(Object)
     );
+  });
+
+  it('normalizes customData user fallback before resolving tenant', async () => {
+    hoisted.verifyPaddleWebhook.mockResolvedValue({
+      eventData: {
+        eventType: 'subscription.updated',
+        eventId: 'evt_verified',
+        data: {
+          id: 'sub_provider_1',
+          customData: {
+            userId: '  user_from_custom_data  ',
+          },
+        },
+      },
+      signatureValid: true,
+      signatureBypassed: false,
+    });
+
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.dbUserFindFirst).toHaveBeenCalledTimes(1);
+    const query = hoisted.dbUserFindFirst.mock.calls[0]?.[0] as {
+      where: (
+        users: { id: string },
+        ops: { eq: (left: string, right: string) => unknown }
+      ) => unknown;
+    };
+    const eq = vi.fn();
+    query.where({ id: 'users.id' }, { eq });
+    expect(eq).toHaveBeenCalledWith('users.id', 'user_from_custom_data');
+  });
+});
+
+describe('handlePaddleWebhookCore lead conversion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    hoisted.sha256Hex.mockReturnValue('payload_hash');
+    hoisted.parsePaddleWebhookBody.mockReturnValue({
+      parsedPayload: {
+        event_type: 'transaction.completed',
+        event_id: 'evt_payload',
+        data: {
+          id: 'txn_payload_1',
+          subscriptionId: 'sub_provider_1',
+          customData: { leadId: 'lead_payload_1' },
+        },
+      },
+      eventTypeFromPayload: 'transaction.completed',
+      eventIdFromPayload: 'evt_payload',
+      eventTimestampFromPayload: null,
+    });
+    hoisted.verifyPaddleWebhook.mockResolvedValue({
+      eventData: {
+        eventType: 'transaction.completed',
+        eventId: 'evt_verified',
+        data: {
+          id: 'txn_verified_1',
+          subscriptionId: 'sub_provider_1',
+          customData: { leadId: 'lead_1' },
+        },
+      },
+      signatureValid: true,
+      signatureBypassed: false,
+    });
+    hoisted.findSubscriptionByProviderReference.mockResolvedValue({
+      id: 'sub_internal_1',
+      tenantId: 'tenant_1',
+      userId: 'user_1',
+    });
+    hoisted.dbUserFindFirst.mockResolvedValue(null);
+    hoisted.insertWebhookEvent.mockResolvedValue({
+      inserted: true,
+      webhookEventRowId: 'webhook_event_1',
+    });
+    hoisted.persistInvoiceAndLedgerInvariants.mockResolvedValue(undefined);
+    hoisted.hasTenantLeadForConversion.mockResolvedValue(true);
+    hoisted.convertLeadToMember.mockResolvedValue({
+      userId: 'member_user_1',
+      createdSubscriptionId: 'membership_1',
+    });
+    hoisted.handlePaddleEvent.mockResolvedValue(undefined);
+    hoisted.markWebhookProcessed.mockResolvedValue(undefined);
+    hoisted.markWebhookFailed.mockResolvedValue(undefined);
+  });
+
+  it('converts a canonical tenant-scoped lead for transaction.completed', async () => {
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.hasTenantLeadForConversion).toHaveBeenCalledWith(
+      { tenantId: 'tenant_1' },
+      { leadId: 'lead_1' }
+    );
+    expect(hoisted.convertLeadToMember).toHaveBeenCalledWith(
+      { tenantId: 'tenant_1' },
+      { leadId: 'lead_1' }
+    );
+    expect(hoisted.handlePaddleEvent).toHaveBeenCalledTimes(1);
+    expect(hoisted.markWebhookProcessed).toHaveBeenCalledTimes(1);
+    expect(hoisted.markWebhookFailed).not.toHaveBeenCalled();
+  });
+
+  it('skips lead conversion when the webhook cannot resolve a canonical tenant', async () => {
+    hoisted.findSubscriptionByProviderReference.mockResolvedValue(null);
+    hoisted.dbUserFindFirst.mockResolvedValue(null);
+
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.insertWebhookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: null,
+        processingScopeKey: 'global',
+      }),
+      expect.any(Object)
+    );
+    expect(hoisted.convertLeadToMember).not.toHaveBeenCalled();
+    expect(hoisted.handlePaddleEvent).toHaveBeenCalledTimes(1);
+    expect(hoisted.markWebhookProcessed).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips lead conversion for missing, empty, or malformed provider lead IDs', async () => {
+    for (const leadId of [undefined, '', '   ', '../lead_1', 'lead 1']) {
+      vi.clearAllMocks();
+      hoisted.sha256Hex.mockReturnValue('payload_hash');
+      hoisted.parsePaddleWebhookBody.mockReturnValue({
+        parsedPayload: { data: {} },
+        eventTypeFromPayload: 'transaction.completed',
+        eventIdFromPayload: 'evt_payload',
+        eventTimestampFromPayload: null,
+      });
+      hoisted.verifyPaddleWebhook.mockResolvedValue({
+        eventData: {
+          eventType: 'transaction.completed',
+          eventId: 'evt_verified',
+          data: {
+            id: 'txn_verified_1',
+            subscriptionId: 'sub_provider_1',
+            customData: { leadId },
+          },
+        },
+        signatureValid: true,
+        signatureBypassed: false,
+      });
+      hoisted.findSubscriptionByProviderReference.mockResolvedValue({ tenantId: 'tenant_1' });
+      hoisted.insertWebhookEvent.mockResolvedValue({
+        inserted: true,
+        webhookEventRowId: 'webhook_event_1',
+      });
+      hoisted.persistInvoiceAndLedgerInvariants.mockResolvedValue(undefined);
+      hoisted.hasTenantLeadForConversion.mockResolvedValue(true);
+      hoisted.handlePaddleEvent.mockResolvedValue(undefined);
+      hoisted.markWebhookProcessed.mockResolvedValue(undefined);
+
+      const result = await callPaddleWebhookCore();
+
+      expect(result).toEqual({ status: 200, body: { success: true } });
+      expect(hoisted.hasTenantLeadForConversion).not.toHaveBeenCalled();
+      expect(hoisted.convertLeadToMember).not.toHaveBeenCalled();
+      expect(hoisted.handlePaddleEvent).toHaveBeenCalledTimes(1);
+      expect(hoisted.markWebhookProcessed).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('skips conversion when canonical lead ownership does not match the resolved tenant', async () => {
+    hoisted.hasTenantLeadForConversion.mockResolvedValueOnce(false);
+
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.hasTenantLeadForConversion).toHaveBeenCalledWith(
+      { tenantId: 'tenant_1' },
+      { leadId: 'lead_1' }
+    );
+    expect(hoisted.convertLeadToMember).not.toHaveBeenCalled();
+    expect(hoisted.handlePaddleEvent).toHaveBeenCalledTimes(1);
+    expect(hoisted.markWebhookProcessed).toHaveBeenCalledTimes(1);
+    expect(hoisted.markWebhookFailed).not.toHaveBeenCalled();
+  });
+
+  it('uses subscriptionId before transaction id for canonical tenant resolution', async () => {
+    hoisted.verifyPaddleWebhook.mockResolvedValue({
+      eventData: {
+        eventType: 'transaction.completed',
+        eventId: 'evt_verified',
+        data: {
+          id: 'txn_verified_1',
+          subscriptionId: 'sub_provider_1',
+          customData: { userId: 'canonical_user', leadId: 'lead_1' },
+        },
+      },
+      signatureValid: true,
+      signatureBypassed: false,
+    });
+    hoisted.findSubscriptionByProviderReference.mockImplementation(async reference =>
+      reference === 'sub_provider_1'
+        ? { id: 'sub_internal_1', tenantId: 'tenant_from_subscription', userId: 'canonical_user' }
+        : null
+    );
+    hoisted.hasTenantLeadForConversion.mockResolvedValueOnce(true);
+
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.findSubscriptionByProviderReference).toHaveBeenCalledWith('sub_provider_1');
+    expect(hoisted.findSubscriptionByProviderReference).not.toHaveBeenCalledWith('txn_verified_1');
+    expect(hoisted.dbUserFindFirst).not.toHaveBeenCalled();
+    expect(hoisted.convertLeadToMember).toHaveBeenCalledWith(
+      { tenantId: 'tenant_from_subscription' },
+      { leadId: 'lead_1' }
+    );
+  });
+
+  it('skips lead conversion when provider user metadata conflicts with canonical subscription', async () => {
+    hoisted.verifyPaddleWebhook.mockResolvedValue({
+      eventData: {
+        eventType: 'transaction.completed',
+        eventId: 'evt_verified',
+        data: {
+          id: 'txn_verified_1',
+          subscriptionId: 'sub_provider_1',
+          customData: { userId: 'user_bad', leadId: 'lead_1' },
+        },
+      },
+      signatureValid: true,
+      signatureBypassed: false,
+    });
+    hoisted.findSubscriptionByProviderReference.mockResolvedValue({
+      id: 'sub_internal_1',
+      tenantId: 'tenant_1',
+      userId: 'user_real',
+    });
+
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.hasTenantLeadForConversion).not.toHaveBeenCalled();
+    expect(hoisted.convertLeadToMember).not.toHaveBeenCalled();
+    expect(hoisted.handlePaddleEvent).toHaveBeenCalledTimes(1);
+    expect(hoisted.markWebhookProcessed).toHaveBeenCalledTimes(1);
+    expect(hoisted.markWebhookFailed).not.toHaveBeenCalled();
+  });
+
+  it('skips lead conversion when provider user metadata cannot be reconciled to subscription user', async () => {
+    hoisted.findSubscriptionByProviderReference.mockResolvedValue({
+      id: 'sub_internal_1',
+      tenantId: 'tenant_1',
+      userId: null,
+    });
+    hoisted.verifyPaddleWebhook.mockResolvedValue({
+      eventData: {
+        eventType: 'transaction.completed',
+        eventId: 'evt_verified',
+        data: {
+          id: 'txn_verified_1',
+          subscriptionId: 'sub_provider_1',
+          customData: { userId: 'user_unproven', leadId: 'lead_1' },
+        },
+      },
+      signatureValid: true,
+      signatureBypassed: false,
+    });
+
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.hasTenantLeadForConversion).not.toHaveBeenCalled();
+    expect(hoisted.convertLeadToMember).not.toHaveBeenCalled();
+    expect(hoisted.handlePaddleEvent).toHaveBeenCalledTimes(1);
+    expect(hoisted.markWebhookProcessed).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run lead conversion for duplicate webhook receipts', async () => {
+    hoisted.insertWebhookEvent.mockResolvedValue({
+      inserted: false,
+      webhookEventRowId: null,
+    });
+
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 200, body: { success: true, duplicate: true } });
+    expect(hoisted.convertLeadToMember).not.toHaveBeenCalled();
+    expect(hoisted.handlePaddleEvent).not.toHaveBeenCalled();
+    expect(hoisted.markWebhookProcessed).not.toHaveBeenCalled();
+  });
+
+  it('preserves invalid-signature persistence without lead conversion', async () => {
+    hoisted.verifyPaddleWebhook.mockRejectedValueOnce(new Error('Invalid signature'));
+    hoisted.persistInvalidSignatureAttempt.mockResolvedValueOnce({
+      inserted: true,
+      webhookEventRowId: 'webhook_event_invalid_1',
+    });
+
+    const result = await callPaddleWebhookCore();
+
+    expect(result).toEqual({ status: 401, body: { error: 'Invalid signature' } });
+    expect(hoisted.persistInvalidSignatureAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'transaction.completed',
+        eventId: 'evt_payload',
+        processingScopeKey: 'global',
+      }),
+      expect.any(Object)
+    );
+    expect(hoisted.convertLeadToMember).not.toHaveBeenCalled();
+    expect(hoisted.insertWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it('marks the webhook failed for unexpected conversion errors', async () => {
+    hoisted.convertLeadToMember.mockRejectedValueOnce(new Error('database unavailable'));
+
+    await expect(callPaddleWebhookCore()).rejects.toThrow('database unavailable');
+
+    expect(hoisted.markWebhookFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhookEventRowId: 'webhook_event_1',
+        eventType: 'transaction.completed',
+        eventId: 'evt_verified',
+        tenantId: 'tenant_1',
+      }),
+      expect.any(Object)
+    );
+    expect(hoisted.handlePaddleEvent).not.toHaveBeenCalled();
+    expect(hoisted.markWebhookProcessed).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/webhooks/paddle/_core.ts
+++ b/apps/web/src/app/api/webhooks/paddle/_core.ts
@@ -34,8 +34,8 @@ type PaddleWebhookData = {
   id?: string;
   subscriptionId?: string | null;
   subscription_id?: string | null;
-  customData?: { userId?: string };
-  custom_data?: { userId?: string };
+  customData?: { userId?: string; tenantId?: string; leadId?: unknown };
+  custom_data?: { userId?: string; tenantId?: string; leadId?: unknown };
 };
 
 type PaddleTransactionData = {
@@ -48,6 +48,106 @@ function normalizeText(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null;
   const normalized = value.trim();
   return normalized.length > 0 ? normalized : null;
+}
+
+const PADDLE_LEAD_ID_PATTERN = /^[A-Za-z0-9_:-]{1,128}$/;
+
+function normalizePaddleLeadId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  const leadId = normalizeText(value);
+  if (!leadId || !PADDLE_LEAD_ID_PATTERN.test(leadId)) return null;
+
+  return leadId;
+}
+
+function getPaddleLeadId(data: unknown): string | null {
+  return normalizePaddleLeadId(getPaddleCustomData(data)?.leadId);
+}
+
+function getPaddleCustomData(data: unknown): PaddleWebhookData['customData'] | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+
+  const payload = data as PaddleWebhookData;
+  return payload.custom_data ?? payload.customData;
+}
+
+function getPaddleSubscriptionReferences(data: unknown): string[] {
+  if (!data || typeof data !== 'object') return [];
+
+  const payload = data as PaddleWebhookData;
+  return [
+    normalizeText(payload.subscriptionId),
+    normalizeText(payload.subscription_id),
+    normalizeText(payload.id),
+  ].filter(
+    (value, index, values): value is string => Boolean(value) && values.indexOf(value) === index
+  );
+}
+
+type WebhookSubscription = NonNullable<
+  Awaited<ReturnType<typeof findSubscriptionByProviderReference>>
+>;
+
+async function resolveWebhookSubscription(data: unknown): Promise<WebhookSubscription | null> {
+  for (const subscriptionReference of getPaddleSubscriptionReferences(data)) {
+    const subscription = await findSubscriptionByProviderReference(subscriptionReference);
+    if (subscription?.tenantId) return subscription;
+  }
+
+  return null;
+}
+
+function hasLeadConversionProviderConflict(params: {
+  data: unknown;
+  tenantId: string;
+  subscription: WebhookSubscription | null;
+}): boolean {
+  const customData = getPaddleCustomData(params.data);
+  const providerUserId = normalizeText(customData?.userId);
+  const providerTenantId = normalizeText(customData?.tenantId);
+  const subscriptionTenantId = normalizeText(params.subscription?.tenantId);
+  const subscriptionUserId = normalizeText(params.subscription?.userId);
+
+  if (providerTenantId && providerTenantId !== params.tenantId) return true;
+  if (subscriptionTenantId && subscriptionTenantId !== params.tenantId) return true;
+  if (params.subscription && providerUserId && !subscriptionUserId) return true;
+  if (subscriptionUserId && providerUserId && subscriptionUserId !== providerUserId) return true;
+
+  return false;
+}
+
+async function reconcilePaddleLeadConversion(params: {
+  eventType: string | undefined;
+  data: unknown;
+  tenantId: string | null;
+  subscription: WebhookSubscription | null;
+}): Promise<void> {
+  if (params.eventType !== 'transaction.completed' || !params.tenantId) return;
+
+  const leadId = getPaddleLeadId(params.data);
+  if (!leadId) return;
+
+  if (
+    hasLeadConversionProviderConflict({
+      data: params.data,
+      tenantId: params.tenantId,
+      subscription: params.subscription,
+    })
+  ) {
+    return;
+  }
+
+  const { convertLeadToMember, hasTenantLeadForConversion } =
+    await import('@interdomestik/domain-leads');
+
+  const leadBelongsToTenant = await hasTenantLeadForConversion(
+    { tenantId: params.tenantId },
+    { leadId }
+  );
+  if (!leadBelongsToTenant) return;
+
+  await convertLeadToMember({ tenantId: params.tenantId }, { leadId });
 }
 
 function resolveProcessingScopeKey(params: {
@@ -110,17 +210,15 @@ export async function requestPasswordResetOnboarding(params: {
   });
 }
 
-async function resolveWebhookTenantId(data: unknown): Promise<string | null> {
-  const payload = (data ?? {}) as PaddleWebhookData;
-  const customData = payload.customData || payload.custom_data;
-  const subscriptionId = payload.id || payload.subscriptionId || payload.subscription_id;
+async function resolveWebhookTenantId(
+  data: unknown,
+  subscription: WebhookSubscription | null
+): Promise<string | null> {
+  const customData = getPaddleCustomData(data);
 
-  if (subscriptionId) {
-    const subscription = await findSubscriptionByProviderReference(subscriptionId);
-    if (subscription?.tenantId) return subscription.tenantId;
-  }
+  if (subscription?.tenantId) return subscription.tenantId;
 
-  const userId = customData?.userId;
+  const userId = normalizeText(customData?.userId);
   if (userId) {
     // db-access-guard: system-exempt -- reason: Paddle customData userId is a fallback only after canonical subscription lookup cannot resolve tenant
     const userRecord = await db.query.user.findFirst({
@@ -206,7 +304,8 @@ export async function handlePaddleWebhookCore(args: {
   const normalizedEventId = normalizeText(eventId);
   const data = (eventData as { data?: unknown }).data;
 
-  const tenantId = await resolveWebhookTenantId(data);
+  const subscription = await resolveWebhookSubscription(data);
+  const tenantId = await resolveWebhookTenantId(data, subscription);
   const processingScopeKey = resolveProcessingScopeKey({ tenantId, billingEntity });
   const dedupeKey = resolveScopedDedupeKey({
     processingScopeKey,
@@ -254,33 +353,7 @@ export async function handlePaddleWebhookCore(args: {
       { logAuditEvent }
     );
 
-    // Intercept transaction.completed for Lead Conversion
-    if (eventType === 'transaction.completed' && data) {
-      const payload = data as {
-        custom_data?: { leadId?: string };
-        customData?: { leadId?: string };
-      };
-      const customData = payload.custom_data || payload.customData;
-
-      if (customData?.leadId) {
-        const { convertLeadToMember } = await import('@interdomestik/domain-leads');
-        await convertLeadToMember(
-          { tenantId: tenantId || 'unknown' },
-          { leadId: customData.leadId }
-        );
-
-        // Also mark payment attempt as succeeded?
-        // convertLeadToMember handles lead status.
-        // We might want to update leadPaymentAttempts status separately if convert doesn't do it for card.
-        // Domain logic `convertLeadToMember` does: update memberLeads -> converted.
-        // It doesn't seem to touch `leadPaymentAttempts` status in my previous implementation?
-        // Let's assume for now convert checks membership creation.
-
-        // TODO: Ideally we update the specific payment attempt linked to this transaction?
-        // But valid point: createLeadAction -> startPayment -> creates attempt.
-        // If we have attempt ID in metadata, even better.
-      }
-    }
+    await reconcilePaddleLeadConversion({ eventType, data, tenantId, subscription });
 
     await handlePaddleEvent(
       { eventType, data },

--- a/docs/plans/2026-05-09-p33-sec11-paddle-lead-conversion-tenant-guard-hardening.md
+++ b/docs/plans/2026-05-09-p33-sec11-paddle-lead-conversion-tenant-guard-hardening.md
@@ -1,0 +1,82 @@
+---
+status: implementation
+date: 2026-05-09
+slice: P33-SEC11
+title: Paddle Lead Conversion Tenant Guard Hardening
+owner: platform + security + qa
+phase: Phase C
+---
+
+# P33-SEC11 Paddle Lead Conversion Tenant Guard Hardening
+
+## Summary
+
+P33-SEC11 implements the DG15-promoted Paddle `transaction.completed` lead conversion guard.
+The implementation keeps `apps/web/src/proxy.ts`, canonical routes, auth/session architecture,
+tenancy architecture, schema/migrations, Storage, Stripe, README, AGENTS, and architecture docs
+unchanged.
+
+## Implementation
+
+- The Paddle route no longer calls `convertLeadToMember` with `tenantId || 'unknown'`.
+- Lead conversion now skips before domain conversion when the webhook cannot resolve a canonical
+  tenant.
+- Provider `customData.leadId` is treated as untrusted metadata and must normalize to a non-empty
+  bounded identifier before use.
+- Transaction tenant resolution now checks explicit Paddle subscription references before the
+  transaction `id`, so `transaction.completed` events do not fall back to provider
+  `customData.userId` while a canonical `subscriptionId` is available.
+- Cross-tenant or missing leads are skipped by a domain-owned tenant-scoped lead ownership
+  preflight before `convertLeadToMember`.
+- Provider user or tenant metadata conflicts with canonical subscription context skip lead
+  conversion before any member, subscription, card, or lead write.
+- Unexpected domain conversion failures still mark the webhook failed and rethrow through the
+  existing webhook processing failure path.
+- Duplicate webhook receipts and invalid-signature persistence remain unchanged and do not attempt
+  lead conversion.
+- SEC10 tenant resolution precedence remains unchanged: canonical subscription state is checked
+  before provider `customData.userId` fallback.
+
+## Residual
+
+Paddle lead payment attempts still do not have a canonical provider transaction reference that can
+be safely reconciled from the current webhook payload without broadening schema or payment
+architecture. SEC11 therefore does not update lead payment attempt state from the route-level
+branch. A future slice should either add a canonical attempt-to-provider reference or explicitly
+accept this absence.
+
+## DB Access Posture Result
+
+`pnpm check:db-access` passes with `616` scanned entries and posture counts:
+
+| Tenant posture     | Count |
+| ------------------ | ----: |
+| `tenant-context`   |     5 |
+| `tenant-scoped`    |   163 |
+| `tenant-predicate` |   353 |
+| `admin-privileged` |     0 |
+| `system-exempt`    |    28 |
+| `unclassified`     |    67 |
+
+SEC11 adds one reviewed tenant-scoped helper in `packages/domain-leads/src/convert.ts` and does
+not change the remaining unclassified hard-case count.
+
+## Verification Plan
+
+- Focused app webhook route tests for safe conversion, null tenant skip, missing/empty/malformed
+  lead IDs, cross-tenant or missing lead skip, provider customData conflict skip, subscriptionId
+  precedence over transaction id, duplicate receipt behavior, invalid-signature behavior, and
+  unexpected conversion failure handling.
+- Focused domain-leads tests for the tenant-scoped lead ownership helper.
+- `pnpm check:db-access`.
+- `pnpm security:guard`.
+- `pnpm verify-slice -- --static`.
+- `pnpm verify-slice -- --required-gates`.
+- Mandatory implementation reviewer pool and diff-scoped Codex Security scan before required
+  gates.
+
+## Rollback
+
+Rollback is a normal revert of the route-level guard and focused tests. The failure mode after
+rollback would be a return to the pre-SEC11 synthetic tenant fallback and direct provider
+`customData.leadId` use in the Paddle lead conversion branch.

--- a/docs/security/db-access-posture-baseline.md
+++ b/docs/security/db-access-posture-baseline.md
@@ -11,15 +11,15 @@ last_reviewed: 2026-05-09
 > Status: Archived implementation receipt. The authoritative execution state remains in
 > `docs/plans/current-program.md` and `docs/plans/current-tracker.md`.
 
-Generated from `scripts/ci/db-access-baseline.json` on 2026-05-09 after P33-SEC10
-cleared the Paddle billing webhook/provider-event tenant-resolution cluster.
+Generated from `scripts/ci/db-access-baseline.json` on 2026-05-09 after P33-SEC11
+added the tenant-scoped Paddle lead conversion ownership helper.
 
 ## Summary
 
 | Metric                      |      Value |
 | --------------------------- | ---------: |
 | Baseline version            |          2 |
-| Baseline entries            |        615 |
+| Baseline entries            |        616 |
 | Guard runtime sample        |      1.00s |
 | Pre-SEC04 runtime reference |      0.69s |
 | Baseline JSON size          | 6390 lines |
@@ -28,13 +28,15 @@ SEC04B reduced the v2 classifier's unclassified entries from `262` to `80`, meet
 DG05 target without classifying the remaining hard cases. P33-SEC10 then reduced the
 canonical baseline from `80` to `67` by resolving every current unclassified Paddle
 webhook entry under `packages/domain-membership-billing/src/paddle-webhooks/**`.
+P33-SEC11 preserved the `67` unclassified count while adding one reviewed
+tenant-scoped helper in `packages/domain-leads/src/convert.ts`.
 
 ## Counts By Posture
 
 | Tenant posture     | Count |
 | ------------------ | ----: |
 | `tenant-context`   |     5 |
-| `tenant-scoped`    |   162 |
+| `tenant-scoped`    |   163 |
 | `tenant-predicate` |   353 |
 | `admin-privileged` |     0 |
 | `system-exempt`    |    28 |
@@ -45,7 +47,7 @@ webhook entry under `packages/domain-membership-billing/src/paddle-webhooks/**`.
 | Risk             | Count |
 | ---------------- | ----: |
 | `app-layer`      |   315 |
-| `domain-wrapper` |   300 |
+| `domain-wrapper` |   301 |
 
 ## Counts By Posture, Risk, And File Prefix
 
@@ -61,7 +63,7 @@ webhook entry under `packages/domain-membership-billing/src/paddle-webhooks/**`.
 |    19 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |    19 | `tenant-predicate` | `domain-wrapper` | `packages/domain-communications/src`     |
 |    14 | `tenant-predicate` | `domain-wrapper` | `packages/domain-analytics/src`          |
-|    14 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-leads/src`              |
+|    15 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-leads/src`              |
 |    13 | `system-exempt`    | `domain-wrapper` | `packages/domain-analytics/src`          |
 |    12 | `tenant-predicate` | `domain-wrapper` | `packages/domain-referrals/src`          |
 |     8 | `system-exempt`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
@@ -101,3 +103,7 @@ unclassified entries under the authorized Paddle webhook package path. All `13` 
 the remaining `1` unclassified `packages/domain-membership-billing/src` entry is
 `packages/domain-membership-billing/src/commissions/create.ts` and is outside the SEC10 billing
 webhook scope.
+
+P33-SEC11 note: the baseline now includes the tenant-scoped lead ownership preflight helper in
+`packages/domain-leads/src/convert.ts`. It adds one reviewed direct DB access entry and does not
+change the remaining `67` unclassified hard cases.

--- a/docs/security/db-access-posture-burndown.md
+++ b/docs/security/db-access-posture-burndown.md
@@ -14,6 +14,8 @@ last_reviewed: 2026-05-09
 SEC04B reduced the DB access posture baseline from `262` unclassified entries to `80`.
 Classification stopped when the `<= 80` target was reached. P33-SEC10 later reduced the
 baseline to `67` by resolving the current Paddle billing webhook/provider-event cluster.
+P33-SEC11 preserved the `67` unclassified count while adding one reviewed tenant-scoped
+lead ownership preflight helper for Paddle lead conversion.
 
 ## Burn-Down Summary
 
@@ -23,7 +25,7 @@ baseline to `67` by resolving the current Paddle billing webhook/provider-event 
 | SEC04B unclassified baseline    |    80 |
 | P33-SEC10 unclassified baseline |    67 |
 | Entries removed from scan       |     4 |
-| Reviewed `tenant-scoped` calls  |   162 |
+| Reviewed `tenant-scoped` calls  |   163 |
 | Reviewed `system-exempt` calls  |    28 |
 
 ## Classification Rules Used

--- a/packages/domain-leads/src/convert.test.ts
+++ b/packages/domain-leads/src/convert.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createQueuedFrom } from '../../../scripts/tests/queued-select-mock';
 
 const tableRefs = vi.hoisted(() => ({
-  memberLeads: { table: 'memberLeads', id: 'memberLeads.id' },
+  memberLeads: { table: 'memberLeads', id: 'memberLeads.id', tenantId: 'memberLeads.tenantId' },
   membershipCards: { table: 'membershipCards' },
   subscriptions: { table: 'subscriptions' },
   user: { table: 'user' },
@@ -58,7 +58,7 @@ vi.mock('nanoid', () => ({
   customAlphabet: vi.fn(() => () => 'REFCODE01'),
 }));
 
-import { convertLeadToMember } from './convert';
+import { convertLeadToMember, hasTenantLeadForConversion } from './convert';
 
 type InsertRecord = {
   table: unknown;
@@ -104,6 +104,50 @@ function createTransactionHarness() {
 
   return { conflictRecords, insertRecords, tx, updateCalls };
 }
+
+describe('hasTenantLeadForConversion', () => {
+  beforeEach(() => {
+    mocks.db.query.memberLeads.findFirst.mockReset();
+    mocks.db.transaction.mockReset();
+    mocks.eq.mockClear();
+    mocks.and.mockClear();
+  });
+
+  it('returns true when the lead belongs to the tenant', async () => {
+    mocks.db.query.memberLeads.findFirst.mockResolvedValue({ id: 'lead-1' });
+
+    const result = await hasTenantLeadForConversion({ tenantId: 'tenant-1' }, { leadId: 'lead-1' });
+
+    expect(result).toBe(true);
+    expect(mocks.db.query.memberLeads.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: { id: true },
+      })
+    );
+    const query = mocks.db.query.memberLeads.findFirst.mock.calls[0]?.[0] as {
+      where: (
+        lead: typeof tableRefs.memberLeads,
+        ops: { eq: typeof mocks.eq; and: typeof mocks.and }
+      ) => unknown;
+    };
+    query.where(tableRefs.memberLeads, { eq: mocks.eq, and: mocks.and });
+    expect(mocks.eq).toHaveBeenCalledWith(tableRefs.memberLeads.id, 'lead-1');
+    expect(mocks.eq).toHaveBeenCalledWith(tableRefs.memberLeads.tenantId, 'tenant-1');
+    expect(mocks.db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns false without writes when the lead is missing or belongs to another tenant', async () => {
+    mocks.db.query.memberLeads.findFirst.mockResolvedValue(null);
+
+    const result = await hasTenantLeadForConversion(
+      { tenantId: 'tenant-1' },
+      { leadId: 'lead-other' }
+    );
+
+    expect(result).toBe(false);
+    expect(mocks.db.transaction).not.toHaveBeenCalled();
+  });
+});
 
 describe('convertLeadToMember', () => {
   afterEach(() => {

--- a/packages/domain-leads/src/convert.ts
+++ b/packages/domain-leads/src/convert.ts
@@ -35,6 +35,19 @@ function resolveLeadConversionPlanId(planId?: string): string {
   return normalizedPlanId;
 }
 
+export async function hasTenantLeadForConversion(
+  ctx: { tenantId: string },
+  args: { leadId: string }
+): Promise<boolean> {
+  // db-access-guard: tenant-scoped -- reason: lead ownership is constrained by caller tenantId in the query predicate
+  const lead = await db.query.memberLeads.findFirst({
+    where: (l, { eq, and }) => and(eq(l.id, args.leadId), eq(l.tenantId, ctx.tenantId)),
+    columns: { id: true },
+  });
+
+  return Boolean(lead);
+}
+
 export async function convertLeadToMember(
   ctx: { tenantId: string },
   args: { leadId: string; planId?: string }

--- a/scripts/ci/db-access-baseline.json
+++ b/scripts/ci/db-access-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-05-09T15:49:15.294Z",
+  "generatedAt": "2026-05-09T18:13:42.922Z",
   "policy": "see docs/dev/db-access-guard.md",
   "scanRoots": ["apps/web/src", "packages"],
   "approvedDatabaseInternalPatterns": [
@@ -23,11 +23,11 @@
   "counts": {
     "byRisk": {
       "app-layer": 315,
-      "domain-wrapper": 300
+      "domain-wrapper": 301
     },
     "byTenantPosture": {
       "tenant-context": 5,
-      "tenant-scoped": 162,
+      "tenant-scoped": 163,
       "tenant-predicate": 353,
       "admin-privileged": 0,
       "system-exempt": 28,
@@ -1864,7 +1864,7 @@
     },
     {
       "file": "apps/web/src/app/api/webhooks/paddle/_core.ts",
-      "line": 126,
+      "line": 222,
       "callee": "db.query",
       "method": "query",
       "risk": "app-layer",
@@ -4930,7 +4930,18 @@
     },
     {
       "file": "packages/domain-leads/src/convert.ts",
-      "line": 45,
+      "line": 43,
+      "callee": "db.query",
+      "method": "query",
+      "risk": "domain-wrapper",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "lead ownership is constrained by caller tenantId in the query predicate",
+      "source": "const lead = await db.query.memberLeads.findFirst({"
+    },
+    {
+      "file": "packages/domain-leads/src/convert.ts",
+      "line": 58,
       "callee": "db.query",
       "method": "query",
       "risk": "domain-wrapper",
@@ -4940,7 +4951,7 @@
     },
     {
       "file": "packages/domain-leads/src/convert.ts",
-      "line": 65,
+      "line": 78,
       "callee": "db.transaction",
       "method": "transaction",
       "risk": "domain-wrapper",
@@ -4951,7 +4962,7 @@
     },
     {
       "file": "packages/domain-leads/src/convert.ts",
-      "line": 68,
+      "line": 81,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "domain-wrapper",
@@ -4962,7 +4973,7 @@
     },
     {
       "file": "packages/domain-leads/src/convert.ts",
-      "line": 90,
+      "line": 103,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "domain-wrapper",
@@ -4973,7 +4984,7 @@
     },
     {
       "file": "packages/domain-leads/src/convert.ts",
-      "line": 111,
+      "line": 124,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "domain-wrapper",
@@ -4984,7 +4995,7 @@
     },
     {
       "file": "packages/domain-leads/src/convert.ts",
-      "line": 124,
+      "line": 137,
       "callee": "tx.update",
       "method": "update",
       "risk": "domain-wrapper",


### PR DESCRIPTION
## Summary

Implements `P33-SEC11 Paddle Lead Conversion Tenant Guard Hardening` from DG15.

- removes the `tenantId || 'unknown'` Paddle lead conversion fallback
- validates provider `customData.leadId` before use
- resolves explicit Paddle subscription references before transaction IDs for `transaction.completed`
- skips lead conversion on null tenant, provider user/tenant conflicts, unreconciled provider user metadata, or non-owned leads
- adds a narrow domain-leads tenant-scoped ownership preflight before `convertLeadToMember`
- preserves duplicate webhook and invalid-signature persistence behavior
- updates DB access posture receipts for the new reviewed helper (`616` entries, `tenant-scoped=163`, `unclassified=67`)

## Verification

- `pnpm --filter @interdomestik/web test:unit --run src/app/api/webhooks/paddle/_core.test.ts` ✅ 15 tests
- `pnpm --filter @interdomestik/domain-leads test:unit --run src/convert.test.ts` ✅ 5 tests
- `pnpm check:db-access` ✅ 616 entries match baseline; `unclassified=67`
- `pnpm security:guard` ✅
- `pnpm verify-slice -- --static` ✅
- Diff-scoped Codex Security scan ✅ no reportable findings: `/tmp/codex-security-scans/interdomestik-crystal-home/working-tree-final-20260509T181956Z/report.md`
- `pnpm verify-slice -- --required-gates` ⚠️ blocked locally at `db:rls:test:required` because Docker daemon is not running, so local Supabase/Postgres on `127.0.0.1:54322` could not start. The failure was `connect ECONNREFUSED 127.0.0.1:54322`, followed by `Docker daemon is not running` from `./scripts/m4-gatekeeper.sh`.

## Reviewer Pool

Mandatory implementation reviewer pool completed after fixes:

- security/auth/tenancy: no remaining must-fix findings
- maintainability/code quality: no remaining must-fix findings
- tests/gates/edge cases: no remaining must-fix findings
- product/workflow/performance: no must-fix findings

## Residual

Lead payment attempts still lack a canonical provider transaction reference that can be safely reconciled from the webhook payload without schema/payment architecture expansion. SEC11 documents this as a future-slice residual and does not update lead payment attempt state from the route branch.
