### PR TITLE
feat: add assistance workflow intents

### DIFF
--- a/packages/domain-assistance/src/rules.ts
+++ b/packages/domain-assistance/src/rules.ts
@@ -12,3 +12,4 @@ export * from './rules/outcomes';
 export * from './rules/procedure-guide';
 export * from './rules/session-digest';
 export * from './rules/vehicle-damage';
+export * from './rules/workflow-intents';

--- a/packages/domain-assistance/src/rules/workflow-intents.test.ts
+++ b/packages/domain-assistance/src/rules/workflow-intents.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  AssistanceDisclaimerCode,
+  AssistanceOutcome,
+  AssistancePackSummary,
+  AssistanceProvenance,
+  AssistanceSessionDigest,
+  AssistanceServiceZone,
+  CountryRuleMetadata,
+  EscalationRecommendation,
+} from '../types';
+import { createAssistanceOutcome } from './outcomes';
+import { createAssistanceSessionDigest } from './session-digest';
+import { createAssistanceWorkflowIntents } from './workflow-intents';
+
+const CREATED_AT = '2026-05-19T12:00:00.000Z';
+
+const COUNTRY_RULE: CountryRuleMetadata = {
+  country: 'DE',
+  sourceReference: 'synthetic-workflow/de/2026-05',
+  owner: 'product-legal-review',
+  lastReviewed: '2026-05-01',
+  confidence: 0.91,
+};
+
+const MEMBER_DISCLAIMERS: readonly AssistanceDisclaimerCode[] = [
+  'not_legal_advice',
+  'not_medical_advice',
+  'not_insurer_assessment',
+  'not_professional_opinion',
+  'educational_only',
+  'professional_review_required',
+];
+
+const FREE_DISCLAIMERS: readonly AssistanceDisclaimerCode[] = [
+  'not_legal_advice',
+  'not_medical_advice',
+  'not_insurer_assessment',
+  'not_professional_opinion',
+  'educational_only',
+];
+
+function outcome(
+  overrides: Partial<Parameters<typeof createAssistanceOutcome>[0]> = {}
+): AssistanceOutcome {
+  return createAssistanceOutcome({
+    kind: 'eligible',
+    zone: 'member',
+    reasons: [{ code: 'synthetic_reason_code' }],
+    evidence: [
+      {
+        kind: 'document_reference',
+        referenceId: 'synthetic-evidence-reference',
+        summaryKey: 'synthetic_evidence_summary',
+        sourceReference: 'synthetic-evidence/de/2026-05',
+      },
+    ],
+    countryRuleMetadata: [COUNTRY_RULE],
+    humanReviewRequired: false,
+    disclaimers: MEMBER_DISCLAIMERS,
+    piiClassification: 'incident_sensitive',
+    createdAt: CREATED_AT,
+    ...overrides,
+  });
+}
+
+function packSummary(
+  packId: string,
+  packType: AssistancePackSummary['packType'],
+  sourceOutcome: AssistanceOutcome
+): AssistancePackSummary {
+  return {
+    packId,
+    packType,
+    outcomeKind: sourceOutcome.kind,
+    zone: sourceOutcome.zone,
+    requiredHumanReview: sourceOutcome.humanReviewRequired,
+  };
+}
+
+function digest(
+  overrides: Partial<{
+    sessionId: string;
+    zone: AssistanceServiceZone;
+    memberId: string | null;
+    country: string;
+    outcomes: readonly AssistanceOutcome[];
+    packSummaries: readonly AssistancePackSummary[];
+    escalationRecommendation: EscalationRecommendation;
+    consentState: AssistanceSessionDigest['consentState'];
+    disclaimersShown: readonly AssistanceDisclaimerCode[];
+  }> = {}
+): AssistanceSessionDigest {
+  const outcomes = overrides.outcomes ?? [outcome()];
+  const firstOutcome = outcomes[0];
+
+  if (firstOutcome === undefined) {
+    throw new Error('workflow intent tests require at least one outcome');
+  }
+
+  const packSummaries = overrides.packSummaries ?? [
+    packSummary('pack-legal-basis-1', 'legal_basis', firstOutcome),
+  ];
+
+  return createAssistanceSessionDigest({
+    sessionId: overrides.sessionId ?? 'session-workflow-1',
+    zone: overrides.zone ?? 'member',
+    memberId: overrides.memberId === null ? undefined : (overrides.memberId ?? 'member-workflow-1'),
+    country: overrides.country ?? 'DE',
+    packSummaries,
+    outcomes,
+    escalationRecommendation: overrides.escalationRecommendation ?? 'none',
+    consentState: overrides.consentState ?? 'explicit_consent_recorded',
+    disclaimersShown: overrides.disclaimersShown ?? MEMBER_DISCLAIMERS,
+    createdAt: CREATED_AT,
+  });
+}
+
+describe('createAssistanceWorkflowIntents', () => {
+  it('returns deterministic non-executing member-zone intents for explicit-consent sessions', () => {
+    const freeOutcome = outcome({
+      kind: 'requires_member_zone',
+      zone: 'free',
+      countryRuleMetadata: [],
+      disclaimers: FREE_DISCLAIMERS,
+      piiClassification: 'none',
+    });
+    const source = digest({
+      zone: 'free',
+      outcomes: [freeOutcome],
+      packSummaries: [packSummary('pack-incident-1', 'incident_scene', freeOutcome)],
+      escalationRecommendation: 'member_zone',
+      disclaimersShown: FREE_DISCLAIMERS,
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents).toHaveLength(1);
+    expect(intents[0]).toMatchObject({
+      intentKind: 'blocked_workflow_intent',
+      targetSurface: 'member_zone',
+      executionAllowed: false,
+      blocked: true,
+      requiredConsentState: 'explicit_consent_recorded',
+      piiClassification: 'none',
+      redactionPosture: 'none',
+    });
+    expect(intents[0]?.blockers).toEqual(['final_or_executable_outcome_blocked']);
+    expect(intents[0]?.referenceKey).toMatch(/^assist-wfi:member_zone:[a-z0-9]+$/);
+  });
+
+  it('returns an empty intent list for anonymous free-zone sessions with no target surface', () => {
+    const freeOutcome = outcome({
+      kind: 'eligible',
+      zone: 'free',
+      countryRuleMetadata: [],
+      disclaimers: FREE_DISCLAIMERS,
+      piiClassification: 'none',
+    });
+    const source = digest({
+      zone: 'free',
+      outcomes: [freeOutcome],
+      packSummaries: [packSummary('pack-incident-1', 'incident_scene', freeOutcome)],
+      escalationRecommendation: 'none',
+      consentState: 'anonymous',
+      disclaimersShown: FREE_DISCLAIMERS,
+    });
+
+    expect(createAssistanceWorkflowIntents(source)).toEqual([]);
+  });
+
+  it('prepares support handoff, claim context, and professional review targets without side effects', () => {
+    const legalOutcome = outcome();
+    const recoveryOutcome = outcome({
+      kind: 'requires_professional_recovery',
+      humanReviewRequired: true,
+    });
+    const source = digest({
+      outcomes: [legalOutcome, recoveryOutcome],
+      packSummaries: [
+        packSummary('pack-legal-basis-1', 'legal_basis', legalOutcome),
+        packSummary('pack-recovery-1', 'recovery_eligibility', recoveryOutcome),
+      ],
+      escalationRecommendation: 'staff_handoff',
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents.map(intent => intent.targetSurface)).toEqual([
+      'claim_context',
+      'support_handoff',
+      'professional_recovery_review',
+    ]);
+    expect(intents.every(intent => intent.executionAllowed === false)).toBe(true);
+    expect(intents.every(intent => !('createdRecordIds' in intent))).toBe(true);
+    expect(intents.every(intent => !('externalRecordIds' in intent))).toBe(true);
+    expect(intents.every(intent => intent.requiredHumanReview)).toBe(true);
+  });
+
+  it('fails closed for professional recovery recommendations instead of activating recovery', () => {
+    const source = digest({
+      escalationRecommendation: 'professional_recovery',
+      outcomes: [outcome({ kind: 'requires_professional_recovery', humanReviewRequired: true })],
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents.map(intent => intent.targetSurface)).toEqual([
+      'claim_context',
+      'crm_follow_up',
+      'professional_recovery_review',
+    ]);
+    expect(
+      intents.every(intent => intent.blockers.includes('professional_recovery_activation_blocked'))
+    ).toBe(true);
+    expect(intents.every(intent => intent.executionAllowed === false)).toBe(true);
+  });
+
+  it.each([
+    [
+      'missing member identity',
+      digest({ memberId: null, escalationRecommendation: 'staff_handoff' }),
+      'member_attachment_missing',
+    ],
+    [
+      'missing explicit consent',
+      digest({ consentState: 'declined', escalationRecommendation: 'staff_handoff' }),
+      'explicit_consent_missing',
+    ],
+    [
+      'missing disclaimers',
+      digest({ disclaimersShown: ['educational_only'], escalationRecommendation: 'staff_handoff' }),
+      'required_disclaimer_missing',
+    ],
+    [
+      'missing country metadata',
+      digest({
+        outcomes: [outcome({ countryRuleMetadata: [] })],
+        escalationRecommendation: 'staff_handoff',
+      }),
+      'country_rule_metadata_missing',
+    ],
+    [
+      'unsupported outcome',
+      digest({ outcomes: [outcome({ kind: 'unsupported_country' })] }),
+      'final_or_executable_outcome_blocked',
+    ],
+  ] as const)('fails closed for %s', (_label, source, expectedBlocker) => {
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents.length).toBeGreaterThan(0);
+    expect(intents.some(intent => intent.blockers.includes(expectedBlocker))).toBe(true);
+    expect(intents.every(intent => intent.executionAllowed === false)).toBe(true);
+  });
+
+  it('fails closed when digest summaries and ordered outcomes disagree', () => {
+    const source = digest({
+      packSummaries: [
+        {
+          packId: 'pack-legal-basis-1',
+          packType: 'legal_basis',
+          outcomeKind: 'eligible',
+          zone: 'free',
+          requiredHumanReview: false,
+        },
+      ],
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents[0]?.blockers).toEqual(
+      expect.arrayContaining(['digest_summary_outcome_mismatch'])
+    );
+  });
+
+  it.each(['manual_review_required', 'uncertain', 'out_of_scope'] as const)(
+    'fails closed for final or unsupported %s outcomes',
+    outcomeKind => {
+      const source = digest({ outcomes: [outcome({ kind: outcomeKind })] });
+
+      const intents = createAssistanceWorkflowIntents(source);
+
+      expect(intents[0]?.blockers).toContain('final_or_executable_outcome_blocked');
+      expect(intents[0]?.executionAllowed).toBe(false);
+    }
+  );
+
+  it('fails closed when country-dependent packs have no session country', () => {
+    const source = {
+      ...digest({ escalationRecommendation: 'staff_handoff' }),
+      country: undefined,
+    } as unknown as AssistanceSessionDigest;
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents[0]?.blockers).toContain('country_rule_metadata_missing');
+  });
+
+  it('requires human-review posture for sensitive medical or legal-professional digests', () => {
+    const sensitive = outcome({
+      piiClassification: 'medical_sensitive',
+      humanReviewRequired: false,
+    });
+    const source = digest({
+      outcomes: [sensitive],
+      packSummaries: [packSummary('pack-injury-1', 'injury_category', sensitive)],
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents[0]?.blockers).toContain('sensitive_human_review_missing');
+    expect(intents[0]?.redactionPosture).toBe('sensitive_reference_only');
+    expect(intents[0]?.requiredHumanReview).toBe(true);
+  });
+
+  it.each([
+    ['legal_financial_sensitive', 'sensitive_reference_only'],
+    ['professional_secret', 'professional_secret_reference_only'],
+  ] as const)(
+    'requires human-review posture for %s digests',
+    (piiClassification, expectedRedactionPosture) => {
+      const sensitive = outcome({
+        piiClassification,
+        humanReviewRequired: false,
+      });
+      const source = digest({
+        outcomes: [sensitive],
+        packSummaries: [packSummary('pack-legal-basis-1', 'legal_basis', sensitive)],
+      });
+
+      const intents = createAssistanceWorkflowIntents(source);
+
+      expect(intents[0]?.blockers).toContain('sensitive_human_review_missing');
+      expect(intents[0]?.requiredHumanReview).toBe(true);
+      expect(intents[0]?.redactionPosture).toBe(expectedRedactionPosture);
+    }
+  );
+
+  it('propagates pack-summary human-review requirements to workflow intents', () => {
+    const reviewOutcome = outcome({ humanReviewRequired: false });
+    const source = digest({
+      outcomes: [reviewOutcome],
+      packSummaries: [
+        {
+          ...packSummary('pack-invalidity-1', 'invalidity_review', reviewOutcome),
+          requiredHumanReview: true,
+        },
+      ],
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents[0]?.requiredHumanReview).toBe(true);
+  });
+
+  it('keeps AI-assisted provenance advisory and non-final', () => {
+    const aiProvenance: AssistanceProvenance = {
+      source: 'ai_assisted',
+      generatedBy: 'domain-assistance',
+      ai: {
+        aiConfidence: 0.82,
+        aiModelVersion: 'synthetic-model-2026-05',
+        aiWorkflowName: 'synthetic-workflow-intent-fixture',
+        aiPromptOrSchemaVersion: 'workflow-intent-v1',
+        role: 'classification',
+      },
+    };
+    const source = digest({
+      outcomes: [
+        outcome({
+          provenance: aiProvenance,
+          humanReviewRequired: true,
+        }),
+      ],
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents[0]?.aiAdvisoryOnly).toBe(true);
+    expect(intents[0]?.requiredHumanReview).toBe(true);
+    expect(intents[0]?.blockers).toContain('ai_non_final_review_required');
+  });
+
+  it('blocks digests that carry created or external record identifiers', () => {
+    const source = {
+      ...digest(),
+      createdRecordIds: ['claim-should-not-exist'],
+    } as unknown as AssistanceSessionDigest;
+
+    const intents = createAssistanceWorkflowIntents(source);
+
+    expect(intents[0]?.blockers).toContain('created_or_external_record_ids_present');
+    expect(intents[0]).not.toHaveProperty('createdRecordIds');
+    expect(intents[0]).not.toHaveProperty('externalRecordIds');
+  });
+
+  it('keeps intent ordering and reference keys deterministic while drifting on meaningful changes', () => {
+    const source = digest({ escalationRecommendation: 'staff_handoff' });
+    const repeated = createAssistanceWorkflowIntents(source);
+    const equivalent = createAssistanceWorkflowIntents(
+      digest({ escalationRecommendation: 'staff_handoff' })
+    );
+    const changed = createAssistanceWorkflowIntents(
+      digest({
+        escalationRecommendation: 'staff_handoff',
+        outcomes: [outcome({ reasons: [{ code: 'meaningful_contract_change' }] })],
+      })
+    );
+
+    expect(repeated.map(intent => intent.targetSurface)).toEqual([
+      'claim_context',
+      'support_handoff',
+    ]);
+    expect(repeated.map(intent => intent.referenceKey)).toEqual(
+      equivalent.map(intent => intent.referenceKey)
+    );
+    expect(repeated.map(intent => intent.referenceKey)).not.toEqual(
+      changed.map(intent => intent.referenceKey)
+    );
+  });
+
+  it('does not leak raw narrative, plate, VIN, medical text, or insurer correspondence into intents', () => {
+    const source = digest({
+      outcomes: [
+        outcome({
+          reasons: [
+            {
+              code: 'Driver wrote raw narrative with PLATE ABC-123, VIN WDD123, medical text and insurer letter',
+            },
+          ],
+          evidence: [
+            {
+              kind: 'document_reference',
+              referenceId:
+                'Driver wrote raw narrative with PLATE ABC-123 and VIN WDD123 in insurer letter',
+              summaryKey: 'medical text from expert report',
+              sourceReference: 'insurer correspondence includes ABC-123 and WDD123',
+            },
+          ],
+        }),
+      ],
+      escalationRecommendation: 'staff_handoff',
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+    const intentText = JSON.stringify(intents);
+
+    expect(intentText).not.toContain('ABC-123');
+    expect(intentText).not.toContain('WDD123');
+    expect(intentText).not.toContain('medical text');
+    expect(intentText).not.toContain('insurer letter');
+    expect(intentText).not.toContain('expert report');
+  });
+});

--- a/packages/domain-assistance/src/rules/workflow-intents.test.ts
+++ b/packages/domain-assistance/src/rules/workflow-intents.test.ts
@@ -198,6 +198,51 @@ describe('createAssistanceWorkflowIntents', () => {
     expect(intents.every(intent => intent.requiredHumanReview)).toBe(true);
   });
 
+  it('scopes evidence to the selected pack summaries instead of source-reference text', () => {
+    const legalOutcome = outcome({
+      evidence: [
+        {
+          kind: 'document_reference',
+          referenceId: 'legal-basis-evidence',
+          sourceReference: 'legal-basis/de/2026-05',
+        },
+      ],
+    });
+    const recoveryOutcome = outcome({
+      kind: 'requires_professional_recovery',
+      humanReviewRequired: true,
+      evidence: [
+        {
+          kind: 'professional_review_reference',
+          referenceId: 'recovery-evidence',
+          sourceReference: 'professional-recovery/de/2026-05',
+        },
+      ],
+    });
+    const source = digest({
+      outcomes: [legalOutcome, recoveryOutcome],
+      packSummaries: [
+        packSummary('pack-legal-basis-1', 'legal_basis', legalOutcome),
+        packSummary('pack-recovery-1', 'recovery_eligibility', recoveryOutcome),
+      ],
+    });
+
+    const intents = createAssistanceWorkflowIntents(source);
+    const claimIntent = intents.find(intent => intent.targetSurface === 'claim_context');
+    const professionalReviewIntent = intents.find(
+      intent => intent.targetSurface === 'professional_recovery_review'
+    );
+
+    expect(claimIntent?.packReferences.map(reference => reference.packId)).toEqual([
+      'pack-legal-basis-1',
+    ]);
+    expect(claimIntent?.evidence.map(reference => reference.kind)).toEqual(['document_reference']);
+    expect(professionalReviewIntent?.evidence.map(reference => reference.kind)).toEqual([
+      'document_reference',
+      'professional_review_reference',
+    ]);
+  });
+
   it('fails closed for professional recovery recommendations instead of activating recovery', () => {
     const source = digest({
       escalationRecommendation: 'professional_recovery',

--- a/packages/domain-assistance/src/rules/workflow-intents.ts
+++ b/packages/domain-assistance/src/rules/workflow-intents.ts
@@ -93,7 +93,9 @@ export function createAssistanceWorkflowIntents(
       const targetBlockers = collectTargetBlockers(digest, candidate.targetSurface);
       const blockers = dedupe([...globalBlockers, ...targetBlockers]);
       const packReferences = selectPackReferences(digest.packSummaries, candidate.packTypes);
-      const evidence = sanitizeEvidenceReferences(collectEvidence(digest.outcomes, packReferences));
+      const evidence = sanitizeEvidenceReferences(
+        collectEvidence(digest.outcomes, digest.packSummaries, packReferences)
+      );
       const reasons = createReasons(candidate.reasonCodes, blockers, digest);
 
       return {
@@ -370,26 +372,17 @@ function selectPackReferences(
 
 function collectEvidence(
   outcomes: readonly AssistanceOutcome[],
+  packSummaries: readonly AssistancePackSummary[],
   packReferences: readonly AssistanceWorkflowPackReference[]
 ): readonly AssistanceEvidenceReference[] {
-  const selectedPackIndexes = new Set(
-    packReferences
-      .map(reference => reference.packId)
-      .flatMap(packId =>
-        outcomes
-          .map((outcome, index) => ({ outcome, index }))
-          .filter(({ outcome }) =>
-            outcome.evidence.some(evidence => evidence.sourceReference?.includes(packId))
-          )
-          .map(({ index }) => index)
-      )
-  );
-  const evidence =
-    selectedPackIndexes.size > 0
-      ? outcomes
-          .filter((_outcome, index) => selectedPackIndexes.has(index))
-          .flatMap(outcome => outcome.evidence)
-      : outcomes.flatMap(outcome => outcome.evidence);
+  const selectedPackIds = new Set(packReferences.map(reference => reference.packId));
+  const evidence = outcomes
+    .filter((_outcome, index) => {
+      const summary = packSummaries[index];
+
+      return summary !== undefined && selectedPackIds.has(summary.packId);
+    })
+    .flatMap(outcome => outcome.evidence);
 
   return dedupeBy(evidence, evidenceReferenceKey);
 }

--- a/packages/domain-assistance/src/rules/workflow-intents.ts
+++ b/packages/domain-assistance/src/rules/workflow-intents.ts
@@ -1,0 +1,603 @@
+import type {
+  AssistanceDisclaimerCode,
+  AssistanceEvidenceReference,
+  AssistanceOutcome,
+  AssistanceOutcomeKind,
+  AssistancePackSummary,
+  AssistancePackType,
+  AssistanceReason,
+  AssistanceSessionDigest,
+  AssistanceWorkflowBlockerCode,
+  AssistanceWorkflowIntent,
+  AssistanceWorkflowIntentKind,
+  AssistanceWorkflowPackReference,
+  AssistanceWorkflowRedactionPosture,
+  AssistanceWorkflowTargetSurface,
+  PiiClassification,
+} from '../types';
+
+const TARGET_ORDER = [
+  'member_zone',
+  'claim_context',
+  'support_handoff',
+  'crm_follow_up',
+  'professional_recovery_review',
+  'blocked_workflow',
+] as const satisfies readonly AssistanceWorkflowTargetSurface[];
+
+const MEMBER_REQUIRED_TARGETS = new Set<AssistanceWorkflowTargetSurface>([
+  'member_zone',
+  'claim_context',
+  'support_handoff',
+  'crm_follow_up',
+  'professional_recovery_review',
+]);
+
+const COUNTRY_DEPENDENT_PACK_TYPES = new Set<AssistancePackType>([
+  'legal_basis',
+  'procedure',
+  'injury_category',
+  'vehicle_damage',
+  'invalidity_review',
+  'recovery_eligibility',
+]);
+
+const SENSITIVE_PII_CLASSIFICATIONS = new Set<PiiClassification>([
+  'medical_sensitive',
+  'legal_financial_sensitive',
+  'professional_secret',
+]);
+
+const BLOCKED_OUTCOME_KINDS = new Set<AssistanceOutcomeKind>([
+  'manual_review_required',
+  'uncertain',
+  'unsupported_country',
+  'out_of_scope',
+  'requires_member_zone',
+  'requires_professional_recovery',
+]);
+
+const sortTextAscending = (left: string, right: string): number => left.localeCompare(right);
+
+type IntentCandidate = {
+  intentKind: AssistanceWorkflowIntentKind;
+  targetSurface: AssistanceWorkflowTargetSurface;
+  reasonCodes: readonly string[];
+  packTypes?: readonly AssistancePackType[];
+};
+
+export function createAssistanceWorkflowIntents(
+  digest: AssistanceSessionDigest
+): readonly AssistanceWorkflowIntent[] {
+  const digestAny = digest as AssistanceSessionDigest & {
+    createdRecordIds?: unknown;
+    externalRecordIds?: unknown;
+  };
+  const reconciliation = reconcileDigestPairs(digest.packSummaries, digest.outcomes);
+  const requiredDisclaimers = collectRequiredDisclaimers(digest.outcomes);
+  const missingDisclaimers = requiredDisclaimers.filter(
+    disclaimer => !digest.disclaimersShown.includes(disclaimer)
+  );
+  const globalBlockers = collectGlobalBlockers({
+    digest,
+    digestHasCreatedRecords:
+      digestAny.createdRecordIds !== undefined || digestAny.externalRecordIds !== undefined,
+    missingDisclaimers,
+    reconciliationBlocked: reconciliation.blocked,
+  });
+  const candidates = createIntentCandidates(digest);
+  const effectiveCandidates = selectEffectiveCandidates(candidates, globalBlockers);
+
+  return effectiveCandidates
+    .map(candidate => {
+      const targetBlockers = collectTargetBlockers(digest, candidate.targetSurface);
+      const blockers = dedupe([...globalBlockers, ...targetBlockers]);
+      const packReferences = selectPackReferences(digest.packSummaries, candidate.packTypes);
+      const evidence = sanitizeEvidenceReferences(collectEvidence(digest.outcomes, packReferences));
+      const reasons = createReasons(candidate.reasonCodes, blockers, digest);
+
+      return {
+        intentKind: blockers.length > 0 ? 'blocked_workflow_intent' : candidate.intentKind,
+        targetSurface: candidate.targetSurface,
+        executionAllowed: false,
+        blocked: blockers.length > 0,
+        outcomeKind: selectOutcomeKind(digest.outcomes, packReferences),
+        reasons,
+        blockers,
+        evidence,
+        packReferences,
+        ...(requiresExplicitConsent(candidate.targetSurface)
+          ? { requiredConsentState: 'explicit_consent_recorded' as const }
+          : {}),
+        requiredDisclaimers,
+        missingDisclaimers,
+        requiredHumanReview:
+          digest.requiredHumanReview ||
+          digest.outcomes.some(outcome => outcome.humanReviewRequired) ||
+          digest.packSummaries.some(summary => summary.requiredHumanReview) ||
+          blockers.includes('sensitive_human_review_missing') ||
+          blockers.includes('ai_non_final_review_required') ||
+          blockers.includes('professional_recovery_activation_blocked'),
+        piiClassification: digest.piiClassification,
+        redactionPosture: redactionPostureFor(digest.piiClassification),
+        aiAdvisoryOnly: digest.aiProvenance.length > 0,
+        referenceKey: createReferenceKey({
+          digest,
+          candidate,
+          blockers,
+          packReferences,
+          missingDisclaimers,
+        }),
+      } satisfies AssistanceWorkflowIntent;
+    })
+    .sort(
+      (left, right) =>
+        TARGET_ORDER.indexOf(left.targetSurface) - TARGET_ORDER.indexOf(right.targetSurface)
+    );
+}
+
+function selectEffectiveCandidates(
+  candidates: readonly IntentCandidate[],
+  globalBlockers: readonly AssistanceWorkflowBlockerCode[]
+): readonly IntentCandidate[] {
+  if (candidates.length > 0) {
+    return candidates;
+  }
+
+  if (globalBlockers.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      intentKind: 'blocked_workflow_intent',
+      targetSurface: 'blocked_workflow',
+      reasonCodes: ['workflow.blocked.fail_closed'],
+    },
+  ];
+}
+
+function createIntentCandidates(digest: AssistanceSessionDigest): readonly IntentCandidate[] {
+  const candidates: IntentCandidate[] = [];
+  const addCandidate = (candidate: IntentCandidate): void => {
+    if (!candidates.some(existing => existing.targetSurface === candidate.targetSurface)) {
+      candidates.push(candidate);
+    }
+  };
+
+  if (
+    digest.escalationRecommendation === 'member_zone' ||
+    digest.outcomes.some(outcome => outcome.kind === 'requires_member_zone')
+  ) {
+    addCandidate({
+      intentKind: 'prepare_member_zone_context',
+      targetSurface: 'member_zone',
+      reasonCodes: ['workflow.member_zone.requested'],
+      packTypes: ['incident_scene'],
+    });
+  }
+
+  const claimContextPackTypes = digest.packSummaries
+    .filter(summary => summary.zone === 'member' && summary.packType !== 'recovery_eligibility')
+    .map(summary => summary.packType);
+
+  if (claimContextPackTypes.length > 0) {
+    addCandidate({
+      intentKind: 'prepare_claim_context_review',
+      targetSurface: 'claim_context',
+      reasonCodes: ['workflow.claim_context.review_requested'],
+      packTypes: claimContextPackTypes,
+    });
+  }
+
+  if (digest.escalationRecommendation === 'staff_handoff') {
+    addCandidate({
+      intentKind: 'prepare_support_handoff_review',
+      targetSurface: 'support_handoff',
+      reasonCodes: ['workflow.support_handoff.requested'],
+    });
+  }
+
+  if (digest.escalationRecommendation === 'emergency_services') {
+    addCandidate({
+      intentKind: 'prepare_support_handoff_review',
+      targetSurface: 'support_handoff',
+      reasonCodes: ['workflow.emergency_services.blocked'],
+    });
+  }
+
+  if (digest.escalationRecommendation === 'professional_recovery') {
+    addCandidate({
+      intentKind: 'prepare_crm_follow_up_review',
+      targetSurface: 'crm_follow_up',
+      reasonCodes: ['workflow.crm_follow_up.review_requested'],
+      packTypes: ['incident_scene'],
+    });
+  }
+
+  if (
+    digest.escalationRecommendation === 'professional_recovery' ||
+    digest.outcomes.some(outcome => outcome.kind === 'requires_professional_recovery')
+  ) {
+    addCandidate({
+      intentKind: 'prepare_professional_recovery_review',
+      targetSurface: 'professional_recovery_review',
+      reasonCodes: ['workflow.professional_recovery.review_requested'],
+    });
+  }
+
+  return candidates;
+}
+
+function collectGlobalBlockers(params: {
+  digest: AssistanceSessionDigest;
+  digestHasCreatedRecords: boolean;
+  missingDisclaimers: readonly AssistanceDisclaimerCode[];
+  reconciliationBlocked: boolean;
+}): readonly AssistanceWorkflowBlockerCode[] {
+  const blockers: AssistanceWorkflowBlockerCode[] = [];
+  const { digest } = params;
+
+  if (digest.sessionId.trim() === '') {
+    blockers.push('session_identity_missing');
+  }
+
+  if (params.missingDisclaimers.length > 0 || digest.disclaimersShown.length === 0) {
+    blockers.push('required_disclaimer_missing');
+  }
+
+  if (params.reconciliationBlocked) {
+    blockers.push('digest_summary_outcome_mismatch');
+  }
+
+  if (digest.packSummaries.length !== digest.outcomes.length) {
+    blockers.push('digest_pair_count_mismatch');
+  }
+
+  if (countryMetadataMissing(digest)) {
+    blockers.push('country_rule_metadata_missing');
+  }
+
+  if (SENSITIVE_PII_CLASSIFICATIONS.has(digest.piiClassification) && !digest.requiredHumanReview) {
+    blockers.push('sensitive_human_review_missing');
+  }
+
+  if (digest.aiProvenance.length > 0) {
+    blockers.push('ai_non_final_review_required');
+  }
+
+  if (digest.outcomes.some(outcome => BLOCKED_OUTCOME_KINDS.has(outcome.kind))) {
+    blockers.push('final_or_executable_outcome_blocked');
+  }
+
+  if (params.digestHasCreatedRecords) {
+    blockers.push('created_or_external_record_ids_present');
+  }
+
+  if (digest.escalationRecommendation === 'professional_recovery') {
+    blockers.push('professional_recovery_activation_blocked');
+  }
+
+  return dedupe(blockers);
+}
+
+function collectTargetBlockers(
+  digest: AssistanceSessionDigest,
+  targetSurface: AssistanceWorkflowTargetSurface
+): readonly AssistanceWorkflowBlockerCode[] {
+  const blockers: AssistanceWorkflowBlockerCode[] = [];
+
+  if (MEMBER_REQUIRED_TARGETS.has(targetSurface) && digest.memberId === undefined) {
+    blockers.push('member_attachment_missing');
+  }
+
+  if (
+    requiresExplicitConsent(targetSurface) &&
+    digest.consentState !== 'explicit_consent_recorded'
+  ) {
+    blockers.push('explicit_consent_missing');
+  }
+
+  if (targetSurface === 'professional_recovery_review') {
+    blockers.push('professional_recovery_activation_blocked');
+  }
+
+  return dedupe(blockers);
+}
+
+function reconcileDigestPairs(
+  packSummaries: readonly AssistancePackSummary[],
+  outcomes: readonly AssistanceOutcome[]
+): { blocked: boolean } {
+  if (packSummaries.length !== outcomes.length) {
+    return { blocked: true };
+  }
+
+  return {
+    blocked: packSummaries.some((summary, index) => {
+      const outcome = outcomes[index];
+
+      return (
+        outcome === undefined ||
+        summary.outcomeKind !== outcome.kind ||
+        summary.zone !== outcome.zone ||
+        summary.requiredHumanReview !== outcome.humanReviewRequired
+      );
+    }),
+  };
+}
+
+function countryMetadataMissing(digest: AssistanceSessionDigest): boolean {
+  return digest.packSummaries.some((summary, index) => {
+    if (!COUNTRY_DEPENDENT_PACK_TYPES.has(summary.packType)) {
+      return false;
+    }
+
+    const outcome = digest.outcomes[index];
+
+    const outcomeCountryMetadataCount = outcome?.countryRuleMetadata.length ?? 0;
+
+    return (
+      digest.country === undefined ||
+      digest.countryRuleMetadata.length === 0 ||
+      outcomeCountryMetadataCount === 0
+    );
+  });
+}
+
+function collectRequiredDisclaimers(
+  outcomes: readonly AssistanceOutcome[]
+): readonly AssistanceDisclaimerCode[] {
+  return dedupe(outcomes.flatMap(outcome => outcome.disclaimers));
+}
+
+function selectPackReferences(
+  packSummaries: readonly AssistancePackSummary[],
+  packTypes?: readonly AssistancePackType[]
+): readonly AssistanceWorkflowPackReference[] {
+  const selected = packTypes
+    ? packSummaries.filter(summary => packTypes.includes(summary.packType))
+    : packSummaries;
+
+  return selected.map(summary => ({
+    packId: summary.packId,
+    packType: summary.packType,
+    outcomeKind: summary.outcomeKind,
+    zone: summary.zone,
+    requiredHumanReview: summary.requiredHumanReview,
+  }));
+}
+
+function collectEvidence(
+  outcomes: readonly AssistanceOutcome[],
+  packReferences: readonly AssistanceWorkflowPackReference[]
+): readonly AssistanceEvidenceReference[] {
+  const selectedPackIndexes = new Set(
+    packReferences
+      .map(reference => reference.packId)
+      .flatMap(packId =>
+        outcomes
+          .map((outcome, index) => ({ outcome, index }))
+          .filter(({ outcome }) =>
+            outcome.evidence.some(evidence => evidence.sourceReference?.includes(packId))
+          )
+          .map(({ index }) => index)
+      )
+  );
+  const evidence =
+    selectedPackIndexes.size > 0
+      ? outcomes
+          .filter((_outcome, index) => selectedPackIndexes.has(index))
+          .flatMap(outcome => outcome.evidence)
+      : outcomes.flatMap(outcome => outcome.evidence);
+
+  return dedupeBy(evidence, evidenceReferenceKey);
+}
+
+function sanitizeEvidenceReferences(
+  evidenceReferences: readonly AssistanceEvidenceReference[]
+): readonly AssistanceEvidenceReference[] {
+  return evidenceReferences.map(evidence => {
+    const material = stableStringify({
+      kind: evidence.kind,
+      referenceId: evidence.referenceId,
+      summaryKey: evidence.summaryKey ?? null,
+      sourceReference: evidence.sourceReference ?? null,
+    });
+
+    const sanitized: AssistanceEvidenceReference = {
+      kind: evidence.kind,
+      referenceId: `evidence:${evidence.kind}:${hashString(material)}`,
+    };
+
+    if (typeof evidence.summaryKey === 'string') {
+      sanitized.summaryKey = `summary:${hashString(evidence.summaryKey)}`;
+    }
+
+    if (typeof evidence.sourceReference === 'string') {
+      sanitized.sourceReference = `source:${hashString(evidence.sourceReference)}`;
+    }
+
+    if (typeof evidence.lastReviewed === 'string') {
+      sanitized.lastReviewed = evidence.lastReviewed;
+    }
+
+    if (typeof evidence.confidence === 'number') {
+      sanitized.confidence = evidence.confidence;
+    }
+
+    return sanitized;
+  });
+}
+
+function selectOutcomeKind(
+  outcomes: readonly AssistanceOutcome[],
+  packReferences: readonly AssistanceWorkflowPackReference[]
+): AssistanceOutcomeKind | undefined {
+  const byPackOutcomeKind = packReferences[0]?.outcomeKind;
+
+  if (byPackOutcomeKind !== undefined) {
+    return byPackOutcomeKind;
+  }
+
+  return outcomes[0]?.kind;
+}
+
+function createReasons(
+  reasonCodes: readonly string[],
+  blockers: readonly AssistanceWorkflowBlockerCode[],
+  digest: AssistanceSessionDigest
+): readonly AssistanceReason[] {
+  return dedupe([
+    ...reasonCodes,
+    ...blockers.map(blocker => `workflow.blocked.${blocker}`),
+    ...digest.outcomes.flatMap(outcome => [
+      `workflow.source_outcome.${outcome.kind}`,
+      ...(outcome.humanReviewRequired ? ['workflow.human_review.required'] : []),
+    ]),
+    ...(digest.aiProvenance.length > 0 ? ['workflow.ai.advisory_only'] : []),
+  ]).map(code => ({ code: sanitizeCode(code) }));
+}
+
+function createReferenceKey(params: {
+  digest: AssistanceSessionDigest;
+  candidate: IntentCandidate;
+  blockers: readonly AssistanceWorkflowBlockerCode[];
+  packReferences: readonly AssistanceWorkflowPackReference[];
+  missingDisclaimers: readonly AssistanceDisclaimerCode[];
+}): string {
+  const material = stableStringify({
+    sessionId: params.digest.sessionId,
+    zone: params.digest.zone,
+    memberId: params.digest.memberId ?? null,
+    country: params.digest.country ?? null,
+    consentState: params.digest.consentState,
+    escalationRecommendation: params.digest.escalationRecommendation,
+    intentKind: params.candidate.intentKind,
+    targetSurface: params.candidate.targetSurface,
+    packReferences: params.packReferences,
+    outcomes: params.digest.outcomes.map(outcome => ({
+      kind: outcome.kind,
+      zone: outcome.zone,
+      reasonFingerprints: outcome.reasons
+        .map(reason => hashString(sanitizeCode(reason.code)))
+        .sort(sortTextAscending),
+      evidence: outcome.evidence.map(evidence => ({
+        kind: evidence.kind,
+        referenceIdFingerprint: hashString(evidence.referenceId),
+        summaryKeyFingerprint:
+          evidence.summaryKey === undefined ? null : hashString(evidence.summaryKey),
+        sourceReferenceFingerprint:
+          evidence.sourceReference === undefined ? null : hashString(evidence.sourceReference),
+      })),
+      countryRuleMetadata: outcome.countryRuleMetadata.map(metadata => ({
+        country: metadata.country,
+        sourceReference: metadata.sourceReference,
+        lastReviewed: metadata.lastReviewed,
+        confidence: metadata.confidence,
+      })),
+      humanReviewRequired: outcome.humanReviewRequired,
+      disclaimers: [...outcome.disclaimers].sort(sortTextAscending),
+      provenanceSource: outcome.provenance.source,
+      piiClassification: outcome.piiClassification,
+    })),
+    blockers: [...params.blockers].sort(sortTextAscending),
+    missingDisclaimers: [...params.missingDisclaimers].sort(sortTextAscending),
+    piiClassification: params.digest.piiClassification,
+    ai: params.digest.aiProvenance.map(ai => ({
+      role: ai.role,
+      workflow: ai.aiWorkflowName,
+      schema: ai.aiPromptOrSchemaVersion,
+      model: ai.aiModelVersion,
+      confidence: ai.aiConfidence,
+    })),
+  });
+
+  return `assist-wfi:${params.candidate.targetSurface}:${hashString(material)}`;
+}
+
+function requiresExplicitConsent(targetSurface: AssistanceWorkflowTargetSurface): boolean {
+  return MEMBER_REQUIRED_TARGETS.has(targetSurface);
+}
+
+function redactionPostureFor(
+  piiClassification: PiiClassification
+): AssistanceWorkflowRedactionPosture {
+  if (piiClassification === 'none') {
+    return 'none';
+  }
+
+  if (piiClassification === 'identifier_minimal') {
+    return 'identifier_hash_only';
+  }
+
+  if (piiClassification === 'professional_secret') {
+    return 'professional_secret_reference_only';
+  }
+
+  return 'sensitive_reference_only';
+}
+
+function sanitizeCode(code: string): string {
+  const normalized = code
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_.:-]/g, '_');
+
+  return normalized === '' ? 'workflow.unknown' : normalized;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(item => stableStringify(item)).join(',')}]`;
+  }
+
+  return `{${Object.entries(value)
+    .sort(([left], [right]) => sortTextAscending(left, right))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+    .join(',')}}`;
+}
+
+function hashString(value: string): string {
+  let hash = 0x811c9dc5;
+
+  for (const character of value) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return (hash >>> 0).toString(36).padStart(7, '0');
+}
+
+function evidenceReferenceKey(evidence: AssistanceEvidenceReference): string {
+  return [
+    evidence.kind,
+    evidence.referenceId,
+    evidence.summaryKey ?? '',
+    evidence.sourceReference ?? '',
+  ].join(':');
+}
+
+function dedupe<T extends string>(values: readonly T[]): readonly T[] {
+  return [...new Set(values)];
+}
+
+function dedupeBy<T>(values: readonly T[], getKey: (value: T) => string): readonly T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+
+  for (const value of values) {
+    const key = getKey(value);
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(value);
+    }
+  }
+
+  return result;
+}

--- a/packages/domain-assistance/src/types.ts
+++ b/packages/domain-assistance/src/types.ts
@@ -251,3 +251,78 @@ export interface AssistanceSessionDigest {
   externalRecordIds?: never;
   createdRecordIds?: never;
 }
+
+export const ASSISTANCE_WORKFLOW_INTENT_KINDS = [
+  'prepare_member_zone_context',
+  'prepare_claim_context_review',
+  'prepare_support_handoff_review',
+  'prepare_crm_follow_up_review',
+  'prepare_professional_recovery_review',
+  'blocked_workflow_intent',
+] as const;
+
+export type AssistanceWorkflowIntentKind = (typeof ASSISTANCE_WORKFLOW_INTENT_KINDS)[number];
+
+export const ASSISTANCE_WORKFLOW_TARGET_SURFACES = [
+  'member_zone',
+  'claim_context',
+  'support_handoff',
+  'crm_follow_up',
+  'professional_recovery_review',
+  'blocked_workflow',
+] as const;
+
+export type AssistanceWorkflowTargetSurface = (typeof ASSISTANCE_WORKFLOW_TARGET_SURFACES)[number];
+
+export const ASSISTANCE_WORKFLOW_BLOCKER_CODES = [
+  'session_identity_missing',
+  'member_attachment_missing',
+  'explicit_consent_missing',
+  'required_disclaimer_missing',
+  'country_rule_metadata_missing',
+  'digest_pair_count_mismatch',
+  'digest_summary_outcome_mismatch',
+  'sensitive_human_review_missing',
+  'ai_non_final_review_required',
+  'final_or_executable_outcome_blocked',
+  'created_or_external_record_ids_present',
+  'professional_recovery_activation_blocked',
+] as const;
+
+export type AssistanceWorkflowBlockerCode = (typeof ASSISTANCE_WORKFLOW_BLOCKER_CODES)[number];
+
+export type AssistanceWorkflowRedactionPosture =
+  | 'none'
+  | 'identifier_hash_only'
+  | 'sensitive_reference_only'
+  | 'professional_secret_reference_only';
+
+export interface AssistanceWorkflowPackReference {
+  packId: string;
+  packType: AssistancePackType;
+  outcomeKind: AssistanceOutcomeKind;
+  zone: AssistanceServiceZone;
+  requiredHumanReview: boolean;
+}
+
+export interface AssistanceWorkflowIntent {
+  intentKind: AssistanceWorkflowIntentKind;
+  targetSurface: AssistanceWorkflowTargetSurface;
+  executionAllowed: false;
+  blocked: boolean;
+  outcomeKind?: AssistanceOutcomeKind;
+  reasons: readonly AssistanceReason[];
+  blockers: readonly AssistanceWorkflowBlockerCode[];
+  evidence: readonly AssistanceEvidenceReference[];
+  packReferences: readonly AssistanceWorkflowPackReference[];
+  requiredConsentState?: Extract<AssistanceConsentState, 'explicit_consent_recorded'>;
+  requiredDisclaimers: readonly AssistanceDisclaimerCode[];
+  missingDisclaimers: readonly AssistanceDisclaimerCode[];
+  requiredHumanReview: boolean;
+  piiClassification: PiiClassification;
+  redactionPosture: AssistanceWorkflowRedactionPosture;
+  aiAdvisoryOnly: boolean;
+  referenceKey: string;
+  externalRecordIds?: never;
+  createdRecordIds?: never;
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "maxTrackedBytes": 29200000,
-  "maxTrackedFiles": 3770,
+  "maxTrackedBytes": 29250000,
+  "maxTrackedFiles": 3772,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {


### PR DESCRIPTION
## Summary
- add ASSIST-09 workflow intent contract types and exported helper in `packages/domain-assistance`
- add deterministic readonly workflow intent creation over `AssistanceSessionDigest` with literal `executionAllowed: false`
- add fail-closed blocker handling, redacted evidence references, and stable reference keys without UI/runtime/DB/CRM/claim/handoff/outbox/AI changes
- add focused domain-assistance unit coverage for consent, disclaimers, human review, AI non-finality, deterministic ordering, and leakage guards
- update repo size budget for the two new tracked files and measured byte delta

## Verification
- `pnpm --filter @interdomestik/domain-assistance test:unit`
- `pnpm --filter @interdomestik/domain-assistance type-check`
- `pnpm exec prettier --check packages/domain-assistance/src/types.ts packages/domain-assistance/src/rules.ts packages/domain-assistance/src/rules/workflow-intents.ts packages/domain-assistance/src/rules/workflow-intents.test.ts scripts/repo-size-budget.json`
- `pnpm repo:size:check`
- `interdomestik_qa.scope_audit` for `packages/domain-assistance/` and `scripts/repo-size-budget.json`
- `interdomestik_qa.security_guard`
- `pnpm pr:verify`
- `pnpm e2e:gate` (MCP `interdomestik_qa.e2e_gate` timed out after 120s; direct required gate passed: 128 passed, 4 skipped)

## Notes
- Sidecar subagents were spawned for independent review/verification, but all timed out without final reports and were closed to avoid leaving background work running.
- `interdomestik_qa.pr_verify` also timed out before direct `pnpm pr:verify`; the first direct retry hit a stale `.next/lock`, no Next build process was running, and the subsequent retry passed.