### PR TITLE
fix: harden claim ai tenant writes

### DIFF
--- a/apps/web/src/lib/ai/claim-workflows.test.ts
+++ b/apps/web/src/lib/ai/claim-workflows.test.ts
@@ -6,13 +6,20 @@ const mocks = vi.hoisted(() => {
   const txInsert = vi.fn(() => ({
     values: txInsertValues,
   }));
-  const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const txUpdateReturning = vi.fn();
+  const txUpdateWhere = vi.fn(() => ({
+    returning: txUpdateReturning,
+  }));
   const txUpdateSet = vi.fn(() => ({
     where: txUpdateWhere,
   }));
   const txUpdate = vi.fn(() => ({
     set: txUpdateSet,
   }));
+  const tenantWriteTx = {
+    insert: txInsert,
+    update: txUpdate,
+  };
   const transaction = vi.fn(
     async (
       callback: (tx: { insert: typeof txInsert; update: typeof txUpdate }) => Promise<unknown>
@@ -61,8 +68,14 @@ const mocks = vi.hoisted(() => {
     txInsert,
     txInsertOnConflictDoNothing,
     txInsertValues,
+    txUpdate,
+    txUpdateReturning,
     txUpdateSet,
     updateReturning,
+    withTenantContext: vi.fn(
+      async (_context: unknown, callback: (tx: typeof tenantWriteTx) => Promise<unknown>) =>
+        callback(tenantWriteTx)
+    ),
   };
 });
 
@@ -79,6 +92,10 @@ vi.mock('@/lib/inngest/client', () => ({
 vi.mock('@/lib/storage/evidence-bucket', () => ({
   DEFAULT_EVIDENCE_BUCKET: 'claim-evidence',
   resolveEvidenceBucketName: mocks.resolveEvidenceBucketName,
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  withTenantContext: mocks.withTenantContext,
 }));
 
 vi.mock('@interdomestik/database/schema', () => ({
@@ -208,7 +225,7 @@ describe('processClaimDocumentWorkflowRunService', () => {
     mocks.txInsertValues.mockImplementation(() => ({
       onConflictDoNothing: mocks.txInsertOnConflictDoNothing,
     }));
-    mocks.updateReturning.mockResolvedValue([{ id: 'run-1' }]);
+    mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
   });
 
   it('processes a queued claim-intake run and persists a document extraction', async () => {
@@ -245,6 +262,15 @@ describe('processClaimDocumentWorkflowRunService', () => {
         claimSnapshot: { incidentDate: '2026-02-15' },
       })
     );
+    expect(mocks.withTenantContext).toHaveBeenCalledWith(
+      { tenantId: 'tenant-1', role: 'system' },
+      expect.any(Function)
+    );
+    expect(mocks.txUpdate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ __name: 'ai_runs' })
+    );
+    expect(mocks.txUpdateReturning).toHaveBeenCalledWith({ id: { __name: 'ai_runs.id' } });
     expect(mocks.txInsert).toHaveBeenCalledWith(
       expect.objectContaining({ __name: 'document_extractions' })
     );

--- a/apps/web/src/lib/ai/claim-workflows.ts
+++ b/apps/web/src/lib/ai/claim-workflows.ts
@@ -7,6 +7,7 @@ import { extractLegalDocument } from '@interdomestik/domain-ai/legal/extract';
 import { db } from '@/lib/db.server';
 import { inngest } from '@/lib/inngest/client';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
+import { withTenantContext } from '@interdomestik/database';
 import { aiRuns, claims, documentExtractions, documents } from '@interdomestik/database/schema';
 import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
@@ -26,6 +27,49 @@ type ProcessClaimDocumentWorkflowDeps = {
 };
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const CLAIM_AI_TENANT_CONTEXT_ROLE = 'system' as const;
+
+function getClaimAiTenantContext(tenantId: string) {
+  return { tenantId, role: CLAIM_AI_TENANT_CONTEXT_ROLE };
+}
+
+function getClaimAiProcessingPatch(startedAt: Date) {
+  return {
+    status: 'processing' as const,
+    startedAt,
+    errorCode: null,
+    errorMessage: null,
+  };
+}
+
+function getClaimAiCompletedPatch(args: {
+  completedAt: Date;
+  extraction: Record<string, unknown>;
+  runId: string;
+  workflow: ClaimAiWorkflow;
+}) {
+  return {
+    status: 'completed' as const,
+    responseJson: {
+      event: getEventName(args.workflow),
+      runId: args.runId,
+    },
+    outputJson: args.extraction,
+    reviewStatus: 'pending' as const,
+    completedAt: args.completedAt,
+    errorCode: null,
+    errorMessage: null,
+  };
+}
+
+function getClaimAiFailedPatch(message: string, completedAt: Date) {
+  return {
+    status: 'failed' as const,
+    completedAt,
+    errorCode: 'claim_ai_processing_failed' as const,
+    errorMessage: message,
+  };
+}
 
 function getEventName(workflow: ClaimAiWorkflow) {
   return workflow === 'legal_doc_extract'
@@ -168,6 +212,7 @@ export async function processClaimDocumentWorkflowRunService(args: {
   }
 
   const workflow = queuedRun.workflow;
+  const tenantContext = getClaimAiTenantContext(queuedRun.tenantId);
 
   if (queuedRun.status === 'completed' || queuedRun.status === 'failed') {
     return {
@@ -178,17 +223,13 @@ export async function processClaimDocumentWorkflowRunService(args: {
     };
   }
 
-  // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-  const [claimedRun] = await db
-    .update(aiRuns)
-    .set({
-      status: 'processing',
-      startedAt: new Date(),
-      errorCode: null,
-      errorMessage: null,
-    })
-    .where(and(eq(aiRuns.id, args.runId), eq(aiRuns.status, 'queued')))
-    .returning({ id: aiRuns.id });
+  const [claimedRun] = await withTenantContext(tenantContext, async tx =>
+    tx
+      .update(aiRuns)
+      .set(getClaimAiProcessingPatch(new Date()))
+      .where(and(eq(aiRuns.id, args.runId), eq(aiRuns.status, 'queued')))
+      .returning({ id: aiRuns.id })
+  );
 
   if (!claimedRun) {
     return {
@@ -252,29 +293,22 @@ export async function processClaimDocumentWorkflowRunService(args: {
       updatedAt: completedAt,
     };
 
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-    await db.transaction(async tx => {
-      // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
+    await withTenantContext(tenantContext, async tx => {
       await tx
         .insert(documentExtractions)
         .values(extractionRow)
         .onConflictDoNothing({ target: documentExtractions.sourceRunId });
 
-      // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
       await tx
         .update(aiRuns)
-        .set({
-          status: 'completed',
-          responseJson: {
-            event: getEventName(workflow),
+        .set(
+          getClaimAiCompletedPatch({
+            completedAt,
+            extraction,
             runId: args.runId,
-          },
-          outputJson: extraction,
-          reviewStatus: 'pending',
-          completedAt,
-          errorCode: null,
-          errorMessage: null,
-        })
+            workflow,
+          })
+        )
         .where(eq(aiRuns.id, args.runId));
     });
 
@@ -288,16 +322,12 @@ export async function processClaimDocumentWorkflowRunService(args: {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Claim AI workflow failed.';
 
-    // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-    await db
-      .update(aiRuns)
-      .set({
-        status: 'failed',
-        completedAt: new Date(),
-        errorCode: 'claim_ai_processing_failed',
-        errorMessage: message,
-      })
-      .where(eq(aiRuns.id, args.runId));
+    await withTenantContext(tenantContext, async tx => {
+      await tx
+        .update(aiRuns)
+        .set(getClaimAiFailedPatch(message, new Date()))
+        .where(eq(aiRuns.id, args.runId));
+    });
 
     throw error;
   }

--- a/scripts/ci/db-access-baseline.json
+++ b/scripts/ci/db-access-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-05-17T17:27:06.744Z",
+  "generatedAt": "2026-05-17T18:11:31.344Z",
   "policy": "see docs/dev/db-access-guard.md",
   "scanRoots": ["apps/web/src", "packages"],
   "approvedDatabaseInternalPatterns": [
@@ -22,12 +22,12 @@
   "methods": ["query", "select", "insert", "update", "delete", "execute", "transaction"],
   "counts": {
     "byRisk": {
-      "app-layer": 305,
+      "app-layer": 304,
       "domain-wrapper": 300
     },
     "byTenantPosture": {
-      "tenant-context": 22,
-      "tenant-scoped": 169,
+      "tenant-context": 26,
+      "tenant-scoped": 164,
       "tenant-predicate": 366,
       "admin-privileged": 0,
       "system-exempt": 48,
@@ -2928,7 +2928,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 110,
+      "line": 111,
       "callee": "db.update",
       "method": "update",
       "risk": "app-layer",
@@ -2939,7 +2939,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 134,
+      "line": 135,
       "callee": "db.select",
       "method": "select",
       "risk": "app-layer",
@@ -2949,58 +2949,43 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 182,
-      "callee": "db.update",
+      "line": 185,
+      "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "const [claimedRun] = await db .update(aiRuns)"
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-alias",
+      "source": "tx .update(aiRuns)"
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 256,
-      "callee": "db.transaction",
-      "method": "transaction",
-      "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "await db.transaction(async tx => {"
-    },
-    {
-      "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 258,
+      "line": 260,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
       "source": "await tx .insert(documentExtractions)"
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 264,
+      "line": 265,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
       "source": "await tx .update(aiRuns)"
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 292,
-      "callee": "db.update",
+      "line": 293,
+      "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "await db .update(aiRuns)"
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
+      "source": "await tx .update(aiRuns)"
     },
     {
       "file": "apps/web/src/lib/audit.core.ts",


### PR DESCRIPTION
## Summary
- Move claim AI processing writes behind withTenantContext using the queued run tenant id.
- Update claim AI workflow tests to assert the tenant-context callback path.
- Refresh DB access baseline: tenant-context 22 -> 26, tenant-scoped 169 -> 164, unclassified remains 0.

## Test Plan
- pnpm --filter @interdomestik/web test:unit --run src/lib/ai/claim-workflows.test.ts
- pnpm --filter @interdomestik/web type-check
- pnpm check:db-access
- pnpm repo:size:check
- pnpm security:guard
- git diff --check

## Scope
- No proxy, routing, docs, README, or AGENTS changes.