### PR TITLE
feat(crm): add controlled routing application service

### DIFF
--- a/apps/web/e2e/gate/admin-crm-routing-rules.spec.ts
+++ b/apps/web/e2e/gate/admin-crm-routing-rules.spec.ts
@@ -111,6 +111,14 @@ async function ruleEnabled(tenantId: string, source: string): Promise<boolean | 
   return rule?.enabled ?? null;
 }
 
+async function ruleArchived(tenantId: string, source: string): Promise<boolean> {
+  const rule = await db.query.crmRoutingRules.findFirst({
+    columns: { archivedAt: true },
+    where: and(eq(crmRoutingRules.tenantId, tenantId), eq(crmRoutingRules.source, source)),
+  });
+  return Boolean(rule?.archivedAt);
+}
+
 test.describe('Admin CRM routing rules @admin-crm-routing-rules', () => {
   test('admin can create, reorder, disable, and archive a routing rule', async ({
     page,
@@ -141,6 +149,8 @@ test.describe('Admin CRM routing rules @admin-crm-routing-rules', () => {
       await createForm.locator('input[name="priority"]').fill('1001');
       await createForm.locator('input[name="source"]').fill(createdSource);
       await createForm.locator('button[type="submit"]').click();
+      await expect.poll(async () => rulePriority(context.tenantId, createdSource)).not.toBeNull();
+      await gotoApp(page, adminCrmRoute(testInfo), testInfo, { marker: 'admin-crm-page-ready' });
 
       const createdRow = page.getByTestId(RULE_ROW_MARKER).filter({ hasText: createdSource });
       await expect(createdRow.first()).toBeVisible();
@@ -155,13 +165,24 @@ test.describe('Admin CRM routing rules @admin-crm-routing-rules', () => {
           return created !== null && seeded !== null && created < seeded;
         })
         .toBe(true);
+      await gotoApp(page, adminCrmRoute(testInfo), testInfo, { marker: 'admin-crm-page-ready' });
 
       await createdRow.first().getByTestId(ENABLED_BUTTON_MARKER).click();
       await expect(page.getByTestId(ACTION_RESULT_MARKER).first()).toBeVisible();
       await expect.poll(async () => ruleEnabled(context.tenantId, createdSource)).toBe(false);
+      await gotoApp(page, adminCrmRoute(testInfo), testInfo, { marker: 'admin-crm-page-ready' });
 
-      await createdRow.first().getByTestId(ARCHIVE_BUTTON_MARKER).click();
-      await expect(createdRow.first().getByTestId(ARCHIVE_BUTTON_MARKER)).toBeDisabled();
+      const disabledRow = page.getByTestId(RULE_ROW_MARKER).filter({ hasText: createdSource });
+      await expect(disabledRow.first().getByTestId(ENABLED_BUTTON_MARKER)).toBeEnabled();
+      await expect(disabledRow.first().getByTestId(ARCHIVE_BUTTON_MARKER)).toBeEnabled();
+      await disabledRow.first().getByTestId(ARCHIVE_BUTTON_MARKER).click();
+      await expect.poll(async () => ruleArchived(context.tenantId, createdSource)).toBe(true);
+      await gotoApp(page, adminCrmRoute(testInfo), testInfo, { marker: 'admin-crm-page-ready' });
+
+      const archivedRow = page.getByTestId(RULE_ROW_MARKER).filter({ hasText: createdSource });
+      await expect(archivedRow.first().getByTestId(ARCHIVE_BUTTON_MARKER)).toBeDisabled({
+        timeout: 15000,
+      });
     } finally {
       await restoreTenantWidePriorities(context.tenantId, prioritySnapshot);
       await cleanupRules(context.tenantId, [seededSource, createdSource]);

--- a/apps/web/e2e/gate/staff-support-handoffs.spec.ts
+++ b/apps/web/e2e/gate/staff-support-handoffs.spec.ts
@@ -472,17 +472,19 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
       await expect(memberPage).toHaveURL(/\/member\/help\?support=created$/, {
         timeout: 15000,
       });
-      await expect(memberPage.getByTestId('member-support-handoff-created')).toBeVisible();
-      await expect(memberPage.getByTestId('member-support-handoff-advisory-generic')).toBeVisible({
-        timeout: 15000,
-      });
+      await expect(
+        currentMemberSurface().getByTestId('member-support-handoff-created')
+      ).toBeVisible();
+      await expect(
+        currentMemberSurface().getByTestId('member-support-handoff-advisory-generic')
+      ).toBeVisible({ timeout: 15000 });
 
       await gotoApp(memberPage, routes.memberHelp(testInfo), testInfo, {
         marker: 'member-page-ready',
       });
-      await expect(memberPage.getByTestId('member-support-handoff-advisory-generic')).toBeVisible({
-        timeout: 15000,
-      });
+      await expect(
+        currentMemberSurface().getByTestId('member-support-handoff-advisory-generic')
+      ).toBeVisible({ timeout: 15000 });
 
       await gotoApp(memberPage, claimHelpPath, testInfo, {
         marker: 'member-page-ready',
@@ -506,7 +508,9 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
       await expect(memberPage).toHaveURL(/\/member\/help\?support=created$/, {
         timeout: 15000,
       });
-      await expect(memberPage.getByTestId('member-support-handoff-created')).toBeVisible();
+      await expect(
+        currentMemberSurface().getByTestId('member-support-handoff-created')
+      ).toBeVisible();
     } finally {
       await cleanupHandoffBySubject(subject);
       await cleanupHandoffBySubject(secondSubject);

--- a/apps/web/src/app/[locale]/admin/crm/_routing-rules-panel.tsx
+++ b/apps/web/src/app/[locale]/admin/crm/_routing-rules-panel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Archive, ArrowDown, ArrowUp, PauseCircle, PlayCircle, Save } from 'lucide-react';
-import { useActionState, type ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { useCallback, useState, type ReactNode } from 'react';
 
 import {
   archiveRoutingRuleAction,
@@ -22,6 +23,11 @@ import {
 } from './_routing-types';
 
 const initialActionState: AdminCrmRoutingActionState = { status: 'idle' };
+
+type AdminCrmRoutingServerAction = (
+  previousState: AdminCrmRoutingActionState,
+  formData: FormData
+) => Promise<AdminCrmRoutingActionState>;
 
 export type AdminCrmRoutingRulesPanelCopy = {
   actions: {
@@ -83,14 +89,9 @@ export function AdminCrmRoutingRulesPanel({
   copy: AdminCrmRoutingRulesPanelCopy;
   payload: AdminCrmRoutingRulesPayload;
 }>) {
-  const [createState, createAction, createPending] = useActionState(
-    createRoutingRuleAction,
-    initialActionState
-  );
-  const [reorderState, reorderAction, reorderPending] = useActionState(
-    reorderRoutingRulesAction,
-    initialActionState
-  );
+  const [createState, createAction, createPending] = useRoutingRuleAction(createRoutingRuleAction);
+  const [reorderState, reorderAction, reorderPending] =
+    useRoutingRuleAction(reorderRoutingRulesAction);
   const activeRules = payload.rules.filter(rule => !rule.archived);
 
   return (
@@ -176,18 +177,12 @@ function RoutingRuleRow({
   reorderPending: boolean;
   rule: AdminCrmRoutingRuleSummary;
 }>) {
-  const [updateState, updateAction, updatePending] = useActionState(
-    updateRoutingRuleAction,
-    initialActionState
+  const [updateState, updateAction, updatePending] = useRoutingRuleAction(updateRoutingRuleAction);
+  const [enabledState, enabledAction, enabledPending] = useRoutingRuleAction(
+    setRoutingRuleEnabledAction
   );
-  const [enabledState, enabledAction, enabledPending] = useActionState(
-    setRoutingRuleEnabledAction,
-    initialActionState
-  );
-  const [archiveState, archiveAction, archivePending] = useActionState(
-    archiveRoutingRuleAction,
-    initialActionState
-  );
+  const [archiveState, archiveAction, archivePending] =
+    useRoutingRuleAction(archiveRoutingRuleAction);
   const rowState = currentRowState(updateState, enabledState, archiveState);
   const scopeLabel = rule.scope.kind === 'tenant' ? copy.rule.tenantScope : rule.scope.branchLabel;
   const filterLabel = filterSummary(rule, copy);
@@ -290,6 +285,27 @@ function RoutingRuleRow({
       </td>
     </tr>
   );
+}
+
+function useRoutingRuleAction(action: AdminCrmRoutingServerAction) {
+  const router = useRouter();
+  const [state, setState] = useState<AdminCrmRoutingActionState>(initialActionState);
+  const [pending, setPending] = useState(false);
+  const formAction = useCallback(
+    async (formData: FormData) => {
+      setPending(true);
+      try {
+        const result = await action(initialActionState, formData);
+        setState(result);
+        if (result.status === 'ok') router.refresh();
+      } finally {
+        setPending(false);
+      }
+    },
+    [action, router]
+  );
+
+  return [state, formAction, pending] as const;
 }
 
 function RuleFields({

--- a/apps/web/src/lib/domain-crm/lead-mutation-repository.ts
+++ b/apps/web/src/lib/domain-crm/lead-mutation-repository.ts
@@ -338,7 +338,7 @@ export function createCrmLeadMutationRepository(
           transferOwnershipInDatabase(tx as never, params, { validateTarget: false })
         );
       } catch (error) {
-        if (error instanceof MissingOpenOwnershipHistoryError && useTransaction) return null;
+        if (error instanceof MissingOpenOwnershipHistoryError) return null;
         throw error;
       }
     },

--- a/apps/web/src/lib/domain-crm/lead-mutation-repository.ts
+++ b/apps/web/src/lib/domain-crm/lead-mutation-repository.ts
@@ -20,6 +20,7 @@ import {
 } from '@interdomestik/database/schema';
 import { withTenant } from '@interdomestik/database/tenant-security';
 
+type CrmLeadMutationDb = typeof db;
 type CrmLeadRow = typeof crmLeads.$inferSelect;
 type CrmActivityRow = typeof crmActivities.$inferSelect;
 
@@ -69,13 +70,16 @@ function mapActivity(row: CrmActivityRow): CrmLeadActivity {
 
 class MissingOpenOwnershipHistoryError extends Error {}
 
-async function hasValidTransferTarget(params: {
-  targetAgentId: string;
-  targetBranchId: string;
-  tenantId: string;
-}): Promise<boolean> {
+async function hasValidTransferTarget(
+  database: Pick<CrmLeadMutationDb, 'query'>,
+  params: {
+    targetAgentId: string;
+    targetBranchId: string;
+    tenantId: string;
+  }
+): Promise<boolean> {
   // db-access-guard: tenant-scoped -- reason: validates transfer target agent belongs to the authorized CRM actor tenant and target branch
-  const targetAgent = await db.query.user.findFirst({
+  const targetAgent = await database.query.user.findFirst({
     columns: { id: true },
     where: and(
       eq(user.id, params.targetAgentId),
@@ -88,7 +92,7 @@ async function hasValidTransferTarget(params: {
   if (!targetAgent) return false;
 
   // db-access-guard: tenant-scoped -- reason: validates transfer target branch belongs to the authorized CRM actor tenant
-  const targetBranch = await db.query.branches.findFirst({
+  const targetBranch = await database.query.branches.findFirst({
     columns: { id: true },
     where: and(eq(branches.id, params.targetBranchId), eq(branches.tenantId, params.tenantId)),
   });
@@ -96,139 +100,9 @@ async function hasValidTransferTarget(params: {
   return Boolean(targetBranch);
 }
 
-export const crmLeadMutationRepository: CrmLeadMutationRepository = {
-  async createLead(params: { actor: CrmActorContext; lead: CreateCrmLeadData }) {
-    const now = new Date();
-    const branchId = params.actor.scope.branchId;
-    if (!branchId) {
-      throw new Error('CRM lead creation requires actor branch scope');
-    }
-
-    // db-access-guard: tenant-scoped -- reason: creates CRM lead and initial ownership history with explicit authorized CRM actor tenant
-    return db.transaction(async tx => {
-      // db-access-guard: tenant-scoped -- reason: tenantId comes from explicit authorized CRM actor context
-      const [created] = await tx
-        .insert(crmLeads)
-        .values({
-          agentId: params.actor.actorId,
-          branchId,
-          companyName: params.lead.companyName ?? undefined,
-          createdAt: now,
-          email: params.lead.email ?? undefined,
-          fullName: params.lead.fullName ?? undefined,
-          id: params.lead.leadId,
-          notes: params.lead.notes ?? undefined,
-          phone: params.lead.phone ?? undefined,
-          source: params.lead.source ?? undefined,
-          stage: params.lead.stage,
-          lostAt: params.lead.stage === 'lost' ? now : null,
-          tenantId: params.actor.tenantId,
-          type: params.lead.type,
-          updatedAt: now,
-          wonAt: params.lead.stage === 'won' ? now : null,
-        })
-        .returning();
-
-      // db-access-guard: tenant-scoped -- reason: ownership history copies explicit tenantId from authorized CRM actor after lead creation
-      await tx.insert(crmLeadOwnershipHistory).values({
-        agentId: params.actor.actorId,
-        branchId,
-        changedById: params.actor.actorId,
-        createdAt: now,
-        effectiveFrom: now,
-        id: randomUUID(),
-        leadId: created.id,
-        reason: 'created',
-        tenantId: params.actor.tenantId,
-      });
-
-      return mapLead(created);
-    });
-  },
-
-  async findById(params: { actor: CrmActorContext; leadId: string }) {
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from explicit authorized CRM actor context before domain authorization
-    const lead = await db.query.crmLeads.findFirst({
-      where: withTenant(params.actor.tenantId, crmLeads.tenantId, eq(crmLeads.id, params.leadId)),
-    });
-    return lead ? mapLead(lead) : null;
-  },
-
-  async recordActivity(params: { activity: RecordCrmLeadActivityInput; actor: CrmActorContext }) {
-    const branchId = params.actor.scope.branchId;
-    if (!branchId) {
-      throw new Error('CRM activity creation requires actor branch scope');
-    }
-
-    // `crm_activities` is the write-side event source that CRM11 timeline reads project from.
-    // Domain writes do not write timeline rows directly.
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from explicit authorized CRM actor context
-    const [created] = await db
-      .insert(crmActivities)
-      .values({
-        agentId: params.actor.actorId,
-        branchId,
-        id: params.activity.activityId,
-        leadId: params.activity.leadId,
-        occurredAt: new Date(params.activity.occurredAt),
-        summary: params.activity.summary,
-        tenantId: params.actor.tenantId,
-        type: params.activity.type,
-      })
-      .returning();
-    return mapActivity(created);
-  },
-
-  async updateStage(params: {
-    actor: CrmActorContext;
-    fromStage: CrmLeadStage;
-    leadId: string;
-    stage: CrmLeadStage;
-  }) {
-    const branchId = params.actor.scope.branchId;
-    if (!branchId) return null;
-
-    const now = new Date();
-    return db.transaction(async tx => {
-      // db-access-guard: tenant-scoped -- reason: tenantId, agentId, durable branchId, and current stage from authorized CRM actor constrain update
-      const [updated] = await tx
-        .update(crmLeads)
-        .set({
-          lostAt: params.stage === 'lost' ? now : null,
-          stage: params.stage,
-          updatedAt: now,
-          wonAt: params.stage === 'won' ? now : null,
-        })
-        .where(
-          and(
-            eq(crmLeads.id, params.leadId),
-            eq(crmLeads.tenantId, params.actor.tenantId),
-            eq(crmLeads.agentId, params.actor.actorId),
-            eq(crmLeads.branchId, branchId),
-            eq(crmLeads.stage, params.fromStage)
-          )
-        )
-        .returning();
-
-      if (!updated) return null;
-
-      // db-access-guard: tenant-scoped -- reason: history row copies explicit tenantId from authorized CRM actor after scoped stage update
-      await tx.insert(crmLeadStageHistory).values({
-        changedById: params.actor.actorId,
-        createdAt: now,
-        fromStage: params.fromStage,
-        id: randomUUID(),
-        leadId: params.leadId,
-        occurredAt: now,
-        tenantId: params.actor.tenantId,
-        toStage: params.stage,
-      });
-
-      return mapLead(updated);
-    });
-  },
-
-  async transferOwnership(params: {
+async function transferOwnershipInDatabase(
+  database: Pick<CrmLeadMutationDb, 'insert' | 'query' | 'update'>,
+  params: {
     actor: CrmActorContext;
     currentAgentId: string;
     currentBranchId: string;
@@ -236,74 +110,239 @@ export const crmLeadMutationRepository: CrmLeadMutationRepository = {
     reason: string;
     targetAgentId: string;
     targetBranchId: string;
-  }) {
-    const now = new Date();
-    const targetIsValid = await hasValidTransferTarget({
+  },
+  options: { validateTarget?: boolean } = {}
+) {
+  const now = new Date();
+  if (options.validateTarget ?? true) {
+    const targetIsValid = await hasValidTransferTarget(database, {
       targetAgentId: params.targetAgentId,
       targetBranchId: params.targetBranchId,
       tenantId: params.actor.tenantId,
     });
     if (!targetIsValid) return null;
+  }
 
-    try {
-      return await db.transaction(async tx => {
-        // db-access-guard: tenant-scoped -- reason: tenantId and expected current lead ownership from authorized CRM actor constrain transfer update
+  // db-access-guard: tenant-scoped -- reason: tenantId and expected current lead ownership from authorized CRM actor constrain transfer update
+  const [updated] = await database
+    .update(crmLeads)
+    .set({
+      agentId: params.targetAgentId,
+      branchId: params.targetBranchId,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(crmLeads.id, params.leadId),
+        eq(crmLeads.tenantId, params.actor.tenantId),
+        eq(crmLeads.agentId, params.currentAgentId),
+        eq(crmLeads.branchId, params.currentBranchId)
+      )
+    )
+    .returning();
+
+  if (!updated) return null;
+
+  // db-access-guard: tenant-scoped -- reason: closes the current open ownership row for the same tenant-scoped lead transfer
+  const closedRows = await database
+    .update(crmLeadOwnershipHistory)
+    .set({ effectiveTo: now })
+    .where(
+      and(
+        eq(crmLeadOwnershipHistory.tenantId, params.actor.tenantId),
+        eq(crmLeadOwnershipHistory.leadId, params.leadId),
+        eq(crmLeadOwnershipHistory.agentId, params.currentAgentId),
+        eq(crmLeadOwnershipHistory.branchId, params.currentBranchId),
+        isNull(crmLeadOwnershipHistory.effectiveTo)
+      )
+    )
+    .returning({ id: crmLeadOwnershipHistory.id });
+
+  if (closedRows.length !== 1) {
+    throw new MissingOpenOwnershipHistoryError('missing open CRM lead ownership history row');
+  }
+
+  // db-access-guard: tenant-scoped -- reason: opens the new ownership row for the same tenant-scoped lead transfer
+  await database.insert(crmLeadOwnershipHistory).values({
+    agentId: params.targetAgentId,
+    branchId: params.targetBranchId,
+    changedById: params.actor.actorId,
+    createdAt: now,
+    effectiveFrom: now,
+    id: randomUUID(),
+    leadId: params.leadId,
+    reason: params.reason,
+    tenantId: params.actor.tenantId,
+  });
+
+  return mapLead(updated);
+}
+
+export function createCrmLeadMutationRepository(
+  database: CrmLeadMutationDb = db,
+  options: { useTransaction?: boolean } = {}
+): CrmLeadMutationRepository {
+  const useTransaction = options.useTransaction ?? true;
+  return {
+    async createLead(params: { actor: CrmActorContext; lead: CreateCrmLeadData }) {
+      const now = new Date();
+      const branchId = params.actor.scope.branchId;
+      if (!branchId) {
+        throw new Error('CRM lead creation requires actor branch scope');
+      }
+
+      // db-access-guard: tenant-scoped -- reason: creates CRM lead and initial ownership history with explicit authorized CRM actor tenant
+      return database.transaction(async tx => {
+        // db-access-guard: tenant-scoped -- reason: tenantId comes from explicit authorized CRM actor context
+        const [created] = await tx
+          .insert(crmLeads)
+          .values({
+            agentId: params.actor.actorId,
+            branchId,
+            companyName: params.lead.companyName ?? undefined,
+            createdAt: now,
+            email: params.lead.email ?? undefined,
+            fullName: params.lead.fullName ?? undefined,
+            id: params.lead.leadId,
+            notes: params.lead.notes ?? undefined,
+            phone: params.lead.phone ?? undefined,
+            source: params.lead.source ?? undefined,
+            stage: params.lead.stage,
+            lostAt: params.lead.stage === 'lost' ? now : null,
+            tenantId: params.actor.tenantId,
+            type: params.lead.type,
+            updatedAt: now,
+            wonAt: params.lead.stage === 'won' ? now : null,
+          })
+          .returning();
+
+        // db-access-guard: tenant-scoped -- reason: ownership history copies explicit tenantId from authorized CRM actor after lead creation
+        await tx.insert(crmLeadOwnershipHistory).values({
+          agentId: params.actor.actorId,
+          branchId,
+          changedById: params.actor.actorId,
+          createdAt: now,
+          effectiveFrom: now,
+          id: randomUUID(),
+          leadId: created.id,
+          reason: 'created',
+          tenantId: params.actor.tenantId,
+        });
+
+        return mapLead(created);
+      });
+    },
+
+    async findById(params: { actor: CrmActorContext; leadId: string }) {
+      // db-access-guard: tenant-scoped -- reason: tenantId comes from explicit authorized CRM actor context before domain authorization
+      const lead = await database.query.crmLeads.findFirst({
+        where: withTenant(params.actor.tenantId, crmLeads.tenantId, eq(crmLeads.id, params.leadId)),
+      });
+      return lead ? mapLead(lead) : null;
+    },
+
+    async recordActivity(params: { activity: RecordCrmLeadActivityInput; actor: CrmActorContext }) {
+      const branchId = params.actor.scope.branchId;
+      if (!branchId) {
+        throw new Error('CRM activity creation requires actor branch scope');
+      }
+
+      // `crm_activities` is the write-side event source that CRM11 timeline reads project from.
+      // Domain writes do not write timeline rows directly.
+      // db-access-guard: tenant-scoped -- reason: tenantId comes from explicit authorized CRM actor context
+      const [created] = await database
+        .insert(crmActivities)
+        .values({
+          agentId: params.actor.actorId,
+          branchId,
+          id: params.activity.activityId,
+          leadId: params.activity.leadId,
+          occurredAt: new Date(params.activity.occurredAt),
+          summary: params.activity.summary,
+          tenantId: params.actor.tenantId,
+          type: params.activity.type,
+        })
+        .returning();
+      return mapActivity(created);
+    },
+
+    async updateStage(params: {
+      actor: CrmActorContext;
+      fromStage: CrmLeadStage;
+      leadId: string;
+      stage: CrmLeadStage;
+    }) {
+      const branchId = params.actor.scope.branchId;
+      if (!branchId) return null;
+
+      const now = new Date();
+      return database.transaction(async tx => {
+        // db-access-guard: tenant-scoped -- reason: tenantId, agentId, durable branchId, and current stage from authorized CRM actor constrain update
         const [updated] = await tx
           .update(crmLeads)
           .set({
-            agentId: params.targetAgentId,
-            branchId: params.targetBranchId,
+            lostAt: params.stage === 'lost' ? now : null,
+            stage: params.stage,
             updatedAt: now,
+            wonAt: params.stage === 'won' ? now : null,
           })
           .where(
             and(
               eq(crmLeads.id, params.leadId),
               eq(crmLeads.tenantId, params.actor.tenantId),
-              eq(crmLeads.agentId, params.currentAgentId),
-              eq(crmLeads.branchId, params.currentBranchId)
+              eq(crmLeads.agentId, params.actor.actorId),
+              eq(crmLeads.branchId, branchId),
+              eq(crmLeads.stage, params.fromStage)
             )
           )
           .returning();
 
         if (!updated) return null;
 
-        // db-access-guard: tenant-scoped -- reason: closes the current open ownership row for the same tenant-scoped lead transfer
-        const closedRows = await tx
-          .update(crmLeadOwnershipHistory)
-          .set({ effectiveTo: now })
-          .where(
-            and(
-              eq(crmLeadOwnershipHistory.tenantId, params.actor.tenantId),
-              eq(crmLeadOwnershipHistory.leadId, params.leadId),
-              eq(crmLeadOwnershipHistory.agentId, params.currentAgentId),
-              eq(crmLeadOwnershipHistory.branchId, params.currentBranchId),
-              isNull(crmLeadOwnershipHistory.effectiveTo)
-            )
-          )
-          .returning({ id: crmLeadOwnershipHistory.id });
-
-        if (closedRows.length !== 1) {
-          throw new MissingOpenOwnershipHistoryError('missing open CRM lead ownership history row');
-        }
-
-        // db-access-guard: tenant-scoped -- reason: opens the new ownership row for the same tenant-scoped lead transfer
-        await tx.insert(crmLeadOwnershipHistory).values({
-          agentId: params.targetAgentId,
-          branchId: params.targetBranchId,
+        // db-access-guard: tenant-scoped -- reason: history row copies explicit tenantId from authorized CRM actor after scoped stage update
+        await tx.insert(crmLeadStageHistory).values({
           changedById: params.actor.actorId,
           createdAt: now,
-          effectiveFrom: now,
+          fromStage: params.fromStage,
           id: randomUUID(),
           leadId: params.leadId,
-          reason: params.reason,
+          occurredAt: now,
           tenantId: params.actor.tenantId,
+          toStage: params.stage,
         });
 
         return mapLead(updated);
       });
-    } catch (error) {
-      if (error instanceof MissingOpenOwnershipHistoryError) return null;
-      throw error;
-    }
-  },
-};
+    },
+
+    async transferOwnership(params: {
+      actor: CrmActorContext;
+      currentAgentId: string;
+      currentBranchId: string;
+      leadId: string;
+      reason: string;
+      targetAgentId: string;
+      targetBranchId: string;
+    }) {
+      try {
+        if (!useTransaction) {
+          return await transferOwnershipInDatabase(database, params);
+        }
+        const targetIsValid = await hasValidTransferTarget(database, {
+          targetAgentId: params.targetAgentId,
+          targetBranchId: params.targetBranchId,
+          tenantId: params.actor.tenantId,
+        });
+        if (!targetIsValid) return null;
+        return await database.transaction(async tx =>
+          transferOwnershipInDatabase(tx as never, params, { validateTarget: false })
+        );
+      } catch (error) {
+        if (error instanceof MissingOpenOwnershipHistoryError && useTransaction) return null;
+        throw error;
+      }
+    },
+  };
+}
+
+export const crmLeadMutationRepository = createCrmLeadMutationRepository();

--- a/apps/web/src/lib/domain-crm/routing-application-service.test.ts
+++ b/apps/web/src/lib/domain-crm/routing-application-service.test.ts
@@ -104,6 +104,64 @@ function auditRow() {
   };
 }
 
+async function auditRows() {
+  return [auditRow()];
+}
+
+function createInsertValues(table: unknown) {
+  if (table === crmRoutingAssignmentsAudit) {
+    return {
+      onConflictDoNothing() {
+        return { returning: vi.fn(auditRows) };
+      },
+    };
+  }
+  return Promise.resolve([]);
+}
+
+async function groupedRows(selection: unknown, table: unknown) {
+  if (table === crmLeads) return [{ agentId: 'agent-2', count: 4 }];
+  if (selection && table === crmLeadOwnershipHistory) {
+    return [{ agentId: 'agent-2', count: 1 }];
+  }
+  return [{ agentId: 'agent-2', count: 2 }];
+}
+
+function createSelectQuery(selection: unknown) {
+  return {
+    from(table: unknown) {
+      return {
+        where() {
+          return {
+            groupBy: vi.fn(() => groupedRows(selection, table)),
+          };
+        },
+      };
+    },
+  };
+}
+
+async function updatedRows(table: unknown) {
+  if (table === crmLeads) return [leadRow({ agentId: 'agent-2' })];
+  if (table === crmLeadOwnershipHistory) return [{ id: 'ownership-history-1' }];
+  if (table === crmRoutingCursors) return [{ ruleId: 'rule-1' }];
+  return [];
+}
+
+function createUpdateQuery(table: unknown) {
+  return {
+    set() {
+      return {
+        where() {
+          return {
+            returning: vi.fn(() => updatedRows(table)),
+          };
+        },
+      };
+    },
+  };
+}
+
 function createFakeDatabase() {
   const writeTables: unknown[] = [];
   const committedWriteTables: unknown[] = [];
@@ -114,16 +172,7 @@ function createFakeDatabase() {
     insert(table: unknown) {
       writeTables.push(table);
       return {
-        values() {
-          if (table === crmRoutingAssignmentsAudit) {
-            return {
-              onConflictDoNothing() {
-                return { returning: vi.fn(async () => [auditRow()]) };
-              },
-            };
-          }
-          return Promise.resolve([]);
-        },
+        values: () => createInsertValues(table),
       };
     },
     query: {
@@ -136,41 +185,10 @@ function createFakeDatabase() {
       crmLeadOwnershipHistory: { findMany: vi.fn(async () => []) },
       user: { findFirst: vi.fn(async () => ({ id: 'agent-2' })) },
     },
-    select: vi.fn((selection: unknown) => ({
-      from(table: unknown) {
-        return {
-          where() {
-            return {
-              groupBy: vi.fn(async () => {
-                if (table === crmLeads) return [{ agentId: 'agent-2', count: 4 }];
-                if (selection && table === crmLeadOwnershipHistory) {
-                  return [{ agentId: 'agent-2', count: 1 }];
-                }
-                return [{ agentId: 'agent-2', count: 2 }];
-              }),
-            };
-          },
-        };
-      },
-    })),
+    select: vi.fn(createSelectQuery),
     update(table: unknown) {
       writeTables.push(table);
-      return {
-        set() {
-          return {
-            where() {
-              return {
-                returning: vi.fn(async () => {
-                  if (table === crmLeads) return [leadRow({ agentId: 'agent-2' })];
-                  if (table === crmLeadOwnershipHistory) return [{ id: 'ownership-history-1' }];
-                  if (table === crmRoutingCursors) return [{ ruleId: 'rule-1' }];
-                  return [];
-                }),
-              };
-            },
-          };
-        },
-      };
+      return createUpdateQuery(table);
     },
   };
 

--- a/apps/web/src/lib/domain-crm/routing-application-service.test.ts
+++ b/apps/web/src/lib/domain-crm/routing-application-service.test.ts
@@ -1,0 +1,355 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CrmRoutingApplicationRollback,
+  type ApplyCrmLeadRoutingDecisionResult,
+} from '@interdomestik/domain-crm/routing';
+import type { CrmOutboxEvent } from '@interdomestik/domain-crm/outbox';
+import {
+  crmLeadOwnershipHistory,
+  crmLeads,
+  crmRoutingAssignmentsAudit,
+  crmRoutingCursors,
+} from '@interdomestik/database/schema';
+
+const applyMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@interdomestik/domain-crm/routing', async importActual => {
+  const actual = await importActual<typeof import('@interdomestik/domain-crm/routing')>();
+  return {
+    ...actual,
+    applyCrmLeadRoutingDecision: applyMock,
+  };
+});
+
+import { createApplyCrmLeadRoutingDecisionCoordinator } from './routing-application-service';
+
+const actor = {
+  actorId: 'manager-1',
+  role: 'branch_manager' as const,
+  scope: { branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
+
+const outboxEvent: CrmOutboxEvent = {
+  aggregateId: 'lead-1',
+  aggregateType: 'lead',
+  availableAt: '2026-05-16T10:00:00.000Z',
+  createdAt: '2026-05-16T10:00:00.000Z',
+  event: {
+    aggregateId: 'lead-1',
+    aggregateType: 'lead',
+    occurredAt: '2026-05-16T10:00:00.000Z',
+    payload: {
+      agentId: 'agent-2',
+      leadId: 'lead-1',
+      reasonCode: 'rule_match',
+      ruleId: 'rule-1',
+      strategy: 'round_robin',
+    },
+    tenantId: 'tenant-1',
+    type: 'crm.lead.routed',
+  },
+  id: 'outbox-1',
+  idempotencyKey: 'route:lead-1',
+  retryCount: 0,
+  status: 'pending',
+  tenantId: 'tenant-1',
+  type: 'crm.lead.routed',
+};
+
+function leadRow(overrides: Record<string, unknown> = {}) {
+  return {
+    agentId: 'agent-old',
+    branchId: 'branch-1',
+    companyName: null,
+    createdAt: new Date('2026-05-16T09:00:00.000Z'),
+    email: null,
+    fullName: null,
+    id: 'lead-1',
+    lastContactedAt: null,
+    lostAt: null,
+    notes: null,
+    phone: null,
+    score: 0,
+    source: 'website',
+    stage: 'qualified',
+    tenantId: 'tenant-1',
+    type: 'business',
+    updatedAt: new Date('2026-05-16T09:00:00.000Z'),
+    utmCampaign: null,
+    utmContent: null,
+    utmMedium: null,
+    utmSource: null,
+    wonAt: null,
+    ...overrides,
+  };
+}
+
+function auditRow() {
+  return {
+    actorId: 'manager-1',
+    branchId: 'branch-1',
+    createdAt: new Date('2026-05-16T10:00:00.000Z'),
+    id: 'audit-1',
+    idempotencyKey: 'route:lead-1',
+    leadId: 'lead-1',
+    metadata: null,
+    occurredAt: new Date('2026-05-16T10:00:00.000Z'),
+    reasonCode: 'rule_match',
+    ruleId: 'rule-1',
+    selectedAgentId: 'agent-2',
+    strategy: 'round_robin',
+    tenantId: 'tenant-1',
+  };
+}
+
+function createFakeDatabase() {
+  const writeTables: unknown[] = [];
+  const committedWriteTables: unknown[] = [];
+  const transactionIds: string[] = [];
+  let activeTransactionId: string | null = null;
+
+  const tx = {
+    insert(table: unknown) {
+      writeTables.push(table);
+      return {
+        values() {
+          if (table === crmRoutingAssignmentsAudit) {
+            return {
+              onConflictDoNothing() {
+                return { returning: vi.fn(async () => [auditRow()]) };
+              },
+            };
+          }
+          return Promise.resolve([]);
+        },
+      };
+    },
+    query: {
+      branches: { findFirst: vi.fn(async () => ({ id: 'branch-1' })) },
+      crmRoutingAssignmentsAudit: { findFirst: vi.fn(async () => null) },
+      crmRoutingCursors: { findMany: vi.fn(async () => []) },
+      crmRoutingRules: { findMany: vi.fn(async () => []) },
+      crmLeads: { findFirst: vi.fn(async () => leadRow()) },
+      crmActivities: { findMany: vi.fn(async () => []) },
+      crmLeadOwnershipHistory: { findMany: vi.fn(async () => []) },
+      user: { findFirst: vi.fn(async () => ({ id: 'agent-2' })) },
+    },
+    select: vi.fn((selection: unknown) => ({
+      from(table: unknown) {
+        return {
+          where() {
+            return {
+              groupBy: vi.fn(async () => {
+                if (table === crmLeads) return [{ agentId: 'agent-2', count: 4 }];
+                if (selection && table === crmLeadOwnershipHistory) {
+                  return [{ agentId: 'agent-2', count: 1 }];
+                }
+                return [{ agentId: 'agent-2', count: 2 }];
+              }),
+            };
+          },
+        };
+      },
+    })),
+    update(table: unknown) {
+      writeTables.push(table);
+      return {
+        set() {
+          return {
+            where() {
+              return {
+                returning: vi.fn(async () => {
+                  if (table === crmLeads) return [leadRow({ agentId: 'agent-2' })];
+                  if (table === crmLeadOwnershipHistory) return [{ id: 'ownership-history-1' }];
+                  if (table === crmRoutingCursors) return [{ ruleId: 'rule-1' }];
+                  return [];
+                }),
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  const database = {
+    async transaction<T>(callback: (transaction: typeof tx) => Promise<T>) {
+      activeTransactionId = 'tx-1';
+      transactionIds.push(activeTransactionId);
+      try {
+        const result = await callback(tx);
+        committedWriteTables.push(...writeTables);
+        return result;
+      } finally {
+        activeTransactionId = null;
+      }
+    },
+  };
+
+  return {
+    activeTransactionId: () => activeTransactionId,
+    committedWriteTables,
+    database,
+    transactionIds,
+    writeTables,
+  };
+}
+
+describe('routing application service coordinator', () => {
+  beforeEach(() => {
+    applyMock.mockReset();
+  });
+
+  it('runs ownership, cursor, audit, and outbox calls inside one transaction', async () => {
+    const fake = createFakeDatabase();
+    const outboxTransactionIds: Array<string | null> = [];
+    const outbox = {
+      appendEvent: vi.fn(async () => {
+        outboxTransactionIds.push(fake.activeTransactionId());
+        return { outboxEvent, status: 'enqueued' as const };
+      }),
+    };
+    const createOutboxPort = vi.fn(transaction => {
+      expect(transaction).toBeDefined();
+      return outbox;
+    });
+
+    applyMock.mockImplementation(async (_input, ports) => {
+      await ports.transferLeadOwnership({
+        actor,
+        currentAgentId: 'agent-old',
+        currentBranchId: 'branch-1',
+        leadId: 'lead-1',
+        reason: 'routing_rule',
+        targetAgentId: 'agent-2',
+        targetBranchId: 'branch-1',
+      });
+      await ports.advanceRoutingCursor({
+        advancement: {
+          agentId: 'agent-2',
+          nextCursor: 'agent-2',
+          priorCursor: 'agent-1',
+          ruleId: 'rule-1',
+          tenantId: 'tenant-1',
+        },
+        idempotencyKey: 'route:lead-1',
+      });
+      await ports.appendRoutingAssignmentAudit({
+        auditRecord: {
+          actorId: 'manager-1',
+          agentId: 'agent-2',
+          branchId: 'branch-1',
+          idempotencyKey: 'route:lead-1',
+          leadId: 'lead-1',
+          occurredAt: '2026-05-16T10:00:00.000Z',
+          reasonCode: 'rule_match',
+          ruleId: 'rule-1',
+          strategy: 'round_robin',
+          tenantId: 'tenant-1',
+        },
+        idempotencyKey: 'route:lead-1',
+      });
+      await ports.outbox.appendEvent({ event: {} });
+      return {
+        agentId: 'agent-2',
+        event: {
+          agentId: 'agent-2',
+          branchId: 'branch-1',
+          fromAgentId: 'agent-old',
+          leadId: 'lead-1',
+          reasonCode: 'rule_match',
+          ruleId: 'rule-1',
+          strategy: 'round_robin',
+        },
+        outcome: 'routed',
+        ownershipChanged: true,
+        ruleId: 'rule-1',
+        strategy: 'round_robin',
+      } satisfies ApplyCrmLeadRoutingDecisionResult;
+    });
+
+    const apply = createApplyCrmLeadRoutingDecisionCoordinator({
+      database: fake.database as never,
+      createOutboxPort,
+      services: { outboxEventId: () => 'outbox-1' },
+    });
+
+    await expect(
+      apply({
+        actor,
+        idempotencyKey: 'route:lead-1',
+        leadId: 'lead-1',
+        now: '2026-05-16T10:00:00.000Z',
+      })
+    ).resolves.toMatchObject({ outcome: 'routed' });
+
+    expect(fake.transactionIds).toEqual(['tx-1']);
+    expect(createOutboxPort).toHaveBeenCalledTimes(1);
+    expect(fake.writeTables).toEqual([
+      crmLeads,
+      crmLeadOwnershipHistory,
+      crmLeadOwnershipHistory,
+      crmRoutingCursors,
+      crmRoutingAssignmentsAudit,
+    ]);
+    expect(outboxTransactionIds).toEqual(['tx-1']);
+  });
+
+  it('rolls back transaction writes when the domain service raises a typed rollback', async () => {
+    const fake = createFakeDatabase();
+    applyMock.mockImplementation(async (_input, ports) => {
+      await ports.advanceRoutingCursor({
+        advancement: {
+          agentId: 'agent-2',
+          nextCursor: 'agent-2',
+          priorCursor: 'agent-1',
+          ruleId: 'rule-1',
+          tenantId: 'tenant-1',
+        },
+        idempotencyKey: 'route:lead-1',
+      });
+      throw new CrmRoutingApplicationRollback({
+        outcome: 'stale_lead',
+        reason: 'concurrent_owner_change',
+      });
+    });
+
+    const apply = createApplyCrmLeadRoutingDecisionCoordinator({
+      database: fake.database as never,
+      createOutboxPort: () => ({ appendEvent: vi.fn() }),
+    });
+
+    await expect(
+      apply({
+        actor,
+        idempotencyKey: 'route:lead-1',
+        leadId: 'lead-1',
+        now: '2026-05-16T10:00:00.000Z',
+      })
+    ).resolves.toEqual({ outcome: 'stale_lead', reason: 'concurrent_owner_change' });
+
+    expect(fake.writeTables).toEqual([crmRoutingCursors]);
+    expect(fake.committedWriteTables).toEqual([]);
+  });
+
+  it('maps unexpected adapter failures to repository_failure', async () => {
+    const fake = createFakeDatabase();
+    applyMock.mockRejectedValueOnce(new Error('db unavailable'));
+
+    const apply = createApplyCrmLeadRoutingDecisionCoordinator({
+      database: fake.database as never,
+      createOutboxPort: () => ({ appendEvent: vi.fn() }),
+    });
+
+    await expect(
+      apply({
+        actor,
+        idempotencyKey: 'route:lead-1',
+        leadId: 'lead-1',
+        now: '2026-05-16T10:00:00.000Z',
+      })
+    ).resolves.toEqual({ outcome: 'repository_failure' });
+  });
+});

--- a/apps/web/src/lib/domain-crm/routing-application-service.ts
+++ b/apps/web/src/lib/domain-crm/routing-application-service.ts
@@ -1,11 +1,9 @@
-import type {
-  ApplyCrmLeadRoutingDecisionInput,
-  ApplyCrmLeadRoutingDecisionResult,
-  CrmLeadRoutingApplicationPorts,
-} from '@interdomestik/domain-crm/routing';
 import {
   applyCrmLeadRoutingDecision,
   CrmRoutingApplicationRollback,
+  type ApplyCrmLeadRoutingDecisionInput,
+  type ApplyCrmLeadRoutingDecisionResult,
+  type CrmLeadRoutingApplicationPorts,
   type CrmRoutingCursorMap,
   type CrmRoutingDedupeState,
   type CrmRoutingLeadLifecycleState,

--- a/apps/web/src/lib/domain-crm/routing-application-service.ts
+++ b/apps/web/src/lib/domain-crm/routing-application-service.ts
@@ -1,0 +1,256 @@
+import type {
+  ApplyCrmLeadRoutingDecisionInput,
+  ApplyCrmLeadRoutingDecisionResult,
+  CrmLeadRoutingApplicationPorts,
+} from '@interdomestik/domain-crm/routing';
+import {
+  applyCrmLeadRoutingDecision,
+  CrmRoutingApplicationRollback,
+  type CrmRoutingCursorMap,
+  type CrmRoutingDedupeState,
+  type CrmRoutingLeadLifecycleState,
+  type CrmRoutingLeadSnapshot,
+  type CrmRoutingRule,
+  type CrmRoutingWorkloadSnapshot,
+} from '@interdomestik/domain-crm/routing';
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+import type { CrmOutboxPort } from '@interdomestik/domain-crm/outbox';
+import { randomUUID } from 'node:crypto';
+import { and, count, eq, gte, inArray, isNull } from 'drizzle-orm';
+
+import { db } from '@interdomestik/database/db';
+import {
+  crmActivities,
+  crmLeadOwnershipHistory,
+  crmLeads,
+  crmRoutingCursors,
+} from '@interdomestik/database/schema';
+
+import { createCrmLeadMutationRepository } from './lead-mutation-repository';
+import { createCrmRoutingRepository } from './routing-repository';
+
+type CrmRoutingApplicationDb = typeof db;
+type CrmLeadRow = typeof crmLeads.$inferSelect;
+type AgentCountRow = { agentId: string; count: number };
+
+export type ApplyCrmLeadRoutingDecisionCoordinatorOptions = {
+  database?: CrmRoutingApplicationDb;
+  createOutboxPort(database: CrmRoutingApplicationDb): Pick<CrmOutboxPort, 'appendEvent'>;
+  services?: {
+    outboxEventId(): string;
+  };
+};
+
+function toRoutingLifecycle(stage: string): CrmRoutingLeadLifecycleState {
+  if (
+    stage === 'new' ||
+    stage === 'contacted' ||
+    stage === 'qualified' ||
+    stage === 'proposal' ||
+    stage === 'negotiation' ||
+    stage === 'won' ||
+    stage === 'lost'
+  ) {
+    return stage;
+  }
+  return 'closed';
+}
+
+function toRoutingLeadSnapshot(row: CrmLeadRow): CrmRoutingLeadSnapshot {
+  return {
+    assignedAgentId: row.agentId,
+    branchId: row.branchId ?? null,
+    dedupeState: 'clean' satisfies CrmRoutingDedupeState,
+    id: row.id,
+    lifecycleState: toRoutingLifecycle(row.stage),
+    source: row.source ?? null,
+    tenantId: row.tenantId,
+    type: row.type,
+    utmCampaign: row.utmCampaign ?? null,
+    utmMedium: row.utmMedium ?? null,
+    utmSource: row.utmSource ?? null,
+  };
+}
+
+function startOfUtcDay(value: string): Date {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return new Date(0);
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function configuredAgentIds(rules: readonly CrmRoutingRule[]): string[] {
+  return [
+    ...new Set(
+      rules.flatMap(rule =>
+        [...rule.agentIds, rule.fallbackAgentId ?? ''].map(agentId => agentId.trim())
+      )
+    ),
+  ].filter(Boolean);
+}
+
+function buildWorkloadSnapshot(params: {
+  agentIds: readonly string[];
+  newLeadsAssignedToday: readonly AgentCountRow[];
+  openFollowUps: readonly AgentCountRow[];
+  openLeads: readonly AgentCountRow[];
+  now: string;
+}): CrmRoutingWorkloadSnapshot {
+  const openLeadCounts = new Map(params.openLeads.map(row => [row.agentId, row.count]));
+  const followUpCounts = new Map(params.openFollowUps.map(row => [row.agentId, row.count]));
+  const assignedTodayCounts = new Map(
+    params.newLeadsAssignedToday.map(row => [row.agentId, row.count])
+  );
+  const agents: Record<string, CrmRoutingWorkloadSnapshot['agents'][string]> = {};
+  for (const agentId of params.agentIds) {
+    agents[agentId] = {
+      capacityState: 'available',
+      newLeadsAssignedToday: assignedTodayCounts.get(agentId) ?? 0,
+      openFollowUps: followUpCounts.get(agentId) ?? 0,
+      openLeads: openLeadCounts.get(agentId) ?? 0,
+    };
+  }
+  return { agents, snapshotAt: params.now };
+}
+
+function createRoutingApplicationPorts(
+  database: CrmRoutingApplicationDb,
+  params: {
+    outbox: Pick<CrmOutboxPort, 'appendEvent'>;
+    services: { outboxEventId(): string };
+  }
+): CrmLeadRoutingApplicationPorts {
+  const routing = createCrmRoutingRepository(database);
+  const leads = createCrmLeadMutationRepository(database, { useTransaction: false });
+
+  return {
+    advanceRoutingCursor: routing.advanceRoutingCursor,
+    appendRoutingAssignmentAudit: routing.appendRoutingAssignmentAudit,
+    findRoutingAssignmentAuditByIdempotency: routing.findRoutingAssignmentAuditByIdempotency,
+    async getLeadRoutingSnapshot(params: { actor: CrmActorContext; leadId: string }) {
+      const predicates = [
+        eq(crmLeads.tenantId, params.actor.tenantId),
+        eq(crmLeads.id, params.leadId),
+      ];
+      if (params.actor.role === 'branch_manager') {
+        const branchId = params.actor.scope.branchId;
+        if (!branchId) return null;
+        predicates.push(eq(crmLeads.branchId, branchId));
+      }
+
+      // db-access-guard: tenant-scoped -- reason: controlled CRM routing reads only the target lead by explicit actor tenant, lead id, and branch-manager branch scope when present
+      const row = await database.query.crmLeads.findFirst({
+        where: and(...predicates),
+      });
+      return row ? toRoutingLeadSnapshot(row) : null;
+    },
+    async getRoutingCursors(params: { actor: CrmActorContext; ruleIds: readonly string[] }) {
+      if (params.ruleIds.length === 0) return {};
+
+      // db-access-guard: tenant-scoped -- reason: controlled CRM routing cursor reads constrain by explicit actor tenant and selected rule ids
+      const rows = await database.query.crmRoutingCursors.findMany({
+        where: and(
+          eq(crmRoutingCursors.tenantId, params.actor.tenantId),
+          inArray(crmRoutingCursors.ruleId, [...params.ruleIds])
+        ),
+      });
+
+      return Object.fromEntries(
+        rows.map(row => [row.ruleId, row.cursorValue ?? null])
+      ) as CrmRoutingCursorMap;
+    },
+    async getRoutingWorkloadSnapshot(params: {
+      actor: CrmActorContext;
+      now: string;
+      rules: readonly CrmRoutingRule[];
+    }) {
+      const agentIds = configuredAgentIds(params.rules);
+      if (agentIds.length === 0) {
+        return { agents: {}, snapshotAt: params.now };
+      }
+      const openStages = ['new', 'contacted', 'qualified', 'proposal', 'negotiation'];
+      const dayStart = startOfUtcDay(params.now);
+
+      // db-access-guard: tenant-scoped -- reason: controlled CRM routing workload lead counts constrain by actor tenant and configured routing agent ids
+      const openLeads = await database
+        .select({ agentId: crmLeads.agentId, count: count() })
+        .from(crmLeads)
+        .where(
+          and(
+            eq(crmLeads.tenantId, params.actor.tenantId),
+            inArray(crmLeads.agentId, agentIds),
+            inArray(crmLeads.stage, openStages)
+          )
+        )
+        .groupBy(crmLeads.agentId);
+
+      // db-access-guard: tenant-scoped -- reason: controlled CRM routing workload follow-up counts constrain by actor tenant and configured routing agent ids
+      const openFollowUps = await database
+        .select({ agentId: crmActivities.agentId, count: count() })
+        .from(crmActivities)
+        .where(
+          and(
+            eq(crmActivities.tenantId, params.actor.tenantId),
+            inArray(crmActivities.agentId, agentIds),
+            eq(crmActivities.type, 'follow_up'),
+            isNull(crmActivities.completedAt)
+          )
+        )
+        .groupBy(crmActivities.agentId);
+
+      // db-access-guard: tenant-scoped -- reason: controlled CRM routing same-day assignment counts constrain by actor tenant and configured routing agent ids
+      const assignedToday = await database
+        .select({ agentId: crmLeadOwnershipHistory.agentId, count: count() })
+        .from(crmLeadOwnershipHistory)
+        .where(
+          and(
+            eq(crmLeadOwnershipHistory.tenantId, params.actor.tenantId),
+            inArray(crmLeadOwnershipHistory.agentId, agentIds),
+            gte(crmLeadOwnershipHistory.effectiveFrom, dayStart)
+          )
+        )
+        .groupBy(crmLeadOwnershipHistory.agentId);
+
+      return buildWorkloadSnapshot({
+        agentIds,
+        newLeadsAssignedToday: assignedToday,
+        now: params.now,
+        openFollowUps,
+        openLeads,
+      });
+    },
+    listRoutingRules: routing.listRoutingRules,
+    outbox: params.outbox,
+    services: params.services,
+    async transferLeadOwnership(params) {
+      const updated = await leads.transferOwnership(params);
+      return Boolean(updated);
+    },
+  };
+}
+
+export function createApplyCrmLeadRoutingDecisionCoordinator(
+  options: ApplyCrmLeadRoutingDecisionCoordinatorOptions
+) {
+  const database = options.database ?? db;
+  const services = options.services ?? { outboxEventId: randomUUID };
+
+  return async function applyCrmLeadRoutingDecisionInTransaction(
+    input: ApplyCrmLeadRoutingDecisionInput
+  ): Promise<ApplyCrmLeadRoutingDecisionResult> {
+    try {
+      return await database.transaction(async tx => {
+        const transaction = tx as never as CrmRoutingApplicationDb;
+        return applyCrmLeadRoutingDecision(
+          input,
+          createRoutingApplicationPorts(transaction, {
+            outbox: options.createOutboxPort(transaction),
+            services,
+          })
+        );
+      });
+    } catch (error) {
+      if (error instanceof CrmRoutingApplicationRollback) return error.result;
+      return { outcome: 'repository_failure' };
+    }
+  };
+}

--- a/apps/web/src/lib/domain-crm/routing-repository.test.ts
+++ b/apps/web/src/lib/domain-crm/routing-repository.test.ts
@@ -362,7 +362,7 @@ describe('crmRoutingRepository', () => {
         auditRecord,
         idempotencyKey: auditRecord.idempotencyKey,
       })
-    ).resolves.toEqual(auditRecord);
+    ).resolves.toEqual({ auditRecord, status: 'existing' });
 
     expect(findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -370,6 +370,30 @@ describe('crmRoutingRepository', () => {
       })
     );
     expect(insert).toHaveBeenCalledWith(crmRoutingAssignmentsAudit);
+  });
+
+  it('reads assignment audit replay rows by tenant and idempotency key', async () => {
+    const findFirst = vi.fn(async () => auditRow());
+    const fakeDb = {
+      query: {
+        crmRoutingAssignmentsAudit: { findFirst },
+        crmRoutingRules: { findMany: vi.fn() },
+      },
+    };
+    const repository = createCrmRoutingRepository(fakeDb as never);
+
+    await expect(
+      repository.findRoutingAssignmentAuditByIdempotency({
+        idempotencyKey: 'route:lead-1',
+        tenantId: 'tenant-1',
+      })
+    ).resolves.toEqual(auditRecord);
+
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.anything(),
+      })
+    );
   });
 
   it('creates admin routing rules with the session tenant and domain agentIds vocabulary', async () => {

--- a/apps/web/src/lib/domain-crm/routing-repository.test.ts
+++ b/apps/web/src/lib/domain-crm/routing-repository.test.ts
@@ -26,8 +26,13 @@ import {
 } from './routing-repository';
 
 type AdminRoutingDb = Parameters<typeof createAdminCrmRoutingRuleRepository>[0];
+type RoutingRepositoryDb = Parameters<typeof createCrmRoutingRepository>[0];
 
 const now = new Date('2026-05-16T08:00:00.000Z');
+
+function routingRepositoryDb(database: unknown): RoutingRepositoryDb {
+  return database as RoutingRepositoryDb;
+}
 
 const branchManager: CrmActorContext = {
   actorId: 'manager-1',
@@ -157,7 +162,7 @@ describe('crmRoutingRepository', () => {
       },
       update: vi.fn(),
     };
-    const repository = createCrmRoutingRepository(fakeDb as never);
+    const repository = createCrmRoutingRepository(routingRepositoryDb(fakeDb));
 
     await expect(repository.listRoutingRules({ actor: branchManager })).resolves.toEqual([
       {
@@ -254,7 +259,7 @@ describe('crmRoutingRepository', () => {
       },
       update: vi.fn(),
     };
-    const repository = createCrmRoutingRepository(fakeDb as never);
+    const repository = createCrmRoutingRepository(routingRepositoryDb(fakeDb));
 
     await expect(
       repository.advanceRoutingCursor({
@@ -355,7 +360,7 @@ describe('crmRoutingRepository', () => {
       },
       update: vi.fn(),
     };
-    const repository = createCrmRoutingRepository(fakeDb as never);
+    const repository = createCrmRoutingRepository(routingRepositoryDb(fakeDb));
 
     await expect(
       repository.appendRoutingAssignmentAudit({
@@ -380,7 +385,7 @@ describe('crmRoutingRepository', () => {
         crmRoutingRules: { findMany: vi.fn() },
       },
     };
-    const repository = createCrmRoutingRepository(fakeDb as never);
+    const repository = createCrmRoutingRepository(routingRepositoryDb(fakeDb));
 
     await expect(
       repository.findRoutingAssignmentAuditByIdempotency({

--- a/apps/web/src/lib/domain-crm/routing-repository.ts
+++ b/apps/web/src/lib/domain-crm/routing-repository.ts
@@ -215,6 +215,17 @@ function auditValues(params: {
 
 export function createCrmRoutingRepository(database: CrmRoutingDb = db): CrmRoutingRepository {
   return {
+    async findRoutingAssignmentAuditByIdempotency(params) {
+      // db-access-guard: tenant-scoped -- reason: routing application idempotency replay constrains by explicit tenantId and opaque idempotency key
+      const existing = await database.query.crmRoutingAssignmentsAudit.findFirst({
+        where: and(
+          eq(crmRoutingAssignmentsAudit.tenantId, params.tenantId),
+          eq(crmRoutingAssignmentsAudit.idempotencyKey, params.idempotencyKey)
+        ),
+      });
+      return existing ? mapAudit(existing) : null;
+    },
+
     async listRoutingRules(params: { actor: CrmActorContext }) {
       const actor = params.actor;
       if (actor.role === 'member') return [];
@@ -317,7 +328,7 @@ export function createCrmRoutingRepository(database: CrmRoutingDb = db): CrmRout
         .returning();
 
       if (inserted[0]) {
-        return mapAudit(inserted[0]);
+        return { auditRecord: mapAudit(inserted[0]), status: 'appended' };
       }
 
       if (!values.idempotencyKey) {
@@ -336,7 +347,7 @@ export function createCrmRoutingRepository(database: CrmRoutingDb = db): CrmRout
         throw new Error('CRM routing audit idempotency conflict did not return an existing row');
       }
 
-      return mapAudit(existing);
+      return { auditRecord: mapAudit(existing), status: 'existing' };
     },
   };
 }

--- a/packages/domain-crm/package.json
+++ b/packages/domain-crm/package.json
@@ -50,6 +50,7 @@
     "./reporting/repository": "./src/reporting/repository.ts",
     "./reporting/types": "./src/reporting/types.ts",
     "./routing": "./src/routing/index.ts",
+    "./routing/application-service": "./src/routing/application-service.ts",
     "./routing/mutations": "./src/routing/mutations.ts",
     "./routing/repository": "./src/routing/repository.ts",
     "./routing/types": "./src/routing/types.ts",

--- a/packages/domain-crm/src/routing/application-service.test.ts
+++ b/packages/domain-crm/src/routing/application-service.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it, vi, type MockedFunction } from 'vitest';
+
+import type { CrmActorContext } from '../context';
+import type { CreateCrmOutboxEventData, CrmOutboxEvent } from '../outbox/types';
+import type { CrmOutboxAppendResult } from '../outbox/repository';
+import {
+  applyCrmLeadRoutingDecision,
+  CrmRoutingApplicationRollback,
+  type CrmLeadRoutingApplicationPorts,
+} from './application-service';
+import type {
+  CrmRoutingAssignmentAuditRecord,
+  CrmRoutingCursorAdvancement,
+  CrmRoutingCursorMap,
+  CrmRoutingLeadSnapshot,
+  CrmRoutingRule,
+  CrmRoutingWorkloadSnapshot,
+} from './types';
+
+const now = '2026-05-16T10:00:00.000Z';
+
+const adminActor: CrmActorContext = {
+  actorId: 'admin-1',
+  role: 'admin',
+  scope: {},
+  tenantId: 'tenant-1',
+};
+
+const managerActor: CrmActorContext = {
+  actorId: 'manager-1',
+  role: 'branch_manager',
+  scope: { branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
+
+const staffActor: CrmActorContext = {
+  actorId: 'staff-1',
+  role: 'staff',
+  scope: { branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
+
+function lead(overrides: Partial<CrmRoutingLeadSnapshot> = {}): CrmRoutingLeadSnapshot {
+  return {
+    assignedAgentId: 'agent-old',
+    branchId: 'branch-1',
+    dedupeState: 'clean',
+    id: 'lead-1',
+    lifecycleState: 'qualified',
+    source: 'website',
+    tenantId: 'tenant-1',
+    type: 'business',
+    ...overrides,
+  };
+}
+
+function rule(overrides: Partial<CrmRoutingRule> = {}): CrmRoutingRule {
+  return {
+    agentIds: ['agent-1', 'agent-2'],
+    branchId: 'branch-1',
+    enabled: true,
+    id: 'rule-1',
+    leadType: 'business',
+    priority: 10,
+    source: 'website',
+    strategy: 'round_robin',
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+function workload(): CrmRoutingWorkloadSnapshot {
+  return {
+    agents: {
+      'agent-1': { newLeadsAssignedToday: 0, openFollowUps: 0, openLeads: 0 },
+      'agent-2': { newLeadsAssignedToday: 0, openFollowUps: 0, openLeads: 0 },
+    },
+    snapshotAt: now,
+  };
+}
+
+function storedOutboxEvent(event: CreateCrmOutboxEventData): CrmOutboxEvent {
+  return {
+    aggregateId: event.event.aggregateId,
+    aggregateType: event.event.aggregateType,
+    availableAt: event.availableAt,
+    createdAt: now,
+    event: event.event,
+    id: event.id,
+    idempotencyKey: event.idempotencyKey,
+    retryCount: 0,
+    status: 'pending',
+    tenantId: event.event.tenantId,
+    type: event.event.type,
+  };
+}
+
+class InMemoryRoutingApplicationPorts implements CrmLeadRoutingApplicationPorts {
+  auditReplay: CrmRoutingAssignmentAuditRecord | null = null;
+  audits: CrmRoutingAssignmentAuditRecord[] = [];
+  cursorConflictsRemaining = 0;
+  cursors: CrmRoutingCursorMap = {};
+  leadSnapshots: CrmRoutingLeadSnapshot[] = [lead()];
+  outboxEvents: CreateCrmOutboxEventData[] = [];
+  rules: CrmRoutingRule[] = [rule()];
+  transfers: unknown[] = [];
+
+  readonly advanceRoutingCursor = vi.fn(
+    async (params: { advancement: CrmRoutingCursorAdvancement }) => {
+      if (this.cursorConflictsRemaining > 0) {
+        this.cursorConflictsRemaining -= 1;
+        return { reason: 'cursor_conflict' as const, success: false as const };
+      }
+      this.cursors = {
+        ...this.cursors,
+        [params.advancement.ruleId]: params.advancement.nextCursor,
+      };
+      return { advancement: params.advancement, success: true as const };
+    }
+  );
+
+  readonly appendRoutingAssignmentAudit: MockedFunction<
+    CrmLeadRoutingApplicationPorts['appendRoutingAssignmentAudit']
+  > = vi.fn(async (params: { auditRecord: CrmRoutingAssignmentAuditRecord }) => {
+    this.audits.push(params.auditRecord);
+    return { auditRecord: params.auditRecord, status: 'appended' as const };
+  });
+
+  readonly findRoutingAssignmentAuditByIdempotency = vi.fn(async () => this.auditReplay);
+
+  readonly getLeadRoutingSnapshot = vi.fn(async () => this.leadSnapshots[0] ?? null);
+
+  readonly getRoutingCursors = vi.fn(async () => this.cursors);
+
+  readonly getRoutingWorkloadSnapshot = vi.fn(async () => workload());
+
+  readonly listRoutingRules = vi.fn(async () => this.rules);
+
+  readonly outbox = {
+    appendEvent: vi.fn(
+      async (params: { event: CreateCrmOutboxEventData }): Promise<CrmOutboxAppendResult> => {
+        this.outboxEvents.push(params.event);
+        return { outboxEvent: storedOutboxEvent(params.event), status: 'enqueued' };
+      }
+    ),
+  };
+
+  readonly services = {
+    outboxEventId: vi.fn(() => 'outbox-1'),
+  };
+
+  readonly transferLeadOwnership = vi.fn(async params => {
+    this.transfers.push(params);
+    return true;
+  });
+}
+
+function input(overrides: Partial<Parameters<typeof applyCrmLeadRoutingDecision>[0]> = {}) {
+  return {
+    actor: managerActor,
+    idempotencyKey: 'route:lead-1',
+    leadId: 'lead-1',
+    now,
+    ...overrides,
+  };
+}
+
+describe('applyCrmLeadRoutingDecision', () => {
+  it('fails closed before repository reads for unauthorized actors and blank idempotency keys', async () => {
+    const ports = new InMemoryRoutingApplicationPorts();
+
+    await expect(applyCrmLeadRoutingDecision(input({ actor: staffActor }), ports)).resolves.toEqual(
+      { outcome: 'rejected', reason: 'role_scope' }
+    );
+    await expect(
+      applyCrmLeadRoutingDecision(input({ idempotencyKey: '   ' }), ports)
+    ).resolves.toEqual({ outcome: 'rejected', reason: 'invalid_override' });
+
+    expect(ports.getLeadRoutingSnapshot).not.toHaveBeenCalled();
+    expect(ports.findRoutingAssignmentAuditByIdempotency).not.toHaveBeenCalled();
+    expect(ports.audits).toHaveLength(0);
+    expect(ports.outboxEvents).toHaveLength(0);
+  });
+
+  it('returns idempotent replay without reselecting or writing', async () => {
+    const ports = new InMemoryRoutingApplicationPorts();
+    ports.auditReplay = {
+      actorId: 'manager-1',
+      agentId: 'agent-2',
+      branchId: 'branch-1',
+      idempotencyKey: 'route:lead-1',
+      leadId: 'lead-1',
+      occurredAt: now,
+      reasonCode: 'rule_match',
+      ruleId: 'rule-1',
+      strategy: 'round_robin',
+      tenantId: 'tenant-1',
+    };
+
+    await expect(applyCrmLeadRoutingDecision(input(), ports)).resolves.toEqual({
+      agentId: 'agent-2',
+      outcome: 'idempotent_replay',
+      ruleId: 'rule-1',
+      strategy: 'round_robin',
+    });
+
+    expect(ports.getLeadRoutingSnapshot).not.toHaveBeenCalled();
+    expect(ports.audits).toHaveLength(0);
+    expect(ports.outboxEvents).toHaveLength(0);
+  });
+
+  it('rejects replay divergence for the same idempotency key', async () => {
+    const ports = new InMemoryRoutingApplicationPorts();
+    ports.auditReplay = {
+      actorId: 'someone-else',
+      agentId: 'agent-2',
+      branchId: 'branch-1',
+      idempotencyKey: 'route:lead-1',
+      leadId: 'lead-1',
+      occurredAt: now,
+      reasonCode: 'rule_match',
+      ruleId: 'rule-1',
+      strategy: 'round_robin',
+      tenantId: 'tenant-1',
+    };
+
+    await expect(applyCrmLeadRoutingDecision(input(), ports)).resolves.toEqual({
+      outcome: 'rejected',
+      reason: 'invalid_override',
+    });
+  });
+
+  it('routes a lead with cursor advance, ownership transfer, audit append, and outbox append', async () => {
+    const ports = new InMemoryRoutingApplicationPorts();
+    ports.cursors = { 'rule-1': 'agent-1' };
+
+    await expect(applyCrmLeadRoutingDecision(input(), ports)).resolves.toMatchObject({
+      agentId: 'agent-2',
+      outcome: 'routed',
+      ownershipChanged: true,
+      ruleId: 'rule-1',
+      strategy: 'round_robin',
+    });
+
+    expect(ports.advanceRoutingCursor).toHaveBeenCalledTimes(1);
+    expect(ports.transferLeadOwnership).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentAgentId: 'agent-old',
+        leadId: 'lead-1',
+        targetAgentId: 'agent-2',
+      })
+    );
+    expect(ports.audits).toHaveLength(1);
+    expect(ports.outboxEvents).toHaveLength(1);
+    expect(ports.outboxEvents[0]?.event).toMatchObject({
+      aggregateId: 'lead-1',
+      payload: { agentId: 'agent-2', leadId: 'lead-1', ruleId: 'rule-1' },
+      type: 'crm.lead.routed',
+    });
+  });
+
+  it('keeps same-owner routing auditable without ownership transfer', async () => {
+    const ports = new InMemoryRoutingApplicationPorts();
+    ports.leadSnapshots = [lead({ assignedAgentId: 'agent-2' })];
+    ports.cursors = { 'rule-1': 'agent-1' };
+
+    await expect(applyCrmLeadRoutingDecision(input({ actor: adminActor }), ports)).resolves.toEqual(
+      expect.objectContaining({
+        outcome: 'routed',
+        ownershipChanged: false,
+      })
+    );
+
+    expect(ports.transferLeadOwnership).not.toHaveBeenCalled();
+    expect(ports.audits).toHaveLength(1);
+    expect(ports.outboxEvents).toHaveLength(1);
+  });
+
+  it('returns manual review and no_rule without writes', async () => {
+    const manualPorts = new InMemoryRoutingApplicationPorts();
+    manualPorts.rules = [rule({ strategy: 'manual_only' })];
+    await expect(applyCrmLeadRoutingDecision(input(), manualPorts)).resolves.toEqual({
+      outcome: 'manual_review',
+      reason: 'manual_only',
+      ruleId: 'rule-1',
+    });
+
+    const noRulePorts = new InMemoryRoutingApplicationPorts();
+    noRulePorts.rules = [rule({ source: 'referral' })];
+    await expect(applyCrmLeadRoutingDecision(input(), noRulePorts)).resolves.toEqual({
+      outcome: 'no_rule',
+    });
+
+    expect(manualPorts.audits).toHaveLength(0);
+    expect(noRulePorts.outboxEvents).toHaveLength(0);
+  });
+
+  it('returns stale_lead for terminal, dedupe, and concurrent owner-change states', async () => {
+    const terminalPorts = new InMemoryRoutingApplicationPorts();
+    terminalPorts.leadSnapshots = [lead({ lifecycleState: 'won' })];
+    await expect(applyCrmLeadRoutingDecision(input(), terminalPorts)).resolves.toEqual({
+      outcome: 'stale_lead',
+      reason: 'lifecycle_terminal',
+    });
+
+    const dedupePorts = new InMemoryRoutingApplicationPorts();
+    dedupePorts.leadSnapshots = [lead({ dedupeState: 'merge_pending' })];
+    await expect(applyCrmLeadRoutingDecision(input(), dedupePorts)).resolves.toEqual({
+      outcome: 'stale_lead',
+      reason: 'dedupe_state',
+    });
+
+    const concurrentPorts = new InMemoryRoutingApplicationPorts();
+    concurrentPorts.getLeadRoutingSnapshot.mockResolvedValueOnce(lead());
+    concurrentPorts.getLeadRoutingSnapshot.mockResolvedValueOnce(
+      lead({ assignedAgentId: 'agent-raced' })
+    );
+    await expect(applyCrmLeadRoutingDecision(input(), concurrentPorts)).resolves.toEqual({
+      outcome: 'stale_lead',
+      reason: 'concurrent_owner_change',
+    });
+  });
+
+  it('retries cursor conflicts at most three times', async () => {
+    const retryPorts = new InMemoryRoutingApplicationPorts();
+    retryPorts.cursorConflictsRemaining = 2;
+    await expect(applyCrmLeadRoutingDecision(input(), retryPorts)).resolves.toMatchObject({
+      outcome: 'routed',
+    });
+    expect(retryPorts.advanceRoutingCursor).toHaveBeenCalledTimes(3);
+
+    const exhaustedPorts = new InMemoryRoutingApplicationPorts();
+    exhaustedPorts.cursorConflictsRemaining = 3;
+    await expect(applyCrmLeadRoutingDecision(input(), exhaustedPorts)).resolves.toEqual({
+      outcome: 'cursor_conflict_exhausted',
+    });
+    expect(exhaustedPorts.audits).toHaveLength(0);
+    expect(exhaustedPorts.outboxEvents).toHaveLength(0);
+  });
+
+  it('throws a rollback signal when a post-cursor ownership failure would otherwise commit partial writes', async () => {
+    const ports = new InMemoryRoutingApplicationPorts();
+    ports.transferLeadOwnership.mockResolvedValueOnce(false);
+    ports.cursors = { 'rule-1': 'agent-1' };
+
+    try {
+      await applyCrmLeadRoutingDecision(input(), ports);
+      throw new Error('expected rollback signal');
+    } catch (error) {
+      expect(error).toBeInstanceOf(CrmRoutingApplicationRollback);
+      expect(error).toMatchObject({
+        result: { outcome: 'stale_lead', reason: 'concurrent_owner_change' },
+      });
+    }
+    expect(ports.advanceRoutingCursor).toHaveBeenCalledTimes(1);
+    expect(ports.audits).toHaveLength(0);
+    expect(ports.outboxEvents).toHaveLength(0);
+  });
+
+  it('throws a rollback signal when an idempotency conflict returns a divergent audit row', async () => {
+    const ports = new InMemoryRoutingApplicationPorts();
+    ports.appendRoutingAssignmentAudit.mockResolvedValueOnce({
+      auditRecord: {
+        actorId: 'manager-1',
+        agentId: 'agent-2',
+        branchId: 'branch-raced',
+        idempotencyKey: 'route:lead-1',
+        leadId: 'lead-1',
+        occurredAt: now,
+        reasonCode: 'fallback_agent',
+        ruleId: 'rule-1',
+        strategy: 'round_robin',
+        tenantId: 'tenant-1',
+      },
+      status: 'existing',
+    });
+
+    await expect(applyCrmLeadRoutingDecision(input(), ports)).rejects.toMatchObject({
+      result: { outcome: 'rejected', reason: 'invalid_override' },
+    });
+    expect(ports.outboxEvents).toHaveLength(0);
+  });
+
+  it('throws an idempotent rollback signal when a late same-key audit replay is identical', async () => {
+    const ports = new InMemoryRoutingApplicationPorts();
+    ports.appendRoutingAssignmentAudit.mockImplementationOnce(async params => ({
+      auditRecord: params.auditRecord,
+      status: 'existing' as const,
+    }));
+
+    await expect(applyCrmLeadRoutingDecision(input(), ports)).rejects.toMatchObject({
+      result: {
+        agentId: 'agent-1',
+        outcome: 'idempotent_replay',
+        ruleId: 'rule-1',
+        strategy: 'round_robin',
+      },
+    });
+    expect(ports.outboxEvents).toHaveLength(0);
+  });
+});

--- a/packages/domain-crm/src/routing/application-service.ts
+++ b/packages/domain-crm/src/routing/application-service.ts
@@ -1,0 +1,385 @@
+import type { CrmActorContext } from '../context';
+import type { CrmOutboxPort } from '../outbox/repository';
+import { createCrmOutboxEventData } from '../outbox/mutations';
+import type { CrmLeadRoutedEvent } from '../outbox/types';
+import { selectCrmLeadAssignee } from './mutations';
+import type {
+  CrmRoutingAssignmentAuditAppendResult,
+  CrmRoutingCursorAdvanceResult,
+} from './repository';
+import type {
+  CrmLeadRoutedEventData,
+  CrmRoutingAssignmentAuditRecord,
+  CrmRoutingCursorAdvancement,
+  CrmRoutingCursorMap,
+  CrmRoutingLeadSnapshot,
+  CrmRoutingManualOverride,
+  CrmRoutingManualReviewReason,
+  CrmRoutingRejectionReason,
+  CrmRoutingRule,
+  CrmRoutingStrategy,
+  CrmRoutingWorkloadSnapshot,
+} from './types';
+
+const CRM_ROUTING_CURSOR_RETRY_LIMIT = 3;
+
+export interface ApplyCrmLeadRoutingDecisionInput {
+  actor: CrmActorContext;
+  leadId: string;
+  idempotencyKey: string;
+  now: string;
+  override?: CrmRoutingManualOverride;
+}
+
+export type ApplyCrmLeadRoutingDecisionResult =
+  | {
+      outcome: 'routed';
+      agentId: string;
+      ruleId: string;
+      strategy: CrmRoutingStrategy;
+      event: CrmLeadRoutedEventData;
+      ownershipChanged: boolean;
+    }
+  | {
+      outcome: 'idempotent_replay';
+      agentId: string;
+      ruleId: string;
+      strategy: CrmRoutingStrategy;
+    }
+  | { outcome: 'manual_review'; reason: CrmRoutingManualReviewReason; ruleId?: string }
+  | { outcome: 'no_rule' }
+  | { outcome: 'rejected'; reason: CrmRoutingRejectionReason }
+  | { outcome: 'cursor_conflict_exhausted' }
+  | {
+      outcome: 'stale_lead';
+      reason: 'lifecycle_terminal' | 'dedupe_state' | 'concurrent_owner_change';
+    }
+  | { outcome: 'repository_failure' };
+
+export class CrmRoutingApplicationRollback extends Error {
+  constructor(readonly result: ApplyCrmLeadRoutingDecisionResult) {
+    super(`CRM routing application rollback: ${result.outcome}`);
+  }
+}
+
+export interface CrmLeadRoutingApplicationPorts {
+  advanceRoutingCursor(params: {
+    advancement: CrmRoutingCursorAdvancement;
+    idempotencyKey: string;
+  }): Promise<CrmRoutingCursorAdvanceResult>;
+  appendRoutingAssignmentAudit(params: {
+    auditRecord: CrmRoutingAssignmentAuditRecord;
+    idempotencyKey: string;
+  }): Promise<CrmRoutingAssignmentAuditAppendResult>;
+  findRoutingAssignmentAuditByIdempotency(params: {
+    idempotencyKey: string;
+    tenantId: string;
+  }): Promise<CrmRoutingAssignmentAuditRecord | null>;
+  getLeadRoutingSnapshot(params: {
+    actor: CrmActorContext;
+    leadId: string;
+  }): Promise<CrmRoutingLeadSnapshot | null>;
+  getRoutingCursors(params: {
+    actor: CrmActorContext;
+    ruleIds: readonly string[];
+  }): Promise<CrmRoutingCursorMap>;
+  getRoutingWorkloadSnapshot(params: {
+    actor: CrmActorContext;
+    now: string;
+    rules: readonly CrmRoutingRule[];
+  }): Promise<CrmRoutingWorkloadSnapshot>;
+  listRoutingRules(params: { actor: CrmActorContext }): Promise<readonly CrmRoutingRule[]>;
+  outbox: Pick<CrmOutboxPort, 'appendEvent'>;
+  services: {
+    outboxEventId(): string;
+  };
+  transferLeadOwnership(params: {
+    actor: CrmActorContext;
+    currentAgentId: string;
+    currentBranchId: string;
+    leadId: string;
+    reason: string;
+    targetAgentId: string;
+    targetBranchId: string;
+  }): Promise<boolean>;
+}
+
+function normalizeIdempotencyKey(value: string): string | null {
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isTerminalLead(lead: CrmRoutingLeadSnapshot): boolean {
+  return (
+    lead.lifecycleState === 'archived' ||
+    lead.lifecycleState === 'closed' ||
+    lead.lifecycleState === 'converted' ||
+    lead.lifecycleState === 'lost' ||
+    lead.lifecycleState === 'won'
+  );
+}
+
+function hasBlockedDedupeState(lead: CrmRoutingLeadSnapshot): boolean {
+  return lead.dedupeState === 'merge_pending' || lead.dedupeState === 'merged_loser';
+}
+
+function staleLeadResult(
+  lead: CrmRoutingLeadSnapshot
+): Extract<ApplyCrmLeadRoutingDecisionResult, { outcome: 'stale_lead' }> | null {
+  if (isTerminalLead(lead)) return { outcome: 'stale_lead', reason: 'lifecycle_terminal' };
+  if (hasBlockedDedupeState(lead)) return { outcome: 'stale_lead', reason: 'dedupe_state' };
+  return null;
+}
+
+function replayResult(params: {
+  audit: CrmRoutingAssignmentAuditRecord;
+  input: ApplyCrmLeadRoutingDecisionInput;
+}): ApplyCrmLeadRoutingDecisionResult {
+  const { audit, input } = params;
+  if (audit.leadId !== input.leadId || audit.actorId !== input.actor.actorId) {
+    return { outcome: 'rejected', reason: 'invalid_override' };
+  }
+  return {
+    agentId: audit.agentId,
+    outcome: 'idempotent_replay',
+    ruleId: audit.ruleId,
+    strategy: audit.strategy,
+  };
+}
+
+function auditMatches(params: {
+  actual: CrmRoutingAssignmentAuditRecord;
+  expected: CrmRoutingAssignmentAuditRecord;
+}): boolean {
+  return (
+    params.actual.actorId === params.expected.actorId &&
+    params.actual.agentId === params.expected.agentId &&
+    (params.actual.branchId ?? null) === (params.expected.branchId ?? null) &&
+    (params.actual.idempotencyKey ?? null) === (params.expected.idempotencyKey ?? null) &&
+    params.actual.leadId === params.expected.leadId &&
+    params.actual.occurredAt === params.expected.occurredAt &&
+    params.actual.reasonCode === params.expected.reasonCode &&
+    params.actual.ruleId === params.expected.ruleId &&
+    params.actual.strategy === params.expected.strategy &&
+    params.actual.tenantId === params.expected.tenantId
+  );
+}
+
+function authorizeApplicationActor(
+  actor: CrmActorContext
+): Extract<ApplyCrmLeadRoutingDecisionResult, { outcome: 'rejected' }> | null {
+  if (!actor.tenantId.trim()) return { outcome: 'rejected', reason: 'tenant_scope' };
+  if (actor.role === 'admin') return null;
+  if (actor.role !== 'branch_manager') return { outcome: 'rejected', reason: 'role_scope' };
+  if (!actor.scope.branchId?.trim()) return { outcome: 'rejected', reason: 'branch_scope' };
+  return null;
+}
+
+function scopeRulesForActor(
+  actor: CrmActorContext,
+  rules: readonly CrmRoutingRule[]
+): readonly CrmRoutingRule[] {
+  if (actor.role !== 'branch_manager') return rules;
+  return rules.filter(rule => rule.branchId === actor.scope.branchId);
+}
+
+function toRoutedEvent(params: {
+  auditRecord: CrmRoutingAssignmentAuditRecord;
+  event: CrmLeadRoutedEventData;
+  input: ApplyCrmLeadRoutingDecisionInput;
+}): CrmLeadRoutedEvent {
+  return {
+    actor: {
+      actorId: params.input.actor.actorId,
+      branchId: params.input.actor.scope.branchId ?? null,
+      role: params.input.actor.role,
+      tenantId: params.input.actor.tenantId,
+    },
+    aggregateId: params.input.leadId,
+    aggregateType: 'lead',
+    idempotencyKey: params.input.idempotencyKey,
+    occurredAt: params.auditRecord.occurredAt,
+    payload: params.event,
+    tenantId: params.auditRecord.tenantId,
+    type: 'crm.lead.routed',
+  };
+}
+
+async function appendRoutedEvent(params: {
+  auditRecord: CrmRoutingAssignmentAuditRecord;
+  event: CrmLeadRoutedEventData;
+  input: ApplyCrmLeadRoutingDecisionInput;
+  ports: CrmLeadRoutingApplicationPorts;
+}): Promise<void> {
+  const event = createCrmOutboxEventData(
+    {
+      event: toRoutedEvent(params),
+      idempotencyKey: params.input.idempotencyKey,
+    },
+    {
+      clock: { now: () => params.input.now },
+      ids: { outboxEventId: params.ports.services.outboxEventId },
+    }
+  );
+  if ('success' in event) {
+    throw new Error(`Invalid CRM routed event: ${event.reason}`);
+  }
+  await params.ports.outbox.appendEvent({ event });
+}
+
+async function applyAssignedDecision(params: {
+  decision: Extract<ReturnType<typeof selectCrmLeadAssignee>, { outcome: 'assigned' }>;
+  input: ApplyCrmLeadRoutingDecisionInput;
+  ports: CrmLeadRoutingApplicationPorts;
+  selectedFromLead: CrmRoutingLeadSnapshot;
+}): Promise<ApplyCrmLeadRoutingDecisionResult | 'cursor_conflict'> {
+  const { decision, input, ports, selectedFromLead } = params;
+  const currentLead = await ports.getLeadRoutingSnapshot({
+    actor: input.actor,
+    leadId: input.leadId,
+  });
+  if (!currentLead) return { outcome: 'rejected', reason: 'tenant_scope' };
+
+  const stale = staleLeadResult(currentLead);
+  if (stale) return stale;
+
+  if (
+    currentLead.assignedAgentId !== selectedFromLead.assignedAgentId ||
+    currentLead.branchId !== selectedFromLead.branchId
+  ) {
+    return { outcome: 'stale_lead', reason: 'concurrent_owner_change' };
+  }
+
+  const currentAgentId = currentLead.assignedAgentId;
+  const currentBranchId = currentLead.branchId;
+  if (!currentAgentId || !currentBranchId || !decision.event.branchId) {
+    return { outcome: 'rejected', reason: 'branch_scope' };
+  }
+
+  if (decision.cursorAdvancement) {
+    const cursorResult = await ports.advanceRoutingCursor({
+      advancement: decision.cursorAdvancement,
+      idempotencyKey: input.idempotencyKey,
+    });
+    if (!cursorResult.success) return 'cursor_conflict';
+  }
+
+  const ownershipChanged = currentAgentId !== decision.agentId;
+  if (ownershipChanged) {
+    const transferred = await ports.transferLeadOwnership({
+      actor: input.actor,
+      currentAgentId,
+      currentBranchId,
+      leadId: input.leadId,
+      reason: 'routing_rule',
+      targetAgentId: decision.agentId,
+      targetBranchId: decision.event.branchId,
+    });
+    if (!transferred) {
+      throw new CrmRoutingApplicationRollback({
+        outcome: 'stale_lead',
+        reason: 'concurrent_owner_change',
+      });
+    }
+  }
+
+  const auditAppend = await ports.appendRoutingAssignmentAudit({
+    auditRecord: decision.auditRecord,
+    idempotencyKey: input.idempotencyKey,
+  });
+  const audit = auditAppend.auditRecord;
+  if (!auditMatches({ actual: audit, expected: decision.auditRecord })) {
+    throw new CrmRoutingApplicationRollback({
+      outcome: 'rejected',
+      reason: 'invalid_override',
+    });
+  }
+  if (auditAppend.status === 'existing') {
+    throw new CrmRoutingApplicationRollback({
+      agentId: audit.agentId,
+      outcome: 'idempotent_replay',
+      ruleId: audit.ruleId,
+      strategy: audit.strategy,
+    });
+  }
+  await appendRoutedEvent({
+    auditRecord: decision.auditRecord,
+    event: decision.event,
+    input,
+    ports,
+  });
+
+  return {
+    agentId: decision.agentId,
+    event: decision.event,
+    outcome: 'routed',
+    ownershipChanged,
+    ruleId: decision.ruleId,
+    strategy: decision.strategy,
+  };
+}
+
+export async function applyCrmLeadRoutingDecision(
+  input: ApplyCrmLeadRoutingDecisionInput,
+  ports: CrmLeadRoutingApplicationPorts
+): Promise<ApplyCrmLeadRoutingDecisionResult> {
+  const idempotencyKey = normalizeIdempotencyKey(input.idempotencyKey);
+  if (!idempotencyKey) return { outcome: 'rejected', reason: 'invalid_override' };
+
+  const normalizedInput = { ...input, idempotencyKey };
+  const actorDenied = authorizeApplicationActor(normalizedInput.actor);
+  if (actorDenied) return actorDenied;
+
+  const replay = await ports.findRoutingAssignmentAuditByIdempotency({
+    idempotencyKey,
+    tenantId: input.actor.tenantId,
+  });
+  if (replay) return replayResult({ audit: replay, input: normalizedInput });
+
+  for (let attempt = 0; attempt < CRM_ROUTING_CURSOR_RETRY_LIMIT; attempt += 1) {
+    const lead = await ports.getLeadRoutingSnapshot({
+      actor: normalizedInput.actor,
+      leadId: normalizedInput.leadId,
+    });
+    if (!lead) return { outcome: 'rejected', reason: 'tenant_scope' };
+
+    const stale = staleLeadResult(lead);
+    if (stale) return stale;
+
+    const rules = scopeRulesForActor(
+      normalizedInput.actor,
+      await ports.listRoutingRules({ actor: normalizedInput.actor })
+    );
+    const workloadSnapshot = await ports.getRoutingWorkloadSnapshot({
+      actor: normalizedInput.actor,
+      now: normalizedInput.now,
+      rules,
+    });
+    const cursors = await ports.getRoutingCursors({
+      actor: normalizedInput.actor,
+      ruleIds: rules.map(rule => rule.id),
+    });
+    const decision = selectCrmLeadAssignee(
+      { ...normalizedInput, lead },
+      rules,
+      workloadSnapshot,
+      cursors
+    );
+
+    if (decision.outcome === 'assigned') {
+      const result = await applyAssignedDecision({
+        decision,
+        input: normalizedInput,
+        ports,
+        selectedFromLead: lead,
+      });
+      if (result === 'cursor_conflict') continue;
+      return result;
+    }
+    if (decision.outcome === 'manual_review') return decision;
+    if (decision.outcome === 'no_rule') return decision;
+    return decision;
+  }
+
+  return { outcome: 'cursor_conflict_exhausted' };
+}

--- a/packages/domain-crm/src/routing/application-service.ts
+++ b/packages/domain-crm/src/routing/application-service.ts
@@ -319,6 +319,48 @@ async function applyAssignedDecision(params: {
   };
 }
 
+type RoutingApplicationAttemptResult = ApplyCrmLeadRoutingDecisionResult | 'cursor_conflict';
+
+async function applyRoutingDecisionAttempt(params: {
+  input: ApplyCrmLeadRoutingDecisionInput;
+  ports: CrmLeadRoutingApplicationPorts;
+}): Promise<RoutingApplicationAttemptResult> {
+  const { input, ports } = params;
+  const lead = await ports.getLeadRoutingSnapshot({
+    actor: input.actor,
+    leadId: input.leadId,
+  });
+  if (!lead) return { outcome: 'rejected', reason: 'tenant_scope' };
+
+  const stale = staleLeadResult(lead);
+  if (stale) return stale;
+
+  const rules = scopeRulesForActor(
+    input.actor,
+    await ports.listRoutingRules({ actor: input.actor })
+  );
+  const workloadSnapshot = await ports.getRoutingWorkloadSnapshot({
+    actor: input.actor,
+    now: input.now,
+    rules,
+  });
+  const cursors = await ports.getRoutingCursors({
+    actor: input.actor,
+    ruleIds: rules.map(rule => rule.id),
+  });
+  const decision = selectCrmLeadAssignee({ ...input, lead }, rules, workloadSnapshot, cursors);
+
+  if (decision.outcome === 'assigned') {
+    return applyAssignedDecision({
+      decision,
+      input,
+      ports,
+      selectedFromLead: lead,
+    });
+  }
+  return decision;
+}
+
 export async function applyCrmLeadRoutingDecision(
   input: ApplyCrmLeadRoutingDecisionInput,
   ports: CrmLeadRoutingApplicationPorts
@@ -337,48 +379,9 @@ export async function applyCrmLeadRoutingDecision(
   if (replay) return replayResult({ audit: replay, input: normalizedInput });
 
   for (let attempt = 0; attempt < CRM_ROUTING_CURSOR_RETRY_LIMIT; attempt += 1) {
-    const lead = await ports.getLeadRoutingSnapshot({
-      actor: normalizedInput.actor,
-      leadId: normalizedInput.leadId,
-    });
-    if (!lead) return { outcome: 'rejected', reason: 'tenant_scope' };
-
-    const stale = staleLeadResult(lead);
-    if (stale) return stale;
-
-    const rules = scopeRulesForActor(
-      normalizedInput.actor,
-      await ports.listRoutingRules({ actor: normalizedInput.actor })
-    );
-    const workloadSnapshot = await ports.getRoutingWorkloadSnapshot({
-      actor: normalizedInput.actor,
-      now: normalizedInput.now,
-      rules,
-    });
-    const cursors = await ports.getRoutingCursors({
-      actor: normalizedInput.actor,
-      ruleIds: rules.map(rule => rule.id),
-    });
-    const decision = selectCrmLeadAssignee(
-      { ...normalizedInput, lead },
-      rules,
-      workloadSnapshot,
-      cursors
-    );
-
-    if (decision.outcome === 'assigned') {
-      const result = await applyAssignedDecision({
-        decision,
-        input: normalizedInput,
-        ports,
-        selectedFromLead: lead,
-      });
-      if (result === 'cursor_conflict') continue;
-      return result;
-    }
-    if (decision.outcome === 'manual_review') return decision;
-    if (decision.outcome === 'no_rule') return decision;
-    return decision;
+    const result = await applyRoutingDecisionAttempt({ input: normalizedInput, ports });
+    if (result === 'cursor_conflict') continue;
+    return result;
   }
 
   return { outcome: 'cursor_conflict_exhausted' };

--- a/packages/domain-crm/src/routing/index.test.ts
+++ b/packages/domain-crm/src/routing/index.test.ts
@@ -113,9 +113,13 @@ class InMemoryRoutingRepository implements CrmRoutingRepository {
   async appendRoutingAssignmentAudit(params: {
     auditRecord: CrmRoutingAssignmentAuditRecord;
     idempotencyKey?: string | null;
-  }): Promise<CrmRoutingAssignmentAuditRecord> {
+  }) {
     this.auditRecords.push(params.auditRecord);
-    return params.auditRecord;
+    return { auditRecord: params.auditRecord, status: 'appended' as const };
+  }
+
+  async findRoutingAssignmentAuditByIdempotency(): Promise<CrmRoutingAssignmentAuditRecord | null> {
+    return null;
   }
 
   async advanceRoutingCursor(params: {

--- a/packages/domain-crm/src/routing/index.test.ts
+++ b/packages/domain-crm/src/routing/index.test.ts
@@ -118,7 +118,10 @@ class InMemoryRoutingRepository implements CrmRoutingRepository {
     return { auditRecord: params.auditRecord, status: 'appended' as const };
   }
 
-  async findRoutingAssignmentAuditByIdempotency(): Promise<CrmRoutingAssignmentAuditRecord | null> {
+  async findRoutingAssignmentAuditByIdempotency(_params: {
+    idempotencyKey: string;
+    tenantId: string;
+  }): Promise<CrmRoutingAssignmentAuditRecord | null> {
     return null;
   }
 

--- a/packages/domain-crm/src/routing/index.ts
+++ b/packages/domain-crm/src/routing/index.ts
@@ -1,3 +1,4 @@
+export * from './application-service';
 export * from './mutations';
 export * from './repository';
 export * from './types';

--- a/packages/domain-crm/src/routing/repository.ts
+++ b/packages/domain-crm/src/routing/repository.ts
@@ -9,16 +9,24 @@ export type CrmRoutingCursorAdvanceResult =
   | { success: true; advancement: CrmRoutingCursorAdvancement }
   | { success: false; reason: 'cursor_conflict' };
 
+export type CrmRoutingAssignmentAuditAppendResult =
+  | { status: 'appended'; auditRecord: CrmRoutingAssignmentAuditRecord }
+  | { status: 'existing'; auditRecord: CrmRoutingAssignmentAuditRecord };
+
 export interface CrmRoutingRepository {
   appendRoutingAssignmentAudit(params: {
     auditRecord: CrmRoutingAssignmentAuditRecord;
     idempotencyKey?: string | null;
-  }): Promise<CrmRoutingAssignmentAuditRecord>;
+  }): Promise<CrmRoutingAssignmentAuditAppendResult>;
   advanceRoutingCursor(params: {
     advancement: CrmRoutingCursorAdvancement;
     idempotencyKey?: string | null;
   }): Promise<CrmRoutingCursorAdvanceResult>;
   listRoutingRules(params: { actor: CrmActorContext }): Promise<readonly CrmRoutingRule[]>;
+  findRoutingAssignmentAuditByIdempotency(params: {
+    idempotencyKey: string;
+    tenantId: string;
+  }): Promise<CrmRoutingAssignmentAuditRecord | null>;
 }
 
 export type {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 28490000,
-  "maxTrackedFiles": 3706,
+  "maxTrackedBytes": 28550000,
+  "maxTrackedFiles": 3710,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 13800000,
-    "source/scripts": 5900000,
+    "source/scripts": 5925000,
     "tests/e2e": 4194304,
     "docs/text": 3450000,
     "config/data/messages": 1572864,


### PR DESCRIPTION
## Summary
- add the P38-CRM23 pure `applyCrmLeadRoutingDecision` domain entry point with typed outcomes, idempotent replay, cursor retry handling, manual-review/rejection/no-write paths, and SQL-free package boundaries
- add the app-side CRM routing coordinator that runs ownership transfer, cursor advance, assignment audit append, and `crm.lead.routed` outbox append in one transaction
- add focused domain/app coverage plus narrow E2E hardening for the CRM09 routing-rule gate and the staff support handoff duplicate advisory locator

## Verification
- `git diff --check`
- `pnpm --filter @interdomestik/web type-check && pnpm --filter @interdomestik/web lint`
- `pnpm --filter @interdomestik/web run build:ci`
- focused E2E: `admin-crm-routing-rules.spec.ts` + `staff-support-handoffs.spec.ts` (6 passed)
- `pnpm check:db-access`
- `pnpm db:migrations:check-journal`
- `pnpm db:rls:test:required`
- `pnpm security:guard`
- `pnpm ci:local:quick`
- `pnpm pr:verify` (PR fast gate: 128 passed / 4 skipped; smoke: 13 passed / 1 skipped)

## Local Docker note
- `pnpm ci:local:pr` / full Docker verification was attempted earlier and repeatedly exited `137` during the Next TypeScript build after DB migration/disk cleanup/reduced heap. Host `pr:verify`, focused E2E, DB/RLS checks, and `security:guard` passed as the least-risk fallback.