### PR TITLE
P36-CRM-DM06 CRM Lead Detail Read-Side Domain Port

### DIFF
--- a/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts
@@ -1,124 +1,80 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
-  findLeadFirst: vi.fn(),
-  dbSelect: vi.fn(),
-}));
-
-vi.mock('@interdomestik/database/db', () => ({
-  db: {
-    query: {
-      crmLeads: {
-        findFirst: hoisted.findLeadFirst,
-      },
-    },
-    select: hoisted.dbSelect,
+  getAgentCrmLeadDetail: vi.fn(),
+  crmLeadDetailRepository: {
+    findAgentLead: vi.fn(),
+    listAgentLeadDeals: vi.fn(),
   },
 }));
 
-vi.mock('@interdomestik/database/tenant-security', () => ({
-  withTenant: vi.fn((tenantId: unknown, col: unknown, conds?: unknown) => ({
-    withTenant: [tenantId, col, conds],
-  })),
+vi.mock('@interdomestik/domain-crm/lead-details', () => ({
+  getAgentCrmLeadDetail: hoisted.getAgentCrmLeadDetail,
 }));
 
-vi.mock('drizzle-orm', () => ({
-  and: vi.fn((...args: unknown[]) => ({ and: args })),
-  eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
+vi.mock('@/lib/domain-crm/lead-detail-repository', () => ({
+  crmLeadDetailRepository: hoisted.crmLeadDetailRepository,
 }));
 
-vi.mock('@interdomestik/database/schema', () => ({
-  crmLeads: {
-    id: 'crmLeads.id',
-    tenantId: 'crmLeads.tenantId',
-    agentId: 'crmLeads.agentId',
-  },
-  crmDeals: {
-    tenantId: 'crmDeals.tenantId',
-    leadId: 'crmDeals.leadId',
-    agentId: 'crmDeals.agentId',
-    $inferSelect: {} as unknown,
-  },
-}));
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
 
-import { getAgentLeadDetailsCore } from './_core';
+import { AgentLeadDetailsAccessDeniedError, getAgentLeadDetailsCore } from './_core';
+
+const actor: CrmActorContext = {
+  actorId: 'agent-1',
+  role: 'agent',
+  scope: { agentId: 'agent-1', branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
 
 describe('getAgentLeadDetailsCore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.getAgentCrmLeadDetail.mockResolvedValue({
+      success: true,
+      lead: { id: 'lead-1', agentId: 'agent-1', branchId: 'branch-1', tenantId: 'tenant-1' },
+      deals: [{ id: 'deal-1', agentId: 'agent-1', leadId: 'lead-1', tenantId: 'tenant-1' }],
+    });
   });
 
-  it('returns not_found when lead missing', async () => {
-    hoisted.findLeadFirst.mockResolvedValueOnce(null);
+  it('delegates lead detail reads to the domain CRM lead-detail API with actor context', async () => {
+    const result = await getAgentLeadDetailsCore({ actor, leadId: 'lead-1' });
 
-    const result = await getAgentLeadDetailsCore({
-      leadId: 'l1',
-      tenantId: 'tenant-1',
-      viewerAgentId: 'a1',
+    expect(result).toEqual({
+      kind: 'ok',
+      lead: { id: 'lead-1', agentId: 'agent-1', branchId: 'branch-1', tenantId: 'tenant-1' },
+      deals: [{ id: 'deal-1', agentId: 'agent-1', leadId: 'lead-1', tenantId: 'tenant-1' }],
     });
+    expect(hoisted.getAgentCrmLeadDetail).toHaveBeenCalledWith(
+      { actor, leadId: 'lead-1' },
+      hoisted.crmLeadDetailRepository
+    );
+  });
+
+  it('maps absent scoped leads to not_found', async () => {
+    hoisted.getAgentCrmLeadDetail.mockResolvedValueOnce({ success: false, error: 'not_found' });
+
+    const result = await getAgentLeadDetailsCore({ actor, leadId: 'lead-1' });
+
     expect(result).toEqual({ kind: 'not_found' });
   });
 
-  it('returns not_found when no lead matches the tenant and viewer agent scope', async () => {
-    hoisted.findLeadFirst.mockResolvedValueOnce(null);
-
-    const result = await getAgentLeadDetailsCore({
-      leadId: 'l1',
-      tenantId: 'tenant-1',
-      viewerAgentId: 'a1',
-    });
-    expect(result).toEqual({ kind: 'not_found' });
-    expect(hoisted.dbSelect).not.toHaveBeenCalled();
-  });
-
-  it('returns ok when agent owns lead', async () => {
-    hoisted.findLeadFirst.mockResolvedValueOnce({ id: 'l1', agentId: 'a1' });
-    hoisted.dbSelect.mockReturnValueOnce({
-      from: () => ({
-        where: async () => [],
-      }),
+  it('raises a typed access-denied error when the domain CRM lead-detail read is forbidden', async () => {
+    hoisted.getAgentCrmLeadDetail.mockResolvedValueOnce({
+      success: false,
+      error: 'forbidden',
+      reason: 'branch_scope',
     });
 
-    const result = await getAgentLeadDetailsCore({
-      leadId: 'l1',
-      tenantId: 'tenant-1',
-      viewerAgentId: 'a1',
-    });
-    expect(result.kind).toBe('ok');
-    if (result.kind === 'ok') {
-      expect(result.lead).toEqual({ id: 'l1', agentId: 'a1' });
-      expect(result.deals).toEqual([]);
+    try {
+      await getAgentLeadDetailsCore({ actor, leadId: 'lead-1' });
+      throw new Error('Expected getAgentLeadDetailsCore to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentLeadDetailsAccessDeniedError);
+      expect(error).toMatchObject({
+        name: 'AgentLeadDetailsAccessDeniedError',
+        reason: 'branch_scope',
+      });
     }
-  });
-
-  it('filters lead and deal reads by tenant and viewer agent', async () => {
-    hoisted.findLeadFirst.mockResolvedValueOnce({ id: 'l1', agentId: 'a1' });
-    const where = vi.fn().mockResolvedValue([]);
-    hoisted.dbSelect.mockReturnValueOnce({
-      from: vi.fn(() => ({ where })),
-    });
-
-    await getAgentLeadDetailsCore({
-      leadId: 'l1',
-      tenantId: 'tenant-1',
-      viewerAgentId: 'a1',
-    });
-
-    expect(hoisted.findLeadFirst).toHaveBeenCalledWith({
-      where: {
-        withTenant: [
-          'tenant-1',
-          'crmLeads.tenantId',
-          { and: [{ eq: ['crmLeads.id', 'l1'] }, { eq: ['crmLeads.agentId', 'a1'] }] },
-        ],
-      },
-    });
-    expect(where).toHaveBeenCalledWith({
-      withTenant: [
-        'tenant-1',
-        'crmDeals.tenantId',
-        { and: [{ eq: ['crmDeals.leadId', 'l1'] }, { eq: ['crmDeals.agentId', 'a1'] }] },
-      ],
-    });
   });
 });

--- a/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.ts
+++ b/apps/web/src/app/[locale]/(agent)/agent/leads/[id]/_core.ts
@@ -1,41 +1,46 @@
-import { db } from '@interdomestik/database/db';
-import { crmDeals, crmLeads } from '@interdomestik/database/schema';
-import { withTenant } from '@interdomestik/database/tenant-security';
-import { and, eq } from 'drizzle-orm';
+import {
+  getAgentCrmLeadDetail,
+  type AgentCrmLeadDetailAuthorizationDenialReason,
+} from '@interdomestik/domain-crm/lead-details';
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
 
-export type AgentLeadDetails = Awaited<ReturnType<typeof db.query.crmLeads.findFirst>>;
+import {
+  crmLeadDetailRepository,
+  type AgentCrmLeadDetailDealRow,
+  type AgentCrmLeadDetailLeadRow,
+} from '@/lib/domain-crm/lead-detail-repository';
 
-export type AgentLeadDealRow = typeof crmDeals.$inferSelect;
+export type AgentLeadDetails = AgentCrmLeadDetailLeadRow | null;
+
+export type AgentLeadDealRow = AgentCrmLeadDetailDealRow;
 
 export type AgentLeadDetailsResult =
   | { kind: 'ok'; lead: NonNullable<AgentLeadDetails>; deals: AgentLeadDealRow[] }
   | { kind: 'not_found' };
 
+export class AgentLeadDetailsAccessDeniedError extends Error {
+  constructor(readonly reason: AgentCrmLeadDetailAuthorizationDenialReason) {
+    super(`CRM lead detail read denied: ${reason}`);
+    this.name = 'AgentLeadDetailsAccessDeniedError';
+  }
+}
+
 export async function getAgentLeadDetailsCore(args: {
+  actor: CrmActorContext;
   leadId: string;
-  tenantId: string;
-  viewerAgentId: string;
 }): Promise<AgentLeadDetailsResult> {
-  const lead = await db.query.crmLeads.findFirst({
-    where: withTenant(
-      args.tenantId,
-      crmLeads.tenantId,
-      and(eq(crmLeads.id, args.leadId), eq(crmLeads.agentId, args.viewerAgentId))
-    ),
-  });
+  const result = await getAgentCrmLeadDetail(
+    { actor: args.actor, leadId: args.leadId },
+    crmLeadDetailRepository
+  );
 
-  if (!lead) return { kind: 'not_found' };
+  if (result.success) {
+    return { kind: 'ok', lead: result.lead, deals: result.deals };
+  }
 
-  const deals = await db
-    .select()
-    .from(crmDeals)
-    .where(
-      withTenant(
-        args.tenantId,
-        crmDeals.tenantId,
-        and(eq(crmDeals.leadId, args.leadId), eq(crmDeals.agentId, args.viewerAgentId))
-      )
-    );
+  if (result.error === 'not_found') {
+    return { kind: 'not_found' };
+  }
 
-  return { kind: 'ok', lead, deals };
+  throw new AgentLeadDetailsAccessDeniedError(result.reason);
 }

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
@@ -3,6 +3,12 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
+  AgentLeadDetailsAccessDeniedError: class AgentLeadDetailsAccessDeniedError extends Error {
+    constructor(readonly reason: string) {
+      super(`CRM lead detail read denied: ${reason}`);
+      this.name = 'AgentLeadDetailsAccessDeniedError';
+    }
+  },
   headersMock: vi.fn(async () => new Headers()),
   redirectMock: vi.fn((params: { href: string; locale: string }) => {
     throw new Error(`redirect:${params.href}:${params.locale}`);
@@ -53,6 +59,7 @@ vi.mock('@/actions/agent-crm-follow-up', () => ({
 }));
 
 vi.mock('@/app/[locale]/(agent)/agent/leads/[id]/_core', () => ({
+  AgentLeadDetailsAccessDeniedError: hoisted.AgentLeadDetailsAccessDeniedError,
   getAgentLeadDetailsCore: hoisted.getAgentLeadDetailsCoreMock,
 }));
 
@@ -102,7 +109,7 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.getSessionMock.mockResolvedValue({
-      user: { id: 'agent-1', tenantId: 'tenant-1' },
+      user: { branchId: 'branch-1', id: 'agent-1', role: 'agent', tenantId: 'tenant-1' },
     });
     hoisted.getTranslationsMock.mockImplementation(
       async (namespace = 'agent.leads_page') =>
@@ -163,7 +170,9 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
   });
 
   it('rejects a session with missing tenant identity before loading lead details', async () => {
-    const session = { user: { id: 'agent-1', tenantId: null } };
+    const session = {
+      user: { branchId: 'branch-1', id: 'agent-1', role: 'agent', tenantId: null },
+    };
     hoisted.getSessionMock.mockResolvedValue(session);
     hoisted.ensureTenantIdMock.mockImplementationOnce(() => {
       throw new Error('Session missing tenantId. Data integrity issue.');
@@ -178,22 +187,53 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
     expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
   });
 
-  it('passes tenant identity into the lead detail core before loading activities', async () => {
+  it('passes actor context into the lead detail core before loading activities', async () => {
     await AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' });
 
     expect(hoisted.setRequestLocaleMock).toHaveBeenCalledWith('en');
     expect(hoisted.getAgentLeadDetailsCoreMock).toHaveBeenCalledWith({
+      actor: {
+        actorId: 'agent-1',
+        role: 'agent',
+        scope: { agentId: 'agent-1', branchId: 'branch-1' },
+        tenantId: 'tenant-1',
+      },
       leadId: 'lead-1',
-      tenantId: 'tenant-1',
-      viewerAgentId: 'agent-1',
     });
     expect(hoisted.getLeadActivitiesMock).toHaveBeenCalledWith('lead-1');
+  });
+
+  it('rejects a non-agent or branchless session before loading lead details', async () => {
+    hoisted.getSessionMock.mockResolvedValueOnce({
+      user: { branchId: null, id: 'agent-1', role: 'agent', tenantId: 'tenant-1' },
+    });
+
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' })).rejects.toThrow(
+      'not-found'
+    );
+
+    expect(hoisted.notFoundMock).toHaveBeenCalled();
+    expect(hoisted.getAgentLeadDetailsCoreMock).not.toHaveBeenCalled();
+    expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
   });
 
   it('does not load activities when the lead detail core returns not_found', async () => {
     hoisted.getAgentLeadDetailsCoreMock.mockResolvedValueOnce({
       kind: 'not_found',
     });
+
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' })).rejects.toThrow(
+      'not-found'
+    );
+
+    expect(hoisted.notFoundMock).toHaveBeenCalled();
+    expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('does not load activities when the lead detail core denies access', async () => {
+    hoisted.getAgentLeadDetailsCoreMock.mockRejectedValueOnce(
+      new hoisted.AgentLeadDetailsAccessDeniedError('branch_scope')
+    );
 
     await expect(AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' })).rejects.toThrow(
       'not-found'

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
@@ -3,12 +3,16 @@ import {
   scheduleAgentLeadFollowUp,
 } from '@/actions/agent-crm-follow-up';
 import { getLeadActivities } from '@/actions/activities';
-import { getAgentLeadDetailsCore } from '@/app/[locale]/(agent)/agent/leads/[id]/_core';
+import {
+  AgentLeadDetailsAccessDeniedError,
+  getAgentLeadDetailsCore,
+} from '@/app/[locale]/(agent)/agent/leads/[id]/_core';
 import { ActivityFeed } from '@/components/crm/activity-feed';
 import { LogActivityDialog } from '@/components/crm/log-activity-dialog';
 import type { AppLocale } from '@/i18n/locales';
 import { Link, redirect } from '@/i18n/routing';
 import { auth } from '@/lib/auth';
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
 import {
   deriveCrmLeadNextAction,
   type CrmLeadNextAction,
@@ -187,12 +191,36 @@ export async function AgentLeadDetailV2Page({
   }
 
   const tenantId = ensureTenantId(session);
+  const agentId = session.user.id;
+  const role = session.user.role;
+  const branchId = session.user.branchId ?? null;
 
-  const leadResult = await getAgentLeadDetailsCore({
-    leadId: id,
+  if (role !== 'agent' || !branchId) {
+    notFound();
+  }
+
+  const actor = {
+    actorId: agentId,
+    role,
+    scope: {
+      agentId,
+      branchId,
+    },
     tenantId,
-    viewerAgentId: session.user.id,
-  });
+  } satisfies CrmActorContext;
+
+  let leadResult;
+  try {
+    leadResult = await getAgentLeadDetailsCore({
+      actor,
+      leadId: id,
+    });
+  } catch (error) {
+    if (error instanceof AgentLeadDetailsAccessDeniedError) {
+      notFound();
+    }
+    throw error;
+  }
 
   if (leadResult.kind === 'not_found') notFound();
 

--- a/apps/web/src/lib/domain-crm/lead-detail-repository.test.ts
+++ b/apps/web/src/lib/domain-crm/lead-detail-repository.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  findLeadFirst: vi.fn(),
+  dbSelect: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database/db', () => ({
+  db: {
+    query: {
+      crmLeads: {
+        findFirst: hoisted.findLeadFirst,
+      },
+    },
+    select: hoisted.dbSelect,
+  },
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  crmDeals: {
+    agentId: 'crmDeals.agentId',
+    leadId: 'crmDeals.leadId',
+    tenantId: 'crmDeals.tenantId',
+  },
+  crmLeads: {
+    agentId: 'crmLeads.agentId',
+    branchId: 'crmLeads.branchId',
+    id: 'crmLeads.id',
+    tenantId: 'crmLeads.tenantId',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
+}));
+
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+
+import { crmLeadDetailRepository } from './lead-detail-repository';
+import type { AgentCrmLeadDetailLeadRow } from './lead-detail-repository';
+
+const actor: CrmActorContext = {
+  actorId: 'agent-1',
+  role: 'agent',
+  scope: { agentId: 'agent-1', branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
+
+function createSelectChain(result: unknown) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue(result),
+  };
+}
+
+describe('crmLeadDetailRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters lead reads by tenant, agent, and durable branch custody', async () => {
+    hoisted.findLeadFirst.mockResolvedValueOnce({ id: 'lead-1' });
+
+    await crmLeadDetailRepository.findAgentLead({ actor, leadId: 'lead-1' });
+
+    expect(hoisted.findLeadFirst).toHaveBeenCalledWith({
+      where: {
+        and: [
+          { eq: ['crmLeads.id', 'lead-1'] },
+          { eq: ['crmLeads.tenantId', 'tenant-1'] },
+          { eq: ['crmLeads.agentId', 'agent-1'] },
+          { eq: ['crmLeads.branchId', 'branch-1'] },
+        ],
+      },
+    });
+  });
+
+  it('filters deal reads by tenant and agent after receiving an authorized lead', async () => {
+    const chain = createSelectChain([{ id: 'deal-1' }]);
+    hoisted.dbSelect.mockReturnValueOnce(chain);
+
+    await crmLeadDetailRepository.listAgentLeadDeals({
+      actor,
+      lead: {
+        id: 'lead-1',
+        agentId: 'agent-1',
+        branchId: 'branch-1',
+        tenantId: 'tenant-1',
+      } as AgentCrmLeadDetailLeadRow,
+    });
+
+    expect(chain.where).toHaveBeenCalledWith({
+      and: [
+        { eq: ['crmDeals.leadId', 'lead-1'] },
+        { eq: ['crmDeals.tenantId', 'tenant-1'] },
+        { eq: ['crmDeals.agentId', 'agent-1'] },
+      ],
+    });
+  });
+
+  it('fails closed before querying when branch scope is missing', async () => {
+    await expect(
+      crmLeadDetailRepository.findAgentLead({
+        actor: { ...actor, scope: { agentId: 'agent-1', branchId: null } },
+        leadId: 'lead-1',
+      })
+    ).rejects.toThrow('CRM lead detail read requires actor branch scope');
+    expect(hoisted.findLeadFirst).not.toHaveBeenCalled();
+
+    await expect(
+      crmLeadDetailRepository.listAgentLeadDeals({
+        actor: { ...actor, scope: { agentId: 'agent-1', branchId: null } },
+        lead: {
+          id: 'lead-1',
+          agentId: 'agent-1',
+          branchId: 'branch-1',
+          tenantId: 'tenant-1',
+        } as AgentCrmLeadDetailLeadRow,
+      })
+    ).rejects.toThrow('CRM lead detail read requires actor branch scope');
+    expect(hoisted.dbSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/domain-crm/lead-detail-repository.ts
+++ b/apps/web/src/lib/domain-crm/lead-detail-repository.ts
@@ -1,0 +1,50 @@
+import type { AgentCrmLeadDetailRepository } from '@interdomestik/domain-crm/lead-details';
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+import { db } from '@interdomestik/database/db';
+import { crmDeals, crmLeads } from '@interdomestik/database/schema';
+import { and, eq } from 'drizzle-orm';
+
+export type AgentCrmLeadDetailLeadRow = typeof crmLeads.$inferSelect;
+export type AgentCrmLeadDetailDealRow = typeof crmDeals.$inferSelect;
+
+function requireBranchScope(actor: CrmActorContext): string {
+  const branchId = actor.scope.branchId;
+  if (!branchId) {
+    throw new Error('CRM lead detail read requires actor branch scope');
+  }
+  return branchId;
+}
+
+export const crmLeadDetailRepository: AgentCrmLeadDetailRepository<
+  AgentCrmLeadDetailLeadRow,
+  AgentCrmLeadDetailDealRow
+> = {
+  async findAgentLead(params) {
+    const branchId = requireBranchScope(params.actor);
+
+    const lead = await db.query.crmLeads.findFirst({
+      where: and(
+        eq(crmLeads.id, params.leadId),
+        eq(crmLeads.tenantId, params.actor.tenantId),
+        eq(crmLeads.agentId, params.actor.actorId),
+        eq(crmLeads.branchId, branchId)
+      ),
+    });
+    return lead ?? null;
+  },
+
+  async listAgentLeadDeals(params) {
+    requireBranchScope(params.actor);
+
+    return db
+      .select()
+      .from(crmDeals)
+      .where(
+        and(
+          eq(crmDeals.leadId, params.lead.id),
+          eq(crmDeals.tenantId, params.actor.tenantId),
+          eq(crmDeals.agentId, params.actor.actorId)
+        )
+      );
+  },
+};

--- a/packages/domain-crm/package.json
+++ b/packages/domain-crm/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./context": "./src/context.ts",
     "./dashboards": "./src/dashboards/index.ts",
+    "./lead-details": "./src/lead-details/index.ts",
     "./leads/follow-up": "./src/leads/follow-up.ts",
     "./leads": "./src/leads/index.ts",
     "./leads/mutations": "./src/leads/mutations.ts",

--- a/packages/domain-crm/src/index.ts
+++ b/packages/domain-crm/src/index.ts
@@ -1,5 +1,6 @@
 export * from './context';
 export * from './dashboards';
+export * from './lead-details';
 export * from './leads';
 export * from './notifications';
 export * from './support-handoffs';

--- a/packages/domain-crm/src/lead-details/index.test.ts
+++ b/packages/domain-crm/src/lead-details/index.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CrmActorContext } from '../context';
+import {
+  authorizeAgentCrmLeadDetailRead,
+  getAgentCrmLeadDetail,
+  type AgentCrmLeadDetailRepository,
+} from './index';
+
+const agentActor: CrmActorContext = {
+  actorId: 'agent-1',
+  role: 'agent',
+  scope: { agentId: 'agent-1', branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
+
+type LeadRow = {
+  agentId: string;
+  branchId: string | null;
+  id: string;
+  tenantId: string;
+};
+
+type DealRow = {
+  agentId: string;
+  id: string;
+  leadId: string;
+  tenantId: string;
+};
+
+function lead(overrides: Partial<LeadRow> = {}): LeadRow {
+  return {
+    agentId: 'agent-1',
+    branchId: 'branch-1',
+    id: 'lead-1',
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+function repository(
+  foundLead: LeadRow | null = lead()
+): AgentCrmLeadDetailRepository<LeadRow, DealRow> {
+  return {
+    findAgentLead: vi.fn(async () => foundLead),
+    listAgentLeadDeals: vi.fn(async () => [
+      {
+        agentId: 'agent-1',
+        id: 'deal-1',
+        leadId: 'lead-1',
+        tenantId: 'tenant-1',
+      },
+    ]),
+  };
+}
+
+describe('getAgentCrmLeadDetail', () => {
+  it('rejects non-agent actors before reading lead details', async () => {
+    const repo = repository();
+
+    const result = await getAgentCrmLeadDetail(
+      {
+        actor: {
+          ...agentActor,
+          role: 'staff',
+          scope: { branchId: 'branch-1', staffId: 'staff-1' },
+        },
+        leadId: 'lead-1',
+      },
+      repo
+    );
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'role_scope' });
+    expect(repo.findAgentLead).not.toHaveBeenCalled();
+    expect(repo.listAgentLeadDeals).not.toHaveBeenCalled();
+  });
+
+  it('rejects wrong-agent actor scope before reading lead details', async () => {
+    const repo = repository();
+
+    const result = await getAgentCrmLeadDetail(
+      {
+        actor: { ...agentActor, scope: { ...agentActor.scope, agentId: 'agent-2' } },
+        leadId: 'lead-1',
+      },
+      repo
+    );
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'agent_scope' });
+    expect(repo.findAgentLead).not.toHaveBeenCalled();
+    expect(repo.listAgentLeadDeals).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing branch scope before reading lead details', async () => {
+    const repo = repository();
+
+    const result = await getAgentCrmLeadDetail(
+      {
+        actor: { ...agentActor, scope: { agentId: 'agent-1', branchId: null } },
+        leadId: 'lead-1',
+      },
+      repo
+    );
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'branch_scope' });
+    expect(repo.findAgentLead).not.toHaveBeenCalled();
+    expect(repo.listAgentLeadDeals).not.toHaveBeenCalled();
+  });
+
+  it('returns not_found without reading deals when the scoped lead is absent', async () => {
+    const repo = repository(null);
+
+    const result = await getAgentCrmLeadDetail({ actor: agentActor, leadId: 'lead-1' }, repo);
+
+    expect(result).toEqual({ success: false, error: 'not_found' });
+    expect(repo.findAgentLead).toHaveBeenCalledWith({ actor: agentActor, leadId: 'lead-1' });
+    expect(repo.listAgentLeadDeals).not.toHaveBeenCalled();
+  });
+
+  it('rejects cross-tenant leads before deal data is returned', async () => {
+    const repo = repository(lead({ tenantId: 'tenant-2' }));
+
+    const result = await getAgentCrmLeadDetail({ actor: agentActor, leadId: 'lead-1' }, repo);
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'tenant_scope' });
+    expect(repo.listAgentLeadDeals).not.toHaveBeenCalled();
+  });
+
+  it('rejects wrong-agent leads before deal data is returned', async () => {
+    const repo = repository(lead({ agentId: 'agent-2' }));
+
+    const result = await getAgentCrmLeadDetail({ actor: agentActor, leadId: 'lead-1' }, repo);
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'agent_scope' });
+    expect(repo.listAgentLeadDeals).not.toHaveBeenCalled();
+  });
+
+  it('rejects wrong-branch leads before deal data is returned', async () => {
+    const repo = repository(lead({ branchId: 'branch-2' }));
+
+    const result = await getAgentCrmLeadDetail({ actor: agentActor, leadId: 'lead-1' }, repo);
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'branch_scope' });
+    expect(repo.listAgentLeadDeals).not.toHaveBeenCalled();
+  });
+
+  it('returns authorized lead detail rows through the repository', async () => {
+    const repo = repository();
+
+    const result = await getAgentCrmLeadDetail({ actor: agentActor, leadId: 'lead-1' }, repo);
+
+    expect(result).toEqual({
+      success: true,
+      lead: lead(),
+      deals: [
+        {
+          agentId: 'agent-1',
+          id: 'deal-1',
+          leadId: 'lead-1',
+          tenantId: 'tenant-1',
+        },
+      ],
+    });
+    expect(repo.listAgentLeadDeals).toHaveBeenCalledWith({ actor: agentActor, lead: lead() });
+  });
+
+  it('exposes explicit authorization reasons for direct guard tests', () => {
+    expect(authorizeAgentCrmLeadDetailRead(agentActor)).toBeNull();
+    expect(authorizeAgentCrmLeadDetailRead({ ...agentActor, role: 'member' })).toBe('role_scope');
+    expect(
+      authorizeAgentCrmLeadDetailRead({
+        ...agentActor,
+        scope: { ...agentActor.scope, agentId: 'agent-2' },
+      })
+    ).toBe('agent_scope');
+    expect(
+      authorizeAgentCrmLeadDetailRead({
+        ...agentActor,
+        scope: { ...agentActor.scope, branchId: undefined },
+      })
+    ).toBe('branch_scope');
+    expect(authorizeAgentCrmLeadDetailRead(agentActor, lead({ tenantId: 'tenant-2' }))).toBe(
+      'tenant_scope'
+    );
+    expect(authorizeAgentCrmLeadDetailRead(agentActor, lead({ agentId: 'agent-2' }))).toBe(
+      'agent_scope'
+    );
+    expect(authorizeAgentCrmLeadDetailRead(agentActor, lead({ branchId: 'branch-2' }))).toBe(
+      'branch_scope'
+    );
+  });
+});

--- a/packages/domain-crm/src/lead-details/index.ts
+++ b/packages/domain-crm/src/lead-details/index.ts
@@ -1,0 +1,82 @@
+import type { CrmActorContext } from '../context';
+
+export type AgentCrmLeadDetailAuthorizationDenialReason =
+  | 'agent_scope'
+  | 'branch_scope'
+  | 'role_scope'
+  | 'tenant_scope';
+
+export type AgentCrmLeadDetailLead = {
+  agentId: string;
+  branchId?: string | null;
+  id: string;
+  tenantId: string;
+};
+
+export type AgentCrmLeadDetailDeal = {
+  agentId: string;
+  leadId: string;
+  tenantId: string;
+};
+
+export type AgentCrmLeadDetailRepository<
+  TLead extends AgentCrmLeadDetailLead = AgentCrmLeadDetailLead,
+  TDeal extends AgentCrmLeadDetailDeal = AgentCrmLeadDetailDeal,
+> = {
+  findAgentLead(params: { actor: CrmActorContext; leadId: string }): Promise<TLead | null>;
+  listAgentLeadDeals(params: { actor: CrmActorContext; lead: TLead }): Promise<readonly TDeal[]>;
+};
+
+export type AgentCrmLeadDetailResult<
+  TLead extends AgentCrmLeadDetailLead = AgentCrmLeadDetailLead,
+  TDeal extends AgentCrmLeadDetailDeal = AgentCrmLeadDetailDeal,
+> =
+  | { success: true; lead: TLead; deals: TDeal[] }
+  | { success: false; error: 'not_found' }
+  | {
+      success: false;
+      error: 'forbidden';
+      reason: AgentCrmLeadDetailAuthorizationDenialReason;
+    };
+
+export function authorizeAgentCrmLeadDetailRead(
+  actor: CrmActorContext,
+  lead?: AgentCrmLeadDetailLead
+): AgentCrmLeadDetailAuthorizationDenialReason | null {
+  if (actor.role !== 'agent') return 'role_scope';
+  if (actor.scope.agentId && actor.scope.agentId !== actor.actorId) return 'agent_scope';
+  if (!actor.scope.branchId) return 'branch_scope';
+
+  if (!lead) return null;
+
+  if (lead.tenantId !== actor.tenantId) return 'tenant_scope';
+  if (lead.agentId !== actor.actorId) return 'agent_scope';
+  if (lead.branchId !== actor.scope.branchId) return 'branch_scope';
+  return null;
+}
+
+export async function getAgentCrmLeadDetail<
+  TLead extends AgentCrmLeadDetailLead,
+  TDeal extends AgentCrmLeadDetailDeal,
+>(
+  input: { actor: CrmActorContext; leadId: string },
+  repository: AgentCrmLeadDetailRepository<TLead, TDeal>
+): Promise<AgentCrmLeadDetailResult<TLead, TDeal>> {
+  const actorDenied = authorizeAgentCrmLeadDetailRead(input.actor);
+  if (actorDenied) {
+    return { success: false, error: 'forbidden', reason: actorDenied };
+  }
+
+  const lead = await repository.findAgentLead({ actor: input.actor, leadId: input.leadId });
+  if (!lead) {
+    return { success: false, error: 'not_found' };
+  }
+
+  const leadDenied = authorizeAgentCrmLeadDetailRead(input.actor, lead);
+  if (leadDenied) {
+    return { success: false, error: 'forbidden', reason: leadDenied };
+  }
+
+  const deals = await repository.listAgentLeadDeals({ actor: input.actor, lead });
+  return { success: true, lead, deals: [...deals] };
+}


### PR DESCRIPTION
## Summary
- Add `@interdomestik/domain-crm/lead-details` with `getAgentCrmLeadDetail({ actor, leadId })` and explicit tenant/agent/branch authorization.
- Move agent lead-detail lead/deal database reads out of the route core into `apps/web/src/lib/domain-crm/lead-detail-repository.ts`.
- Preserve agent lead detail UI/output while mapping unauthorized or missing scoped reads to not found.
- Add focused negative tests for cross-tenant, wrong-agent, wrong-branch, non-agent, and missing branch cases.

## Scope Notes
- No changes to `apps/web/src/proxy.ts`, canonical routes, auth/tenancy architecture, Stripe, README, AGENTS.md, broad docs, task aggregates, automation, AI, campaigns, cron/NPS, or `member_leads` unification.
- Remaining lead detail activity feed path stays on existing activity APIs; DM06 only ports lead/deal reads.
- `crmDeals` has no branch column, so deal reads are reached only after domain authorization of the lead's tenant, agent, and branch custody; adapter queries still constrain tenant and agent.

## Verification
- `pnpm --filter @interdomestik/domain-crm test:unit --run src/lead-details/index.test.ts`
- `pnpm --filter @interdomestik/domain-crm test:unit`
- `pnpm --filter @interdomestik/domain-crm type-check`
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(agent)/agent/leads/[id]/_core.test.ts' src/lib/domain-crm/lead-detail-repository.test.ts src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx`
- `pnpm --filter @interdomestik/web test:unit --run src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm --filter @interdomestik/web lint`
- `pnpm check:db-access`
- `pnpm security:guard` via Interdomestik QA MCP and required slice gate
- `pnpm purity:audit`
- `git diff --check`
- `pnpm verify-slice -- --static`
- `pnpm verify-slice -- --required-gates`
- Interdomestik QA MCP `scope_audit`

## Review Notes
- Runtime policy did not allow subagent reviewer spawning because the user did not explicitly request subagents. I performed the required local fallback review; no must-fix issues found.
