### PR TITLE
fix: harden policy ai tenant writes

### DIFF
--- a/apps/web/src/app/api/policies/analyze/_services.test.ts
+++ b/apps/web/src/app/api/policies/analyze/_services.test.ts
@@ -7,7 +7,10 @@ const mocks = vi.hoisted(() => {
   const txInsert = vi.fn(() => ({
     values: txInsertValues,
   }));
-  const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const txUpdateReturning = vi.fn();
+  const txUpdateWhere = vi.fn(() => ({
+    returning: txUpdateReturning,
+  }));
   const txUpdateSet = vi.fn(() => ({
     where: txUpdateWhere,
   }));
@@ -69,12 +72,23 @@ const mocks = vi.hoisted(() => {
     txInsertReturning,
     txInsertValues,
     txUpdate,
+    txUpdateReturning,
     txUpdateSet,
     txUpdateWhere,
     update,
     updateReturning,
     updateSet,
     updateWhere,
+    withTenantContext: vi.fn(
+      async (
+        _context: { tenantId: string; role?: string },
+        callback: (tx: { insert: typeof txInsert; update: typeof txUpdate }) => Promise<unknown>
+      ) =>
+        callback({
+          insert: txInsert,
+          update: txUpdate,
+        })
+    ),
   };
 });
 
@@ -84,6 +98,7 @@ vi.mock('@/lib/db.server', () => ({
 
 vi.mock('@interdomestik/database', () => ({
   createAdminClient: mocks.createAdminClient,
+  withTenantContext: mocks.withTenantContext,
 }));
 
 vi.mock('@interdomestik/database/schema', () => ({
@@ -121,6 +136,7 @@ describe('queuePolicyAnalysisService', () => {
     }));
     mocks.txInsertReturning.mockResolvedValue([{ id: 'policy-1' }]);
     mocks.txInsertOnConflictDoNothing.mockResolvedValue(undefined);
+    mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
   });
 
   it('persists a placeholder policy, document, and queued ai run in one transaction', async () => {
@@ -134,7 +150,11 @@ describe('queuePolicyAnalysisService', () => {
     });
 
     expect(result).toEqual({ policyId: 'policy-1', runId: 'run-1' });
-    expect(mocks.transaction).toHaveBeenCalledOnce();
+    expect(mocks.withTenantContext).toHaveBeenCalledWith(
+      { tenantId: 'tenant-1', role: 'system' },
+      expect.any(Function)
+    );
+    expect(mocks.transaction).not.toHaveBeenCalled();
     expect(mocks.txInsert).toHaveBeenCalledTimes(3);
 
     expect(mocks.txInsert).toHaveBeenNthCalledWith(1, { __name: 'policies' });
@@ -224,6 +244,7 @@ describe('processPolicyAnalysisRunService', () => {
       },
     ]);
     mocks.updateReturning.mockResolvedValue([{ id: 'run-1' }]);
+    mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
     mocks.txInsertValues.mockImplementation(() => ({
       onConflictDoNothing: mocks.txInsertOnConflictDoNothing,
       returning: mocks.txInsertReturning,
@@ -263,19 +284,24 @@ describe('processPolicyAnalysisRunService', () => {
       policyId: 'policy-1',
       analysis,
     });
-    expect(mocks.update).toHaveBeenCalledWith({ __name: 'ai_runs' });
-    expect(mocks.updateSet).toHaveBeenCalledWith(
+    expect(mocks.withTenantContext).toHaveBeenCalledWith(
+      { tenantId: 'tenant-1', role: 'system' },
+      expect.any(Function)
+    );
+    expect(mocks.txUpdate).toHaveBeenCalledWith({ __name: 'ai_runs' });
+    expect(mocks.txUpdateSet).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         status: 'processing',
         startedAt: expect.any(Date),
       })
     );
-    expect(mocks.updateReturning).toHaveBeenCalledWith({ id: undefined });
-    expect(mocks.transaction).toHaveBeenCalledOnce();
-    expect(mocks.txUpdate).toHaveBeenCalledTimes(2);
-    expect(mocks.txUpdate).toHaveBeenNthCalledWith(1, { __name: 'policies' });
+    expect(mocks.txUpdateReturning).toHaveBeenCalledWith({ id: undefined });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+    expect(mocks.txUpdate).toHaveBeenCalledTimes(3);
+    expect(mocks.txUpdate).toHaveBeenNthCalledWith(2, { __name: 'policies' });
     expect(mocks.txUpdateSet).toHaveBeenNthCalledWith(
-      1,
+      2,
       expect.objectContaining({
         provider: 'Acme Insurance',
         policyNumber: 'POL-123',
@@ -305,9 +331,9 @@ describe('processPolicyAnalysisRunService', () => {
     expect(mocks.txInsertOnConflictDoNothing).toHaveBeenCalledWith({
       target: { __name: 'document_extractions.source_run_id' },
     });
-    expect(mocks.txUpdate).toHaveBeenNthCalledWith(2, { __name: 'ai_runs' });
+    expect(mocks.txUpdate).toHaveBeenNthCalledWith(3, { __name: 'ai_runs' });
     expect(mocks.txUpdateSet).toHaveBeenNthCalledWith(
-      2,
+      3,
       expect.objectContaining({
         status: 'completed',
         outputJson: analysis,
@@ -342,7 +368,7 @@ describe('processPolicyAnalysisRunService', () => {
     ).rejects.toThrow();
 
     expect(mocks.transaction).not.toHaveBeenCalled();
-    expect(mocks.updateSet).toHaveBeenCalledWith(
+    expect(mocks.txUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'failed',
         errorCode: 'policy_extract_failed',
@@ -352,7 +378,7 @@ describe('processPolicyAnalysisRunService', () => {
   });
 
   it('skips when another worker already claimed the queued run', async () => {
-    mocks.updateReturning.mockResolvedValueOnce([]);
+    mocks.txUpdateReturning.mockResolvedValueOnce([]);
 
     const result = await processPolicyAnalysisRunService({
       runId: 'run-1',

--- a/apps/web/src/app/api/policies/analyze/_services.ts
+++ b/apps/web/src/app/api/policies/analyze/_services.ts
@@ -9,6 +9,7 @@ import { db } from '@/lib/db.server';
 import { inngest } from '@/lib/inngest/client';
 import { downloadTenantObject, uploadTenantObject } from '@/lib/storage/service-role';
 import { POLICIES_BUCKET, buildPolicyStoragePath } from '@/lib/storage/tenant-prefix';
+import { withTenantContext } from '@interdomestik/database';
 import { aiRuns, documentExtractions, documents, policies } from '@interdomestik/database/schema';
 import { getResponsesWorkflowConfig } from '@interdomestik/domain-ai/models';
 import { policyExtractSchema } from '@interdomestik/domain-ai/schemas/policy-extract';
@@ -135,14 +136,12 @@ export async function analyzePdfService(buffer: Buffer): Promise<string> {
 export async function queuePolicyAnalysisService(
   data: QueuePolicyAnalysisArgs
 ): Promise<{ policyId: string; runId: string }> {
-  // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-  return db.transaction(async tx => {
+  return withTenantContext({ tenantId: data.tenantId, role: 'system' }, async tx => {
     const policyId = nanoid();
     const documentId = nanoid();
     const runId = nanoid();
     const now = new Date();
 
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
     await tx
       .insert(policies)
       .values({
@@ -156,7 +155,6 @@ export async function queuePolicyAnalysisService(
       })
       .returning();
 
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
     await tx.insert(documents).values({
       id: documentId,
       tenantId: data.tenantId,
@@ -172,7 +170,6 @@ export async function queuePolicyAnalysisService(
       uploadedAt: now,
     });
 
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
     await tx.insert(aiRuns).values({
       id: runId,
       tenantId: data.tenantId,
@@ -303,17 +300,20 @@ export async function processPolicyAnalysisRunService(args: {
   }
 
   const startedAt = new Date();
-  // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-  const [claimedRun] = await db
-    .update(aiRuns)
-    .set({
-      status: 'processing',
-      startedAt,
-      errorCode: null,
-      errorMessage: null,
-    })
-    .where(and(eq(aiRuns.id, runId), eq(aiRuns.status, 'queued')))
-    .returning({ id: aiRuns.id });
+  const [claimedRun] = await withTenantContext(
+    { tenantId: queuedRun.tenantId, role: 'system' },
+    async tx =>
+      tx
+        .update(aiRuns)
+        .set({
+          status: 'processing',
+          startedAt,
+          errorCode: null,
+          errorMessage: null,
+        })
+        .where(and(eq(aiRuns.id, runId), eq(aiRuns.status, 'queued')))
+        .returning({ id: aiRuns.id })
+  );
 
   if (!claimedRun) {
     return {
@@ -348,9 +348,7 @@ export async function processPolicyAnalysisRunService(args: {
     const policyExtract = policyExtractSchema.parse(analysis);
     const completedAt = new Date();
 
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-    await db.transaction(async tx => {
-      // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
+    await withTenantContext({ tenantId: queuedRun.tenantId, role: 'system' }, async tx => {
       await tx
         .update(policies)
         .set({
@@ -360,7 +358,6 @@ export async function processPolicyAnalysisRunService(args: {
         })
         .where(eq(policies.id, policyId));
 
-      // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
       await tx
         .insert(documentExtractions)
         .values({
@@ -380,7 +377,6 @@ export async function processPolicyAnalysisRunService(args: {
         })
         .onConflictDoNothing({ target: documentExtractions.sourceRunId });
 
-      // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
       await tx
         .update(aiRuns)
         .set({
@@ -408,16 +404,17 @@ export async function processPolicyAnalysisRunService(args: {
     const completedAt = new Date();
     const message = error instanceof Error ? error.message : 'Policy extraction failed.';
 
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-    await db
-      .update(aiRuns)
-      .set({
-        status: 'failed',
-        completedAt,
-        errorCode: 'policy_extract_failed',
-        errorMessage: message,
-      })
-      .where(eq(aiRuns.id, runId));
+    await withTenantContext({ tenantId: queuedRun.tenantId, role: 'system' }, async tx => {
+      await tx
+        .update(aiRuns)
+        .set({
+          status: 'failed',
+          completedAt,
+          errorCode: 'policy_extract_failed',
+          errorMessage: message,
+        })
+        .where(eq(aiRuns.id, runId));
+    });
 
     throw error;
   }

--- a/apps/web/src/app/api/policies/analyze/route.test.ts
+++ b/apps/web/src/app/api/policies/analyze/route.test.ts
@@ -11,6 +11,7 @@ const hoisted = vi.hoisted(() => ({
   returning: vi.fn(),
   values: vi.fn(),
   transaction: vi.fn(),
+  withTenantContext: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -47,6 +48,7 @@ vi.mock('@interdomestik/database', () => ({
   db: {
     transaction: hoisted.transaction,
   },
+  withTenantContext: hoisted.withTenantContext,
 }));
 
 describe('POST /api/policies/analyze', () => {
@@ -69,6 +71,14 @@ describe('POST /api/policies/analyze', () => {
           values: hoisted.values,
         }),
       })
+    );
+    hoisted.withTenantContext.mockImplementation(
+      async (_context: unknown, callback: (tx: unknown) => unknown) =>
+        callback({
+          insert: () => ({
+            values: hoisted.values,
+          }),
+        })
     );
 
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test';

--- a/scripts/ci/db-access-baseline.json
+++ b/scripts/ci/db-access-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-05-17T16:58:50.611Z",
+  "generatedAt": "2026-05-17T17:27:06.744Z",
   "policy": "see docs/dev/db-access-guard.md",
   "scanRoots": ["apps/web/src", "packages"],
   "approvedDatabaseInternalPatterns": [
@@ -22,12 +22,12 @@
   "methods": ["query", "select", "insert", "update", "delete", "execute", "transaction"],
   "counts": {
     "byRisk": {
-      "app-layer": 307,
+      "app-layer": 305,
       "domain-wrapper": 300
     },
     "byTenantPosture": {
-      "tenant-context": 14,
-      "tenant-scoped": 179,
+      "tenant-context": 22,
+      "tenant-scoped": 169,
       "tenant-predicate": 366,
       "admin-privileged": 0,
       "system-exempt": 48,
@@ -1561,51 +1561,37 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 139,
-      "callee": "db.transaction",
-      "method": "transaction",
-      "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "return db.transaction(async tx => {"
-    },
-    {
-      "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 146,
+      "line": 145,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
       "source": "await tx .insert(policies)"
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 160,
+      "line": 158,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
       "source": "await tx.insert(documents).values({"
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 176,
+      "line": 173,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
       "source": "await tx.insert(aiRuns).values({"
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 216,
+      "line": 213,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
@@ -1616,7 +1602,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 262,
+      "line": 259,
       "callee": "db.select",
       "method": "select",
       "risk": "app-layer",
@@ -1627,69 +1613,53 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 307,
-      "callee": "db.update",
+      "line": 306,
+      "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "const [claimedRun] = await db .update(aiRuns)"
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-alias",
+      "source": "tx .update(aiRuns)"
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
       "line": 352,
-      "callee": "db.transaction",
-      "method": "transaction",
-      "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "await db.transaction(async tx => {"
-    },
-    {
-      "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 354,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
       "source": "await tx .update(policies)"
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 364,
+      "line": 361,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
       "source": "await tx .insert(documentExtractions)"
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 384,
+      "line": 380,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
       "source": "await tx .update(aiRuns)"
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 412,
-      "callee": "db.update",
+      "line": 408,
+      "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "await db .update(aiRuns)"
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
+      "source": "await tx .update(aiRuns)"
     },
     {
       "file": "apps/web/src/app/api/privacy/data-deletion/_core.ts",


### PR DESCRIPTION
## Summary
- Move policy AI queue and processing writes behind withTenantContext using the resolved tenant id.
- Update policy AI service tests to assert the tenant-context write path.
- Refresh DB access baseline: tenant-context 14 -> 22, tenant-scoped 179 -> 169, unclassified remains 0.

## Test Plan
- pnpm --filter @interdomestik/web test:unit --run src/app/api/policies/analyze/_services.test.ts
- pnpm --filter @interdomestik/web type-check
- pnpm check:db-access
- pnpm repo:size:check
- pnpm security:guard
- git diff --check

## Scope
- No proxy, routing, docs, README, or AGENTS changes.