### PR TITLE
ci: harden local Docker PR parity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,12 @@ services:
       BETTER_AUTH_SECRET: test-secret-for-ci-only-do-not-use-in-production
       NODE_OPTIONS: --max-old-space-size=4096
       QA_MCP_CONTRACT_TIMEOUT_MS: '30000'
+      CI_LOCAL_PR_NUMBER: ${CI_LOCAL_PR_NUMBER:-}
+      CI_LOCAL_PR_TITLE: ${CI_LOCAL_PR_TITLE:-}
+      CI_LOCAL_PR_AUTHOR: ${CI_LOCAL_PR_AUTHOR:-}
+      CI_LOCAL_BASE_REF: ${CI_LOCAL_BASE_REF:-origin/main}
+      CI_LOCAL_BASE_SHA: ${CI_LOCAL_BASE_SHA:-}
+      CI_LOCAL_HEAD_SHA: ${CI_LOCAL_HEAD_SHA:-}
       SONAR_HOST_URL: ${SONAR_HOST_URL:-http://sonarqube:9000}
       SONAR_PROJECT_KEY: ${SONAR_PROJECT_KEY:-interdomestik}
       SONAR_ORGANIZATION: ${SONAR_ORGANIZATION:-}

--- a/docker/Dockerfile.ci-parity
+++ b/docker/Dockerfile.ci-parity
@@ -6,6 +6,7 @@ ENV PNPM_HOME=/pnpm
 ENV PNPM_STORE_DIR=/pnpm-store
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
 ENV PATH=$PNPM_HOME:$PATH
+ARG GITLEAKS_VERSION=8.30.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -20,6 +21,15 @@ RUN apt-get update \
     procps \
     ripgrep \
     unzip \
+  && arch="$(uname -m)" \
+  && case "$arch" in \
+    x86_64) gitleaks_archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" ;; \
+    aarch64|arm64) gitleaks_archive="gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz" ;; \
+    *) echo "Unsupported platform for gitleaks: linux-${arch}" >&2; exit 1 ;; \
+  esac \
+  && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${gitleaks_archive}" -o "/tmp/${gitleaks_archive}" \
+  && tar -xzf "/tmp/${gitleaks_archive}" -C /tmp gitleaks \
+  && install /tmp/gitleaks /usr/local/bin/gitleaks \
   && npm exec --yes playwright@1.60.0 -- install-deps chromium \
   && corepack enable \
   && corepack prepare pnpm@10.28.2 --activate \
@@ -39,6 +49,7 @@ RUN apt-get update \
     /home/node/.sonar \
   && node --version \
   && pnpm --version \
+  && gitleaks version \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/package.json
+++ b/package.json
@@ -87,6 +87,8 @@
     "ci:local:pr": "bash scripts/ci-local-parity.sh pr",
     "ci:local:full": "bash scripts/ci-local-parity.sh full",
     "ci:local:sonar": "node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh sonar",
+    "ci:local:sonar:pr": "node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh sonar-pr",
+    "ci:local:ready": "node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh ready",
     "ci:local:clean": "bash scripts/ci-local-parity.sh clean",
     "test:ci:contracts": "node --test scripts/ci/*.test.mjs",
     "sonar:start": "docker compose --profile sonar up -d sonarqube db",

--- a/scripts/ci-local-parity.sh
+++ b/scripts/ci-local-parity.sh
@@ -17,7 +17,7 @@ POSTGRES_SERVICE="ci-postgres"
 RUNNER_SERVICE="ci-parity"
 
 usage() {
-  echo 'Usage: scripts/ci-local-parity.sh [quick|pr|full|sonar|clean]'
+  echo 'Usage: scripts/ci-local-parity.sh [quick|pr|full|sonar|sonar-pr|ready|clean]'
 }
 
 run() {
@@ -38,7 +38,7 @@ d() {
 
 ensure_mode() {
   case "${MODE}" in
-    quick|pr|full|sonar|clean)
+    quick|pr|full|sonar|sonar-pr|ready|clean)
       return 0
       ;;
     -h|--help|help)
