### PR TITLE
fix: harden ai dispatch failure writes

### DIFF
--- a/apps/web/src/app/api/policies/analyze/_services.ts
+++ b/apps/web/src/app/api/policies/analyze/_services.ts
@@ -5,6 +5,7 @@ import {
   analyzePolicyImages,
   analyzePolicyText,
 } from '@/lib/ai/policy-analyzer';
+import { markAiRunDispatchFailedWithTenantContext } from '@/lib/ai/dispatch-failure';
 import { db } from '@/lib/db.server';
 import { inngest } from '@/lib/inngest/client';
 import { downloadTenantObject, uploadTenantObject } from '@/lib/storage/service-role';
@@ -209,16 +210,13 @@ export async function markPolicyAnalysisRunDispatchFailedService(args: {
   runId: string;
   message: string;
 }) {
-  // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-  await db
-    .update(aiRuns)
-    .set({
-      status: 'failed',
-      completedAt: new Date(),
-      errorCode: 'policy_extract_dispatch_failed',
-      errorMessage: args.message,
-    })
-    .where(and(eq(aiRuns.id, args.runId), eq(aiRuns.status, 'queued')));
+  await markAiRunDispatchFailedWithTenantContext({
+    entityType: 'policy',
+    errorCode: 'policy_extract_dispatch_failed',
+    message: args.message,
+    runId: args.runId,
+    workflow: POLICY_EXTRACT_WORKFLOW,
+  });
 }
 
 async function downloadPolicyFileService(filePath: string, tenantId: string): Promise<Buffer> {

--- a/apps/web/src/lib/ai/claim-workflows.ts
+++ b/apps/web/src/lib/ai/claim-workflows.ts
@@ -4,6 +4,7 @@ import {
 } from '@interdomestik/domain-ai';
 import { extractClaimIntake } from '@interdomestik/domain-ai/claims/intake-extract';
 import { extractLegalDocument } from '@interdomestik/domain-ai/legal/extract';
+import { markAiRunDispatchFailedWithTenantContext } from '@/lib/ai/dispatch-failure';
 import { db } from '@/lib/db.server';
 import { inngest } from '@/lib/inngest/client';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
@@ -150,16 +151,12 @@ export async function markClaimAiRunDispatchFailedService(args: {
   runId: string;
   message: string;
 }) {
-  // db-access-guard: tenant-scoped -- reason: tenantId comes from validated AI policy queue input or queued run row
-  await db
-    .update(aiRuns)
-    .set({
-      status: 'failed',
-      completedAt: new Date(),
-      errorCode: 'claim_ai_dispatch_failed',
-      errorMessage: args.message,
-    })
-    .where(and(eq(aiRuns.id, args.runId), eq(aiRuns.status, 'queued')));
+  await markAiRunDispatchFailedWithTenantContext({
+    entityType: 'claim',
+    errorCode: 'claim_ai_dispatch_failed',
+    message: args.message,
+    runId: args.runId,
+  });
 }
 
 export async function processClaimDocumentWorkflowRunService(args: {

--- a/apps/web/src/lib/ai/dispatch-failure.test.ts
+++ b/apps/web/src/lib/ai/dispatch-failure.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const txUpdateWhere = vi.fn();
+  const txUpdateSet = vi.fn(() => ({
+    where: txUpdateWhere,
+  }));
+  const txUpdate = vi.fn(() => ({
+    set: txUpdateSet,
+  }));
+  const selectWhere = vi.fn();
+  const selectFrom = vi.fn(() => ({
+    where: selectWhere,
+  }));
+  const select = vi.fn(() => ({
+    from: selectFrom,
+  }));
+
+  return {
+    db: {
+      select,
+    },
+    selectWhere,
+    txUpdate,
+    txUpdateSet,
+    txUpdateWhere,
+    withTenantContext: vi.fn(
+      async (
+        _context: { tenantId: string; role?: string },
+        callback: (tx: { update: typeof txUpdate }) => Promise<unknown>
+      ) =>
+        callback({
+          update: txUpdate,
+        })
+    ),
+  };
+});
+
+vi.mock('@/lib/db.server', () => ({
+  db: mocks.db,
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  withTenantContext: mocks.withTenantContext,
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  aiRuns: {
+    __name: 'ai_runs',
+    entityType: { __name: 'ai_runs.entity_type' },
+    id: { __name: 'ai_runs.id' },
+    status: { __name: 'ai_runs.status' },
+    tenantId: { __name: 'ai_runs.tenant_id' },
+    workflow: { __name: 'ai_runs.workflow' },
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ __op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ __op: 'eq', left, right })),
+}));
+
+import { markAiRunDispatchFailedWithTenantContext } from './dispatch-failure';
+
+describe('markAiRunDispatchFailedWithTenantContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectWhere.mockResolvedValue([{ tenantId: 'tenant-1' }]);
+  });
+
+  it.each([
+    {
+      errorCode: 'policy_extract_dispatch_failed',
+      entityType: 'policy',
+      workflow: 'policy_extract',
+    },
+    {
+      errorCode: 'claim_ai_dispatch_failed',
+      entityType: 'claim',
+      workflow: undefined,
+    },
+  ])('updates queued $entityType AI runs inside tenant context', async args => {
+    await markAiRunDispatchFailedWithTenantContext({
+      ...args,
+      runId: 'run-1',
+      message: 'Inngest dispatch failed.',
+    });
+
+    expect(mocks.withTenantContext).toHaveBeenCalledWith(
+      { tenantId: 'tenant-1', role: 'system' },
+      expect.any(Function)
+    );
+    expect(mocks.txUpdate).toHaveBeenCalledWith(expect.objectContaining({ __name: 'ai_runs' }));
+    expect(mocks.txUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        errorCode: args.errorCode,
+        errorMessage: 'Inngest dispatch failed.',
+      })
+    );
+  });
+
+  it('does not write when the queued AI run is gone', async () => {
+    mocks.selectWhere.mockResolvedValue([]);
+
+    await markAiRunDispatchFailedWithTenantContext({
+      entityType: 'policy',
+      errorCode: 'policy_extract_dispatch_failed',
+      message: 'Inngest dispatch failed.',
+      runId: 'run-1',
+      workflow: 'policy_extract',
+    });
+
+    expect(mocks.withTenantContext).not.toHaveBeenCalled();
+    expect(mocks.txUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai/dispatch-failure.ts
+++ b/apps/web/src/lib/ai/dispatch-failure.ts
@@ -1,0 +1,46 @@
+import { db } from '@/lib/db.server';
+import { withTenantContext } from '@interdomestik/database';
+import { aiRuns } from '@interdomestik/database/schema';
+import { and, eq, type SQL } from 'drizzle-orm';
+
+type MarkAiRunDispatchFailedArgs = {
+  entityType: string;
+  errorCode: string;
+  message: string;
+  runId: string;
+  workflow?: string;
+};
+
+export async function markAiRunDispatchFailedWithTenantContext(args: MarkAiRunDispatchFailedArgs) {
+  const predicates: SQL[] = [
+    eq(aiRuns.id, args.runId),
+    eq(aiRuns.entityType, args.entityType),
+    eq(aiRuns.status, 'queued'),
+  ];
+
+  if (args.workflow) {
+    predicates.splice(1, 0, eq(aiRuns.workflow, args.workflow));
+  }
+
+  // db-access-guard: tenant-scoped -- reason: runId is a queued AI run emitted by the caller workflow
+  const [queuedRun] = await db
+    .select({ tenantId: aiRuns.tenantId })
+    .from(aiRuns)
+    .where(and(...predicates));
+
+  if (!queuedRun?.tenantId) {
+    return;
+  }
+
+  await withTenantContext({ tenantId: queuedRun.tenantId, role: 'system' }, async tx => {
+    await tx
+      .update(aiRuns)
+      .set({
+        status: 'failed',
+        completedAt: new Date(),
+        errorCode: args.errorCode,
+        errorMessage: args.message,
+      })
+      .where(and(eq(aiRuns.id, args.runId), eq(aiRuns.status, 'queued')));
+  });
+}

--- a/scripts/ci/db-access-baseline.json
+++ b/scripts/ci/db-access-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-05-17T18:11:31.344Z",
+  "generatedAt": "2026-05-17T19:04:55.390Z",
   "policy": "see docs/dev/db-access-guard.md",
   "scanRoots": ["apps/web/src", "packages"],
   "approvedDatabaseInternalPatterns": [
@@ -26,8 +26,8 @@
       "domain-wrapper": 300
     },
     "byTenantPosture": {
-      "tenant-context": 26,
-      "tenant-scoped": 164,
+      "tenant-context": 27,
+      "tenant-scoped": 163,
       "tenant-predicate": 366,
       "admin-privileged": 0,
       "system-exempt": 48,
@@ -1561,7 +1561,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 145,
+      "line": 146,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -1571,7 +1571,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 158,
+      "line": 159,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -1581,7 +1581,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 173,
+      "line": 174,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -1591,18 +1591,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 213,
-      "callee": "db.update",
-      "method": "update",
-      "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "await db .update(aiRuns)"
-    },
-    {
-      "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 259,
+      "line": 257,
       "callee": "db.select",
       "method": "select",
       "risk": "app-layer",
@@ -1613,7 +1602,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 306,
+      "line": 304,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -1623,7 +1612,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 352,
+      "line": 350,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -1633,7 +1622,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 361,
+      "line": 359,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -1643,7 +1632,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 380,
+      "line": 378,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -1653,7 +1642,7 @@
     },
     {
       "file": "apps/web/src/app/api/policies/analyze/_services.ts",
-      "line": 408,
+      "line": 406,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -2928,18 +2917,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 111,
-      "callee": "db.update",
-      "method": "update",
-      "risk": "app-layer",
-      "tenantPosture": "tenant-scoped",
-      "tenantPostureReason": "tenant-scoped: directive",
-      "tenantPostureDetail": "tenantId comes from validated AI policy queue input or queued run row",
-      "source": "await db .update(aiRuns)"
-    },
-    {
-      "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 135,
+      "line": 175,
       "callee": "db.select",
       "method": "select",
       "risk": "app-layer",
@@ -2949,7 +2927,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 185,
+      "line": 224,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -2959,7 +2937,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 260,
+      "line": 294,
       "callee": "tx.insert",
       "method": "insert",
       "risk": "app-layer",
@@ -2969,7 +2947,7 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 265,
+      "line": 299,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",
@@ -2979,7 +2957,28 @@
     },
     {
       "file": "apps/web/src/lib/ai/claim-workflows.ts",
-      "line": 293,
+      "line": 323,
+      "callee": "tx.update",
+      "method": "update",
+      "risk": "app-layer",
+      "tenantPosture": "tenant-context",
+      "tenantPostureReason": "tenant-context: callback-tx-block",
+      "source": "await tx .update(aiRuns)"
+    },
+    {
+      "file": "apps/web/src/lib/ai/dispatch-failure.ts",
+      "line": 28,
+      "callee": "db.select",
+      "method": "select",
+      "risk": "app-layer",
+      "tenantPosture": "tenant-scoped",
+      "tenantPostureReason": "tenant-scoped: directive",
+      "tenantPostureDetail": "runId is a queued AI run emitted by the caller workflow",
+      "source": "const [queuedRun] = await db .select({ tenantId: aiRuns.tenantId })"
+    },
+    {
+      "file": "apps/web/src/lib/ai/dispatch-failure.ts",
+      "line": 38,
       "callee": "tx.update",
       "method": "update",
       "risk": "app-layer",

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "maxTrackedBytes": 28577000,
-  "maxTrackedFiles": 3721,
+  "maxTrackedFiles": 3723,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {


### PR DESCRIPTION
## Summary
- Resolve policy and claim AI dispatch-failure writes through a shared `withTenantContext` helper.
- Load the queued AI run tenant before the failure write and skip the update when the queued run is already gone.
- Refresh the DB access baseline with `unclassified=0` and reduced duplicated new code for Sonar.
- Adjust the repo-size file-count budget for the two new helper/test files; total bytes remain under budget.

## Validation
- `pnpm --filter @interdomestik/web test:unit --run src/lib/ai/dispatch-failure.test.ts src/app/api/policies/analyze/_services.test.ts src/lib/ai/claim-workflows.test.ts`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm check:db-access`
- `pnpm repo:size:check`
- `node --test scripts/ci/repo-size-audit.test.mjs`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`
