### PR TITLE
fix: harden assistance workflow intent reasons

### DIFF
--- a/packages/domain-assistance/src/rules/workflow-intents.test.ts
+++ b/packages/domain-assistance/src/rules/workflow-intents.test.ts
@@ -492,9 +492,23 @@ describe('createAssistanceWorkflowIntents', () => {
     const intentText = JSON.stringify(intents);
 
     expect(intentText).not.toContain('ABC-123');
+    expect(intentText).not.toContain('abc-123');
     expect(intentText).not.toContain('WDD123');
+    expect(intentText).not.toContain('wdd123');
     expect(intentText).not.toContain('medical text');
+    expect(intentText).not.toContain('medical_text');
     expect(intentText).not.toContain('insurer letter');
+    expect(intentText).not.toContain('insurer_letter');
     expect(intentText).not.toContain('expert report');
+    expect(intentText).not.toContain('expert_report');
+    expect(intents.flatMap(intent => intent.reasons.map(reason => reason.code))).toEqual(
+      expect.arrayContaining([
+        'workflow.claim_context.review_requested',
+        'workflow.source_outcome.eligible',
+      ])
+    );
+    expect(
+      intents.every(intent => intent.reasons.every(reason => reason.code.startsWith('workflow.')))
+    ).toBe(true);
   });
 });

--- a/packages/domain-assistance/src/rules/workflow-intents.ts
+++ b/packages/domain-assistance/src/rules/workflow-intents.ts
@@ -449,7 +449,19 @@ function createReasons(
       ...(outcome.humanReviewRequired ? ['workflow.human_review.required'] : []),
     ]),
     ...(digest.aiProvenance.length > 0 ? ['workflow.ai.advisory_only'] : []),
-  ]).map(code => ({ code: sanitizeCode(code) }));
+  ])
+    .map(toWorkflowReason)
+    .filter((reason): reason is AssistanceReason => reason !== undefined);
+}
+
+function toWorkflowReason(code: string): AssistanceReason | undefined {
+  const sanitized = sanitizeCode(code);
+
+  if (!sanitized.startsWith('workflow.')) {
+    return undefined;
+  }
+
+  return { code: sanitized };
 }
 
 function createReferenceKey(params: {


### PR DESCRIPTION
## Summary
- Adds an explicit internal-code boundary for assistance workflow-intent reasons so only sanitized `workflow.*` reason codes can be returned.
- Strengthens the workflow-intent privacy regression to check raw and normalized sensitive tokens, including narrative, plate, VIN, medical, insurer, expert-report, and source-record text.
- Keeps the slice pure `packages/domain-assistance`: no UI, CRM/claim/handoff creation, outbox, DB/RLS, AI runtime/model/prompt changes, routing/auth/tenancy changes, Stripe, README, AGENTS, or architecture-doc edits.

## Verification
- `pnpm --filter @interdomestik/domain-assistance type-check`
- `pnpm --filter @interdomestik/domain-assistance test:unit -- workflow-intents.test.ts`
- `pnpm --filter @interdomestik/domain-assistance test:unit`
- `git diff --check`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`

## Scope And Review Notes
- `interdomestik_qa.scope_audit` was attempted, but the MCP call generated local `.codex/config.toml` approval metadata and then reported that generated file as outside scope. After stashing that tool-generated local metadata, fallback changed-file audit showed only `packages/domain-assistance/src/rules/workflow-intents.ts` and `packages/domain-assistance/src/rules/workflow-intents.test.ts`.
- A dedicated diff-scoped Codex Security scan tool was not exposed by tool discovery; `pnpm security:guard` and focused diff scans were used as the fallback.
- Sidecar reviewer subagents were dispatched for this small implementation slice, but both stalled and were closed without findings. Local fallback review plus full gates were completed.