@@ -54,6 +54,68 @@ ensure_mode() {
 
 clean_outer() {
   docker compose --profile "${COMPOSE_PROFILE}" rm -sf "${POSTGRES_SERVICE}" "${RUNNER_SERVICE}" >/dev/null 2>&1 || true
+}
+
+detect_pull_request_context() {
+  if [[ -n "${CI_LOCAL_PR_NUMBER:-}" && -n "${SONAR_PULLREQUEST_KEY:-}" && -n "${SONAR_PULLREQUEST_BRANCH:-}" && -n "${SONAR_PULLREQUEST_BASE:-}" ]]; then
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    return 1
+  fi
+
+  local pr_json
+  if ! pr_json="$(gh pr view --json number,headRefName,baseRefName,title,author 2>/dev/null)"; then
+    return 1
+  fi
+
+  export CI_LOCAL_PR_NUMBER
+  export CI_LOCAL_PR_TITLE
+  export CI_LOCAL_PR_AUTHOR
+  export CI_LOCAL_BASE_REF
+  export SONAR_PULLREQUEST_KEY
+  export SONAR_PULLREQUEST_BRANCH
+  export SONAR_PULLREQUEST_BASE
+
+  CI_LOCAL_PR_NUMBER="$(echo "${pr_json}" | jq -r '.number // empty')"
+  CI_LOCAL_PR_TITLE="$(echo "${pr_json}" | jq -r '.title // empty')"
+  CI_LOCAL_PR_AUTHOR="$(echo "${pr_json}" | jq -r '.author.login // empty')"
+  SONAR_PULLREQUEST_KEY="${CI_LOCAL_PR_NUMBER}"
+  SONAR_PULLREQUEST_BRANCH="$(echo "${pr_json}" | jq -r '.headRefName // empty')"
+  SONAR_PULLREQUEST_BASE="$(echo "${pr_json}" | jq -r '.baseRefName // empty')"
+  CI_LOCAL_BASE_REF="origin/${SONAR_PULLREQUEST_BASE}"
+
+  [[ -n "${CI_LOCAL_PR_NUMBER}" && -n "${SONAR_PULLREQUEST_BRANCH}" && -n "${SONAR_PULLREQUEST_BASE}" ]]
+}
+
+export_default_git_context() {
+  export CI_LOCAL_HEAD_SHA
+  export CI_LOCAL_BASE_REF
+  export CI_LOCAL_BASE_SHA
+
+  CI_LOCAL_HEAD_SHA="${CI_LOCAL_HEAD_SHA:-$(git rev-parse HEAD)}"
+  CI_LOCAL_BASE_REF="${CI_LOCAL_BASE_REF:-origin/main}"
+
+  if git rev-parse --verify "${CI_LOCAL_BASE_REF}" >/dev/null 2>&1; then
+    CI_LOCAL_BASE_SHA="${CI_LOCAL_BASE_SHA:-$(git merge-base "${CI_LOCAL_BASE_REF}" HEAD)}"
+  else
+    CI_LOCAL_BASE_SHA="${CI_LOCAL_BASE_SHA:-$(git rev-parse HEAD~1)}"
+  fi
+}
+
+run_host_pr_finalizer_if_available() {
+  if [[ -z "${CI_LOCAL_PR_NUMBER:-}" ]]; then
+    echo "No open GitHub PR detected; skipping remote PR finalizer."
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "GitHub CLI is unavailable; skipping remote PR finalizer for PR #${CI_LOCAL_PR_NUMBER}."
+    return 0
+  fi
+
+  run_shell "GITHUB_ACTIONS=true PR_FINALIZER_SKIP_CHECK_POLLING=false PR_NUMBER='${CI_LOCAL_PR_NUMBER}' pnpm pr:finalize"
 }
 
 cleanup_outer() {
@@ -82,6 +144,13 @@ run_outer() {
   fi
 
   run node scripts/ci/reviewer-preflight.mjs
+  detect_pull_request_context || true
+  export_default_git_context
+
+  if [[ "${MODE}" == "sonar-pr" && -z "${CI_LOCAL_PR_NUMBER:-}" ]]; then
+    echo "Unable to detect an open GitHub PR for this branch; set SONAR_PULLREQUEST_* manually or open a PR first." >&2
+    exit 2
+  fi
 
   export DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@ci-postgres:5432/interdomestik_test}"
   export NEXT_PUBLIC_SUPABASE_ANON_KEY="${NEXT_PUBLIC_SUPABASE_ANON_KEY:-local-ci-placeholder-anon-key}"
@@ -104,6 +173,10 @@ run_outer() {
   run docker compose --profile "${COMPOSE_PROFILE}" up -d "${POSTGRES_SERVICE}"
   run docker compose --profile "${COMPOSE_PROFILE}" run --rm "${RUNNER_SERVICE}" \
     bash scripts/ci-local-parity.sh --inside "${MODE}"
+
+  if [[ "${MODE}" == "ready" ]]; then
+    run_host_pr_finalizer_if_available
+  fi
 }
 
 export_ci_defaults() {
@@ -147,6 +220,21 @@ wait_for_postgres() {
   exit 1
 }
 
+resolve_ci_base_ref() {
+  if git rev-parse --verify "${CI_LOCAL_BASE_REF:-origin/main}" >/dev/null 2>&1; then
+    echo "${CI_LOCAL_BASE_REF:-origin/main}"
+    return 0
+  fi
+
+  echo 'HEAD~1'
+}
+
+changed_files_for_validation_surface() {
+  local base_ref
+  base_ref="$(resolve_ci_base_ref)"
+  git diff --name-only "${base_ref}...HEAD" || true
+}
+
 install_dependencies() {
   run pnpm install --frozen-lockfile --prefer-offline
 }
@@ -173,6 +261,7 @@ load_e2e_credentials() {
 }
 
 run_ci_audit() {
+  run pnpm repo:size:check
   run node scripts/check-env-ci.mjs
   run pnpm test:ci:contracts
   run pnpm check:e2e-contracts:base
@@ -182,6 +271,61 @@ run_ci_audit() {
   run pnpm purity:audit
   run pnpm db:migrations:check-journal
   run pnpm check:e2e-quarantine-budget
+}
+
+run_validation_surface_check() {
+  local changed_files_path
+  local output
+  changed_files_path="$(mktemp)"
+  changed_files_for_validation_surface >"${changed_files_path}"
+  output="$(node scripts/ci/validation-surface-policy.mjs --event-name pull_request --changed-files-path "${changed_files_path}")"
+  rm -f "${changed_files_path}"
+
+  printf '%s\n' "${output}"
+  CI_LOCAL_VALIDATION_SHOULD_RUN="$(printf '%s\n' "${output}" | awk -F= '$1 == "should_run" {print $2}' | tail -n 1)"
+  CI_LOCAL_VALIDATION_REASON="$(printf '%s\n' "${output}" | awk -F= '$1 == "reason" {print $2}' | tail -n 1)"
+  export CI_LOCAL_VALIDATION_SHOULD_RUN CI_LOCAL_VALIDATION_REASON
+}
+
+should_run_heavy_validation() {
+  [[ "${CI_LOCAL_VALIDATION_SHOULD_RUN:-true}" == "true" ]]
+}
+
+run_commitlint_check() {
+  local from_ref="${CI_LOCAL_BASE_SHA:-}"
+  local to_ref="${CI_LOCAL_HEAD_SHA:-HEAD}"
+
+  if [[ "${CI_LOCAL_PR_AUTHOR:-}" == "dependabot[bot]" && -n "${CI_LOCAL_PR_TITLE:-}" ]]; then
+    local transformed_title="${CI_LOCAL_PR_TITLE}"
+    if ! printf '%s\n' "${transformed_title}" | rg -q '^[a-z][a-z0-9-]*(\([^)]+\))?!?:[[:space:]]'; then
+      transformed_title="chore(deps): $(printf '%s' "${CI_LOCAL_PR_TITLE}" | tr '[:upper:]' '[:lower:]')"
+    fi
+    printf '\n==> pnpm exec commitlint (dependabot title)\n'
+    printf '%s\n' "${transformed_title}" | pnpm exec commitlint
+    return 0
+  fi
+
+  if [[ -z "${from_ref}" ]]; then
+    from_ref="$(git merge-base "$(resolve_ci_base_ref)" HEAD)"
+  fi
+
+  run pnpm exec commitlint --from "${from_ref}" --to "${to_ref}"
+}
+
+run_gitleaks_check() {
+  local log_opts='--all'
+  mkdir -p /tmp/gitleaks-artifacts
+
+  if [[ -n "${CI_LOCAL_BASE_SHA:-}" && -n "${CI_LOCAL_HEAD_SHA:-}" ]]; then
+    log_opts="${CI_LOCAL_BASE_SHA}..${CI_LOCAL_HEAD_SHA}"
+  fi
+
+  run gitleaks git --redact --log-opts="${log_opts}" --report-format sarif --report-path /tmp/gitleaks-artifacts/gitleaks.sarif
+}
+
+run_github_edge_checks() {
+  run_commitlint_check
+  run_gitleaks_check
 }
 
 run_static_checks() {
@@ -255,6 +399,20 @@ run_sonar_checks() {
   run pnpm sonar:gate
 }
 
+run_optional_sonar_pr_checks() {
+  if [[ -z "${SONAR_TOKEN:-}" ]]; then
+    echo "Skipping Sonar PR parity because SONAR_TOKEN is not set."
+    return 0
+  fi
+
+  if [[ -z "${SONAR_PULLREQUEST_KEY:-}" || -z "${SONAR_PULLREQUEST_BRANCH:-}" || -z "${SONAR_PULLREQUEST_BASE:-}" ]]; then
+    echo "Skipping Sonar PR parity because no PR context was detected."
+    return 0
+  fi
+
+  run_sonar_checks
+}
+
 run_strict_e2e_guards() {
   run_shell '! rg "page\\.goto" apps/web/e2e/golden apps/web/e2e/gate -g "*.spec.ts" | rg -v "apps/web/e2e/gate/tenant-resolution.spec.ts"'
   run_shell '! rg -n "/(sq|en|mk|sr|de|hr)/api" apps/web/e2e -g "*.ts"'
@@ -307,28 +465,47 @@ run_pilot_gate_p0() {
 }
 
 run_quick_inside() {
+  run_validation_surface_check
   run_ci_audit
-  run_static_checks
+  run_github_edge_checks
+  if should_run_heavy_validation; then
+    run_static_checks
+  else
+    echo "Skipping static checks: ${CI_LOCAL_VALIDATION_REASON:-validation surface skipped}"
+  fi
   run_security_checks
 }
 
 run_pr_inside() {
+  run_validation_surface_check
   run_ci_audit
-  run_static_checks
-  run_unit_checks
-  run_rls_integration_gate
-  run_pr_e2e_gate
-  run_pilot_gate_p0
+  run_github_edge_checks
+  if should_run_heavy_validation; then
+    run_static_checks
+    run_unit_checks
+    run_rls_integration_gate
+    run_pr_e2e_gate
+    run_pilot_gate_p0
+  else
+    echo "Skipping heavy PR checks: ${CI_LOCAL_VALIDATION_REASON:-validation surface skipped}"
+  fi
   run_security_checks
 }
 
 run_full_inside() {
   run_pr_inside
-  run_merge_e2e_gate
+  if should_run_heavy_validation; then
+    run_merge_e2e_gate
+  fi
 }
 
 run_sonar_inside() {
   run_sonar_checks
+}
+
+run_ready_inside() {
+  run_pr_inside
+  run_optional_sonar_pr_checks
 }
 
 run_inside() {
@@ -348,6 +525,12 @@ run_inside() {
       ;;
     sonar)
       run_sonar_inside
+      ;;
+    sonar-pr)
+      run_sonar_inside
+      ;;
+    ready)
+      run_ready_inside
       ;;
     *)
       usage >&2

--- a/scripts/ci-local-parity.sh
+++ b/scripts/ci-local-parity.sh
@@ -57,7 +57,8 @@ clean_outer() {
 }
 
 detect_pull_request_context() {
-  if [[ -n "${CI_LOCAL_PR_NUMBER:-}" && -n "${SONAR_PULLREQUEST_KEY:-}" && -n "${SONAR_PULLREQUEST_BRANCH:-}" && -n "${SONAR_PULLREQUEST_BASE:-}" ]]; then
+  if [[ -n "${SONAR_PULLREQUEST_KEY:-}" && -n "${SONAR_PULLREQUEST_BRANCH:-}" && -n "${SONAR_PULLREQUEST_BASE:-}" ]]; then
+    export CI_LOCAL_PR_NUMBER="${CI_LOCAL_PR_NUMBER:-${SONAR_PULLREQUEST_KEY}}"
     return 0
   fi
 
@@ -147,7 +148,7 @@ run_outer() {
   detect_pull_request_context || true
   export_default_git_context
 
-  if [[ "${MODE}" == "sonar-pr" && -z "${CI_LOCAL_PR_NUMBER:-}" ]]; then
+  if [[ "${MODE}" == "sonar-pr" && ( -z "${SONAR_PULLREQUEST_KEY:-}" || -z "${SONAR_PULLREQUEST_BRANCH:-}" || -z "${SONAR_PULLREQUEST_BASE:-}" ) ]]; then
     echo "Unable to detect an open GitHub PR for this branch; set SONAR_PULLREQUEST_* manually or open a PR first." >&2
     exit 2
   fi

--- a/scripts/ci/reviewer-preflight.mjs
+++ b/scripts/ci/reviewer-preflight.mjs
@@ -6,12 +6,22 @@ import process from 'node:process';
 const GIT_BIN = '/usr/bin/git';
 const SAFE_EXEC_ENV = Object.freeze({ PATH: '/usr/bin:/bin:/usr/sbin:/sbin' });
 const PROTECTED_PATHS = new Set(['apps/web/src/proxy.ts']);
+const SENSITIVE_PATH_PATTERNS = [
+  /^apps\/web\/src\/app\/api\/auth\//u,
+  /^apps\/web\/src\/lib\/auth/u,
+  /^packages\/shared-auth\//u,
+  /^packages\/database\/src\/.*tenant/u,
+  /^packages\/database\/src\/.*rls/u,
+];
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
 const TEST_OR_CONFIG_PATTERN =
   /(\.test\.|\.spec\.|playwright\.config\.|next\.config\.|instrumentation\.)/u;
 const LOCAL_URL_PATTERN = /https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/u;
 const EMPTY_CATCH_PATTERN = /catch\s*(?:\([^)]*\)\s*)?\{\s*\}/u;
 const ENV_OR_FALLBACK_PATTERN = /process\.env\.[A-Z0-9_]+\s*\|\|\s*['"`]/u;
+const TEST_ONLY_VALUE_PATTERN =
+  /(test-secret-for-(?:ci|local)|dummy-token|NEXT_PUBLIC_BILLING_TEST_MODE\s*[:=]\s*['"]?1)/u;
+const ENV_ESCAPE_PATTERN = /\$[A-Z][A-Z0-9_]*|\$\{[A-Z][A-Z0-9_]*\}|process\.env\.[A-Z0-9_]+/u;
 
 function git(args) {
   return execFileSync(GIT_BIN, args, {
@@ -161,10 +171,66 @@ function addFinding(findings, file, message, line) {
   findings.push(line ? `${file}:${line} ${message}` : `${file} ${message}`);
 }
 
+function addWarning(warnings, file, message, line) {
+  warnings.push(line ? `${file}:${line} ${message}` : `${file} ${message}`);
+}
+
+function inspectSensitivePath(file, warnings) {
+  if (SENSITIVE_PATH_PATTERNS.some(pattern => pattern.test(file))) {
+    addWarning(
+      warnings,
+      file,
+      'touches auth, tenant, or RLS-sensitive code. Confirm the change is surgical and covered.',
+      1
+    );
+  }
+}
+
+function readJsonFile(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function inspectDeploymentConfig(file, findings) {
+  if (!fs.existsSync(file) || file !== 'apps/web/vercel.json') {
+    return;
+  }
+
+  const parsed = readJsonFile(file);
+  if (!parsed || typeof parsed.ignoreCommand !== 'string') {
+    return;
+  }
+
+  const ignoreCommand = parsed.ignoreCommand.trim();
+  if (/^exit\s+0$/u.test(ignoreCommand)) {
+    addFinding(
+      findings,
+      file,
+      'unconditionally skips Vercel builds; gate deployment pauses behind an environment variable escape hatch.',
+      1
+    );
+    return;
+  }
+
+  if (/\bexit\s+0\b/u.test(ignoreCommand) && !ENV_ESCAPE_PATTERN.test(ignoreCommand)) {
+    addFinding(
+      findings,
+      file,
+      'skips Vercel builds without an environment variable escape hatch.',
+      1
+    );
+  }
+}
+
 function inspectFile(file, findings, warnings, inspectWholeFile) {
   if (PROTECTED_PATHS.has(file)) {
     addFinding(findings, file, 'changes Phase C routing authority; this needs explicit review.', 1);
   }
+  inspectSensitivePath(file, warnings);
+  inspectDeploymentConfig(file, findings);
 
   if (!isProductionAppSource(file) || !fs.existsSync(file)) {
     return;
@@ -212,6 +278,18 @@ function inspectFile(file, findings, warnings, inspectWholeFile) {
   if (ENV_OR_FALLBACK_PATTERN.test(content)) {
     warnings.push(
       `${file} uses || fallback for an env var. Prefer ?? when empty string is a meaningful configured value.`
+    );
+  }
+
+  const testOnlyValueMatch = TEST_ONLY_VALUE_PATTERN.exec(content);
+  if (testOnlyValueMatch) {
+    addFinding(
+      findings,
+      file,
+      'introduces test-only configuration into production source; keep CI/dev placeholders in tests, scripts, or environment setup.',
+      inspectWholeFile
+        ? lineForOffset(content, testOnlyValueMatch.index)
+        : lineForRecordsOffset(records, testOnlyValueMatch.index)
     );
   }
 }

--- a/scripts/ci/reviewer-preflight.test.mjs
+++ b/scripts/ci/reviewer-preflight.test.mjs
@@ -154,3 +154,70 @@ test('review preflight allows local URLs in tests and config files', () => {
     assert.match(result.stdout, /review-preflight passed/u);
   });
 });
+
+test('review preflight blocks unconditional Vercel deployment skips', () => {
+  withTempRepo(root => {
+    writeFile(
+      root,
+      'apps/web/vercel.json',
+      JSON.stringify({ ignoreCommand: 'exit 0' }, null, 2)
+    );
+    commitAll(root, 'initial');
+
+    const result = runPreflight(root, ['apps/web/vercel.json']);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unconditionally skips Vercel builds/u);
+  });
+});
+
+test('review preflight allows deployment skips with an environment escape hatch', () => {
+  withTempRepo(root => {
+    writeFile(
+      root,
+      'apps/web/vercel.json',
+      JSON.stringify(
+        {
+          ignoreCommand: 'if [ "$ENABLE_VERCEL_DEPLOYMENTS" = "1" ]; then exit 1; else exit 0; fi',
+        },
+        null,
+        2
+      )
+    );
+    commitAll(root, 'initial');
+
+    const result = runPreflight(root, ['apps/web/vercel.json']);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /review-preflight passed/u);
+  });
+});
+
+test('review preflight blocks test-only values in production source', () => {
+  withTempRepo(root => {
+    writeFile(
+      root,
+      'apps/web/src/lib/auth-secret.ts',
+      'export const secret = "test-secret-for-ci-only-do-not-use-in-production";\n'
+    );
+    commitAll(root, 'initial');
+
+    const result = runPreflight(root, ['apps/web/src/lib/auth-secret.ts']);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /test-only configuration/u);
+  });
+});
+
+test('review preflight warns on auth and tenant sensitive paths', () => {
+  withTempRepo(root => {
+    writeFile(root, 'packages/shared-auth/src/index.ts', 'export const auth = true;\n');
+    commitAll(root, 'initial');
+
+    const result = runPreflight(root, ['packages/shared-auth/src/index.ts']);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /auth, tenant, or RLS-sensitive code/u);
+    assert.match(result.stdout, /review-preflight passed/u);
+  });
+});

--- a/scripts/docker-workflow.test.mjs
+++ b/scripts/docker-workflow.test.mjs
@@ -108,9 +108,20 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
     packageJson.scripts['ci:local:sonar'],
     'node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh sonar'
   );
+  assert.equal(
+    packageJson.scripts['ci:local:sonar:pr'],
+    'node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh sonar-pr'
+  );
+  assert.equal(
+    packageJson.scripts['ci:local:ready'],
+    'node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh ready'
+  );
   assert.equal(packageJson.scripts['ci:local:clean'], 'bash scripts/ci-local-parity.sh clean');
 
   assert.match(dockerfile, /FROM node:24-bookworm/);
+  assert.match(dockerfile, /ARG GITLEAKS_VERSION=8\.30\.0/);
+  assert.match(dockerfile, /gitleaks_\$\{GITLEAKS_VERSION\}_linux_x64\.tar\.gz/);
+  assert.match(dockerfile, /install \/tmp\/gitleaks \/usr\/local\/bin\/gitleaks/);
   assert.match(dockerfile, /corepack prepare pnpm@10\.28\.2 --activate/);
   assert.match(dockerfile, /playwright@1\.60\.0 -- install-deps chromium/);
   assert.match(dockerfile, /postgresql-client/);
@@ -139,6 +150,10 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
     /DATABASE_URL: postgresql:\/\/postgres:postgres@ci-postgres:5432\/interdomestik_test/
   );
   assert.match(compose, /QA_MCP_CONTRACT_TIMEOUT_MS: '30000'/);
+  assert.match(compose, /CI_LOCAL_PR_NUMBER: \$\{CI_LOCAL_PR_NUMBER:-\}/);
+  assert.match(compose, /CI_LOCAL_BASE_REF: \$\{CI_LOCAL_BASE_REF:-origin\/main\}/);
+  assert.match(compose, /CI_LOCAL_BASE_SHA: \$\{CI_LOCAL_BASE_SHA:-\}/);
+  assert.match(compose, /CI_LOCAL_HEAD_SHA: \$\{CI_LOCAL_HEAD_SHA:-\}/);
   assert.match(compose, /TURBO_CACHE_DIR: \/home\/node\/\.cache\/turbo/);
   assert.match(compose, /SONAR_HOST_URL: \$\{SONAR_HOST_URL:-http:\/\/sonarqube:9000\}/);
   assert.match(compose, /SONAR_PROJECT_KEY: \$\{SONAR_PROJECT_KEY:-interdomestik\}/);
@@ -147,9 +162,20 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
   assert.match(compose, /SONAR_USER_HOME: \/home\/node\/\.sonar/);
 
   assert.match(parityScript, /pnpm test:ci:contracts/);
+  assert.match(parityScript, /detect_pull_request_context\(\)/);
+  assert.match(parityScript, /SONAR_PULLREQUEST_KEY="\$\{CI_LOCAL_PR_NUMBER\}"/);
+  assert.match(parityScript, /export_default_git_context\(\)/);
+  assert.match(parityScript, /run_host_pr_finalizer_if_available\(\)/);
+  assert.match(parityScript, /PR_FINALIZER_SKIP_CHECK_POLLING=false/);
+  assert.match(parityScript, /run_validation_surface_check\(\)/);
+  assert.match(parityScript, /validation-surface-policy\.mjs --event-name pull_request/);
   assert.match(parityScript, /git rev-parse --git-dir/);
   assert.doesNotMatch(parityScript, /export GIT_DIR/);
   assert.match(parityScript, /node scripts\/ci\/reviewer-preflight\.mjs/);
+  assert.match(parityScript, /pnpm repo:size:check/);
+  assert.match(parityScript, /pnpm exec commitlint --from/);
+  assert.match(parityScript, /gitleaks git --redact --log-opts/);
+  assert.match(parityScript, /run_github_edge_checks\(\)/);
   assert.match(parityScript, /pnpm check:e2e-contracts:base/);
   assert.match(parityScript, /pnpm lint:production-warnings/);
   assert.match(parityScript, /pnpm db:migrations:check-journal/);
@@ -169,6 +195,8 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
   assert.match(parityScript, /pnpm sonar:start/);
   assert.match(parityScript, /run_sonar_checks\(\)/);
   assert.match(parityScript, /pnpm sonar:gate/);
+  assert.match(parityScript, /run_optional_sonar_pr_checks\(\)/);
+  assert.match(parityScript, /Skipping Sonar PR parity because SONAR_TOKEN is not set/);
   assert.match(parityScript, /SONAR_RUN_COVERAGE.*true/);
   assert.match(parityScript, /SONAR_SCANNER_FORCE_NATIVE/);
   assert.match(parityScript, /NEXT_PUBLIC_BILLING_TEST_MODE=0/);

--- a/scripts/docker-workflow.test.mjs
+++ b/scripts/docker-workflow.test.mjs
@@ -163,7 +163,12 @@ test('local CI parity runner mirrors required PR gate surfaces in Docker', () =>
 
   assert.match(parityScript, /pnpm test:ci:contracts/);
   assert.match(parityScript, /detect_pull_request_context\(\)/);
+  assert.match(
+    parityScript,
+    /export CI_LOCAL_PR_NUMBER="\$\{CI_LOCAL_PR_NUMBER:-\$\{SONAR_PULLREQUEST_KEY\}\}"/
+  );
   assert.match(parityScript, /SONAR_PULLREQUEST_KEY="\$\{CI_LOCAL_PR_NUMBER\}"/);
+  assert.match(parityScript, /MODE.*sonar-pr[\s\S]*SONAR_PULLREQUEST_KEY/);
   assert.match(parityScript, /export_default_git_context\(\)/);
   assert.match(parityScript, /run_host_pr_finalizer_if_available\(\)/);
   assert.match(parityScript, /PR_FINALIZER_SKIP_CHECK_POLLING=false/);

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 28335000,
+  "maxTrackedBytes": 28350000,
   "maxTrackedFiles": 3696,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 13750000,
-    "source/scripts": 5823000,
+    "source/scripts": 5835000,
     "tests/e2e": 4194304,
     "docs/text": 3400000,
     "config/data/messages": 1572864,


### PR DESCRIPTION
## Summary
- add Docker local ready and Sonar PR parity commands
- mirror more GitHub PR surfaces locally: validation-surface, repo-size, commitlint, gitleaks, and PR finalizer handoff
- harden reviewer preflight for recurring Copilot-style deployment/config/auth comments

## Verification
- node --test scripts/docker-workflow.test.mjs scripts/ci/reviewer-preflight.test.mjs
- pnpm review:preflight
- docker compose --profile ci-local build ci-parity
- pnpm test:ci:contracts
- pnpm repo:size:check
- docker compose --profile ci-local run --rm --no-deps ci-parity bash -lc "gitleaks version && bash -n scripts/ci-local-parity.sh"