### PR TITLE
fix: harden commercial idempotency tenant scope

### DIFF
--- a/apps/web/src/actions/claims/submit.core.ts
+++ b/apps/web/src/actions/claims/submit.core.ts
@@ -85,8 +85,11 @@ export async function submitClaimCore(params: {
 
   return runCommercialActionWithIdempotency({
     action: 'claims.submit',
-    actorUserId: session?.user?.id ?? null,
-    tenantId: session?.user?.tenantId ?? null,
+    scope: {
+      kind: 'tenant',
+      actorUserId: session?.user?.id ?? null,
+      tenantId: session?.user?.tenantId ?? null,
+    },
     idempotencyKey: params.idempotencyKey,
     requestFingerprint: params.data,
     execute: async () => {

--- a/apps/web/src/actions/claims/submit.test.ts
+++ b/apps/web/src/actions/claims/submit.test.ts
@@ -120,8 +120,11 @@ describe('actions/claims/submit', () => {
     expect(mockRunCommercialActionWithIdempotency).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'claims.submit',
-        actorUserId: 'user-1',
-        tenantId: 'tenant-1',
+        scope: {
+          kind: 'tenant',
+          actorUserId: 'user-1',
+          tenantId: 'tenant-1',
+        },
         idempotencyKey: 'claim-submit-1',
         requestFingerprint: validData,
       })

--- a/apps/web/src/actions/free-start/submit.core.ts
+++ b/apps/web/src/actions/free-start/submit.core.ts
@@ -32,6 +32,10 @@ export async function submitFreeStartIntakeCore(params: {
   try {
     return await runCommercialActionWithIdempotency({
       action: 'free-start.submit',
+      scope: {
+        kind: 'public',
+        reason: 'public-free-start-intake-no-tenant-mutation',
+      },
       idempotencyKey: params.idempotencyKey,
       requestFingerprint: params.data,
       execute: async () => {

--- a/apps/web/src/actions/free-start/submit.test.ts
+++ b/apps/web/src/actions/free-start/submit.test.ts
@@ -54,6 +54,10 @@ describe('actions/free-start submitFreeStartIntakeCore', () => {
     expect(mockRunCommercialActionWithIdempotency).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'free-start.submit',
+        scope: {
+          kind: 'public',
+          reason: 'public-free-start-intake-no-tenant-mutation',
+        },
         idempotencyKey: 'free-start-1',
         requestFingerprint: validInput,
       })

--- a/apps/web/src/actions/staff-claims/save-escalation-agreement.core.ts
+++ b/apps/web/src/actions/staff-claims/save-escalation-agreement.core.ts
@@ -26,10 +26,17 @@ export async function saveClaimEscalationAgreementCore(
     session: NonNullable<Session> | null;
   }
 ): Promise<ActionResult<ClaimEscalationAgreementSnapshot>> {
+  if (params.session?.user?.role !== 'staff' || !params.session.user.tenantId) {
+    return { success: false, error: 'Unauthorized' };
+  }
+
   const result = await runCommercialActionWithIdempotency({
     action: 'staff-claims.save-escalation-agreement',
-    actorUserId: params.session?.user?.id ?? null,
-    tenantId: params.session?.user?.tenantId ?? null,
+    scope: {
+      kind: 'tenant',
+      actorUserId: params.session?.user?.id ?? null,
+      tenantId: params.session?.user?.tenantId ?? null,
+    },
     idempotencyKey: params.idempotencyKey,
     requestFingerprint: {
       claimId: params.claimId,

--- a/apps/web/src/actions/staff-claims/save-escalation-agreement.test.ts
+++ b/apps/web/src/actions/staff-claims/save-escalation-agreement.test.ts
@@ -5,8 +5,15 @@ import { describe, expect, it, vi } from 'vitest';
 import { logAuditEvent } from '@/lib/audit';
 import { saveClaimEscalationAgreementCore } from './save-escalation-agreement.core';
 
+const mockRunCommercialActionWithIdempotency = vi.hoisted(() => vi.fn());
+
 vi.mock('@interdomestik/domain-claims/staff-claims/save-escalation-agreement', () => ({
   saveClaimEscalationAgreementCore: vi.fn(),
+}));
+
+vi.mock('@/lib/commercial-action-idempotency', () => ({
+  runCommercialActionWithIdempotency: (...args: unknown[]) =>
+    mockRunCommercialActionWithIdempotency(...args),
 }));
 
 const LOCALES = ['sq', 'en', 'sr', 'mk'] as const;
@@ -18,6 +25,7 @@ const REVALIDATED_LOCALE_PATHS = [
 describe('saveClaimEscalationAgreementCore', () => {
   it('revalidates locale-scoped staff claim paths after a successful save', async () => {
     vi.clearAllMocks();
+    mockRunCommercialActionWithIdempotency.mockImplementation(async ({ execute }) => execute());
     const requestHeaders = new Headers({ 'user-agent': 'Vitest escalation agreement' });
     const revalidatePathSpy = vi
       .spyOn(nextCache, 'revalidatePath')
@@ -44,6 +52,7 @@ describe('saveClaimEscalationAgreementCore', () => {
       decisionNextStatus: 'negotiation',
       decisionReason: 'Member accepted negotiation as the next recovery path.',
       feePercentage: 15,
+      idempotencyKey: 'agreement-1',
       legalActionCapPercentage: 25,
       minimumFee: 25,
       paymentAuthorizationState: 'authorized',
@@ -65,7 +74,39 @@ describe('saveClaimEscalationAgreementCore', () => {
       requestHeaders,
     });
     expect(domainDeps).toEqual({ logAuditEvent });
+    expect(mockRunCommercialActionWithIdempotency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'staff-claims.save-escalation-agreement',
+        scope: {
+          kind: 'tenant',
+          actorUserId: 'staff-1',
+          tenantId: 'tenant-1',
+        },
+        idempotencyKey: 'agreement-1',
+      })
+    );
     expect(revalidatePathSpy.mock.calls.map(([path]) => path)).toEqual(REVALIDATED_LOCALE_PATHS);
     expect(revalidatePathSpy).toHaveBeenCalledTimes(REVALIDATED_LOCALE_PATHS.length);
+  });
+
+  it('preserves Unauthorized for missing staff session before idempotency', async () => {
+    vi.clearAllMocks();
+
+    const result = await saveClaimEscalationAgreementCore({
+      claimId: 'claim-1',
+      decisionNextStatus: 'negotiation',
+      decisionReason: 'Member accepted negotiation as the next recovery path.',
+      feePercentage: 15,
+      idempotencyKey: 'agreement-unauthorized',
+      legalActionCapPercentage: 25,
+      minimumFee: 25,
+      paymentAuthorizationState: 'authorized',
+      requestHeaders: new Headers(),
+      session: null,
+      termsVersion: '2026-03-v1',
+    });
+
+    expect(result).toEqual({ success: false, error: 'Unauthorized' });
+    expect(mockRunCommercialActionWithIdempotency).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/actions/staff-claims/save-recovery-decision.core.ts
+++ b/apps/web/src/actions/staff-claims/save-recovery-decision.core.ts
@@ -23,6 +23,10 @@ export async function saveRecoveryDecisionCore(
     session: NonNullable<Session> | null;
   }
 ): Promise<ActionResult<RecoveryDecisionSnapshot>> {
+  if (params.session?.user?.role !== 'staff' || !params.session.user.tenantId) {
+    return { success: false, error: 'Unauthorized' };
+  }
+
   const requestFingerprint =
     params.decisionType === 'declined'
       ? {
@@ -39,8 +43,11 @@ export async function saveRecoveryDecisionCore(
 
   const result = await runCommercialActionWithIdempotency({
     action: 'staff-claims.save-recovery-decision',
-    actorUserId: params.session?.user?.id ?? null,
-    tenantId: params.session?.user?.tenantId ?? null,
+    scope: {
+      kind: 'tenant',
+      actorUserId: params.session?.user?.id ?? null,
+      tenantId: params.session?.user?.tenantId ?? null,
+    },
     idempotencyKey: params.idempotencyKey,
     requestFingerprint,
     execute: () =>

--- a/apps/web/src/actions/staff-claims/save-recovery-decision.test.ts
+++ b/apps/web/src/actions/staff-claims/save-recovery-decision.test.ts
@@ -79,8 +79,11 @@ describe('saveRecoveryDecisionCore', () => {
     expect(mockRunCommercialActionWithIdempotency).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'staff-claims.save-recovery-decision',
-        actorUserId: 'staff-1',
-        tenantId: 'tenant-1',
+        scope: {
+          kind: 'tenant',
+          actorUserId: 'staff-1',
+          tenantId: 'tenant-1',
+        },
         idempotencyKey: 'decision-1',
         requestFingerprint: {
           claimId: 'claim-1',
@@ -103,5 +106,19 @@ describe('saveRecoveryDecisionCore', () => {
     expect(domainDeps).toEqual({ logAuditEvent, notifyRecoveryDecision });
     expect(revalidatePathSpy.mock.calls.map(([path]) => path)).toEqual(REVALIDATED_LOCALE_PATHS);
     expect(revalidatePathSpy).toHaveBeenCalledTimes(REVALIDATED_LOCALE_PATHS.length);
+  });
+
+  it('preserves Unauthorized for missing staff session before idempotency', async () => {
+    const result = await saveRecoveryDecisionCore({
+      claimId: 'claim-1',
+      decisionType: 'accepted',
+      explanation: 'Evidence is sufficient for staff-led recovery.',
+      idempotencyKey: 'decision-unauthorized',
+      requestHeaders: new Headers(),
+      session: null,
+    });
+
+    expect(result).toEqual({ success: false, error: 'Unauthorized' });
+    expect(mockRunCommercialActionWithIdempotency).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/actions/subscription/cancel.core.ts
+++ b/apps/web/src/actions/subscription/cancel.core.ts
@@ -16,10 +16,17 @@ export async function cancelSubscriptionCore(
   },
   deps: SubscriptionDeps = {}
 ): Promise<CancelSubscriptionResult> {
+  if (!params.session?.user?.tenantId) {
+    return { error: 'Unauthorized', success: undefined };
+  }
+
   return runCommercialActionWithIdempotency({
     action: 'subscription.cancel',
-    actorUserId: params.session?.user?.id ?? null,
-    tenantId: params.session?.user?.tenantId ?? null,
+    scope: {
+      kind: 'tenant',
+      actorUserId: params.session?.user?.id ?? null,
+      tenantId: params.session?.user?.tenantId ?? null,
+    },
     idempotencyKey: params.idempotencyKey,
     requestFingerprint: {
       subscriptionId: params.subscriptionId,

--- a/apps/web/src/actions/subscription/cancel.test.ts
+++ b/apps/web/src/actions/subscription/cancel.test.ts
@@ -1,14 +1,55 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { cancelSubscriptionCore } from './cancel';
 
+const mockRunCommercialActionWithIdempotency = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/commercial-action-idempotency', () => ({
+  runCommercialActionWithIdempotency: (...args: unknown[]) =>
+    mockRunCommercialActionWithIdempotency(...args),
+}));
+
 describe('actions/subscription cancelSubscriptionCore', () => {
   it('returns Unauthorized when session is missing', async () => {
+    vi.clearAllMocks();
+
     const result = await cancelSubscriptionCore({
+      idempotencyKey: 'cancel-unauthorized',
       session: null,
       subscriptionId: 'sub_123',
     });
 
-    expect(result).toEqual({ error: 'Unauthorized' });
+    expect(result).toEqual({ error: 'Unauthorized', success: undefined });
+    expect(mockRunCommercialActionWithIdempotency).not.toHaveBeenCalled();
+  });
+
+  it('passes tenant and actor scope to subscription cancellation idempotency', async () => {
+    vi.clearAllMocks();
+    mockRunCommercialActionWithIdempotency.mockResolvedValueOnce({
+      success: true,
+      error: undefined,
+    });
+
+    const result = await cancelSubscriptionCore({
+      idempotencyKey: 'cancel-1',
+      session: {
+        user: { id: 'member-1', role: 'member', tenantId: 'tenant-1' },
+        session: { id: 'session-1' },
+      } as never,
+      subscriptionId: 'sub_123',
+    });
+
+    expect(result).toEqual({ success: true, error: undefined });
+    expect(mockRunCommercialActionWithIdempotency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'subscription.cancel',
+        scope: {
+          kind: 'tenant',
+          actorUserId: 'member-1',
+          tenantId: 'tenant-1',
+        },
+        idempotencyKey: 'cancel-1',
+      })
+    );
   });
 });

--- a/apps/web/src/lib/actions/business-membership-lead.test.ts
+++ b/apps/web/src/lib/actions/business-membership-lead.test.ts
@@ -97,8 +97,32 @@ describe('submitBusinessMembershipLeadCore', () => {
     expect(mockRunCommercialActionWithIdempotency).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'business-membership.submit',
+        scope: {
+          kind: 'tenant',
+          tenantId: 'tenant_ks',
+        },
         idempotencyKey: 'biz-1',
         requestFingerprint: validInput,
+      })
+    );
+  });
+
+  it('resolves tenant scope before creating an idempotency reservation', async () => {
+    await submitBusinessMembershipLeadCore({
+      idempotencyKey: 'biz-tenant-scope',
+      requestHeaders: new Headers(),
+      data: validInput,
+    });
+
+    expect(mockResolveTenantIdFromRequest.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRunCommercialActionWithIdempotency.mock.invocationCallOrder[0]
+    );
+    expect(mockRunCommercialActionWithIdempotency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: {
+          kind: 'tenant',
+          tenantId: 'tenant_ks',
+        },
       })
     );
   });

--- a/apps/web/src/lib/actions/business-membership-lead.ts
+++ b/apps/web/src/lib/actions/business-membership-lead.ts
@@ -79,8 +79,14 @@ export async function submitBusinessMembershipLeadCore(params: {
   data: SubmitBusinessMembershipLeadInput;
 }): Promise<SubmitBusinessMembershipLeadResult> {
   try {
+    const tenantId = await resolveTenantIdFromRequest();
+
     return await runCommercialActionWithIdempotency({
       action: 'business-membership.submit',
+      scope: {
+        kind: 'tenant',
+        tenantId,
+      },
       idempotencyKey: params.idempotencyKey,
       requestFingerprint: params.data,
       execute: async () => {
@@ -112,7 +118,6 @@ export async function submitBusinessMembershipLeadCore(params: {
           };
         }
 
-        const tenantId = await resolveTenantIdFromRequest();
         const owner = await resolveBusinessLeadOwner(tenantId);
 
         if (!owner) {

--- a/apps/web/src/lib/commercial-action-idempotency.test.ts
+++ b/apps/web/src/lib/commercial-action-idempotency.test.ts
@@ -14,6 +14,9 @@ const hoisted = vi.hoisted(() => ({
   updateWhere: vi.fn(),
   delete: vi.fn(),
   deleteWhere: vi.fn(),
+  and: vi.fn(),
+  eq: vi.fn(),
+  isNull: vi.fn(),
 }));
 
 vi.mock('@interdomestik/database', () => ({
@@ -30,12 +33,66 @@ vi.mock('@interdomestik/database', () => ({
     requestFingerprintHash: 'request_fingerprint_hash_col',
     status: 'status_col',
     responsePayload: 'response_payload_col',
+    tenantId: 'tenant_id_col',
+    actorUserId: 'actor_user_id_col',
   },
-  and: vi.fn(),
-  eq: vi.fn(),
+  and: hoisted.and,
+  eq: hoisted.eq,
+  isNull: hoisted.isNull,
 }));
 
 import { runCommercialActionWithIdempotency } from './commercial-action-idempotency';
+
+type CommercialActionParams = Parameters<typeof runCommercialActionWithIdempotency>[0];
+
+const DEFAULT_CLAIM_FINGERPRINT = { category: 'vehicle', title: 'Damaged bumper' };
+const DEFAULT_FREE_START_FINGERPRINT = { category: 'property' };
+
+function tenantScope(actorUserId = 'user-1', tenantId = 'tenant-1') {
+  return {
+    kind: 'tenant' as const,
+    actorUserId,
+    tenantId,
+  };
+}
+
+function publicFreeStartScope() {
+  return {
+    kind: 'public' as const,
+    reason: 'public-free-start-intake-no-tenant-mutation' as const,
+  };
+}
+
+function claimParams(overrides: Partial<CommercialActionParams> = {}): CommercialActionParams {
+  return {
+    action: 'claims.submit',
+    scope: tenantScope(),
+    idempotencyKey: 'claim-submit-1',
+    requestFingerprint: DEFAULT_CLAIM_FINGERPRINT,
+    execute: vi.fn().mockResolvedValue({ success: true }),
+    ...overrides,
+  };
+}
+
+function freeStartParams(overrides: Partial<CommercialActionParams> = {}): CommercialActionParams {
+  return {
+    action: 'free-start.submit',
+    scope: publicFreeStartScope(),
+    idempotencyKey: 'free-start-1',
+    requestFingerprint: DEFAULT_FREE_START_FINGERPRINT,
+    execute: vi.fn().mockResolvedValue({ success: true }),
+    ...overrides,
+  };
+}
+
+function expectTenantLookup(actorUserId = 'user-1') {
+  expect(hoisted.selectWhere).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      ['eq', 'tenant_id_col', 'tenant-1'],
+      ['eq', 'actor_user_id_col', actorUserId],
+    ])
+  );
+}
 
 describe('runCommercialActionWithIdempotency', () => {
   beforeEach(() => {
@@ -63,19 +120,16 @@ describe('runCommercialActionWithIdempotency', () => {
 
     hoisted.deleteWhere.mockResolvedValue(undefined);
     hoisted.delete.mockReturnValue({ where: hoisted.deleteWhere });
+
+    hoisted.and.mockImplementation((...args: unknown[]) => ['and', ...args]);
+    hoisted.eq.mockImplementation((...args: unknown[]) => ['eq', ...args]);
+    hoisted.isNull.mockImplementation((...args: unknown[]) => ['isNull', ...args]);
   });
 
   it('executes once and persists the successful result for a fresh key', async () => {
     const execute = vi.fn().mockResolvedValue({ success: true, claimId: 'claim-1' });
 
-    const result = await runCommercialActionWithIdempotency({
-      action: 'claims.submit',
-      actorUserId: 'user-1',
-      idempotencyKey: 'claim-submit-1',
-      requestFingerprint: { category: 'vehicle', title: 'Damaged bumper' },
-      tenantId: 'tenant-1',
-      execute,
-    });
+    const result = await runCommercialActionWithIdempotency(claimParams({ execute }));
 
     expect(result).toEqual({ success: true, claimId: 'claim-1' });
     expect(execute).toHaveBeenCalledTimes(1);
@@ -107,18 +161,16 @@ describe('runCommercialActionWithIdempotency', () => {
 
     const execute = vi.fn().mockResolvedValue({ success: true, claimId: 'claim-new' });
 
-    const result = await runCommercialActionWithIdempotency({
-      action: 'claims.submit',
-      actorUserId: 'user-1',
-      fingerprintHash: 'same-fingerprint',
-      idempotencyKey: 'claim-submit-1',
-      requestFingerprint: { category: 'vehicle', title: 'Damaged bumper' },
-      tenantId: 'tenant-1',
-      execute,
-    });
+    const result = await runCommercialActionWithIdempotency(
+      claimParams({
+        fingerprintHash: 'same-fingerprint',
+        execute,
+      })
+    );
 
     expect(result).toEqual({ success: true, claimId: 'claim-existing' });
     expect(execute).not.toHaveBeenCalled();
+    expectTenantLookup();
   });
 
   it('rejects a reused key when the payload fingerprint differs', async () => {
@@ -131,15 +183,13 @@ describe('runCommercialActionWithIdempotency', () => {
       },
     ]);
 
-    const result = await runCommercialActionWithIdempotency({
-      action: 'claims.submit',
-      actorUserId: 'user-1',
-      fingerprintHash: 'different-fingerprint',
-      idempotencyKey: 'claim-submit-1',
-      requestFingerprint: { category: 'vehicle', title: 'Different payload' },
-      tenantId: 'tenant-1',
-      execute: vi.fn(),
-    });
+    const result = await runCommercialActionWithIdempotency(
+      claimParams({
+        fingerprintHash: 'different-fingerprint',
+        requestFingerprint: { category: 'vehicle', title: 'Different payload' },
+        execute: vi.fn(),
+      })
+    );
 
     expect(result).toEqual({
       success: false,
@@ -151,18 +201,12 @@ describe('runCommercialActionWithIdempotency', () => {
   it('releases the reservation when execution throws so the caller can retry', async () => {
     const execute = vi.fn().mockRejectedValue(new Error('boom'));
 
-    await expect(
-      runCommercialActionWithIdempotency({
-        action: 'claims.submit',
-        actorUserId: 'user-1',
-        idempotencyKey: 'claim-submit-1',
-        requestFingerprint: { category: 'vehicle', title: 'Damaged bumper' },
-        tenantId: 'tenant-1',
-        execute,
-      })
-    ).rejects.toThrow('boom');
+    await expect(runCommercialActionWithIdempotency(claimParams({ execute }))).rejects.toThrow(
+      'boom'
+    );
 
     expect(hoisted.deleteWhere).toHaveBeenCalledTimes(1);
+    expect(hoisted.deleteWhere).toHaveBeenCalledWith(['eq', 'id_col', 'idem_1']);
   });
 
   it('releases the reservation when execution returns an explicit failure result', async () => {
@@ -170,20 +214,143 @@ describe('runCommercialActionWithIdempotency', () => {
       .fn()
       .mockResolvedValue({ success: false, error: 'Too many requests. Please wait a moment.' });
 
-    const result = await runCommercialActionWithIdempotency({
-      action: 'claims.submit',
-      actorUserId: 'user-1',
-      idempotencyKey: 'claim-submit-1',
-      requestFingerprint: { category: 'vehicle', title: 'Damaged bumper' },
-      tenantId: 'tenant-1',
-      execute,
-    });
+    const result = await runCommercialActionWithIdempotency(claimParams({ execute }));
 
     expect(result).toEqual({
       success: false,
       error: 'Too many requests. Please wait a moment.',
     });
     expect(hoisted.deleteWhere).toHaveBeenCalledTimes(1);
+    expect(hoisted.deleteWhere).toHaveBeenCalledWith(['eq', 'id_col', 'idem_1']);
     expect(hoisted.updateSet).not.toHaveBeenCalled();
+  });
+
+  it('fails closed before execution or reservation when tenant scope is missing', async () => {
+    const execute = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await runCommercialActionWithIdempotency(
+      claimParams({ scope: tenantScope('user-1', '   '), execute })
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Commercial action idempotency requires a tenant scope.',
+      code: 'IDEMPOTENCY_TENANT_SCOPE_REQUIRED',
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expect(hoisted.insert).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on same-key conflicts outside the resolved tenant scope', async () => {
+    hoisted.returning.mockResolvedValueOnce([]);
+    hoisted.selectLimit.mockResolvedValueOnce([]);
+
+    const execute = vi.fn().mockResolvedValue({ success: true, claimId: 'claim-new' });
+
+    const result = await runCommercialActionWithIdempotency(
+      claimParams({
+        fingerprintHash: 'same-fingerprint',
+        execute,
+      })
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Idempotency key is already reserved for a different scope.',
+      code: 'IDEMPOTENCY_SCOPE_CONFLICT',
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expectTenantLookup();
+  });
+
+  it('fails closed on same-tenant conflicts outside the resolved actor scope', async () => {
+    hoisted.returning.mockResolvedValueOnce([]);
+    hoisted.selectLimit.mockResolvedValueOnce([]);
+
+    const execute = vi.fn().mockResolvedValue({ success: true, claimId: 'claim-new' });
+
+    const result = await runCommercialActionWithIdempotency(
+      claimParams({
+        scope: tenantScope('user-2'),
+        fingerprintHash: 'same-fingerprint',
+        execute,
+      })
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Idempotency key is already reserved for a different scope.',
+      code: 'IDEMPOTENCY_SCOPE_CONFLICT',
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expectTenantLookup('user-2');
+  });
+
+  it('allows explicit public idempotency only for allowlisted public actions', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      data: { claimCategory: 'property' },
+    });
+
+    const result = await runCommercialActionWithIdempotency(freeStartParams({ execute }));
+
+    expect(result).toEqual({
+      success: true,
+      data: { claimCategory: 'property' },
+    });
+    expect(hoisted.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'free-start.submit',
+        actorUserId: null,
+        idempotencyKey: 'free-start-1',
+        tenantId: null,
+      })
+    );
+  });
+
+  it('uses public null-tenant scope before releasing an allowlisted cached response', async () => {
+    hoisted.returning.mockResolvedValueOnce([]);
+    hoisted.selectLimit.mockResolvedValueOnce([
+      {
+        requestFingerprintHash: 'same-fingerprint',
+        responsePayload: { success: true, data: { claimCategory: 'property' } },
+        status: 'completed',
+      },
+    ]);
+
+    const result = await runCommercialActionWithIdempotency(
+      freeStartParams({
+        fingerprintHash: 'same-fingerprint',
+        execute: vi.fn(),
+      })
+    );
+
+    expect(result).toEqual({ success: true, data: { claimCategory: 'property' } });
+    expect(hoisted.selectWhere).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        ['isNull', 'tenant_id_col'],
+        ['isNull', 'actor_user_id_col'],
+      ])
+    );
+  });
+
+  it('rejects public idempotency for non-allowlisted commercial actions', async () => {
+    const execute = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await runCommercialActionWithIdempotency(
+      claimParams({
+        scope: publicFreeStartScope(),
+        requestFingerprint: { category: 'vehicle' },
+        execute,
+      })
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Public idempotency is not allowed for this commercial action.',
+      code: 'PUBLIC_IDEMPOTENCY_NOT_ALLOWED',
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expect(hoisted.insert).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/commercial-action-idempotency.ts
+++ b/apps/web/src/lib/commercial-action-idempotency.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-import { and, commercialActionIdempotency, db, eq } from '@interdomestik/database';
+import { and, commercialActionIdempotency, db, eq, isNull } from '@interdomestik/database';
 
 import type { ActionError } from './safe-action';
 
@@ -13,10 +13,59 @@ type ExistingReservation = {
   status: string;
 };
 
+export type PublicCommercialActionIdempotencyReason = 'public-free-start-intake-no-tenant-mutation';
+
+const PUBLIC_IDEMPOTENCY_ALLOWLIST: Record<string, PublicCommercialActionIdempotencyReason> = {
+  'free-start.submit': 'public-free-start-intake-no-tenant-mutation',
+};
+
+export type CommercialActionIdempotencyScope =
+  | {
+      kind: 'tenant';
+      tenantId?: string | null;
+      actorUserId?: string | null;
+    }
+  | {
+      kind: 'public';
+      reason: PublicCommercialActionIdempotencyReason;
+    };
+
+type ResolvedCommercialActionIdempotencyScope =
+  | {
+      kind: 'tenant';
+      tenantId: string;
+      actorUserId: string | null;
+    }
+  | {
+      kind: 'public';
+    };
+
 function isExplicitFailureResult(result: StoredActionResult): result is StoredActionResult & {
   success: false;
 } {
   return 'success' in result && result.success === false;
+}
+
+function isActionError(
+  value: ResolvedCommercialActionIdempotencyScope | ActionError
+): value is ActionError {
+  return 'success' in value && value.success === false;
+}
+
+function buildScopePredicates(scope: ResolvedCommercialActionIdempotencyScope) {
+  if (scope.kind === 'tenant') {
+    return [
+      eq(commercialActionIdempotency.tenantId, scope.tenantId),
+      scope.actorUserId
+        ? eq(commercialActionIdempotency.actorUserId, scope.actorUserId)
+        : isNull(commercialActionIdempotency.actorUserId),
+    ];
+  }
+
+  return [
+    isNull(commercialActionIdempotency.tenantId),
+    isNull(commercialActionIdempotency.actorUserId),
+  ];
 }
 
 function stableSerialize(value: unknown): string {
@@ -43,8 +92,12 @@ function hashFingerprint(value: unknown): string {
 
 async function findExistingReservation(
   action: string,
-  idempotencyKey: string
+  idempotencyKey: string,
+  scope: ResolvedCommercialActionIdempotencyScope
 ): Promise<ExistingReservation | null> {
+  const scopePredicates = buildScopePredicates(scope);
+
+  // db-access-guard: tenant-scoped -- reason: explicit tenant/public idempotency and actor scope is included in the lookup before cached response release
   const [existing] = await db
     .select({
       id: commercialActionIdempotency.id,
@@ -56,7 +109,8 @@ async function findExistingReservation(
     .where(
       and(
         eq(commercialActionIdempotency.action, action),
-        eq(commercialActionIdempotency.idempotencyKey, idempotencyKey)
+        eq(commercialActionIdempotency.idempotencyKey, idempotencyKey),
+        ...scopePredicates
       )
     )
     .limit(1);
@@ -80,12 +134,59 @@ function buildInProgressError(): ActionError {
   };
 }
 
+function buildMissingTenantScopeError(): ActionError {
+  return {
+    success: false,
+    error: 'Commercial action idempotency requires a tenant scope.',
+    code: 'IDEMPOTENCY_TENANT_SCOPE_REQUIRED',
+  };
+}
+
+function buildScopeConflictError(): ActionError {
+  return {
+    success: false,
+    error: 'Idempotency key is already reserved for a different scope.',
+    code: 'IDEMPOTENCY_SCOPE_CONFLICT',
+  };
+}
+
+function buildPublicIdempotencyNotAllowedError(): ActionError {
+  return {
+    success: false,
+    error: 'Public idempotency is not allowed for this commercial action.',
+    code: 'PUBLIC_IDEMPOTENCY_NOT_ALLOWED',
+  };
+}
+
+function resolveIdempotencyScope(
+  action: string,
+  scope: CommercialActionIdempotencyScope
+): ResolvedCommercialActionIdempotencyScope | ActionError {
+  if (scope.kind === 'public') {
+    if (PUBLIC_IDEMPOTENCY_ALLOWLIST[action] !== scope.reason) {
+      return buildPublicIdempotencyNotAllowedError();
+    }
+
+    return { kind: 'public' };
+  }
+
+  const tenantId = scope.tenantId?.trim();
+  if (!tenantId) {
+    return buildMissingTenantScopeError();
+  }
+
+  return {
+    kind: 'tenant',
+    tenantId,
+    actorUserId: scope.actorUserId ?? null,
+  };
+}
+
 export async function runCommercialActionWithIdempotency<
   TResult extends StoredActionResult,
 >(params: {
   action: string;
-  actorUserId?: string | null;
-  tenantId?: string | null;
+  scope: CommercialActionIdempotencyScope;
   idempotencyKey?: string | null;
   requestFingerprint: unknown;
   fingerprintHash?: string;
@@ -95,14 +196,20 @@ export async function runCommercialActionWithIdempotency<
     return params.execute();
   }
 
+  const scope = resolveIdempotencyScope(params.action, params.scope);
+  if (isActionError(scope)) {
+    return scope;
+  }
+
   const requestFingerprintHash =
     params.fingerprintHash ?? hashFingerprint(params.requestFingerprint);
+  // db-access-guard: tenant-scoped -- reason: explicit tenant/public idempotency scope is resolved before reservation insert values
   const [inserted] = await db
     .insert(commercialActionIdempotency)
     .values({
       id: crypto.randomUUID(),
-      tenantId: params.tenantId ?? null,
-      actorUserId: params.actorUserId ?? null,
+      tenantId: scope.kind === 'tenant' ? scope.tenantId : null,
+      actorUserId: scope.kind === 'tenant' ? scope.actorUserId : null,
       action: params.action,
       idempotencyKey: params.idempotencyKey,
       requestFingerprintHash,
@@ -113,10 +220,10 @@ export async function runCommercialActionWithIdempotency<
     .returning({ id: commercialActionIdempotency.id });
 
   if (!inserted) {
-    const existing = await findExistingReservation(params.action, params.idempotencyKey);
+    const existing = await findExistingReservation(params.action, params.idempotencyKey, scope);
 
     if (!existing) {
-      return buildInProgressError();
+      return buildScopeConflictError();
     }
 
     if (existing.requestFingerprintHash !== requestFingerprintHash) {
@@ -134,12 +241,14 @@ export async function runCommercialActionWithIdempotency<
     const result = await params.execute();
 
     if (isExplicitFailureResult(result)) {
+      // db-access-guard: tenant-scoped -- reason: reservation id was created under the resolved tenant/public idempotency scope
       await db
         .delete(commercialActionIdempotency)
         .where(eq(commercialActionIdempotency.id, inserted.id));
       return result;
     }
 
+    // db-access-guard: tenant-scoped -- reason: reservation id was created under the resolved tenant/public idempotency scope
     await db
       .update(commercialActionIdempotency)
       .set({
@@ -151,6 +260,7 @@ export async function runCommercialActionWithIdempotency<
 
     return result;
   } catch (error) {
+    // db-access-guard: tenant-scoped -- reason: reservation id was created under the resolved tenant/public idempotency scope
     await db
       .delete(commercialActionIdempotency)
       .where(eq(commercialActionIdempotency.id, inserted.id));

--- a/docs/security/db-access-posture-baseline.md
+++ b/docs/security/db-access-posture-baseline.md
@@ -11,8 +11,8 @@ last_reviewed: 2026-05-09
 > Status: Archived implementation receipt. The authoritative execution state remains in
 > `docs/plans/current-program.md` and `docs/plans/current-tracker.md`.
 
-Generated from `scripts/ci/db-access-baseline.json` on 2026-05-09 after P33-SEC11
-added the tenant-scoped Paddle lead conversion ownership helper.
+Generated from `scripts/ci/db-access-baseline.json` on 2026-05-09 after P33-SEC12
+hardened commercial action idempotency tenant scope.
 
 ## Summary
 
@@ -22,7 +22,7 @@ added the tenant-scoped Paddle lead conversion ownership helper.
 | Baseline entries            |        616 |
 | Guard runtime sample        |      1.00s |
 | Pre-SEC04 runtime reference |      0.69s |
-| Baseline JSON size          | 6390 lines |
+| Baseline JSON size          | 6395 lines |
 
 SEC04B reduced the v2 classifier's unclassified entries from `262` to `80`, meeting the
 DG05 target without classifying the remaining hard cases. P33-SEC10 then reduced the
@@ -30,17 +30,19 @@ canonical baseline from `80` to `67` by resolving every current unclassified Pad
 webhook entry under `packages/domain-membership-billing/src/paddle-webhooks/**`.
 P33-SEC11 preserved the `67` unclassified count while adding one reviewed
 tenant-scoped helper in `packages/domain-leads/src/convert.ts`.
+P33-SEC12 then reduced the canonical baseline from `67` to `62` by resolving the
+five-entry commercial action idempotency helper cluster.
 
 ## Counts By Posture
 
 | Tenant posture     | Count |
 | ------------------ | ----: |
 | `tenant-context`   |     5 |
-| `tenant-scoped`    |   163 |
+| `tenant-scoped`    |   168 |
 | `tenant-predicate` |   353 |
 | `admin-privileged` |     0 |
 | `system-exempt`    |    28 |
-| `unclassified`     |    67 |
+| `unclassified`     |    62 |
 
 ## Counts By Risk
 
@@ -54,10 +56,10 @@ tenant-scoped helper in `packages/domain-leads/src/convert.ts`.
 | Count | Tenant posture     | Risk             | File prefix                              |
 | ----: | ------------------ | ---------------- | ---------------------------------------- |
 |   165 | `tenant-predicate` | `app-layer`      | `apps/web/src`                           |
-|    87 | `tenant-scoped`    | `app-layer`      | `apps/web/src`                           |
+|    92 | `tenant-scoped`    | `app-layer`      | `apps/web/src`                           |
 |    56 | `tenant-predicate` | `domain-wrapper` | `packages/domain-claims/src`             |
-|    52 | `unclassified`     | `app-layer`      | `apps/web/src`                           |
 |    48 | `tenant-predicate` | `domain-wrapper` | `packages/domain-users/src`              |
+|    47 | `unclassified`     | `app-layer`      | `apps/web/src`                           |
 |    27 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-claims/src`             |
 |    26 | `tenant-predicate` | `domain-wrapper` | `packages/domain-membership-billing/src` |
 |    19 | `tenant-scoped`    | `domain-wrapper` | `packages/domain-membership-billing/src` |
@@ -91,11 +93,11 @@ tenant-scoped helper in `packages/domain-leads/src/convert.ts`.
 
 ## Remaining Review Input
 
-The remaining `67` unclassified entries are intentionally left as hard cases. The largest
-clusters are commercial action idempotency, legacy agent dashboard reads, campaign execution,
-NPS/engagement cron residue, admin/branch cross-tenant lookups, and smaller one-off
-application/domain paths. Those entries should not be mass-stamped; they need either callsite
-migration, helper-level tenant proof, or a fresh design review.
+The remaining `62` unclassified entries are intentionally left as hard cases. The largest
+clusters are legacy agent dashboard reads, campaign execution, NPS/engagement cron residue,
+admin/branch cross-tenant lookups, and smaller one-off application/domain paths. Those entries
+should not be mass-stamped; they need either callsite migration, helper-level tenant proof, or a
+fresh design review.
 
 P33-SEC10 note: DG14 inventoried `14` billing webhook/provider-event entries, but the synced
 implementation baseline at `f34d0b48ba1b822facff5ee231b5f993f7070174` contained `13`
@@ -107,3 +109,8 @@ webhook scope.
 P33-SEC11 note: the baseline now includes the tenant-scoped lead ownership preflight helper in
 `packages/domain-leads/src/convert.ts`. It adds one reviewed direct DB access entry and does not
 change the remaining `67` unclassified hard cases.
+
+P33-SEC12 note: the commercial action idempotency helper in
+`apps/web/src/lib/commercial-action-idempotency.ts` now requires explicit tenant or allowlisted
+public scope before reservation access. Its five direct DB access entries are reviewed as
+tenant-scoped, reducing the remaining hard cases to `62`.

--- a/docs/security/db-access-posture-burndown.md
+++ b/docs/security/db-access-posture-burndown.md
@@ -16,6 +16,8 @@ Classification stopped when the `<= 80` target was reached. P33-SEC10 later redu
 baseline to `67` by resolving the current Paddle billing webhook/provider-event cluster.
 P33-SEC11 preserved the `67` unclassified count while adding one reviewed tenant-scoped
 lead ownership preflight helper for Paddle lead conversion.
+P33-SEC12 reduced the baseline to `62` by resolving the commercial action idempotency helper
+cluster with explicit tenant or allowlisted public scope.
 
 ## Burn-Down Summary
 
@@ -24,8 +26,9 @@ lead ownership preflight helper for Paddle lead conversion.
 | SEC04A unclassified baseline    |   262 |
 | SEC04B unclassified baseline    |    80 |
 | P33-SEC10 unclassified baseline |    67 |
+| P33-SEC12 unclassified baseline |    62 |
 | Entries removed from scan       |     4 |
-| Reviewed `tenant-scoped` calls  |   163 |
+| Reviewed `tenant-scoped` calls  |   168 |
 | Reviewed `system-exempt` calls  |    28 |
 
 ## Classification Rules Used
@@ -62,12 +65,11 @@ classified.
 
 ## Remaining Evidence Set
 
-The remaining `67` entries are intentionally not classified. They include clusters that need
+The remaining `62` entries are intentionally not classified. They include clusters that need
 migration or a narrower design decision:
 
 | Count | Cluster                                                                                           |
 | ----: | ------------------------------------------------------------------------------------------------- |
-|     5 | Commercial action idempotency records with optional tenant identity.                              |
 |     5 | Legacy agent dashboard reads without current tenant proof.                                        |
 |     7 | Campaign execution and communication paths that batch across users or campaigns.                  |
 |     8 | Cron and public NPS/engagement residue that needs per-tenant job modeling or narrower predicates. |
@@ -79,6 +81,7 @@ Those entries should not be mass-stamped. P33-SEC10 resolved all current unclass
 under `packages/domain-membership-billing/src/paddle-webhooks/**`. DG14 had inventoried `14`
 billing webhook/provider-event entries, but the synced implementation baseline contained `13`
 under that package path; the remaining membership-billing unclassified entry is the non-Paddle
-commission ownership probe listed above. The next action, if further burn-down is needed, is a
-targeted design review for commercial idempotency scoping, legacy agent dashboard ownership,
+commission ownership probe listed above. P33-SEC12 resolved the commercial idempotency cluster by
+requiring explicit tenant or allowlisted public scope before reservation access. The next action,
+if further burn-down is needed, is a targeted design review for legacy agent dashboard ownership,
 campaign/cron/public-token tenancy, or the remaining one-off paths.

--- a/scripts/ci/db-access-baseline.json
+++ b/scripts/ci/db-access-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-05-09T18:13:42.922Z",
+  "generatedAt": "2026-05-09T20:59:20.023Z",
   "policy": "see docs/dev/db-access-guard.md",
   "scanRoots": ["apps/web/src", "packages"],
   "approvedDatabaseInternalPatterns": [
@@ -27,11 +27,11 @@
     },
     "byTenantPosture": {
       "tenant-context": 5,
-      "tenant-scoped": 163,
+      "tenant-scoped": 168,
       "tenant-predicate": 353,
       "admin-privileged": 0,
       "system-exempt": 28,
-      "unclassified": 67
+      "unclassified": 62
     }
   },
   "entries": [
@@ -1864,7 +1864,7 @@
     },
     {
       "file": "apps/web/src/app/api/webhooks/paddle/_core.ts",
-      "line": 222,
+      "line": 224,
       "callee": "db.query",
       "method": "query",
       "risk": "app-layer",
@@ -3156,52 +3156,57 @@
     },
     {
       "file": "apps/web/src/lib/commercial-action-idempotency.ts",
-      "line": 48,
+      "line": 85,
       "callee": "db.select",
       "method": "select",
       "risk": "app-layer",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "explicit tenant/public idempotency scope is included in the lookup before cached response release",
       "source": "const [existing] = await db .select({"
     },
     {
       "file": "apps/web/src/lib/commercial-action-idempotency.ts",
-      "line": 100,
+      "line": 191,
       "callee": "db.insert",
       "method": "insert",
       "risk": "app-layer",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "explicit tenant/public idempotency scope is resolved before reservation insert values",
       "source": "const [inserted] = await db .insert(commercialActionIdempotency)"
     },
     {
       "file": "apps/web/src/lib/commercial-action-idempotency.ts",
-      "line": 137,
+      "line": 229,
       "callee": "db.delete",
       "method": "delete",
       "risk": "app-layer",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "reservation id was created under the resolved tenant/public idempotency scope",
       "source": "await db .delete(commercialActionIdempotency)"
     },
     {
       "file": "apps/web/src/lib/commercial-action-idempotency.ts",
-      "line": 143,
+      "line": 236,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "reservation id was created under the resolved tenant/public idempotency scope",
       "source": "await db .update(commercialActionIdempotency)"
     },
     {
       "file": "apps/web/src/lib/commercial-action-idempotency.ts",
-      "line": 154,
+      "line": 248,
       "callee": "db.delete",
       "method": "delete",
       "risk": "app-layer",
-      "tenantPosture": "unclassified",
-      "tenantPostureReason": "unclassified: no-recognized-context",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "reservation id was created under the resolved tenant/public idempotency scope",
       "source": "await db .delete(commercialActionIdempotency)"
     },
     {


### PR DESCRIPTION
## Summary
- Adds explicit tenant/public idempotency scope resolution before commercial action reservation writes or cached response release.
- Requires canonical non-empty tenant scope for tenant-bound commercial actions and fail-closed handling for cross-tenant/cross-actor same-key conflicts.
- Keeps public idempotency allowlisted for the free-start flow and refreshes DB access posture baseline docs/counts.
- Refactors the idempotency unit fixtures to clear the Sonar new-code duplication gate.

## Verification
- [x] MCP scope audit
- [x] `pnpm verify-slice -- --static`
- [x] Focused unit tests: `pnpm --filter @interdomestik/web test:unit --run src/lib/commercial-action-idempotency.test.ts src/actions/claims/submit.test.ts src/actions/free-start/submit.test.ts src/lib/actions/business-membership-lead.test.ts src/actions/staff-claims/save-recovery-decision.test.ts src/actions/staff-claims/save-escalation-agreement.test.ts src/actions/subscription/cancel.test.ts`
- [x] `pnpm check:db-access`
- [x] GitHub checks green on `c8df9dfb9a45503e74e2b44800e3af7e25e48a03`: CI static/unit/e2e-gate, PR E2E full gate, Pilot Gate, SonarCloud, Secret Scan, Security, Commitlint, Vercel
- [x] PR comments/reviews checked: no inline review threads, no Copilot comments, SonarCloud Quality Gate passed

## Notes
- Did not touch `apps/web/src/proxy.ts`, canonical routes, auth/session architecture, tenancy architecture, broad schema/migrations, Storage redesign, Stripe, README, AGENTS, or architecture docs.