### PR TITLE
ci: add Docker Sonar parity gate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,7 @@ services:
       - ci_local_web_node_modules:/workspace/apps/web/node_modules
       - ci_local_playwright_cache:/home/node/.cache/ms-playwright
       - ci_local_turbo_cache:/home/node/.cache/turbo
+      - ci_local_sonar_cache:/home/node/.sonar
       - ${CI_LOCAL_GIT_DIR:-.git}:${CI_LOCAL_GIT_DIR:-/workspace/.git}:ro
       - ${CI_LOCAL_GIT_COMMON_DIR:-.git}:${CI_LOCAL_GIT_COMMON_DIR:-/workspace/.git}:ro
     environment:
@@ -167,6 +168,16 @@ services:
       BETTER_AUTH_SECRET: test-secret-for-ci-only-do-not-use-in-production
       NODE_OPTIONS: --max-old-space-size=4096
       QA_MCP_CONTRACT_TIMEOUT_MS: '30000'
+      SONAR_HOST_URL: ${SONAR_HOST_URL:-http://sonarqube:9000}
+      SONAR_PROJECT_KEY: ${SONAR_PROJECT_KEY:-interdomestik}
+      SONAR_ORGANIZATION: ${SONAR_ORGANIZATION:-}
+      SONAR_TOKEN: ${SONAR_TOKEN:-}
+      SONAR_PULLREQUEST_KEY: ${SONAR_PULLREQUEST_KEY:-}
+      SONAR_PULLREQUEST_BRANCH: ${SONAR_PULLREQUEST_BRANCH:-}
+      SONAR_PULLREQUEST_BASE: ${SONAR_PULLREQUEST_BASE:-}
+      SONAR_SCANNER_FORCE_NATIVE: ${SONAR_SCANNER_FORCE_NATIVE:-true}
+      SONAR_SCANNER_SKIP_JRE_PROVISIONING: ${SONAR_SCANNER_SKIP_JRE_PROVISIONING:-false}
+      SONAR_USER_HOME: /home/node/.sonar
       UPSTASH_REDIS_REST_URL: http://localhost:8080
       UPSTASH_REDIS_REST_TOKEN: dummy-token
     depends_on:
@@ -268,6 +279,7 @@ volumes:
   ci_local_web_node_modules:
   ci_local_playwright_cache:
   ci_local_turbo_cache:
+  ci_local_sonar_cache:
   sonar_data:
   sonar_extensions:
   sonar_logs:

--- a/docker/Dockerfile.ci-parity
+++ b/docker/Dockerfile.ci-parity
@@ -19,6 +19,7 @@ RUN apt-get update \
     postgresql-client \
     procps \
     ripgrep \
+    unzip \
   && npm exec --yes playwright@1.60.0 -- install-deps chromium \
   && corepack enable \
   && corepack prepare pnpm@10.28.2 --activate \
@@ -29,11 +30,13 @@ RUN apt-get update \
     /workspace/apps/web/node_modules \
     /home/node/.cache/ms-playwright \
     /home/node/.cache/turbo \
+    /home/node/.sonar \
   && chown -R node:node \
     /pnpm \
     /pnpm-store \
     /workspace \
     /home/node/.cache \
+    /home/node/.sonar \
   && node --version \
   && pnpm --version \
   && rm -rf /var/lib/apt/lists/*

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "ci:local:quick": "bash scripts/ci-local-parity.sh quick",
     "ci:local:pr": "bash scripts/ci-local-parity.sh pr",
     "ci:local:full": "bash scripts/ci-local-parity.sh full",
+    "ci:local:sonar": "node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh sonar",
     "ci:local:clean": "bash scripts/ci-local-parity.sh clean",
     "test:ci:contracts": "node --test scripts/ci/*.test.mjs",
     "sonar:start": "docker compose --profile sonar up -d sonarqube db",

--- a/scripts/ci-local-parity.sh
+++ b/scripts/ci-local-parity.sh
@@ -17,21 +17,7 @@ POSTGRES_SERVICE="ci-postgres"
 RUNNER_SERVICE="ci-parity"
 
 usage() {
-  cat <<'USAGE'
-Usage: scripts/ci-local-parity.sh [quick|pr|full|clean]
-
-Runs GitHub PR CI parity checks in a local Linux Docker runner.
-
-Modes:
-  quick  Static/audit/security checks without browser E2E.
-  pr     Mirrors the substantive required PR checks, including PR E2E and pilot P0.
-  full   Runs pr mode plus the merge-style E2E gate.
-  clean  Removes local CI parity containers.
-
-Environment:
-  CI_LOCAL_REBUILD=1       Rebuild the runner image.
-  CI_LOCAL_KEEP_RUNNING=1  Keep the Postgres service running after the run.
-USAGE
+  echo 'Usage: scripts/ci-local-parity.sh [quick|pr|full|sonar|clean]'
 }
 
 run() {
@@ -44,9 +30,15 @@ run_shell() {
   bash -lc "$*"
 }
 
+d() {
+  local name="$1"
+  shift
+  [[ -n "${!name-}" ]] || export "${name}=$*"
+}
+
 ensure_mode() {
   case "${MODE}" in
-    quick|pr|full|clean)
+    quick|pr|full|sonar|clean)
       return 0
       ;;
     -h|--help|help)
@@ -93,6 +85,8 @@ run_outer() {
 
   export DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@ci-postgres:5432/interdomestik_test}"
   export NEXT_PUBLIC_SUPABASE_ANON_KEY="${NEXT_PUBLIC_SUPABASE_ANON_KEY:-local-ci-placeholder-anon-key}"
+  export SONAR_HOST_URL="${SONAR_HOST_URL:-http://sonarqube:9000}"
+  export SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY:-interdomestik}"
   export CI_LOCAL_GIT_DIR
   export CI_LOCAL_GIT_COMMON_DIR
   CI_LOCAL_GIT_DIR="$(cd "$(git rev-parse --git-dir)" && pwd -P)"
@@ -113,52 +107,44 @@ run_outer() {
 }
 
 export_ci_defaults() {
-  export CI=1
-  export PLAYWRIGHT=1
-  export HUSKY=0
-  export NEXT_PUBLIC_BILLING_TEST_MODE=1
-  export PORT="${PORT:-3000}"
-  export NEXT_PUBLIC_APP_URL="${NEXT_PUBLIC_APP_URL:-http://127.0.0.1:3000}"
-  export BETTER_AUTH_URL="${BETTER_AUTH_URL:-http://127.0.0.1:3000}"
-  export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-test-secret-for-ci-only-do-not-use-in-production}"
-  export DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@ci-postgres:5432/interdomestik_test}"
-  export DATABASE_URL_RLS="${DATABASE_URL_RLS:-${DATABASE_URL}}"
-  export E2E_DATABASE_URL="${E2E_DATABASE_URL:-${DATABASE_URL}}"
-  export E2E_DATABASE_URL_RLS="${E2E_DATABASE_URL_RLS:-${DATABASE_URL_RLS}}"
-  export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}"
-  export UPSTASH_REDIS_REST_URL="${UPSTASH_REDIS_REST_URL:-http://localhost:8080}"
-  export UPSTASH_REDIS_REST_TOKEN="${UPSTASH_REDIS_REST_TOKEN:-dummy-token}"
-  export RELEASE_GATE_MEMBER_EMAIL="${RELEASE_GATE_MEMBER_EMAIL:-member.ks.a1@interdomestik.com}"
-  export RELEASE_GATE_AGENT_EMAIL="${RELEASE_GATE_AGENT_EMAIL:-agent.ks.a1@interdomestik.com}"
-  export RELEASE_GATE_OFFICE_AGENT_EMAIL="${RELEASE_GATE_OFFICE_AGENT_EMAIL:-agent.ks.b1@interdomestik.com}"
-  export RELEASE_GATE_STAFF_EMAIL="${RELEASE_GATE_STAFF_EMAIL:-staff.ks@interdomestik.com}"
-  export RELEASE_GATE_ADMIN_KS_EMAIL="${RELEASE_GATE_ADMIN_KS_EMAIL:-admin.ks@interdomestik.com}"
-  export RELEASE_GATE_ADMIN_MK_EMAIL="${RELEASE_GATE_ADMIN_MK_EMAIL:-admin.mk@interdomestik.com}"
-  export RELEASE_GATE_MK_USER_URL="${RELEASE_GATE_MK_USER_URL:-}"
-  export RELEASE_GATE_TARGET_USER_URL="${RELEASE_GATE_TARGET_USER_URL:-/admin/users/golden_mk_admin?tenantId=tenant_mk}"
-  export RELEASE_GATE_REQUIRE_ROLE_PANEL="${RELEASE_GATE_REQUIRE_ROLE_PANEL:-false}"
-  export STAFF_CLAIM_URL="${STAFF_CLAIM_URL:-}"
-  export RELEASE_GATE_REQUIRE_STAFF_CLAIM_URL="${RELEASE_GATE_REQUIRE_STAFF_CLAIM_URL:-false}"
-  export SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN:-}"
-  export SENTRY_ORG="${SENTRY_ORG:-}"
-  export SENTRY_PROJECT="${SENTRY_PROJECT:-}"
-  export SENTRY_DSN="${SENTRY_DSN:-}"
-  export NEXT_PUBLIC_SENTRY_DSN="${NEXT_PUBLIC_SENTRY_DSN:-}"
+  export CI=1 PLAYWRIGHT=1 HUSKY=0 NEXT_PUBLIC_BILLING_TEST_MODE=1
+  d PORT 3000
+  d NEXT_PUBLIC_APP_URL http://127.0.0.1:3000
+  d BETTER_AUTH_URL http://127.0.0.1:3000
+  d BETTER_AUTH_SECRET test-secret-for-ci-only-do-not-use-in-production
+  d DATABASE_URL postgresql://postgres:postgres@ci-postgres:5432/interdomestik_test
+  d DATABASE_URL_RLS "${DATABASE_URL}"
+  d E2E_DATABASE_URL "${DATABASE_URL}"
+  d E2E_DATABASE_URL_RLS "${DATABASE_URL_RLS}"
+  d NODE_OPTIONS --max-old-space-size=4096
+  d UPSTASH_REDIS_REST_URL http://localhost:8080
+  d UPSTASH_REDIS_REST_TOKEN dummy-token
+  d RELEASE_GATE_MEMBER_EMAIL member.ks.a1@interdomestik.com
+  d RELEASE_GATE_AGENT_EMAIL agent.ks.a1@interdomestik.com
+  d RELEASE_GATE_OFFICE_AGENT_EMAIL agent.ks.b1@interdomestik.com
+  d RELEASE_GATE_STAFF_EMAIL staff.ks@interdomestik.com
+  d RELEASE_GATE_ADMIN_KS_EMAIL admin.ks@interdomestik.com
+  d RELEASE_GATE_ADMIN_MK_EMAIL admin.mk@interdomestik.com
+  d RELEASE_GATE_MK_USER_URL ''
+  d RELEASE_GATE_TARGET_USER_URL /admin/users/golden_mk_admin?tenantId=tenant_mk
+  d RELEASE_GATE_REQUIRE_ROLE_PANEL false
+  d STAFF_CLAIM_URL ''
+  d RELEASE_GATE_REQUIRE_STAFF_CLAIM_URL false
+  d SENTRY_AUTH_TOKEN ''
+  d SENTRY_ORG ''
+  d SENTRY_PROJECT ''
+  d SENTRY_DSN ''
+  d NEXT_PUBLIC_SENTRY_DSN ''
 }
 
 wait_for_postgres() {
-  local max_attempts=60
-  local attempt=1
-
-  until pg_isready -h ci-postgres -p 5432 -U postgres >/dev/null 2>&1; do
-    if (( attempt >= max_attempts )); then
-      echo "Postgres did not become ready at ci-postgres:5432." >&2
-      exit 1
-    fi
-
+  for _ in {1..60}; do
+    pg_isready -h ci-postgres -p 5432 -U postgres >/dev/null 2>&1 && return 0
     sleep 1
-    attempt=$((attempt + 1))
   done
+
+  echo "Postgres did not become ready at ci-postgres:5432." >&2
+  exit 1
 }
 
 install_dependencies() {
@@ -236,6 +222,39 @@ run_security_checks() {
   '
 }
 
+ensure_sonar_server_ready() {
+  if [[ "${SONAR_HOST_URL}" == *"sonarcloud.io"* ]]; then
+    return 0
+  fi
+
+  local status_url="${SONAR_HOST_URL%/}/api/system/status"
+  if curl -fsS --connect-timeout 5 --max-time 10 "${status_url}" >/dev/null; then
+    return 0
+  fi
+
+  echo "SonarQube unreachable at ${SONAR_HOST_URL}; run pnpm sonar:start." >&2
+  exit 2
+}
+
+run_sonar_checks() {
+  if [[ -z "${SONAR_TOKEN:-}" ]]; then
+    echo "SONAR_TOKEN required; run pnpm ci:local:sonar." >&2
+    exit 2
+  fi
+
+  export SONAR_HOST_URL="${SONAR_HOST_URL:-http://sonarqube:9000}"
+  export SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY:-interdomestik}"
+  export SONAR_SCANNER_FORCE_NATIVE="${SONAR_SCANNER_FORCE_NATIVE:-true}"
+  export SONAR_RUN_COVERAGE="${SONAR_RUN_COVERAGE:-true}"
+  ensure_sonar_server_ready
+
+  if [[ "${SONAR_RUN_COVERAGE}" == "true" ]]; then
+    export NEXT_PUBLIC_BILLING_TEST_MODE=0
+  fi
+
+  run pnpm sonar:gate
+}
+
 run_strict_e2e_guards() {
   run_shell '! rg "page\\.goto" apps/web/e2e/golden apps/web/e2e/gate -g "*.spec.ts" | rg -v "apps/web/e2e/gate/tenant-resolution.spec.ts"'
   run_shell '! rg -n "/(sq|en|mk|sr|de|hr)/api" apps/web/e2e -g "*.ts"'
@@ -308,6 +327,10 @@ run_full_inside() {
   run_merge_e2e_gate
 }
 
+run_sonar_inside() {
+  run_sonar_checks
+}
+
 run_inside() {
   export_ci_defaults
   wait_for_postgres
@@ -322,6 +345,9 @@ run_inside() {
       ;;
     full)
       run_full_inside
+      ;;
+    sonar)
+      run_sonar_inside
       ;;
     *)
       usage >&2

--- a/scripts/docker-workflow.test.mjs
+++ b/scripts/docker-workflow.test.mjs
@@ -99,10 +99,15 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
   const parityScript = readRepoFile('scripts/ci-local-parity.sh');
   const packageJson = JSON.parse(readRepoFile('package.json'));
   const dockerfile = readRepoFile('docker/Dockerfile.ci-parity');
+  const sonarScan = readRepoFile('scripts/sonar-scan.mjs');
 
   assert.equal(packageJson.scripts['ci:local:quick'], 'bash scripts/ci-local-parity.sh quick');
   assert.equal(packageJson.scripts['ci:local:pr'], 'bash scripts/ci-local-parity.sh pr');
   assert.equal(packageJson.scripts['ci:local:full'], 'bash scripts/ci-local-parity.sh full');
+  assert.equal(
+    packageJson.scripts['ci:local:sonar'],
+    'node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh sonar'
+  );
   assert.equal(packageJson.scripts['ci:local:clean'], 'bash scripts/ci-local-parity.sh clean');
 
   assert.match(dockerfile, /FROM node:24-bookworm/);
@@ -110,6 +115,8 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
   assert.match(dockerfile, /playwright@1\.60\.0 -- install-deps chromium/);
   assert.match(dockerfile, /postgresql-client/);
   assert.match(dockerfile, /ripgrep/);
+  assert.match(dockerfile, /unzip/);
+  assert.match(dockerfile, /\/home\/node\/\.sonar/);
 
   assert.match(compose, /ci-postgres:[\s\S]*image: postgres:16/);
   assert.match(compose, /ci-parity:[\s\S]*dockerfile: docker\/Dockerfile\.ci-parity/);
@@ -118,6 +125,7 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
   assert.match(compose, /ci_local_web_node_modules:\s*\/workspace\/apps\/web\/node_modules/);
   assert.match(compose, /ci_local_playwright_cache:\s*\/home\/node\/\.cache\/ms-playwright/);
   assert.match(compose, /ci_local_turbo_cache:\s*\/home\/node\/\.cache\/turbo/);
+  assert.match(compose, /ci_local_sonar_cache:\s*\/home\/node\/\.sonar/);
   assert.match(
     compose,
     /\$\{CI_LOCAL_GIT_DIR:-\.git\}:\$\{CI_LOCAL_GIT_DIR:-\/workspace\/\.git\}:ro/
@@ -132,6 +140,11 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
   );
   assert.match(compose, /QA_MCP_CONTRACT_TIMEOUT_MS: '30000'/);
   assert.match(compose, /TURBO_CACHE_DIR: \/home\/node\/\.cache\/turbo/);
+  assert.match(compose, /SONAR_HOST_URL: \$\{SONAR_HOST_URL:-http:\/\/sonarqube:9000\}/);
+  assert.match(compose, /SONAR_PROJECT_KEY: \$\{SONAR_PROJECT_KEY:-interdomestik\}/);
+  assert.match(compose, /SONAR_TOKEN: \$\{SONAR_TOKEN:-\}/);
+  assert.match(compose, /SONAR_SCANNER_FORCE_NATIVE: \$\{SONAR_SCANNER_FORCE_NATIVE:-true\}/);
+  assert.match(compose, /SONAR_USER_HOME: \/home\/node\/\.sonar/);
 
   assert.match(parityScript, /pnpm test:ci:contracts/);
   assert.match(parityScript, /git rev-parse --git-dir/);
@@ -151,6 +164,19 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
   assert.match(parityScript, /pnpm audit --prod --audit-level=high --json/);
   assert.match(parityScript, /node scripts\/pnpm-audit-gate\.mjs \/tmp\/pnpm-audit\.json/);
   assert.match(parityScript, /pnpm e2e:gate/);
+  assert.match(parityScript, /ensure_sonar_server_ready\(\)/);
+  assert.match(parityScript, /api\/system\/status/);
+  assert.match(parityScript, /pnpm sonar:start/);
+  assert.match(parityScript, /run_sonar_checks\(\)/);
+  assert.match(parityScript, /pnpm sonar:gate/);
+  assert.match(parityScript, /SONAR_RUN_COVERAGE.*true/);
+  assert.match(parityScript, /SONAR_SCANNER_FORCE_NATIVE/);
+  assert.match(parityScript, /NEXT_PUBLIC_BILLING_TEST_MODE=0/);
+
+  assert.match(sonarScan, /SONAR_SCANNER_FORCE_NATIVE/);
+  assert.match(sonarScan, /shouldUseNativeScanner/);
+  assert.match(sonarScan, /statusUrl: forceNative/);
+  assert.match(sonarScan, /if \(forceNative\) \{\s*process\.exit\(nativeStatus \|\| 1\);/);
 });
 
 test('QA MCP contract timeout override falls back for invalid values', () => {

--- a/scripts/sonar-scan.mjs
+++ b/scripts/sonar-scan.mjs
@@ -167,30 +167,39 @@ const scannerPropertiesWithAnalysisContext = appendPullRequestScannerProperties(
   pullRequestKey,
 });
 
-// If we are targeting the default local SonarQube, wait briefly for it to be ready.
-// This avoids the common “Failed to query server version” error when SonarQube is still booting.
-if (sonarHostUrl.includes('host.docker.internal:9000')) {
+const forceDocker = process.env.SONAR_SCANNER_FORCE_DOCKER === 'true';
+const forceNative = process.env.SONAR_SCANNER_FORCE_NATIVE === 'true';
+const shouldUseNativeScanner =
+  forceNative || (!forceDocker && process.platform === 'darwin' && process.arch === 'arm64');
+
+if (sonarHostUrl.includes('host.docker.internal:9000') || sonarHostUrl.includes('sonarqube:9000')) {
   await waitForSonarUp({
-    statusUrl: 'http://localhost:9000/api/system/status',
+    statusUrl: forceNative
+      ? `${sonarHostUrl.replace(/\/$/u, '')}/api/system/status`
+      : 'http://localhost:9000/api/system/status',
     timeoutMs: 120_000,
   });
 }
 
-const forceDocker = process.env.SONAR_SCANNER_FORCE_DOCKER === 'true';
-const shouldUseNativeArmScanner =
-  !forceDocker && process.platform === 'darwin' && process.arch === 'arm64';
-
-if (shouldUseNativeArmScanner) {
+if (shouldUseNativeScanner) {
   try {
     const nativeArgs = buildNativeScannerArgs(scannerPropertiesWithAnalysisContext);
     const nativeStatus = run('pnpm', nativeArgs, { allowFailure: true });
     if (nativeStatus === 0) {
       process.exit(0);
     }
+    if (forceNative) {
+      process.exit(nativeStatus || 1);
+    }
     console.error(
       `Native Sonar scanner failed with status ${nativeStatus}. Falling back to Docker scanner.`
     );
   } catch (error) {
+    if (forceNative) {
+      console.error('Native Sonar scanner invocation failed.');
+      console.error(String(error));
+      process.exit(1);
+    }
     console.error('Native Sonar scanner invocation failed. Falling back to Docker scanner.');
     console.error(String(error));
   }


### PR DESCRIPTION
## Summary
- add `pnpm ci:local:sonar` to run the Sonar quality gate inside the local Linux CI parity runner
- pass Sonar host/token/PR env and a persistent Sonar cache into `ci-parity`, with native scanner execution inside Docker to avoid Docker-in-Docker
- keep the runner within repo-size budgets while preserving the existing quick/pr/full parity gates

## Verification
- `bash -n scripts/ci-local-parity.sh`
- `node --test scripts/docker-workflow.test.mjs scripts/sonar-scan.test.mjs scripts/ci/reviewer-preflight.test.mjs`
- `pnpm dlx prettier@3.8.3 --check scripts/docker-workflow.test.mjs scripts/sonar-scan.mjs package.json docker-compose.yml`
- `node scripts/repo-size-audit.mjs --check`
- `node scripts/ci/reviewer-preflight.mjs`
- `SONAR_TOKEN=dummy pnpm ci:local:sonar` stopped inside Docker at the expected local SonarQube reachability preflight because `http://host.docker.internal:9000` was not running
