### PR TITLE
fix: stabilize nightly upload signing

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -403,6 +403,7 @@ export default defineConfig({
           INTERDOMESTIK_AUTOMATED: '1',
           INTERDOMESTIK_LOCAL_E2E: '1',
           INTERDOMESTIK_E2E_DIAGNOSTICS: '1',
+          INTERDOMESTIK_E2E_FAKE_STORAGE_SIGNING: '1',
           PLAYWRIGHT: '1',
           BILLING_TEST_MODE: '1',
           NEXT_PUBLIC_BILLING_TEST_MODE: '1',

--- a/apps/web/src/lib/storage/service-role.test.ts
+++ b/apps/web/src/lib/storage/service-role.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const storageUpload = vi.fn();
 const storageDownload = vi.fn();
@@ -17,14 +17,34 @@ const createAdminClient = vi.fn(() => ({
     from: storageFrom,
   },
 }));
+const VALID_CLAIM_UPLOAD_TARGET = {
+  bucket: 'claim-evidence',
+  family: 'claims' as const,
+  path: 'pii/tenants/tenant-a/claims/user-1/unassigned/file.pdf',
+  tenantId: 'tenant-a',
+};
+const CROSS_TENANT_UPLOAD_TARGET = {
+  ...VALID_CLAIM_UPLOAD_TARGET,
+  path: 'pii/tenants/tenant-b/claims/claim-1/file.pdf',
+};
 
 vi.mock('@interdomestik/database', () => ({
   createAdminClient,
 }));
 
+function stubLocalE2EUploadSigningEnv() {
+  vi.stubEnv('INTERDOMESTIK_E2E_FAKE_STORAGE_SIGNING', '1');
+  vi.stubEnv('INTERDOMESTIK_LOCAL_E2E', '1');
+  vi.stubEnv('PLAYWRIGHT', '1');
+}
+
 describe('service-role storage boundary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('asserts tenant prefix before creating signed upload URLs', async () => {
@@ -41,6 +61,62 @@ describe('service-role storage boundary', () => {
 
     expect(createAdminClient).not.toHaveBeenCalled();
     expect(storageFrom).not.toHaveBeenCalled();
+  });
+
+  it('keeps tenant prefix assertion before deterministic E2E upload signing', async () => {
+    stubLocalE2EUploadSigningEnv();
+
+    const { createTenantSignedUploadUrl } = await import('./service-role');
+
+    await expect(createTenantSignedUploadUrl(CROSS_TENANT_UPLOAD_TARGET)).rejects.toThrow(
+      /tenant-a/
+    );
+
+    expect(createAdminClient).not.toHaveBeenCalled();
+    expect(storageFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns deterministic signed upload data only for local E2E storage signing', async () => {
+    stubLocalE2EUploadSigningEnv();
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SUPABASE_URL', '/configured-storage/');
+
+    const { createTenantSignedUploadUrl } = await import('./service-role');
+
+    const result = await createTenantSignedUploadUrl(VALID_CLAIM_UPLOAD_TARGET);
+
+    expect(result).toEqual({
+      data: expect.objectContaining({
+        path: VALID_CLAIM_UPLOAD_TARGET.path,
+        signedUrl: expect.stringContaining(
+          '/configured-storage/storage/v1/object/upload/sign/claim-evidence/pii/tenants/tenant-a/claims/user-1/unassigned/file.pdf'
+        ),
+        token: expect.any(String),
+      }),
+      error: null,
+    });
+    expect(createAdminClient).not.toHaveBeenCalled();
+    expect(storageFrom).not.toHaveBeenCalled();
+  });
+
+  it('uses Supabase upload signing when fake signing is not in local E2E mode', async () => {
+    vi.stubEnv('INTERDOMESTIK_E2E_FAKE_STORAGE_SIGNING', '1');
+    createSignedUploadUrl.mockResolvedValue({
+      data: { path: 'remote-path', signedUrl: 'https://signed.example/upload', token: 'token-1' },
+      error: null,
+    });
+    const { createTenantSignedUploadUrl } = await import('./service-role');
+
+    const result = await createTenantSignedUploadUrl(VALID_CLAIM_UPLOAD_TARGET);
+
+    expect(result).toEqual({
+      data: { path: 'remote-path', signedUrl: 'https://signed.example/upload', token: 'token-1' },
+      error: null,
+    });
+    expect(storageFrom).toHaveBeenCalledWith('claim-evidence');
+    expect(createSignedUploadUrl).toHaveBeenCalledWith(VALID_CLAIM_UPLOAD_TARGET.path, {
+      upsert: true,
+    });
   });
 
   it('passes valid signed download requests to Supabase with the default TTL', async () => {

--- a/apps/web/src/lib/storage/service-role.ts
+++ b/apps/web/src/lib/storage/service-role.ts
@@ -2,6 +2,8 @@ import 'server-only';
 
 import { createAdminClient } from '@interdomestik/database';
 
+import { isLocalE2ERuntime } from '@/lib/runtime-environment';
+
 import {
   type TenantStorageFamily,
   assertTenantStoragePath,
@@ -31,10 +33,47 @@ type UploadTarget = TenantStorageTarget & {
   upsert?: boolean;
 };
 
+function shouldUseDeterministicE2EUploadSigner(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.INTERDOMESTIK_E2E_FAKE_STORAGE_SIGNING === '1' && isLocalE2ERuntime(env);
+}
+
+function resolveDeterministicE2EStorageBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const configuredUrl = env.SUPABASE_URL?.trim() || env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  if (!configuredUrl) return '';
+
+  let end = configuredUrl.length;
+  while (end > 0 && configuredUrl[end - 1] === '/') {
+    end -= 1;
+  }
+  return configuredUrl.slice(0, end);
+}
+
+function createDeterministicE2EUploadSignature(args: TenantStorageTarget) {
+  const encodedPath = args.path
+    .split('/')
+    .map(segment => encodeURIComponent(segment))
+    .join('/');
+  const token = Buffer.from(`${args.bucket}:${args.path}`).toString('base64url');
+  const storageBaseUrl = resolveDeterministicE2EStorageBaseUrl();
+
+  return {
+    data: {
+      path: args.path,
+      signedUrl: `${storageBaseUrl}/storage/v1/object/upload/sign/${args.bucket}/${encodedPath}?token=${token}`,
+      token,
+    },
+    error: null,
+  };
+}
+
 export async function createTenantSignedUploadUrl(
   args: TenantStorageTarget & { upsert?: boolean }
 ) {
   assertTenantStoragePath(args);
+
+  if (shouldUseDeterministicE2EUploadSigner()) {
+    return createDeterministicE2EUploadSignature(args);
+  }
 
   return createAdminClient()
     .storage.from(args.bucket)


### PR DESCRIPTION
## Summary
- add a local-E2E-only deterministic signed upload signer for Playwright runs without Supabase Storage
- keep tenant storage path validation before any E2E fake signing
- enable the fake signer only through the Playwright local E2E server env

## Verification
- pnpm --filter @interdomestik/web test:unit --run src/lib/storage/service-role.test.ts
- pnpm --filter @interdomestik/web test:unit --run src/app/api/uploads/route.test.ts
- pnpm --filter @interdomestik/web exec eslint src/lib/storage/service-role.ts src/lib/storage/service-role.test.ts playwright.config.ts
- pnpm check:e2e-contracts
- pnpm security:guard
- E2E upload security slice: 14/14 passed for gate-ks-sq and gate-mk-mk