### PR TITLE
fix: make storage tenant helper bootstrap-safe

### DIFF
--- a/scripts/ci/storage-tenant-prefix-migration.test.mjs
+++ b/scripts/ci/storage-tenant-prefix-migration.test.mjs
@@ -19,9 +19,17 @@ test('SEC06 migration has a legacy-object preflight', () => {
 
 test('SEC06 migration derives tenant id through a security-definer helper', () => {
   assert.match(sql, /CREATE OR REPLACE FUNCTION private\.current_tenant_id\(\)/);
+  assert.match(sql, /LANGUAGE plpgsql/);
   assert.match(sql, /SECURITY DEFINER/);
-  assert.match(sql, /FROM public\."user" AS u/);
-  assert.match(sql, /u\.id = \(SELECT auth\.uid\(\)\)::text/);
+  assert.match(sql, /actor_id := \(SELECT auth\.uid\(\)\)::text/);
+  assert.match(sql, /to_regclass\('public\."user"'\) IS NULL/);
+  assert.match(sql, /RETURN NULL/);
+  assert.match(
+    sql,
+    /EXECUTE 'SELECT u\.tenant_id FROM public\."user" AS u WHERE u\.id = \$1 LIMIT 1'/
+  );
+  assert.match(sql, /USING actor_id/);
+  assert.match(sql, /RETURN tenant_id;\s+END;\s+\$\$;/);
 });
 
 test('SEC06 migration replaces legacy policies with tenant-prefix folder policies', () => {

--- a/supabase/migrations/00009_storage_tenant_prefix_backstop.sql
+++ b/supabase/migrations/00009_storage_tenant_prefix_backstop.sql
@@ -44,15 +44,27 @@ GRANT USAGE ON SCHEMA private TO authenticated;
 
 CREATE OR REPLACE FUNCTION private.current_tenant_id()
 RETURNS text
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
-  SELECT u.tenant_id
-    FROM public."user" AS u
-   WHERE u.id = (SELECT auth.uid())::text
-   LIMIT 1
+DECLARE
+  actor_id text;
+  tenant_id text;
+BEGIN
+  actor_id := (SELECT auth.uid())::text;
+
+  IF actor_id IS NULL OR to_regclass('public."user"') IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  EXECUTE 'SELECT u.tenant_id FROM public."user" AS u WHERE u.id = $1 LIMIT 1'
+    INTO tenant_id
+    USING actor_id;
+
+  RETURN tenant_id;
+END;
 $$;
 
 REVOKE ALL ON FUNCTION private.current_tenant_id() FROM PUBLIC;


### PR DESCRIPTION
## Summary
- make the Supabase storage tenant helper bootstrap-safe when public."user" is not present during local Supabase startup
- preserve fail-closed storage policies by returning NULL until the app user table exists

## Verification
- pnpm --filter @interdomestik/database test:rls
- pnpm security:guard
- pnpm e2e:gate (120 passed, 4 skipped)

Fixes post-merge main CI e2e-gate failure on supabase start: relation public.user does not exist.