### PR TITLE
feat: add CRM lead activity read-side port

### DIFF
--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx
@@ -21,7 +21,8 @@ const hoisted = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   ensureTenantIdMock: vi.fn(() => 'tenant-1'),
   getAgentLeadDetailsCoreMock: vi.fn(),
-  getLeadActivitiesMock: vi.fn(),
+  getAgentCrmLeadActivitiesMock: vi.fn(),
+  crmLeadActivityRepository: {},
 }));
 
 vi.mock('next/headers', () => ({
@@ -49,18 +50,22 @@ vi.mock('@interdomestik/shared-auth', () => ({
   ensureTenantId: hoisted.ensureTenantIdMock,
 }));
 
-vi.mock('@/actions/activities', () => ({
-  getLeadActivities: hoisted.getLeadActivitiesMock,
-}));
-
 vi.mock('@/actions/agent-crm-follow-up', () => ({
   completeAgentLeadFollowUp: vi.fn(),
   scheduleAgentLeadFollowUp: vi.fn(),
 }));
 
+vi.mock('@/lib/domain-crm/lead-activity-repository', () => ({
+  crmLeadActivityRepository: hoisted.crmLeadActivityRepository,
+}));
+
 vi.mock('@/app/[locale]/(agent)/agent/leads/[id]/_core', () => ({
   AgentLeadDetailsAccessDeniedError: hoisted.AgentLeadDetailsAccessDeniedError,
   getAgentLeadDetailsCore: hoisted.getAgentLeadDetailsCoreMock,
+}));
+
+vi.mock('@interdomestik/domain-crm/lead-activities', () => ({
+  getAgentCrmLeadActivities: hoisted.getAgentCrmLeadActivitiesMock,
 }));
 
 vi.mock('@/components/crm/activity-feed', () => ({
@@ -166,7 +171,7 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
       },
       deals: [],
     });
-    hoisted.getLeadActivitiesMock.mockResolvedValue([]);
+    hoisted.getAgentCrmLeadActivitiesMock.mockResolvedValue({ success: true, activities: [] });
   });
 
   it('rejects a session with missing tenant identity before loading lead details', async () => {
@@ -184,23 +189,30 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
 
     expect(hoisted.ensureTenantIdMock).toHaveBeenCalledWith(session);
     expect(hoisted.getAgentLeadDetailsCoreMock).not.toHaveBeenCalled();
-    expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
+    expect(hoisted.getAgentCrmLeadActivitiesMock).not.toHaveBeenCalled();
   });
 
-  it('passes actor context into the lead detail core before loading activities', async () => {
+  it('passes actor context into the lead detail and activity read domains', async () => {
     await AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' });
 
+    const actor = {
+      actorId: 'agent-1',
+      role: 'agent',
+      scope: { agentId: 'agent-1', branchId: 'branch-1' },
+      tenantId: 'tenant-1',
+    };
     expect(hoisted.setRequestLocaleMock).toHaveBeenCalledWith('en');
     expect(hoisted.getAgentLeadDetailsCoreMock).toHaveBeenCalledWith({
-      actor: {
-        actorId: 'agent-1',
-        role: 'agent',
-        scope: { agentId: 'agent-1', branchId: 'branch-1' },
-        tenantId: 'tenant-1',
-      },
+      actor,
       leadId: 'lead-1',
     });
-    expect(hoisted.getLeadActivitiesMock).toHaveBeenCalledWith('lead-1');
+    expect(hoisted.getAgentCrmLeadActivitiesMock).toHaveBeenCalledWith(
+      {
+        actor,
+        leadId: 'lead-1',
+      },
+      hoisted.crmLeadActivityRepository
+    );
   });
 
   it('rejects a non-agent or branchless session before loading lead details', async () => {
@@ -214,7 +226,7 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
 
     expect(hoisted.notFoundMock).toHaveBeenCalled();
     expect(hoisted.getAgentLeadDetailsCoreMock).not.toHaveBeenCalled();
-    expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
+    expect(hoisted.getAgentCrmLeadActivitiesMock).not.toHaveBeenCalled();
   });
 
   it('does not load activities when the lead detail core returns not_found', async () => {
@@ -227,7 +239,7 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
     );
 
     expect(hoisted.notFoundMock).toHaveBeenCalled();
-    expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
+    expect(hoisted.getAgentCrmLeadActivitiesMock).not.toHaveBeenCalled();
   });
 
   it('does not load activities when the lead detail core denies access', async () => {
@@ -240,7 +252,21 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
     );
 
     expect(hoisted.notFoundMock).toHaveBeenCalled();
-    expect(hoisted.getLeadActivitiesMock).not.toHaveBeenCalled();
+    expect(hoisted.getAgentCrmLeadActivitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('does not render when the activity domain denies the read after lead authorization', async () => {
+    hoisted.getAgentCrmLeadActivitiesMock.mockResolvedValueOnce({
+      success: false,
+      error: 'forbidden',
+      reason: 'branch_scope',
+    });
+
+    await expect(AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' })).rejects.toThrow(
+      'not-found'
+    );
+
+    expect(hoisted.notFoundMock).toHaveBeenCalled();
   });
 
   it('preserves the route locale when redirecting unauthenticated sessions to login', async () => {
@@ -310,24 +336,26 @@ describe('AgentLeadDetailV2Page tenant contract', () => {
   });
 
   it('renders the due follow-up completion action from lead activities', async () => {
-    hoisted.getLeadActivitiesMock.mockResolvedValueOnce([
-      {
-        id: 'follow-up-1',
-        tenantId: 'tenant-1',
-        leadId: 'lead-1',
-        memberId: 'lead-1',
-        agentId: 'agent-1',
-        type: 'follow_up',
-        subject: 'Call back',
-        description: 'Needs a call.',
-        occurredAt: '2026-05-10T08:00:00.000Z',
-        scheduledAt: '2020-01-01T10:00:00.000Z',
-        completedAt: null,
-        createdAt: '2026-05-10T08:00:00.000Z',
-        updatedAt: '2026-05-10T08:00:00.000Z',
-        agent: null,
-      },
-    ]);
+    hoisted.getAgentCrmLeadActivitiesMock.mockResolvedValueOnce({
+      success: true,
+      activities: [
+        {
+          id: 'follow-up-1',
+          tenantId: 'tenant-1',
+          leadId: 'lead-1',
+          agentId: 'agent-1',
+          branchId: 'branch-1',
+          type: 'follow_up',
+          subject: 'Call back',
+          description: 'Needs a call.',
+          occurredAt: '2026-05-10T08:00:00.000Z',
+          scheduledAt: '2020-01-01T10:00:00.000Z',
+          completedAt: null,
+          createdAt: '2026-05-10T08:00:00.000Z',
+          agent: null,
+        },
+      ],
+    });
 
     const element = await AgentLeadDetailV2Page({ id: 'lead-1', locale: 'en' });
     const html = renderToStaticMarkup(element);

--- a/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
+++ b/apps/web/src/features/agent/leads/components/AgentLeadDetailV2Page.tsx
@@ -2,7 +2,6 @@ import {
   completeAgentLeadFollowUp,
   scheduleAgentLeadFollowUp,
 } from '@/actions/agent-crm-follow-up';
-import { getLeadActivities } from '@/actions/activities';
 import {
   AgentLeadDetailsAccessDeniedError,
   getAgentLeadDetailsCore,
@@ -12,12 +11,13 @@ import { LogActivityDialog } from '@/components/crm/log-activity-dialog';
 import type { AppLocale } from '@/i18n/locales';
 import { Link, redirect } from '@/i18n/routing';
 import { auth } from '@/lib/auth';
+import { crmLeadActivityRepository } from '@/lib/domain-crm/lead-activity-repository';
 import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+import { getAgentCrmLeadActivities } from '@interdomestik/domain-crm/lead-activities';
 import {
   deriveCrmLeadNextAction,
   type CrmLeadNextAction,
 } from '@interdomestik/domain-crm/leads/follow-up';
-import type { CrmLeadActivity } from '@interdomestik/domain-crm/leads/types';
 import { Button, Card, CardContent, CardHeader, CardTitle } from '@interdomestik/ui';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { CheckCircle2, PlusCircle } from 'lucide-react';
@@ -79,29 +79,6 @@ function formatDealValue(valueCents: number | null | undefined, locale: AppLocal
     style: 'currency',
     currency: 'EUR',
   }).format((valueCents ?? 0) / 100);
-}
-
-type LeadActivityFeedRow = Awaited<ReturnType<typeof getLeadActivities>>[number];
-
-function toIso(value: Date | string | null | undefined): string | null {
-  if (!value) return null;
-  return value instanceof Date ? value.toISOString() : value;
-}
-
-function mapFeedRowToCrmActivity(row: LeadActivityFeedRow): CrmLeadActivity {
-  return {
-    agentId: row.agentId,
-    completedAt: toIso(row.completedAt),
-    createdAt: toIso(row.createdAt ?? row.occurredAt) ?? new Date(0).toISOString(),
-    description: row.description ?? null,
-    id: row.id,
-    leadId: row.leadId ?? row.memberId,
-    occurredAt: toIso(row.occurredAt ?? row.createdAt) ?? new Date(0).toISOString(),
-    scheduledAt: toIso(row.scheduledAt),
-    subject: row.subject,
-    tenantId: row.tenantId ?? '',
-    type: row.type,
-  };
 }
 
 function formatFollowUpDate(value: string, locale: AppLocale) {
@@ -224,12 +201,21 @@ export async function AgentLeadDetailV2Page({
 
   if (leadResult.kind === 'not_found') notFound();
 
-  const activities = await getLeadActivities(id);
+  const activityResult = await getAgentCrmLeadActivities(
+    {
+      actor,
+      leadId: id,
+    },
+    crmLeadActivityRepository
+  );
+
+  if (!activityResult.success) notFound();
 
   const lead = leadResult.lead;
   const deals = leadResult.deals;
+  const activities = activityResult.activities;
   const nextAction = deriveCrmLeadNextAction({
-    activities: activities.map(mapFeedRowToCrmActivity),
+    activities,
     lead: { id: lead.id, tenantId: lead.tenantId },
     now: new Date().toISOString(),
   });

--- a/apps/web/src/lib/domain-crm/lead-activity-repository.test.ts
+++ b/apps/web/src/lib/domain-crm/lead-activity-repository.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  findActivitiesMany: vi.fn(),
+  findLeadFirst: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database/db', () => ({
+  db: {
+    query: {
+      crmActivities: {
+        findMany: hoisted.findActivitiesMany,
+      },
+      crmLeads: {
+        findFirst: hoisted.findLeadFirst,
+      },
+    },
+  },
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  crmActivities: {
+    agentId: 'crmActivities.agentId',
+    branchId: 'crmActivities.branchId',
+    completedAt: 'crmActivities.completedAt',
+    createdAt: 'crmActivities.createdAt',
+    id: 'crmActivities.id',
+    leadId: 'crmActivities.leadId',
+    occurredAt: 'crmActivities.occurredAt',
+    scheduledAt: 'crmActivities.scheduledAt',
+    summary: 'crmActivities.summary',
+    tenantId: 'crmActivities.tenantId',
+    type: 'crmActivities.type',
+  },
+  crmLeads: {
+    agentId: 'crmLeads.agentId',
+    branchId: 'crmLeads.branchId',
+    id: 'crmLeads.id',
+    tenantId: 'crmLeads.tenantId',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  desc: vi.fn((column: unknown) => ({ desc: column })),
+  eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
+}));
+
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+
+import { crmLeadActivityRepository } from './lead-activity-repository';
+import type { AgentCrmLeadActivityLeadRow } from './lead-activity-repository';
+
+const actor: CrmActorContext = {
+  actorId: 'agent-1',
+  role: 'agent',
+  scope: { agentId: 'agent-1', branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
+
+describe('crmLeadActivityRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters parent lead reads by tenant, agent, and durable branch custody', async () => {
+    hoisted.findLeadFirst.mockResolvedValueOnce({ id: 'lead-1' });
+
+    await crmLeadActivityRepository.findAgentLead({ actor, leadId: 'lead-1' });
+
+    expect(hoisted.findLeadFirst).toHaveBeenCalledWith({
+      where: {
+        and: [
+          { eq: ['crmLeads.id', 'lead-1'] },
+          { eq: ['crmLeads.tenantId', 'tenant-1'] },
+          { eq: ['crmLeads.agentId', 'agent-1'] },
+          { eq: ['crmLeads.branchId', 'branch-1'] },
+        ],
+      },
+    });
+  });
+
+  it('filters activity reads by tenant, agent, lead, and activity branch snapshot', async () => {
+    const createdAt = new Date('2026-05-12T10:00:00.000Z');
+    hoisted.findActivitiesMany.mockResolvedValueOnce([
+      {
+        agent: { name: 'Agent One' },
+        agentId: 'agent-1',
+        branchId: 'branch-1',
+        completedAt: null,
+        createdAt,
+        id: 'activity-1',
+        leadId: 'lead-1',
+        occurredAt: createdAt,
+        scheduledAt: null,
+        summary: 'Call lead',
+        tenantId: 'tenant-1',
+        type: 'call',
+      },
+    ]);
+
+    const result = await crmLeadActivityRepository.listAgentLeadActivities({
+      actor,
+      lead: {
+        id: 'lead-1',
+        agentId: 'agent-1',
+        branchId: 'branch-1',
+        tenantId: 'tenant-1',
+      } as AgentCrmLeadActivityLeadRow,
+      limit: 25,
+    });
+
+    expect(hoisted.findActivitiesMany).toHaveBeenCalledWith({
+      where: {
+        and: [
+          { eq: ['crmActivities.leadId', 'lead-1'] },
+          { eq: ['crmActivities.tenantId', 'tenant-1'] },
+          { eq: ['crmActivities.agentId', 'agent-1'] },
+          { eq: ['crmActivities.branchId', 'branch-1'] },
+        ],
+      },
+      columns: {
+        agentId: true,
+        branchId: true,
+        completedAt: true,
+        createdAt: true,
+        id: true,
+        leadId: true,
+        occurredAt: true,
+        scheduledAt: true,
+        summary: true,
+        tenantId: true,
+        type: true,
+      },
+      limit: 25,
+      orderBy: [{ desc: 'crmActivities.createdAt' }],
+      with: {
+        agent: {
+          columns: { name: true },
+        },
+      },
+    });
+    expect(result).toEqual([
+      {
+        agent: { name: 'Agent One' },
+        agentId: 'agent-1',
+        branchId: 'branch-1',
+        completedAt: null,
+        createdAt: '2026-05-12T10:00:00.000Z',
+        description: null,
+        id: 'activity-1',
+        leadId: 'lead-1',
+        occurredAt: '2026-05-12T10:00:00.000Z',
+        scheduledAt: null,
+        subject: 'Call lead',
+        tenantId: 'tenant-1',
+        type: 'call',
+      },
+    ]);
+  });
+
+  it('fails closed before querying when branch scope is missing', async () => {
+    const branchlessActor = { ...actor, scope: { agentId: 'agent-1', branchId: null } };
+
+    await expect(
+      crmLeadActivityRepository.findAgentLead({ actor: branchlessActor, leadId: 'lead-1' })
+    ).rejects.toThrow('CRM lead activity read requires actor branch scope');
+    expect(hoisted.findLeadFirst).not.toHaveBeenCalled();
+
+    await expect(
+      crmLeadActivityRepository.listAgentLeadActivities({
+        actor: branchlessActor,
+        lead: {
+          id: 'lead-1',
+          agentId: 'agent-1',
+          branchId: 'branch-1',
+          tenantId: 'tenant-1',
+        } as AgentCrmLeadActivityLeadRow,
+        limit: 25,
+      })
+    ).rejects.toThrow('CRM lead activity read requires actor branch scope');
+    expect(hoisted.findActivitiesMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/domain-crm/lead-activity-repository.ts
+++ b/apps/web/src/lib/domain-crm/lead-activity-repository.ts
@@ -32,6 +32,8 @@ function mapActivity(row: AgentCrmLeadActivityRow): AgentCrmLeadActivity {
     branchId: row.branchId ?? null,
     completedAt: toIso(row.completedAt),
     createdAt: toIso(row.createdAt) ?? new Date(0).toISOString(),
+    // The current migrated crm_activities table does not expose a description column; the
+    // legacy activity feed read also rendered these rows from summary-only data.
     description: null,
     id: row.id,
     leadId: row.leadId,

--- a/apps/web/src/lib/domain-crm/lead-activity-repository.ts
+++ b/apps/web/src/lib/domain-crm/lead-activity-repository.ts
@@ -1,0 +1,100 @@
+import type {
+  AgentCrmLeadActivity,
+  AgentCrmLeadActivityRepository,
+} from '@interdomestik/domain-crm/lead-activities';
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+import { db } from '@interdomestik/database/db';
+import { crmActivities, crmLeads } from '@interdomestik/database/schema';
+import { and, desc, eq } from 'drizzle-orm';
+
+export type AgentCrmLeadActivityLeadRow = typeof crmLeads.$inferSelect;
+export type AgentCrmLeadActivityRow = typeof crmActivities.$inferSelect & {
+  agent?: { name: string | null } | null;
+};
+
+function requireBranchScope(actor: CrmActorContext): string {
+  const branchId = actor.scope.branchId;
+  if (!branchId) {
+    throw new Error('CRM lead activity read requires actor branch scope');
+  }
+  return branchId;
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function mapActivity(row: AgentCrmLeadActivityRow): AgentCrmLeadActivity {
+  return {
+    agent: row.agent ? { name: row.agent.name } : null,
+    agentId: row.agentId,
+    branchId: row.branchId ?? null,
+    completedAt: toIso(row.completedAt),
+    createdAt: toIso(row.createdAt) ?? new Date(0).toISOString(),
+    description: null,
+    id: row.id,
+    leadId: row.leadId,
+    occurredAt: toIso(row.occurredAt ?? row.createdAt) ?? new Date(0).toISOString(),
+    scheduledAt: toIso(row.scheduledAt),
+    subject: row.summary,
+    tenantId: row.tenantId,
+    type: row.type,
+  };
+}
+
+export const crmLeadActivityRepository: AgentCrmLeadActivityRepository<
+  AgentCrmLeadActivityLeadRow,
+  AgentCrmLeadActivity
+> = {
+  async findAgentLead(params) {
+    const branchId = requireBranchScope(params.actor);
+
+    // db-access-guard: tenant-predicate -- reason: domain CRM lead activity adapter constrains the parent lead by actor tenant, agent, and durable branch scope before activity reads
+    const lead = await db.query.crmLeads.findFirst({
+      where: and(
+        eq(crmLeads.id, params.leadId),
+        eq(crmLeads.tenantId, params.actor.tenantId),
+        eq(crmLeads.agentId, params.actor.actorId),
+        eq(crmLeads.branchId, branchId)
+      ),
+    });
+    return lead ?? null;
+  },
+
+  async listAgentLeadActivities(params) {
+    const branchId = requireBranchScope(params.actor);
+
+    // db-access-guard: tenant-predicate -- reason: domain CRM lead activity adapter constrains activity feed reads by actor tenant, agent, lead, and activity branch snapshot
+    const activities = await db.query.crmActivities.findMany({
+      where: and(
+        eq(crmActivities.leadId, params.lead.id),
+        eq(crmActivities.tenantId, params.actor.tenantId),
+        eq(crmActivities.agentId, params.actor.actorId),
+        eq(crmActivities.branchId, branchId)
+      ),
+      columns: {
+        agentId: true,
+        branchId: true,
+        completedAt: true,
+        createdAt: true,
+        id: true,
+        leadId: true,
+        occurredAt: true,
+        scheduledAt: true,
+        summary: true,
+        tenantId: true,
+        type: true,
+      },
+      limit: params.limit,
+      orderBy: [desc(crmActivities.createdAt)],
+      with: {
+        agent: {
+          columns: { name: true },
+        },
+      },
+    });
+
+    return activities.map(activity => mapActivity(activity as AgentCrmLeadActivityRow));
+  },
+};

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
       "path-to-regexp": "^8.4.0",
       "picomatch@<2.3.2": "2.3.2",
       "picomatch@>=4.0.0 <4.0.4": "4.0.4",
-      "protobufjs": "7.5.5",
+      "protobufjs": "7.5.6",
       "smol-toml": "1.6.1",
       "yaml@>=2.0.0 <2.8.3": "2.8.3",
       "ip-address": "10.1.1",

--- a/packages/domain-crm/package.json
+++ b/packages/domain-crm/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./context": "./src/context.ts",
     "./dashboards": "./src/dashboards/index.ts",
+    "./lead-activities": "./src/lead-activities/index.ts",
     "./lead-details": "./src/lead-details/index.ts",
     "./leads/follow-up": "./src/leads/follow-up.ts",
     "./leads": "./src/leads/index.ts",

--- a/packages/domain-crm/src/index.ts
+++ b/packages/domain-crm/src/index.ts
@@ -1,5 +1,6 @@
 export * from './context';
 export * from './dashboards';
+export * from './lead-activities';
 export * from './lead-details';
 export * from './leads';
 export * from './notifications';

--- a/packages/domain-crm/src/lead-activities/index.test.ts
+++ b/packages/domain-crm/src/lead-activities/index.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CrmActorContext } from '../context';
 import {
   AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS,
+  authorizeAgentCrmLeadActivityRead,
   getAgentCrmLeadActivities,
   type AgentCrmLeadActivity,
   type AgentCrmLeadActivityLead,
@@ -154,5 +155,23 @@ describe('getAgentCrmLeadActivities', () => {
       lead: lead(),
       limit: AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS,
     });
+  });
+
+  it('normalizes fractional limits before reading the repository', async () => {
+    const repo = repository({});
+
+    await getAgentCrmLeadActivities({ actor, leadId: 'lead-1', limit: 1.5 }, repo);
+
+    expect(repo.listAgentLeadActivities).toHaveBeenCalledWith({
+      actor,
+      lead: lead(),
+      limit: 1,
+    });
+  });
+
+  it('classifies lead mismatches separately from agent scope mismatches', () => {
+    expect(authorizeAgentCrmLeadActivityRead(actor, lead(), activity({ leadId: 'lead-2' }))).toBe(
+      'lead_scope'
+    );
   });
 });

--- a/packages/domain-crm/src/lead-activities/index.test.ts
+++ b/packages/domain-crm/src/lead-activities/index.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CrmActorContext } from '../context';
+import {
+  AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS,
+  getAgentCrmLeadActivities,
+  type AgentCrmLeadActivity,
+  type AgentCrmLeadActivityLead,
+  type AgentCrmLeadActivityRepository,
+} from './index';
+
+const actor: CrmActorContext = {
+  actorId: 'agent-1',
+  role: 'agent',
+  scope: { agentId: 'agent-1', branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
+
+function lead(overrides: Partial<AgentCrmLeadActivityLead> = {}): AgentCrmLeadActivityLead {
+  return {
+    agentId: 'agent-1',
+    branchId: 'branch-1',
+    id: 'lead-1',
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+function activity(overrides: Partial<AgentCrmLeadActivity> = {}): AgentCrmLeadActivity {
+  return {
+    agentId: 'agent-1',
+    branchId: 'branch-1',
+    completedAt: null,
+    createdAt: '2026-05-12T10:00:00.000Z',
+    description: null,
+    id: 'activity-1',
+    leadId: 'lead-1',
+    occurredAt: '2026-05-12T10:00:00.000Z',
+    scheduledAt: null,
+    subject: 'Call lead',
+    tenantId: 'tenant-1',
+    type: 'call',
+    ...overrides,
+  };
+}
+
+function repository(args: {
+  activities?: readonly AgentCrmLeadActivity[];
+  lead?: AgentCrmLeadActivityLead | null;
+}): AgentCrmLeadActivityRepository & {
+  findAgentLead: ReturnType<typeof vi.fn>;
+  listAgentLeadActivities: ReturnType<typeof vi.fn>;
+} {
+  return {
+    findAgentLead: vi.fn().mockResolvedValue(args.lead === undefined ? lead() : args.lead),
+    listAgentLeadActivities: vi.fn().mockResolvedValue(args.activities ?? [activity()]),
+  };
+}
+
+describe('getAgentCrmLeadActivities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects non-agent actors before reading the repository', async () => {
+    const repo = repository({});
+
+    const result = await getAgentCrmLeadActivities(
+      { actor: { ...actor, role: 'staff' }, leadId: 'lead-1' },
+      repo
+    );
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'role_scope' });
+    expect(repo.findAgentLead).not.toHaveBeenCalled();
+    expect(repo.listAgentLeadActivities).not.toHaveBeenCalled();
+  });
+
+  it('rejects wrong agent scope before reading the repository', async () => {
+    const repo = repository({});
+
+    const result = await getAgentCrmLeadActivities(
+      {
+        actor: { ...actor, scope: { agentId: 'other-agent', branchId: 'branch-1' } },
+        leadId: 'lead-1',
+      },
+      repo
+    );
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'agent_scope' });
+    expect(repo.findAgentLead).not.toHaveBeenCalled();
+  });
+
+  it('rejects branchless actors before reading the repository', async () => {
+    const repo = repository({});
+
+    const result = await getAgentCrmLeadActivities(
+      { actor: { ...actor, scope: { agentId: 'agent-1', branchId: null } }, leadId: 'lead-1' },
+      repo
+    );
+
+    expect(result).toEqual({ success: false, error: 'forbidden', reason: 'branch_scope' });
+    expect(repo.findAgentLead).not.toHaveBeenCalled();
+  });
+
+  it('returns not_found without reading activities when the lead is absent', async () => {
+    const repo = repository({ lead: null });
+
+    const result = await getAgentCrmLeadActivities({ actor, leadId: 'lead-1' }, repo);
+
+    expect(result).toEqual({ success: false, error: 'not_found' });
+    expect(repo.listAgentLeadActivities).not.toHaveBeenCalled();
+  });
+
+  it('rejects cross-tenant, wrong-agent, and wrong-branch lead custody before reading activities', async () => {
+    for (const [candidate, reason] of [
+      [lead({ tenantId: 'tenant-2' }), 'tenant_scope'],
+      [lead({ agentId: 'agent-2' }), 'agent_scope'],
+      [lead({ branchId: 'branch-2' }), 'branch_scope'],
+    ] as const) {
+      const repo = repository({ lead: candidate });
+
+      const result = await getAgentCrmLeadActivities({ actor, leadId: 'lead-1' }, repo);
+
+      expect(result).toEqual({ success: false, error: 'forbidden', reason });
+      expect(repo.listAgentLeadActivities).not.toHaveBeenCalled();
+    }
+  });
+
+  it('returns only tenant, agent, branch, and lead scoped activities', async () => {
+    const allowed = activity({ id: 'allowed' });
+    const repo = repository({
+      activities: [
+        allowed,
+        activity({ id: 'cross-tenant', tenantId: 'tenant-2' }),
+        activity({ id: 'wrong-agent', agentId: 'agent-2' }),
+        activity({ id: 'wrong-branch', branchId: 'branch-2' }),
+        activity({ id: 'missing-branch', branchId: null }),
+        activity({ id: 'wrong-lead', leadId: 'lead-2' }),
+      ],
+    });
+
+    const result = await getAgentCrmLeadActivities({ actor, leadId: 'lead-1' }, repo);
+
+    expect(result).toEqual({ success: true, activities: [allowed] });
+  });
+
+  it('caps repository reads to the lead activity max rows', async () => {
+    const repo = repository({});
+
+    await getAgentCrmLeadActivities({ actor, leadId: 'lead-1', limit: 500 }, repo);
+
+    expect(repo.listAgentLeadActivities).toHaveBeenCalledWith({
+      actor,
+      lead: lead(),
+      limit: AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS,
+    });
+  });
+});

--- a/packages/domain-crm/src/lead-activities/index.ts
+++ b/packages/domain-crm/src/lead-activities/index.ts
@@ -53,29 +53,47 @@ function normalizeLimit(limit: number | null | undefined): number {
   return Math.max(1, Math.min(integerLimit, AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS));
 }
 
+function authorizeActor(
+  actor: CrmActorContext
+): AgentCrmLeadActivityAuthorizationDenialReason | null {
+  if (actor.role !== 'agent') return 'role_scope';
+  if (actor.scope.agentId && actor.scope.agentId !== actor.actorId) return 'agent_scope';
+  if (!actor.scope.branchId) return 'branch_scope';
+  return null;
+}
+
+function authorizeLead(
+  actor: CrmActorContext,
+  lead: AgentCrmLeadActivityLead
+): AgentCrmLeadActivityAuthorizationDenialReason | null {
+  if (lead.tenantId !== actor.tenantId) return 'tenant_scope';
+  if (lead.agentId !== actor.actorId) return 'agent_scope';
+  if (lead.branchId !== actor.scope.branchId) return 'branch_scope';
+  return null;
+}
+
+function authorizeActivity(
+  actor: CrmActorContext,
+  lead: AgentCrmLeadActivityLead | undefined,
+  activity: AgentCrmLeadActivity
+): AgentCrmLeadActivityAuthorizationDenialReason | null {
+  if (activity.tenantId !== actor.tenantId) return 'tenant_scope';
+  if (activity.agentId !== actor.actorId) return 'agent_scope';
+  if (lead && activity.leadId !== lead.id) return 'lead_scope';
+  if (activity.branchId !== actor.scope.branchId) return 'branch_scope';
+  return null;
+}
+
 export function authorizeAgentCrmLeadActivityRead(
   actor: CrmActorContext,
   lead?: AgentCrmLeadActivityLead,
   activity?: AgentCrmLeadActivity
 ): AgentCrmLeadActivityAuthorizationDenialReason | null {
-  if (actor.role !== 'agent') return 'role_scope';
-  if (actor.scope.agentId && actor.scope.agentId !== actor.actorId) return 'agent_scope';
-  if (!actor.scope.branchId) return 'branch_scope';
-
-  if (lead) {
-    if (lead.tenantId !== actor.tenantId) return 'tenant_scope';
-    if (lead.agentId !== actor.actorId) return 'agent_scope';
-    if (lead.branchId !== actor.scope.branchId) return 'branch_scope';
-  }
-
-  if (activity) {
-    if (activity.tenantId !== actor.tenantId) return 'tenant_scope';
-    if (activity.agentId !== actor.actorId) return 'agent_scope';
-    if (lead && activity.leadId !== lead.id) return 'lead_scope';
-    if (activity.branchId !== actor.scope.branchId) return 'branch_scope';
-  }
-
-  return null;
+  return (
+    authorizeActor(actor) ??
+    (lead ? authorizeLead(actor, lead) : null) ??
+    (activity ? authorizeActivity(actor, lead, activity) : null)
+  );
 }
 
 export async function getAgentCrmLeadActivities<

--- a/packages/domain-crm/src/lead-activities/index.ts
+++ b/packages/domain-crm/src/lead-activities/index.ts
@@ -6,6 +6,7 @@ export const AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS = 100;
 export type AgentCrmLeadActivityAuthorizationDenialReason =
   | 'agent_scope'
   | 'branch_scope'
+  | 'lead_scope'
   | 'role_scope'
   | 'tenant_scope';
 
@@ -48,10 +49,8 @@ function normalizeLimit(limit: number | null | undefined): number {
   if (!Number.isFinite(limit ?? AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS)) {
     return AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS;
   }
-  return Math.max(
-    1,
-    Math.min(limit ?? AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS, AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS)
-  );
+  const integerLimit = Math.trunc(limit ?? AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS);
+  return Math.max(1, Math.min(integerLimit, AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS));
 }
 
 export function authorizeAgentCrmLeadActivityRead(
@@ -72,7 +71,7 @@ export function authorizeAgentCrmLeadActivityRead(
   if (activity) {
     if (activity.tenantId !== actor.tenantId) return 'tenant_scope';
     if (activity.agentId !== actor.actorId) return 'agent_scope';
-    if (lead && activity.leadId !== lead.id) return 'agent_scope';
+    if (lead && activity.leadId !== lead.id) return 'lead_scope';
     if (activity.branchId !== actor.scope.branchId) return 'branch_scope';
   }
 

--- a/packages/domain-crm/src/lead-activities/index.ts
+++ b/packages/domain-crm/src/lead-activities/index.ts
@@ -1,0 +1,116 @@
+import type { CrmActorContext } from '../context';
+import type { CrmLeadActivity } from '../leads/types';
+
+export const AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS = 100;
+
+export type AgentCrmLeadActivityAuthorizationDenialReason =
+  | 'agent_scope'
+  | 'branch_scope'
+  | 'role_scope'
+  | 'tenant_scope';
+
+export type AgentCrmLeadActivityLead = {
+  agentId: string;
+  branchId?: string | null;
+  id: string;
+  tenantId: string;
+};
+
+export type AgentCrmLeadActivity = Omit<CrmLeadActivity, 'description'> & {
+  description: string | null;
+  agent?: { name: string | null } | null;
+};
+
+export type AgentCrmLeadActivityRepository<
+  TLead extends AgentCrmLeadActivityLead = AgentCrmLeadActivityLead,
+  TActivity extends AgentCrmLeadActivity = AgentCrmLeadActivity,
+> = {
+  findAgentLead(params: { actor: CrmActorContext; leadId: string }): Promise<TLead | null>;
+  listAgentLeadActivities(params: {
+    actor: CrmActorContext;
+    lead: TLead;
+    limit: number;
+  }): Promise<readonly TActivity[]>;
+};
+
+export type AgentCrmLeadActivityResult<
+  TActivity extends AgentCrmLeadActivity = AgentCrmLeadActivity,
+> =
+  | { success: true; activities: TActivity[] }
+  | { success: false; error: 'not_found' }
+  | {
+      success: false;
+      error: 'forbidden';
+      reason: AgentCrmLeadActivityAuthorizationDenialReason;
+    };
+
+function normalizeLimit(limit: number | null | undefined): number {
+  if (!Number.isFinite(limit ?? AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS)) {
+    return AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS;
+  }
+  return Math.max(
+    1,
+    Math.min(limit ?? AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS, AGENT_CRM_LEAD_ACTIVITY_MAX_ROWS)
+  );
+}
+
+export function authorizeAgentCrmLeadActivityRead(
+  actor: CrmActorContext,
+  lead?: AgentCrmLeadActivityLead,
+  activity?: AgentCrmLeadActivity
+): AgentCrmLeadActivityAuthorizationDenialReason | null {
+  if (actor.role !== 'agent') return 'role_scope';
+  if (actor.scope.agentId && actor.scope.agentId !== actor.actorId) return 'agent_scope';
+  if (!actor.scope.branchId) return 'branch_scope';
+
+  if (lead) {
+    if (lead.tenantId !== actor.tenantId) return 'tenant_scope';
+    if (lead.agentId !== actor.actorId) return 'agent_scope';
+    if (lead.branchId !== actor.scope.branchId) return 'branch_scope';
+  }
+
+  if (activity) {
+    if (activity.tenantId !== actor.tenantId) return 'tenant_scope';
+    if (activity.agentId !== actor.actorId) return 'agent_scope';
+    if (lead && activity.leadId !== lead.id) return 'agent_scope';
+    if (activity.branchId !== actor.scope.branchId) return 'branch_scope';
+  }
+
+  return null;
+}
+
+export async function getAgentCrmLeadActivities<
+  TLead extends AgentCrmLeadActivityLead,
+  TActivity extends AgentCrmLeadActivity,
+>(
+  input: { actor: CrmActorContext; leadId: string; limit?: number },
+  repository: AgentCrmLeadActivityRepository<TLead, TActivity>
+): Promise<AgentCrmLeadActivityResult<TActivity>> {
+  const actorDenied = authorizeAgentCrmLeadActivityRead(input.actor);
+  if (actorDenied) {
+    return { success: false, error: 'forbidden', reason: actorDenied };
+  }
+
+  const lead = await repository.findAgentLead({ actor: input.actor, leadId: input.leadId });
+  if (!lead) {
+    return { success: false, error: 'not_found' };
+  }
+
+  const leadDenied = authorizeAgentCrmLeadActivityRead(input.actor, lead);
+  if (leadDenied) {
+    return { success: false, error: 'forbidden', reason: leadDenied };
+  }
+
+  const activities = await repository.listAgentLeadActivities({
+    actor: input.actor,
+    lead,
+    limit: normalizeLimit(input.limit),
+  });
+
+  return {
+    success: true,
+    activities: activities.filter(
+      activity => !authorizeAgentCrmLeadActivityRead(input.actor, lead, activity)
+    ),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ overrides:
   path-to-regexp: ^8.4.0
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  protobufjs: 7.5.5
+  protobufjs: 7.5.6
   smol-toml: 1.6.1
   yaml@>=2.0.0 <2.8.3: 2.8.3
   ip-address: 10.1.1
@@ -13933,10 +13933,10 @@ packages:
         integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
       }
 
-  protobufjs@7.5.5:
+  protobufjs@7.5.6:
     resolution:
       {
-        integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==,
+        integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==,
       }
     engines: { node: '>=12.0.0' }
 
@@ -17659,7 +17659,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
       yargs: 17.7.2
 
   '@hono/node-server@1.19.13(hono@4.12.18)':
@@ -18986,7 +18986,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
 
   '@opentelemetry/otlp-transformer@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -18997,7 +18997,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
 
   '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -19008,7 +19008,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.5
+      protobufjs: 7.5.6
 
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -25261,7 +25261,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  protobufjs@7.5.5:
+  protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary
- Adds `@interdomestik/domain-crm/lead-activities` read-side API for agent lead activity timelines.
- Moves the agent lead detail activity read path behind a web repository adapter with tenant, agent, lead, and branch predicates.
- Adds focused domain and adapter/page tests for cross-tenant, wrong-agent, wrong-branch, missing-branch, and denied-read behavior.

## Local Verification
- `pnpm --filter @interdomestik/domain-crm test:unit --run src/lead-activities/index.test.ts` ✅
- `pnpm --filter @interdomestik/web test:unit --run src/lib/domain-crm/lead-activity-repository.test.ts src/features/agent/leads/components/AgentLeadDetailV2Page.test.tsx` ✅
- `pnpm check:db-access` ✅
- `pnpm security:guard` ✅
- `git diff --check` ✅
- `interdomestik_qa.scope_audit` ✅

## Gate Note
- `pnpm pr:verify` reached `e2e:gate:pr:fast` and failed in `e2e/gate/v1-live-surface-revalidation.spec.ts` (`agent can enter member claim context and return to CRM without session loss`) after 118/124 E2E tests passed.
- Targeted rerun of that spec reproduced the same MK agent/member cross-surface failure.
- The failing surface is outside this slice and this branch does not touch `apps/web/src/proxy.ts`, auth/tenancy, member dashboard, agent dashboard CTA, or route architecture.
