### PR TITLE
feat: add CRM task persistence adapter

### DIFF
--- a/apps/web/src/adapters/crm/task-repository.test.ts
+++ b/apps/web/src/adapters/crm/task-repository.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  db: {},
+}));
+
+vi.mock('@interdomestik/database/db', () => ({
+  db: hoisted.db,
+}));
+
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+import {
+  createCrmTask,
+  CrmTaskRepositoryFailure,
+  type CrmTask,
+} from '@interdomestik/domain-crm/tasks';
+import { crmTaskHistory, crmTasks } from '@interdomestik/database/schema';
+
+import { createCrmTaskRepository } from './task-repository';
+
+type TaskRepositoryDb = NonNullable<Parameters<typeof createCrmTaskRepository>[0]>;
+
+const now = new Date('2026-05-21T08:00:00.000Z');
+
+const agentActor: CrmActorContext = {
+  actorId: 'agent-1',
+  role: 'agent',
+  scope: { agentId: 'agent-1', branchId: 'branch-1' },
+  tenantId: 'tenant-1',
+};
+
+function createTask(): CrmTask {
+  const result = createCrmTask(
+    {
+      actor: agentActor,
+      assignedTo: {
+        actorId: 'agent-1',
+        branchId: 'branch-1',
+        kind: 'actor',
+        role: 'agent',
+        tenantId: 'tenant-1',
+      },
+      dueAt: '2026-05-22T10:00:00.000Z',
+      idempotencyKey: 'crm25-task-create',
+      priority: 'high',
+      subjectProof: {
+        branchId: 'branch-1',
+        subjectReference: { id: 'lead-1', kind: 'lead' },
+        tenantId: 'tenant-1',
+      },
+      subjectReference: { id: 'lead-1', kind: 'lead' },
+      tenantId: 'tenant-1',
+    },
+    {
+      now: () => now.toISOString(),
+      taskId: () => 'task-1',
+    }
+  );
+  if (!result.success) throw new Error(result.reason);
+  return result.task;
+}
+
+function rowFromTask(task: CrmTask) {
+  const assignedTo = task.assignedTo;
+  return {
+    assignedActorId: assignedTo.kind === 'actor' ? assignedTo.actorId : null,
+    assignedBranchId: assignedTo.kind === 'unassigned' ? null : assignedTo.branchId,
+    assignedKind: assignedTo.kind,
+    assignedRole:
+      assignedTo.kind === 'actor' || assignedTo.kind === 'role' ? assignedTo.role : null,
+    assignedTeamId: assignedTo.kind === 'team' ? assignedTo.teamId : null,
+    assignedTenantId: assignedTo.kind === 'unassigned' ? null : assignedTo.tenantId,
+    branchId: task.branchId,
+    cancelledAt: task.cancelledAt ? new Date(task.cancelledAt) : null,
+    cancellationReasonCode: task.cancellationReasonCode,
+    completedAt: task.completedAt ? new Date(task.completedAt) : null,
+    completionReasonCode: task.completionReasonCode,
+    createReasonCode: task.createReasonCode,
+    createdAt: new Date(task.createdAt),
+    createdByBranchId: task.createdBy.branchId,
+    createdById: task.createdBy.actorId,
+    createdByRole: task.createdBy.role,
+    dueAt: task.dueAt ? new Date(task.dueAt) : null,
+    id: task.taskId,
+    idempotencyKey: task.idempotencyKey,
+    lifecycleVersion: task.lifecycleVersion,
+    priority: task.priority,
+    reopenedAt: task.reopenedAt ? new Date(task.reopenedAt) : null,
+    reopenReasonCode: task.reopenReasonCode,
+    status: task.status,
+    subjectId: task.subjectReference.id,
+    subjectKind: task.subjectReference.kind,
+    tenantId: task.tenantId,
+    updatedAt: new Date(task.updatedAt),
+  };
+}
+
+function historyRowFromTask(task: CrmTask) {
+  const entry = task.history[0];
+  if (!entry) throw new Error('missing history');
+  return {
+    actorBranchId: entry.actor.branchId,
+    actorId: entry.actor.actorId,
+    actorRole: entry.actor.role,
+    createdAt: now,
+    event: entry.event,
+    fromStatus: entry.fromStatus,
+    id: 'history-1',
+    occurredAt: new Date(entry.timestamp),
+    reasonCode: entry.reasonCode,
+    taskId: task.taskId,
+    tenantId: entry.actor.tenantId,
+    toStatus: entry.toStatus,
+  };
+}
+
+function createFakeDb(options: {
+  historyRows?: readonly unknown[];
+  leadRow?: unknown;
+  taskRow?: unknown;
+  updateRows?: readonly unknown[];
+}) {
+  const calls: unknown[] = [];
+  const task = createTask();
+  const taskRow = options.taskRow ?? rowFromTask(task);
+  const historyRows = options.historyRows ?? [historyRowFromTask(task)];
+  const leadRow = options.leadRow ?? {
+    agentId: 'agent-1',
+    branchId: 'branch-1',
+    id: 'lead-1',
+    tenantId: 'tenant-1',
+  };
+  const crmTaskFindFirst = vi.fn(async (): Promise<ReturnType<typeof rowFromTask> | null> => null);
+
+  const query = {
+    crmDeals: { findFirst: vi.fn(async () => null) },
+    crmLeads: { findFirst: vi.fn(async () => leadRow) },
+    crmTaskHistory: { findMany: vi.fn(async () => historyRows) },
+    crmTasks: { findFirst: crmTaskFindFirst },
+    supportHandoffs: { findFirst: vi.fn(async () => null) },
+  };
+
+  const tx = {
+    insert(table: unknown) {
+      calls.push({ action: 'insert', table });
+      return {
+        values(values: unknown) {
+          calls.push({ action: 'values', table, values });
+          return {
+            returning: vi.fn(async () => (table === crmTasks ? [taskRow] : [])),
+          };
+        },
+      };
+    },
+    update(table: unknown) {
+      calls.push({ action: 'update', table });
+      return {
+        set(values: unknown) {
+          calls.push({ action: 'set', table, values });
+          return {
+            where(where: unknown) {
+              calls.push({ action: 'where', table, where });
+              return {
+                returning: vi.fn(async () => options.updateRows ?? [taskRow]),
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return {
+    calls,
+    db: {
+      query,
+      transaction: vi.fn(async (callback: (transaction: typeof tx) => unknown) => callback(tx)),
+    } as unknown as TaskRepositoryDb,
+    query,
+    task,
+  };
+}
+
+describe('crmTaskRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a CRM task and initial history row in one transaction without raw subject text', async () => {
+    const fake = createFakeDb({});
+    const repository = createCrmTaskRepository(fake.db);
+
+    const saved = await repository.saveTask({ actor: agentActor, task: fake.task });
+
+    expect(saved).toMatchObject({
+      branchId: 'branch-1',
+      idempotencyKey: 'crm25-task-create',
+      lifecycleVersion: 1,
+      status: 'pending',
+      subjectReference: { id: 'lead-1', kind: 'lead' },
+      taskId: 'task-1',
+      tenantId: 'tenant-1',
+    });
+    expect(fake.db.transaction).toHaveBeenCalledOnce();
+    const persistedValues = fake.calls
+      .filter((call): call is { values: unknown } => {
+        return typeof call === 'object' && call !== null && 'values' in call;
+      })
+      .map(call => call.values);
+    expect(JSON.stringify(persistedValues)).not.toContain('medical diagnosis');
+    expect(fake.calls).toEqual([
+      { action: 'insert', table: crmTasks },
+      expect.objectContaining({
+        action: 'values',
+        table: crmTasks,
+      }),
+      { action: 'insert', table: crmTaskHistory },
+      expect.objectContaining({
+        action: 'values',
+        table: crmTaskHistory,
+      }),
+    ]);
+  });
+
+  it('throws a deterministic conflict and skips history append on stale lifecycle writes', async () => {
+    const fake = createFakeDb({ updateRows: [] });
+    const repository = createCrmTaskRepository(fake.db);
+
+    await expect(
+      repository.saveTask({
+        actor: agentActor,
+        expectedLifecycleVersion: 1,
+        task: { ...fake.task, lifecycleVersion: 2, updatedAt: '2026-05-21T09:00:00.000Z' },
+      })
+    ).rejects.toMatchObject({ reason: 'lifecycle_conflict' });
+
+    expect(fake.calls).toEqual([
+      { action: 'update', table: crmTasks },
+      expect.objectContaining({ action: 'set', table: crmTasks }),
+      expect.objectContaining({ action: 'where', table: crmTasks }),
+    ]);
+  });
+
+  it('does not append history when the task subject is not visible to the actor', async () => {
+    const fake = createFakeDb({
+      leadRow: { agentId: 'agent-2', branchId: 'branch-1', id: 'lead-1', tenantId: 'tenant-1' },
+    });
+    fake.query.crmTasks.findFirst.mockResolvedValueOnce(rowFromTask(fake.task));
+    const repository = createCrmTaskRepository(fake.db);
+
+    await expect(
+      repository.appendTaskHistory({
+        actor: agentActor,
+        entry: fake.task.history[0],
+        expectedLifecycleVersion: 1,
+        taskId: fake.task.taskId,
+      })
+    ).rejects.toMatchObject({ reason: 'subject_not_visible' });
+
+    expect(fake.db.transaction).not.toHaveBeenCalled();
+    expect(fake.calls).toEqual([]);
+  });
+
+  it('replays equivalent idempotent creates and rejects non-equivalent material', async () => {
+    const fake = createFakeDb({});
+    fake.query.crmTasks.findFirst.mockResolvedValueOnce(rowFromTask(fake.task));
+    const repository = createCrmTaskRepository(fake.db);
+
+    await expect(
+      repository.saveTask({ actor: agentActor, task: fake.task })
+    ).resolves.toMatchObject({
+      idempotencyKey: 'crm25-task-create',
+      taskId: 'task-1',
+    });
+    expect(fake.db.transaction).not.toHaveBeenCalled();
+
+    fake.query.crmTasks.findFirst.mockResolvedValueOnce(rowFromTask(fake.task));
+    await expect(
+      repository.saveTask({
+        actor: agentActor,
+        task: { ...fake.task, priority: 'urgent' },
+      })
+    ).rejects.toMatchObject({ reason: 'idempotency_conflict' });
+  });
+
+  it('fails closed for unsupported account/contact subjects and agent-invisible leads', async () => {
+    const invisibleLead = createFakeDb({
+      leadRow: { agentId: 'agent-2', branchId: 'branch-1', id: 'lead-1', tenantId: 'tenant-1' },
+    });
+    const repository = createCrmTaskRepository(invisibleLead.db);
+
+    await expect(
+      repository.validateSubjectReference?.({
+        actor: agentActor,
+        subjectReference: { id: 'lead-1', kind: 'lead' },
+      })
+    ).resolves.toEqual({ reason: 'subject_not_visible', visible: false });
+
+    await expect(
+      repository.validateSubjectReference?.({
+        actor: agentActor,
+        subjectReference: { id: 'account-1', kind: 'account' },
+      })
+    ).resolves.toEqual({ reason: 'subject_proof_missing', visible: false });
+  });
+
+  it('surfaces repository failures with stable reason codes', () => {
+    expect(new CrmTaskRepositoryFailure('lifecycle_conflict')).toMatchObject({
+      name: 'CrmTaskRepositoryFailure',
+      reason: 'lifecycle_conflict',
+    });
+  });
+});

--- a/apps/web/src/adapters/crm/task-repository.test.ts
+++ b/apps/web/src/adapters/crm/task-repository.test.ts
@@ -116,6 +116,7 @@ function historyRowFromTask(task: CrmTask) {
 
 function createFakeDb(options: {
   historyRows?: readonly unknown[];
+  insertTaskError?: unknown;
   leadRow?: unknown;
   taskRow?: unknown;
   updateRows?: readonly unknown[];
@@ -147,7 +148,10 @@ function createFakeDb(options: {
         values(values: unknown) {
           calls.push({ action: 'values', table, values });
           return {
-            returning: vi.fn(async () => (table === crmTasks ? [taskRow] : [])),
+            returning: vi.fn(async () => {
+              if (table === crmTasks && options.insertTaskError) throw options.insertTaskError;
+              return table === crmTasks ? [taskRow] : [];
+            }),
           };
         },
       };
@@ -281,6 +285,29 @@ describe('crmTaskRepository', () => {
         task: { ...fake.task, priority: 'urgent' },
       })
     ).rejects.toMatchObject({ reason: 'idempotency_conflict' });
+  });
+
+  it('replays equivalent idempotent creates after concurrent unique-key races', async () => {
+    const fake = createFakeDb({
+      insertTaskError: Object.assign(new Error('duplicate key value'), {
+        code: '23505',
+        constraint: 'crm_tasks_tenant_idempotency_uq',
+      }),
+    });
+    fake.query.crmTasks.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(rowFromTask(fake.task));
+    const repository = createCrmTaskRepository(fake.db);
+
+    await expect(
+      repository.saveTask({ actor: agentActor, task: fake.task })
+    ).resolves.toMatchObject({
+      idempotencyKey: 'crm25-task-create',
+      taskId: 'task-1',
+    });
+
+    expect(fake.db.transaction).toHaveBeenCalledOnce();
+    expect(fake.query.crmTasks.findFirst).toHaveBeenCalledTimes(2);
   });
 
   it('fails closed for unsupported account/contact subjects and agent-invisible leads', async () => {

--- a/apps/web/src/adapters/crm/task-repository.ts
+++ b/apps/web/src/adapters/crm/task-repository.ts
@@ -13,6 +13,7 @@ import type { CrmActorContext } from '@interdomestik/domain-crm/context';
 import { randomUUID } from 'node:crypto';
 import { and, asc, eq, isNull, sql } from 'drizzle-orm';
 
+import { withTenantContext } from '@interdomestik/database';
 import { db } from '@interdomestik/database/db';
 import {
   crmDeals,
@@ -25,6 +26,41 @@ import {
 type CrmTaskDb = typeof db;
 type CrmTaskRow = typeof crmTasks.$inferSelect;
 type CrmTaskHistoryRow = typeof crmTaskHistory.$inferSelect;
+type CrmTaskTenantRunner = <T>(
+  actor: CrmActorContext,
+  action: (database: CrmTaskDb) => Promise<T>
+) => Promise<T>;
+
+const IDEMPOTENCY_UNIQUE_CONSTRAINT = 'crm_tasks_tenant_idempotency_uq';
+
+function createTenantRunner(database: CrmTaskDb): CrmTaskTenantRunner {
+  return async (actor, action) => {
+    if (database !== db) return action(database);
+    return withTenantContext({ tenantId: actor.tenantId, role: actor.role }, tx =>
+      action(tx as unknown as CrmTaskDb)
+    );
+  };
+}
+
+function databaseErrorRecord(error: unknown): Record<string, unknown> | null {
+  return typeof error === 'object' && error !== null ? (error as Record<string, unknown>) : null;
+}
+
+function isIdempotencyUniqueViolation(error: unknown): boolean {
+  const record = databaseErrorRecord(error);
+  if (!record) return false;
+  const code = typeof record.code === 'string' ? record.code : null;
+  const constraint = typeof record.constraint === 'string' ? record.constraint : null;
+  const message = typeof record.message === 'string' ? record.message : '';
+  if (
+    code === '23505' &&
+    (constraint === IDEMPOTENCY_UNIQUE_CONSTRAINT ||
+      message.includes(IDEMPOTENCY_UNIQUE_CONSTRAINT))
+  ) {
+    return true;
+  }
+  return isIdempotencyUniqueViolation(record.cause);
+}
 
 function toDate(value: string | null | undefined): Date | null {
   if (!value) return null;
@@ -256,6 +292,27 @@ function idempotencyMaterial(task: CrmTask): string {
   });
 }
 
+async function replayIdempotentCreate(
+  database: CrmTaskDb,
+  actor: CrmActorContext,
+  task: CrmTask
+): Promise<CrmTask | null> {
+  if (!task.idempotencyKey) return null;
+  const existingRow = await database.query.crmTasks.findFirst({
+    where: and(
+      eq(crmTasks.tenantId, actor.tenantId),
+      eq(crmTasks.idempotencyKey, task.idempotencyKey)
+    ),
+  });
+  if (!existingRow) return null;
+  const existing = await hydrateVisibleTask(database, actor, existingRow);
+  if (!existing) throw new CrmTaskRepositoryFailure('idempotency_conflict');
+  if (idempotencyMaterial(existing) !== idempotencyMaterial(task)) {
+    throw new CrmTaskRepositoryFailure('idempotency_conflict');
+  }
+  return existing;
+}
+
 async function hydrateVisibleTask(
   database: Pick<CrmTaskDb, 'query'>,
   actor: CrmActorContext,
@@ -337,149 +394,168 @@ async function validateSubjectReference(
   return { branchId: row.branchId ?? null, tenantId: row.tenantId, visible: true };
 }
 
-export function createCrmTaskRepository(database: CrmTaskDb = db): CrmTaskRepository {
+export function createCrmTaskRepository(
+  database: CrmTaskDb = db,
+  runInTenantContext: CrmTaskTenantRunner = createTenantRunner(database)
+): CrmTaskRepository {
   return {
     async appendTaskHistory(params) {
-      const existingRow = await database.query.crmTasks.findFirst({
-        where: taskVisibilityPredicate(params.actor, params.taskId),
-      });
-      if (!existingRow) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+      return runInTenantContext(params.actor, async scopedDatabase => {
+        const existingRow = await scopedDatabase.query.crmTasks.findFirst({
+          where: taskVisibilityPredicate(params.actor, params.taskId),
+        });
+        if (!existingRow) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
 
-      const visibility = await validateSubjectReference(database, {
-        actor: params.actor,
-        subjectReference: {
-          id: existingRow.subjectId,
-          kind: existingRow.subjectKind as CrmTaskSubjectReference['kind'],
-        },
-      });
-      if (!visibility.visible) throw new CrmTaskRepositoryFailure(visibility.reason);
-      if (visibility.branchId !== (existingRow.branchId ?? null)) {
-        throw new CrmTaskRepositoryFailure('subject_not_visible');
-      }
+        const visibility = await validateSubjectReference(scopedDatabase, {
+          actor: params.actor,
+          subjectReference: {
+            id: existingRow.subjectId,
+            kind: existingRow.subjectKind as CrmTaskSubjectReference['kind'],
+          },
+        });
+        if (!visibility.visible) throw new CrmTaskRepositoryFailure(visibility.reason);
+        if (visibility.branchId !== (existingRow.branchId ?? null)) {
+          throw new CrmTaskRepositoryFailure('subject_not_visible');
+        }
 
-      // db-access-guard: tenant-scoped -- reason: CRM task history append constrains by actor tenant, branch-visible task id, and expected lifecycle version.
-      const [row] = await database.transaction(async tx => {
-        const [updated] = await tx
-          .update(crmTasks)
-          .set({
-            lifecycleVersion: sql`${crmTasks.lifecycleVersion} + 1`,
-            status: params.entry.toStatus,
-            updatedAt: new Date(params.entry.timestamp),
-          })
-          .where(
-            and(
-              taskVisibilityPredicate(params.actor, params.taskId),
-              eq(crmTasks.lifecycleVersion, params.expectedLifecycleVersion)
+        // db-access-guard: tenant-scoped -- reason: CRM task history append constrains by actor tenant, branch-visible task id, and expected lifecycle version.
+        const [row] = await scopedDatabase.transaction(async tx => {
+          // db-access-guard: tenant-scoped -- reason: CRM task update runs inside withTenantContext and constrains by actor tenant, branch-visible task id, and expected lifecycle version.
+          const [updated] = await tx
+            .update(crmTasks)
+            .set({
+              lifecycleVersion: sql`${crmTasks.lifecycleVersion} + 1`,
+              status: params.entry.toStatus,
+              updatedAt: new Date(params.entry.timestamp),
+            })
+            .where(
+              and(
+                taskVisibilityPredicate(params.actor, params.taskId),
+                eq(crmTasks.lifecycleVersion, params.expectedLifecycleVersion)
+              )
             )
-          )
-          .returning();
+            .returning();
 
-        if (!updated) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
-        await tx.insert(crmTaskHistory).values(historyValues(params.taskId, params.entry));
-        return [updated];
+          if (!updated) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+          // db-access-guard: tenant-scoped -- reason: CRM task history row runs inside withTenantContext and copies the actor tenant from the validated domain event.
+          await tx.insert(crmTaskHistory).values(historyValues(params.taskId, params.entry));
+          return [updated];
+        });
+
+        const task = await hydrateVisibleTask(scopedDatabase, params.actor, row);
+        if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
+        return task;
       });
-
-      const task = await hydrateVisibleTask(database, params.actor, row);
-      if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
-      return task;
     },
 
     async findTaskById(params) {
-      // db-access-guard: tenant-scoped -- reason: CRM task lookup constrains by actor tenant and branch-visible task id before hydration.
-      const row = await database.query.crmTasks.findFirst({
-        where: taskVisibilityPredicate(params.actor, params.taskId),
+      return runInTenantContext(params.actor, async scopedDatabase => {
+        // db-access-guard: tenant-scoped -- reason: CRM task lookup constrains by actor tenant and branch-visible task id before hydration.
+        const row = await scopedDatabase.query.crmTasks.findFirst({
+          where: taskVisibilityPredicate(params.actor, params.taskId),
+        });
+        return row ? hydrateVisibleTask(scopedDatabase, params.actor, row) : null;
       });
-      return row ? hydrateVisibleTask(database, params.actor, row) : null;
     },
 
     async findTaskByIdempotencyKey(params) {
-      // db-access-guard: tenant-scoped -- reason: CRM task idempotency lookup constrains by actor tenant, branch visibility, and opaque idempotency key.
-      const row = await database.query.crmTasks.findFirst({
-        where: and(
-          taskVisibilityPredicate(params.actor),
-          eq(crmTasks.idempotencyKey, params.idempotencyKey)
-        ),
+      return runInTenantContext(params.actor, async scopedDatabase => {
+        // db-access-guard: tenant-scoped -- reason: CRM task idempotency lookup constrains by actor tenant, branch visibility, and opaque idempotency key.
+        const row = await scopedDatabase.query.crmTasks.findFirst({
+          where: and(
+            taskVisibilityPredicate(params.actor),
+            eq(crmTasks.idempotencyKey, params.idempotencyKey)
+          ),
+        });
+        return row ? hydrateVisibleTask(scopedDatabase, params.actor, row) : null;
       });
-      return row ? hydrateVisibleTask(database, params.actor, row) : null;
     },
 
     async saveTask(params) {
-      const visibility = await validateSubjectReference(database, {
-        actor: params.actor,
-        subjectReference: params.task.subjectReference,
-      });
-      if (!visibility.visible) throw new CrmTaskRepositoryFailure(visibility.reason);
-      if (visibility.branchId !== params.task.branchId) {
-        throw new CrmTaskRepositoryFailure('subject_not_visible');
-      }
-      if (!branchVisible(params.actor, params.task.branchId)) {
-        throw new CrmTaskRepositoryFailure('subject_not_visible');
-      }
-
-      if (params.expectedLifecycleVersion == null) {
-        if (params.task.lifecycleVersion !== 1) {
-          throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+      return runInTenantContext(params.actor, async scopedDatabase => {
+        const visibility = await validateSubjectReference(scopedDatabase, {
+          actor: params.actor,
+          subjectReference: params.task.subjectReference,
+        });
+        if (!visibility.visible) throw new CrmTaskRepositoryFailure(visibility.reason);
+        if (visibility.branchId !== params.task.branchId) {
+          throw new CrmTaskRepositoryFailure('subject_not_visible');
         }
-        if (params.task.idempotencyKey) {
-          const existingRow = await database.query.crmTasks.findFirst({
-            where: and(
-              eq(crmTasks.tenantId, params.actor.tenantId),
-              eq(crmTasks.idempotencyKey, params.task.idempotencyKey)
-            ),
-          });
-          if (existingRow) {
-            const existing = await hydrateVisibleTask(database, params.actor, existingRow);
-            if (!existing) throw new CrmTaskRepositoryFailure('idempotency_conflict');
-            if (idempotencyMaterial(existing) !== idempotencyMaterial(params.task)) {
-              throw new CrmTaskRepositoryFailure('idempotency_conflict');
-            }
-            return existing;
+        if (!branchVisible(params.actor, params.task.branchId)) {
+          throw new CrmTaskRepositoryFailure('subject_not_visible');
+        }
+
+        if (params.expectedLifecycleVersion == null) {
+          if (params.task.lifecycleVersion !== 1) {
+            throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+          }
+          const replayed = await replayIdempotentCreate(scopedDatabase, params.actor, params.task);
+          if (replayed) return replayed;
+
+          try {
+            const [row] = await scopedDatabase.transaction(async tx => {
+              // db-access-guard: tenant-scoped -- reason: CRM task create runs inside withTenantContext after subject visibility validates the actor tenant and branch.
+              const [created] = await tx
+                .insert(crmTasks)
+                .values(taskValues(params.task))
+                .returning();
+              // db-access-guard: tenant-scoped -- reason: CRM task history create runs inside withTenantContext and copies actor tenant from validated task history.
+              await tx
+                .insert(crmTaskHistory)
+                .values(params.task.history.map(entry => historyValues(params.task.taskId, entry)));
+              return [created];
+            });
+            const task = await hydrateVisibleTask(scopedDatabase, params.actor, row);
+            if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
+            return task;
+          } catch (error) {
+            if (!isIdempotencyUniqueViolation(error)) throw error;
+            const replayedAfterRace = await replayIdempotentCreate(
+              scopedDatabase,
+              params.actor,
+              params.task
+            );
+            if (!replayedAfterRace) throw new CrmTaskRepositoryFailure('idempotency_conflict');
+            return replayedAfterRace;
           }
         }
 
-        const [row] = await database.transaction(async tx => {
-          const [created] = await tx.insert(crmTasks).values(taskValues(params.task)).returning();
-          await tx
-            .insert(crmTaskHistory)
-            .values(params.task.history.map(entry => historyValues(params.task.taskId, entry)));
-          return [created];
+        const expectedLifecycleVersion = params.expectedLifecycleVersion;
+        if (params.task.lifecycleVersion !== expectedLifecycleVersion + 1) {
+          throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+        }
+        // db-access-guard: tenant-scoped -- reason: CRM task save constrains by actor tenant, branch-visible task id, and expected lifecycle version.
+        const [row] = await scopedDatabase.transaction(async tx => {
+          // db-access-guard: tenant-scoped -- reason: CRM task save runs inside withTenantContext and constrains by actor tenant, branch-visible task id, and expected lifecycle version.
+          const [updated] = await tx
+            .update(crmTasks)
+            .set(taskValues(params.task))
+            .where(
+              and(
+                taskVisibilityPredicate(params.actor, params.task.taskId),
+                eq(crmTasks.lifecycleVersion, expectedLifecycleVersion)
+              )
+            )
+            .returning();
+          if (!updated) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+
+          const newest = params.task.history.at(-1);
+          if (newest) {
+            // db-access-guard: tenant-scoped -- reason: CRM task history append runs inside withTenantContext and copies the actor tenant from the validated domain event.
+            await tx.insert(crmTaskHistory).values(historyValues(params.task.taskId, newest));
+          }
+          return [updated];
         });
-        const task = await hydrateVisibleTask(database, params.actor, row);
+        const task = await hydrateVisibleTask(scopedDatabase, params.actor, row);
         if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
         return task;
-      }
-
-      const expectedLifecycleVersion = params.expectedLifecycleVersion;
-      if (params.task.lifecycleVersion !== expectedLifecycleVersion + 1) {
-        throw new CrmTaskRepositoryFailure('lifecycle_conflict');
-      }
-      // db-access-guard: tenant-scoped -- reason: CRM task save constrains by actor tenant, branch-visible task id, and expected lifecycle version.
-      const [row] = await database.transaction(async tx => {
-        const [updated] = await tx
-          .update(crmTasks)
-          .set(taskValues(params.task))
-          .where(
-            and(
-              taskVisibilityPredicate(params.actor, params.task.taskId),
-              eq(crmTasks.lifecycleVersion, expectedLifecycleVersion)
-            )
-          )
-          .returning();
-        if (!updated) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
-
-        const newest = params.task.history.at(-1);
-        if (newest) {
-          await tx.insert(crmTaskHistory).values(historyValues(params.task.taskId, newest));
-        }
-        return [updated];
       });
-      const task = await hydrateVisibleTask(database, params.actor, row);
-      if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
-      return task;
     },
 
     validateSubjectReference(params) {
-      return validateSubjectReference(database, params);
+      return runInTenantContext(params.actor, scopedDatabase =>
+        validateSubjectReference(scopedDatabase, params)
+      );
     },
   };
 }

--- a/apps/web/src/adapters/crm/task-repository.ts
+++ b/apps/web/src/adapters/crm/task-repository.ts
@@ -1,0 +1,487 @@
+import type {
+  CrmTask,
+  CrmTaskActorSnapshot,
+  CrmTaskAssignableRole,
+  CrmTaskAssignmentTarget,
+  CrmTaskHistoryEntry,
+  CrmTaskRepository,
+  CrmTaskSubjectReference,
+  CrmTaskSubjectVisibility,
+} from '@interdomestik/domain-crm/tasks';
+import { CrmTaskRepositoryFailure } from '@interdomestik/domain-crm/tasks';
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+import { randomUUID } from 'node:crypto';
+import { and, asc, eq, isNull, sql } from 'drizzle-orm';
+
+import { db } from '@interdomestik/database/db';
+import {
+  crmDeals,
+  crmLeads,
+  crmTaskHistory,
+  crmTasks,
+  supportHandoffs,
+} from '@interdomestik/database/schema';
+
+type CrmTaskDb = typeof db;
+type CrmTaskRow = typeof crmTasks.$inferSelect;
+type CrmTaskHistoryRow = typeof crmTaskHistory.$inferSelect;
+
+function toDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  return new Date(value);
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function requireIso(value: Date | string | null | undefined, label: string): string {
+  const iso = toIso(value);
+  if (!iso) throw new Error(`CRM task row is missing ${label}`);
+  return iso;
+}
+
+function actorBranchId(actor: CrmActorContext): string | null {
+  return actor.scope.branchId ?? null;
+}
+
+function branchVisible(actor: CrmActorContext, branchId: string | null): boolean {
+  if (actor.role === 'admin') return true;
+  if (!branchId) return false;
+  return actorBranchId(actor) === branchId;
+}
+
+function taskVisibilityPredicate(actor: CrmActorContext, taskId?: string) {
+  const predicates = [eq(crmTasks.tenantId, actor.tenantId)];
+  if (taskId) predicates.push(eq(crmTasks.id, taskId));
+  if (actor.role !== 'admin') {
+    const branchId = actorBranchId(actor);
+    if (!branchId) return and(...predicates, sql`false`);
+    predicates.push(eq(crmTasks.branchId, branchId));
+  }
+  return and(...predicates);
+}
+
+function mapAssignment(row: CrmTaskRow): CrmTaskAssignmentTarget {
+  if (row.assignedKind === 'unassigned') return { kind: 'unassigned' };
+  if (row.assignedKind === 'actor') {
+    if (!row.assignedActorId || !row.assignedRole) {
+      throw new Error('CRM task row has malformed actor assignment');
+    }
+    return {
+      actorId: row.assignedActorId,
+      branchId: row.assignedBranchId ?? null,
+      kind: 'actor',
+      role: row.assignedRole as CrmTaskAssignableRole,
+      tenantId: row.assignedTenantId ?? null,
+    };
+  }
+  if (row.assignedKind === 'role') {
+    if (!row.assignedRole) throw new Error('CRM task row has malformed role assignment');
+    return {
+      branchId: row.assignedBranchId ?? null,
+      kind: 'role',
+      role: row.assignedRole as CrmTaskAssignableRole,
+      tenantId: row.assignedTenantId ?? null,
+    };
+  }
+  if (row.assignedKind === 'team') {
+    if (!row.assignedTeamId) throw new Error('CRM task row has malformed team assignment');
+    return {
+      branchId: row.assignedBranchId ?? null,
+      kind: 'team',
+      teamId: row.assignedTeamId,
+      tenantId: row.assignedTenantId ?? null,
+    };
+  }
+  throw new Error(`CRM task row has unsupported assignment kind ${row.assignedKind}`);
+}
+
+function actorSnapshot(
+  row: Pick<CrmTaskRow, 'createdByBranchId' | 'createdById' | 'createdByRole' | 'tenantId'>
+): CrmTaskActorSnapshot {
+  return {
+    actorId: row.createdById,
+    branchId: row.createdByBranchId ?? null,
+    role: row.createdByRole as CrmTaskActorSnapshot['role'],
+    tenantId: row.tenantId,
+  };
+}
+
+function historyActorSnapshot(row: CrmTaskHistoryRow): CrmTaskActorSnapshot {
+  return {
+    actorId: row.actorId,
+    branchId: row.actorBranchId ?? null,
+    role: row.actorRole as CrmTaskActorSnapshot['role'],
+    tenantId: row.tenantId,
+  };
+}
+
+function mapHistoryEntry(row: CrmTaskHistoryRow): CrmTaskHistoryEntry {
+  return {
+    actor: historyActorSnapshot(row),
+    event: row.event as CrmTaskHistoryEntry['event'],
+    fromStatus: row.fromStatus as CrmTaskHistoryEntry['fromStatus'],
+    reasonCode: row.reasonCode as CrmTaskHistoryEntry['reasonCode'],
+    timestamp: requireIso(row.occurredAt, 'history occurredAt'),
+    toStatus: row.toStatus as CrmTaskHistoryEntry['toStatus'],
+  };
+}
+
+function mapTask(row: CrmTaskRow, historyRows: readonly CrmTaskHistoryRow[]): CrmTask {
+  return {
+    assignedTo: mapAssignment(row),
+    branchId: row.branchId ?? null,
+    cancelledAt: toIso(row.cancelledAt),
+    cancellationReasonCode: row.cancellationReasonCode as CrmTask['cancellationReasonCode'],
+    completedAt: toIso(row.completedAt),
+    completionReasonCode: row.completionReasonCode as CrmTask['completionReasonCode'],
+    createReasonCode: row.createReasonCode as CrmTask['createReasonCode'],
+    createdAt: requireIso(row.createdAt, 'createdAt'),
+    createdBy: actorSnapshot(row),
+    dueAt: toIso(row.dueAt),
+    history: historyRows.map(mapHistoryEntry),
+    idempotencyKey: row.idempotencyKey ?? null,
+    lifecycleVersion: row.lifecycleVersion,
+    priority: row.priority as CrmTask['priority'],
+    reopenedAt: toIso(row.reopenedAt),
+    reopenReasonCode: row.reopenReasonCode as CrmTask['reopenReasonCode'],
+    status: row.status as CrmTask['status'],
+    subjectReference: {
+      id: row.subjectId,
+      kind: row.subjectKind as CrmTaskSubjectReference['kind'],
+    },
+    taskId: row.id,
+    tenantId: row.tenantId,
+    updatedAt: requireIso(row.updatedAt, 'updatedAt'),
+  };
+}
+
+function assignmentValues(assignedTo: CrmTaskAssignmentTarget) {
+  if (assignedTo.kind === 'unassigned') {
+    return {
+      assignedActorId: null,
+      assignedBranchId: null,
+      assignedKind: 'unassigned',
+      assignedRole: null,
+      assignedTeamId: null,
+      assignedTenantId: null,
+    };
+  }
+  if (assignedTo.kind === 'actor') {
+    return {
+      assignedActorId: assignedTo.actorId,
+      assignedBranchId: assignedTo.branchId ?? null,
+      assignedKind: 'actor',
+      assignedRole: assignedTo.role,
+      assignedTeamId: null,
+      assignedTenantId: assignedTo.tenantId ?? null,
+    };
+  }
+  if (assignedTo.kind === 'role') {
+    return {
+      assignedActorId: null,
+      assignedBranchId: assignedTo.branchId ?? null,
+      assignedKind: 'role',
+      assignedRole: assignedTo.role,
+      assignedTeamId: null,
+      assignedTenantId: assignedTo.tenantId ?? null,
+    };
+  }
+  return {
+    assignedActorId: null,
+    assignedBranchId: assignedTo.branchId ?? null,
+    assignedKind: 'team',
+    assignedRole: null,
+    assignedTeamId: assignedTo.teamId,
+    assignedTenantId: assignedTo.tenantId ?? null,
+  };
+}
+
+function taskValues(task: CrmTask) {
+  return {
+    ...assignmentValues(task.assignedTo),
+    branchId: task.branchId,
+    cancelledAt: toDate(task.cancelledAt),
+    cancellationReasonCode: task.cancellationReasonCode,
+    completedAt: toDate(task.completedAt),
+    completionReasonCode: task.completionReasonCode,
+    createReasonCode: task.createReasonCode,
+    createdAt: new Date(task.createdAt),
+    createdByBranchId: task.createdBy.branchId ?? null,
+    createdById: task.createdBy.actorId,
+    createdByRole: task.createdBy.role,
+    dueAt: toDate(task.dueAt),
+    id: task.taskId,
+    idempotencyKey: task.idempotencyKey,
+    lifecycleVersion: task.lifecycleVersion,
+    priority: task.priority,
+    reopenedAt: toDate(task.reopenedAt),
+    reopenReasonCode: task.reopenReasonCode,
+    status: task.status,
+    subjectId: task.subjectReference.id,
+    subjectKind: task.subjectReference.kind,
+    tenantId: task.tenantId,
+    updatedAt: new Date(task.updatedAt),
+  };
+}
+
+function historyValues(taskId: string, entry: CrmTaskHistoryEntry, id = randomUUID()) {
+  return {
+    actorBranchId: entry.actor.branchId ?? null,
+    actorId: entry.actor.actorId,
+    actorRole: entry.actor.role,
+    createdAt: new Date(),
+    event: entry.event,
+    fromStatus: entry.fromStatus,
+    id,
+    occurredAt: new Date(entry.timestamp),
+    reasonCode: entry.reasonCode,
+    taskId,
+    tenantId: entry.actor.tenantId,
+    toStatus: entry.toStatus,
+  };
+}
+
+function idempotencyMaterial(task: CrmTask): string {
+  return JSON.stringify({
+    assignedTo: task.assignedTo,
+    createReasonCode: task.createReasonCode,
+    createdBy: task.createdBy,
+    dueAt: task.dueAt,
+    priority: task.priority,
+    subjectReference: task.subjectReference,
+    tenantId: task.tenantId,
+  });
+}
+
+async function hydrateVisibleTask(
+  database: Pick<CrmTaskDb, 'query'>,
+  actor: CrmActorContext,
+  row: CrmTaskRow
+): Promise<CrmTask | null> {
+  if (!branchVisible(actor, row.branchId ?? null)) return null;
+  const visibility = await validateSubjectReference(database, {
+    actor,
+    subjectReference: {
+      id: row.subjectId,
+      kind: row.subjectKind as CrmTaskSubjectReference['kind'],
+    },
+  });
+  if (!visibility.visible) return null;
+
+  const historyRows = await database.query.crmTaskHistory.findMany({
+    orderBy: [
+      asc(crmTaskHistory.occurredAt),
+      asc(crmTaskHistory.createdAt),
+      asc(crmTaskHistory.id),
+    ],
+    where: and(eq(crmTaskHistory.tenantId, actor.tenantId), eq(crmTaskHistory.taskId, row.id)),
+  });
+
+  return mapTask(row, historyRows);
+}
+
+async function validateSubjectReference(
+  database: Pick<CrmTaskDb, 'query'>,
+  params: {
+    actor: CrmActorContext;
+    subjectReference: CrmTaskSubjectReference;
+  }
+): Promise<CrmTaskSubjectVisibility> {
+  const { actor, subjectReference } = params;
+  if (subjectReference.kind === 'account' || subjectReference.kind === 'contact') {
+    return { reason: 'subject_proof_missing', visible: false };
+  }
+
+  if (subjectReference.kind === 'lead') {
+    const row = await database.query.crmLeads.findFirst({
+      where: and(eq(crmLeads.id, subjectReference.id), eq(crmLeads.tenantId, actor.tenantId)),
+    });
+    if (!row) return { reason: 'subject_not_found', visible: false };
+    if (actor.role === 'agent' && row.agentId !== actor.actorId) {
+      return { reason: 'subject_not_visible', visible: false };
+    }
+    if (!branchVisible(actor, row.branchId ?? null)) {
+      return { reason: 'subject_not_visible', visible: false };
+    }
+    return { branchId: row.branchId ?? null, tenantId: row.tenantId, visible: true };
+  }
+
+  if (subjectReference.kind === 'deal') {
+    const row = await database.query.crmDeals.findFirst({
+      where: and(
+        eq(crmDeals.id, subjectReference.id),
+        eq(crmDeals.tenantId, actor.tenantId),
+        isNull(crmDeals.archivedAt)
+      ),
+    });
+    if (!row) return { reason: 'subject_not_found', visible: false };
+    if (!branchVisible(actor, row.branchId ?? null)) {
+      return { reason: 'subject_not_visible', visible: false };
+    }
+    return { branchId: row.branchId ?? null, tenantId: row.tenantId, visible: true };
+  }
+
+  const row = await database.query.supportHandoffs.findFirst({
+    where: and(
+      eq(supportHandoffs.id, subjectReference.id),
+      eq(supportHandoffs.tenantId, actor.tenantId)
+    ),
+  });
+  if (!row) return { reason: 'subject_not_found', visible: false };
+  if (!branchVisible(actor, row.branchId ?? null)) {
+    return { reason: 'subject_not_visible', visible: false };
+  }
+  return { branchId: row.branchId ?? null, tenantId: row.tenantId, visible: true };
+}
+
+export function createCrmTaskRepository(database: CrmTaskDb = db): CrmTaskRepository {
+  return {
+    async appendTaskHistory(params) {
+      const existingRow = await database.query.crmTasks.findFirst({
+        where: taskVisibilityPredicate(params.actor, params.taskId),
+      });
+      if (!existingRow) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+
+      const visibility = await validateSubjectReference(database, {
+        actor: params.actor,
+        subjectReference: {
+          id: existingRow.subjectId,
+          kind: existingRow.subjectKind as CrmTaskSubjectReference['kind'],
+        },
+      });
+      if (!visibility.visible) throw new CrmTaskRepositoryFailure(visibility.reason);
+      if (visibility.branchId !== (existingRow.branchId ?? null)) {
+        throw new CrmTaskRepositoryFailure('subject_not_visible');
+      }
+
+      // db-access-guard: tenant-scoped -- reason: CRM task history append constrains by actor tenant, branch-visible task id, and expected lifecycle version.
+      const [row] = await database.transaction(async tx => {
+        const [updated] = await tx
+          .update(crmTasks)
+          .set({
+            lifecycleVersion: sql`${crmTasks.lifecycleVersion} + 1`,
+            status: params.entry.toStatus,
+            updatedAt: new Date(params.entry.timestamp),
+          })
+          .where(
+            and(
+              taskVisibilityPredicate(params.actor, params.taskId),
+              eq(crmTasks.lifecycleVersion, params.expectedLifecycleVersion)
+            )
+          )
+          .returning();
+
+        if (!updated) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+        await tx.insert(crmTaskHistory).values(historyValues(params.taskId, params.entry));
+        return [updated];
+      });
+
+      const task = await hydrateVisibleTask(database, params.actor, row);
+      if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
+      return task;
+    },
+
+    async findTaskById(params) {
+      // db-access-guard: tenant-scoped -- reason: CRM task lookup constrains by actor tenant and branch-visible task id before hydration.
+      const row = await database.query.crmTasks.findFirst({
+        where: taskVisibilityPredicate(params.actor, params.taskId),
+      });
+      return row ? hydrateVisibleTask(database, params.actor, row) : null;
+    },
+
+    async findTaskByIdempotencyKey(params) {
+      // db-access-guard: tenant-scoped -- reason: CRM task idempotency lookup constrains by actor tenant, branch visibility, and opaque idempotency key.
+      const row = await database.query.crmTasks.findFirst({
+        where: and(
+          taskVisibilityPredicate(params.actor),
+          eq(crmTasks.idempotencyKey, params.idempotencyKey)
+        ),
+      });
+      return row ? hydrateVisibleTask(database, params.actor, row) : null;
+    },
+
+    async saveTask(params) {
+      const visibility = await validateSubjectReference(database, {
+        actor: params.actor,
+        subjectReference: params.task.subjectReference,
+      });
+      if (!visibility.visible) throw new CrmTaskRepositoryFailure(visibility.reason);
+      if (visibility.branchId !== params.task.branchId) {
+        throw new CrmTaskRepositoryFailure('subject_not_visible');
+      }
+      if (!branchVisible(params.actor, params.task.branchId)) {
+        throw new CrmTaskRepositoryFailure('subject_not_visible');
+      }
+
+      if (params.expectedLifecycleVersion == null) {
+        if (params.task.lifecycleVersion !== 1) {
+          throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+        }
+        if (params.task.idempotencyKey) {
+          const existingRow = await database.query.crmTasks.findFirst({
+            where: and(
+              eq(crmTasks.tenantId, params.actor.tenantId),
+              eq(crmTasks.idempotencyKey, params.task.idempotencyKey)
+            ),
+          });
+          if (existingRow) {
+            const existing = await hydrateVisibleTask(database, params.actor, existingRow);
+            if (!existing) throw new CrmTaskRepositoryFailure('idempotency_conflict');
+            if (idempotencyMaterial(existing) !== idempotencyMaterial(params.task)) {
+              throw new CrmTaskRepositoryFailure('idempotency_conflict');
+            }
+            return existing;
+          }
+        }
+
+        const [row] = await database.transaction(async tx => {
+          const [created] = await tx.insert(crmTasks).values(taskValues(params.task)).returning();
+          await tx
+            .insert(crmTaskHistory)
+            .values(params.task.history.map(entry => historyValues(params.task.taskId, entry)));
+          return [created];
+        });
+        const task = await hydrateVisibleTask(database, params.actor, row);
+        if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
+        return task;
+      }
+
+      const expectedLifecycleVersion = params.expectedLifecycleVersion;
+      if (params.task.lifecycleVersion !== expectedLifecycleVersion + 1) {
+        throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+      }
+      // db-access-guard: tenant-scoped -- reason: CRM task save constrains by actor tenant, branch-visible task id, and expected lifecycle version.
+      const [row] = await database.transaction(async tx => {
+        const [updated] = await tx
+          .update(crmTasks)
+          .set(taskValues(params.task))
+          .where(
+            and(
+              taskVisibilityPredicate(params.actor, params.task.taskId),
+              eq(crmTasks.lifecycleVersion, expectedLifecycleVersion)
+            )
+          )
+          .returning();
+        if (!updated) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+
+        const newest = params.task.history.at(-1);
+        if (newest) {
+          await tx.insert(crmTaskHistory).values(historyValues(params.task.taskId, newest));
+        }
+        return [updated];
+      });
+      const task = await hydrateVisibleTask(database, params.actor, row);
+      if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
+      return task;
+    },
+
+    validateSubjectReference(params) {
+      return validateSubjectReference(database, params);
+    },
+  };
+}
+
+export const crmTaskRepository = createCrmTaskRepository();

--- a/packages/database/drizzle/0065_crm_task_persistence.sql
+++ b/packages/database/drizzle/0065_crm_task_persistence.sql
@@ -40,10 +40,35 @@ CREATE TABLE "crm_tasks" (
 	CONSTRAINT "crm_tasks_reopen_reason_check" CHECK ("crm_tasks"."reopen_reason_code" is null or "crm_tasks"."reopen_reason_code" in ('follow_up_required', 'incomplete', 'manually_reopened')),
 	CONSTRAINT "crm_tasks_lifecycle_version_check" CHECK ("crm_tasks"."lifecycle_version" >= 1),
 	CONSTRAINT "crm_tasks_assignment_shape_check" CHECK (
-		("crm_tasks"."assigned_kind" = 'unassigned' and "crm_tasks"."assigned_actor_id" is null and "crm_tasks"."assigned_role" is null and "crm_tasks"."assigned_team_id" is null)
-		or ("crm_tasks"."assigned_kind" = 'actor' and "crm_tasks"."assigned_actor_id" is not null and "crm_tasks"."assigned_role" is not null and "crm_tasks"."assigned_team_id" is null)
-		or ("crm_tasks"."assigned_kind" = 'role' and "crm_tasks"."assigned_actor_id" is null and "crm_tasks"."assigned_role" is not null and "crm_tasks"."assigned_team_id" is null)
-		or ("crm_tasks"."assigned_kind" = 'team' and "crm_tasks"."assigned_actor_id" is null and "crm_tasks"."assigned_role" is null and "crm_tasks"."assigned_team_id" is not null)
+		(
+			"crm_tasks"."assigned_kind" = 'unassigned'
+			and "crm_tasks"."assigned_actor_id" is null
+			and "crm_tasks"."assigned_role" is null
+			and "crm_tasks"."assigned_team_id" is null
+			and "crm_tasks"."assigned_branch_id" is null
+			and "crm_tasks"."assigned_tenant_id" is null
+		)
+		or (
+			"crm_tasks"."assigned_kind" = 'actor'
+			and "crm_tasks"."assigned_actor_id" is not null
+			and "crm_tasks"."assigned_role" is not null
+			and "crm_tasks"."assigned_team_id" is null
+			and ("crm_tasks"."assigned_tenant_id" is null or "crm_tasks"."assigned_tenant_id" = "crm_tasks"."tenant_id")
+		)
+		or (
+			"crm_tasks"."assigned_kind" = 'role'
+			and "crm_tasks"."assigned_actor_id" is null
+			and "crm_tasks"."assigned_role" is not null
+			and "crm_tasks"."assigned_team_id" is null
+			and ("crm_tasks"."assigned_tenant_id" is null or "crm_tasks"."assigned_tenant_id" = "crm_tasks"."tenant_id")
+		)
+		or (
+			"crm_tasks"."assigned_kind" = 'team'
+			and "crm_tasks"."assigned_actor_id" is null
+			and "crm_tasks"."assigned_role" is null
+			and "crm_tasks"."assigned_team_id" is not null
+			and ("crm_tasks"."assigned_tenant_id" is null or "crm_tasks"."assigned_tenant_id" = "crm_tasks"."tenant_id")
+		)
 	)
 );
 --> statement-breakpoint

--- a/packages/database/drizzle/0065_crm_task_persistence.sql
+++ b/packages/database/drizzle/0065_crm_task_persistence.sql
@@ -1,0 +1,117 @@
+CREATE TABLE "crm_tasks" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"branch_id" text,
+	"subject_kind" text NOT NULL,
+	"subject_id" text NOT NULL,
+	"assigned_kind" text NOT NULL,
+	"assigned_actor_id" text,
+	"assigned_role" text,
+	"assigned_team_id" text,
+	"assigned_branch_id" text,
+	"assigned_tenant_id" text,
+	"status" text NOT NULL,
+	"priority" text NOT NULL,
+	"due_at" timestamp with time zone,
+	"idempotency_key" text,
+	"lifecycle_version" integer DEFAULT 1 NOT NULL,
+	"created_by_id" text NOT NULL,
+	"created_by_role" text NOT NULL,
+	"created_by_branch_id" text,
+	"create_reason_code" text NOT NULL,
+	"completed_at" timestamp with time zone,
+	"completion_reason_code" text,
+	"cancelled_at" timestamp with time zone,
+	"cancellation_reason_code" text,
+	"reopened_at" timestamp with time zone,
+	"reopen_reason_code" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "crm_tasks_tenant_id_id_uq" UNIQUE("tenant_id","id"),
+	CONSTRAINT "crm_tasks_subject_kind_check" CHECK ("crm_tasks"."subject_kind" in ('lead', 'deal', 'account', 'contact', 'support_handoff')),
+	CONSTRAINT "crm_tasks_assigned_kind_check" CHECK ("crm_tasks"."assigned_kind" in ('unassigned', 'actor', 'role', 'team')),
+	CONSTRAINT "crm_tasks_status_check" CHECK ("crm_tasks"."status" in ('pending', 'in_progress', 'completed', 'cancelled')),
+	CONSTRAINT "crm_tasks_priority_check" CHECK ("crm_tasks"."priority" in ('low', 'normal', 'high', 'urgent')),
+	CONSTRAINT "crm_tasks_created_by_role_check" CHECK ("crm_tasks"."created_by_role" in ('member', 'agent', 'staff', 'branch_manager', 'admin')),
+	CONSTRAINT "crm_tasks_assigned_role_check" CHECK ("crm_tasks"."assigned_role" is null or "crm_tasks"."assigned_role" in ('agent', 'staff', 'branch_manager', 'admin')),
+	CONSTRAINT "crm_tasks_create_reason_check" CHECK ("crm_tasks"."create_reason_code" in ('manual', 'follow_up', 'support_handoff', 'assistance_review', 'data_quality')),
+	CONSTRAINT "crm_tasks_completion_reason_check" CHECK ("crm_tasks"."completion_reason_code" is null or "crm_tasks"."completion_reason_code" in ('resolved', 'no_longer_needed', 'duplicate', 'converted', 'manually_closed')),
+	CONSTRAINT "crm_tasks_cancellation_reason_check" CHECK ("crm_tasks"."cancellation_reason_code" is null or "crm_tasks"."cancellation_reason_code" in ('not_needed', 'duplicate', 'created_in_error', 'subject_closed')),
+	CONSTRAINT "crm_tasks_reopen_reason_check" CHECK ("crm_tasks"."reopen_reason_code" is null or "crm_tasks"."reopen_reason_code" in ('follow_up_required', 'incomplete', 'manually_reopened')),
+	CONSTRAINT "crm_tasks_lifecycle_version_check" CHECK ("crm_tasks"."lifecycle_version" >= 1),
+	CONSTRAINT "crm_tasks_assignment_shape_check" CHECK (
+		("crm_tasks"."assigned_kind" = 'unassigned' and "crm_tasks"."assigned_actor_id" is null and "crm_tasks"."assigned_role" is null and "crm_tasks"."assigned_team_id" is null)
+		or ("crm_tasks"."assigned_kind" = 'actor' and "crm_tasks"."assigned_actor_id" is not null and "crm_tasks"."assigned_role" is not null and "crm_tasks"."assigned_team_id" is null)
+		or ("crm_tasks"."assigned_kind" = 'role' and "crm_tasks"."assigned_actor_id" is null and "crm_tasks"."assigned_role" is not null and "crm_tasks"."assigned_team_id" is null)
+		or ("crm_tasks"."assigned_kind" = 'team' and "crm_tasks"."assigned_actor_id" is null and "crm_tasks"."assigned_role" is null and "crm_tasks"."assigned_team_id" is not null)
+	)
+);
+--> statement-breakpoint
+CREATE TABLE "crm_task_history" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"task_id" text NOT NULL,
+	"event" text NOT NULL,
+	"from_status" text,
+	"to_status" text NOT NULL,
+	"reason_code" text NOT NULL,
+	"actor_id" text NOT NULL,
+	"actor_role" text NOT NULL,
+	"actor_branch_id" text,
+	"occurred_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "crm_task_history_event_check" CHECK ("crm_task_history"."event" in ('created', 'assigned', 'reassigned', 'due_updated', 'started', 'completed', 'cancelled', 'reopened')),
+	CONSTRAINT "crm_task_history_from_status_check" CHECK ("crm_task_history"."from_status" is null or "crm_task_history"."from_status" in ('pending', 'in_progress', 'completed', 'cancelled')),
+	CONSTRAINT "crm_task_history_to_status_check" CHECK ("crm_task_history"."to_status" in ('pending', 'in_progress', 'completed', 'cancelled')),
+	CONSTRAINT "crm_task_history_reason_code_check" CHECK ("crm_task_history"."reason_code" in ('manual', 'follow_up', 'support_handoff', 'assistance_review', 'data_quality', 'manual_assignment', 'reassignment', 'workload_balance', 'due_date_changed', 'due_date_cleared', 'manual_start', 'resolved', 'no_longer_needed', 'duplicate', 'converted', 'manually_closed', 'not_needed', 'created_in_error', 'subject_closed', 'follow_up_required', 'incomplete', 'manually_reopened')),
+	CONSTRAINT "crm_task_history_actor_role_check" CHECK ("crm_task_history"."actor_role" in ('member', 'agent', 'staff', 'branch_manager', 'admin'))
+);
+--> statement-breakpoint
+ALTER TABLE "crm_tasks" ADD CONSTRAINT "crm_tasks_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_tasks" ADD CONSTRAINT "crm_tasks_assigned_actor_id_user_id_fk" FOREIGN KEY ("assigned_actor_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_tasks" ADD CONSTRAINT "crm_tasks_created_by_id_user_id_fk" FOREIGN KEY ("created_by_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_tasks" ADD CONSTRAINT "crm_tasks_tenant_branch_fk" FOREIGN KEY ("tenant_id","branch_id") REFERENCES "public"."branches"("tenant_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_tasks" ADD CONSTRAINT "crm_tasks_tenant_assigned_branch_fk" FOREIGN KEY ("tenant_id","assigned_branch_id") REFERENCES "public"."branches"("tenant_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_tasks" ADD CONSTRAINT "crm_tasks_tenant_created_by_branch_fk" FOREIGN KEY ("tenant_id","created_by_branch_id") REFERENCES "public"."branches"("tenant_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_task_history" ADD CONSTRAINT "crm_task_history_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_task_history" ADD CONSTRAINT "crm_task_history_actor_id_user_id_fk" FOREIGN KEY ("actor_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_task_history" ADD CONSTRAINT "crm_task_history_tenant_task_fk" FOREIGN KEY ("tenant_id","task_id") REFERENCES "public"."crm_tasks"("tenant_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "crm_task_history" ADD CONSTRAINT "crm_task_history_tenant_actor_branch_fk" FOREIGN KEY ("tenant_id","actor_branch_id") REFERENCES "public"."branches"("tenant_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "crm_tasks_tenant_idempotency_uq" ON "crm_tasks" USING btree ("tenant_id","idempotency_key") WHERE "crm_tasks"."idempotency_key" is not null;--> statement-breakpoint
+CREATE INDEX "crm_tasks_tenant_status_due_idx" ON "crm_tasks" USING btree ("tenant_id","status","due_at");--> statement-breakpoint
+CREATE INDEX "crm_tasks_tenant_branch_status_due_idx" ON "crm_tasks" USING btree ("tenant_id","branch_id","status","due_at");--> statement-breakpoint
+CREATE INDEX "crm_tasks_tenant_subject_idx" ON "crm_tasks" USING btree ("tenant_id","subject_kind","subject_id");--> statement-breakpoint
+CREATE INDEX "crm_tasks_tenant_assigned_actor_status_due_idx" ON "crm_tasks" USING btree ("tenant_id","assigned_actor_id","status","due_at");--> statement-breakpoint
+CREATE INDEX "crm_task_history_tenant_task_occurred_idx" ON "crm_task_history" USING btree ("tenant_id","task_id","occurred_at");--> statement-breakpoint
+DO $$
+DECLARE
+  current_tenant_setting constant text := 'app.current_tenant_id';
+  crm_table text;
+BEGIN
+  FOREACH crm_table IN ARRAY ARRAY[
+    'crm_tasks',
+    'crm_task_history'
+  ]
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', crm_table);
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_policies
+      WHERE schemaname = 'public'
+        AND tablename = crm_table
+        AND policyname = 'tenant_isolation_' || crm_table
+    ) THEN
+      EXECUTE format(
+        'CREATE POLICY %I ON public.%I USING (tenant_id = current_setting(%L, true)::text) WITH CHECK (tenant_id = current_setting(%L, true)::text)',
+        'tenant_isolation_' || crm_table,
+        crm_table,
+        current_tenant_setting,
+        current_tenant_setting
+      );
+    END IF;
+  END LOOP;
+END
+$$;
+--> statement-breakpoint
+REVOKE UPDATE, DELETE ON TABLE "crm_task_history" FROM PUBLIC;

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1778922672627,
       "tag": "0064_crm_routing_persistence",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1779343710000,
+      "tag": "0065_crm_task_persistence",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/crm.ts
+++ b/packages/database/src/schema/crm.ts
@@ -949,10 +949,35 @@ export const crmTasks = pgTable(
     check(
       'crm_tasks_assignment_shape_check',
       sql`
-        (${table.assignedKind} = 'unassigned' and ${table.assignedActorId} is null and ${table.assignedRole} is null and ${table.assignedTeamId} is null)
-        or (${table.assignedKind} = 'actor' and ${table.assignedActorId} is not null and ${table.assignedRole} is not null and ${table.assignedTeamId} is null)
-        or (${table.assignedKind} = 'role' and ${table.assignedActorId} is null and ${table.assignedRole} is not null and ${table.assignedTeamId} is null)
-        or (${table.assignedKind} = 'team' and ${table.assignedActorId} is null and ${table.assignedRole} is null and ${table.assignedTeamId} is not null)
+        (
+          ${table.assignedKind} = 'unassigned'
+          and ${table.assignedActorId} is null
+          and ${table.assignedRole} is null
+          and ${table.assignedTeamId} is null
+          and ${table.assignedBranchId} is null
+          and ${table.assignedTenantId} is null
+        )
+        or (
+          ${table.assignedKind} = 'actor'
+          and ${table.assignedActorId} is not null
+          and ${table.assignedRole} is not null
+          and ${table.assignedTeamId} is null
+          and (${table.assignedTenantId} is null or ${table.assignedTenantId} = ${table.tenantId})
+        )
+        or (
+          ${table.assignedKind} = 'role'
+          and ${table.assignedActorId} is null
+          and ${table.assignedRole} is not null
+          and ${table.assignedTeamId} is null
+          and (${table.assignedTenantId} is null or ${table.assignedTenantId} = ${table.tenantId})
+        )
+        or (
+          ${table.assignedKind} = 'team'
+          and ${table.assignedActorId} is null
+          and ${table.assignedRole} is null
+          and ${table.assignedTeamId} is not null
+          and (${table.assignedTenantId} is null or ${table.assignedTenantId} = ${table.tenantId})
+        )
       `
     ),
   ]

--- a/packages/database/src/schema/crm.ts
+++ b/packages/database/src/schema/crm.ts
@@ -832,6 +832,191 @@ export const supportHandoffs = pgTable(
   ]
 );
 
+export const crmTasks = pgTable(
+  'crm_tasks',
+  {
+    id: text('id').primaryKey(),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    branchId: text('branch_id'),
+    subjectKind: text('subject_kind').notNull(),
+    subjectId: text('subject_id').notNull(),
+    assignedKind: text('assigned_kind').notNull(),
+    assignedActorId: text('assigned_actor_id').references(() => user.id),
+    assignedRole: text('assigned_role'),
+    assignedTeamId: text('assigned_team_id'),
+    assignedBranchId: text('assigned_branch_id'),
+    assignedTenantId: text('assigned_tenant_id'),
+    status: text('status').notNull(),
+    priority: text('priority').notNull(),
+    dueAt: timestamp('due_at', { withTimezone: true }),
+    idempotencyKey: text('idempotency_key'),
+    lifecycleVersion: integer('lifecycle_version').notNull().default(1),
+    createdById: text('created_by_id')
+      .notNull()
+      .references(() => user.id),
+    createdByRole: text('created_by_role').notNull(),
+    createdByBranchId: text('created_by_branch_id'),
+    createReasonCode: text('create_reason_code').notNull(),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+    completionReasonCode: text('completion_reason_code'),
+    cancelledAt: timestamp('cancelled_at', { withTimezone: true }),
+    cancellationReasonCode: text('cancellation_reason_code'),
+    reopenedAt: timestamp('reopened_at', { withTimezone: true }),
+    reopenReasonCode: text('reopen_reason_code'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  table => [
+    unique('crm_tasks_tenant_id_id_uq').on(table.tenantId, table.id),
+    uniqueIndex('crm_tasks_tenant_idempotency_uq')
+      .on(table.tenantId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null`),
+    index('crm_tasks_tenant_status_due_idx').on(table.tenantId, table.status, table.dueAt),
+    index('crm_tasks_tenant_branch_status_due_idx').on(
+      table.tenantId,
+      table.branchId,
+      table.status,
+      table.dueAt
+    ),
+    index('crm_tasks_tenant_subject_idx').on(table.tenantId, table.subjectKind, table.subjectId),
+    index('crm_tasks_tenant_assigned_actor_status_due_idx').on(
+      table.tenantId,
+      table.assignedActorId,
+      table.status,
+      table.dueAt
+    ),
+    foreignKey({
+      columns: [table.tenantId, table.branchId],
+      foreignColumns: [branches.tenantId, branches.id],
+      name: 'crm_tasks_tenant_branch_fk',
+    }),
+    foreignKey({
+      columns: [table.tenantId, table.assignedBranchId],
+      foreignColumns: [branches.tenantId, branches.id],
+      name: 'crm_tasks_tenant_assigned_branch_fk',
+    }),
+    foreignKey({
+      columns: [table.tenantId, table.createdByBranchId],
+      foreignColumns: [branches.tenantId, branches.id],
+      name: 'crm_tasks_tenant_created_by_branch_fk',
+    }),
+    check(
+      'crm_tasks_subject_kind_check',
+      sql`${table.subjectKind} in ('lead', 'deal', 'account', 'contact', 'support_handoff')`
+    ),
+    check(
+      'crm_tasks_assigned_kind_check',
+      sql`${table.assignedKind} in ('unassigned', 'actor', 'role', 'team')`
+    ),
+    check(
+      'crm_tasks_status_check',
+      sql`${table.status} in ('pending', 'in_progress', 'completed', 'cancelled')`
+    ),
+    check(
+      'crm_tasks_priority_check',
+      sql`${table.priority} in ('low', 'normal', 'high', 'urgent')`
+    ),
+    check(
+      'crm_tasks_created_by_role_check',
+      sql`${table.createdByRole} in ('member', 'agent', 'staff', 'branch_manager', 'admin')`
+    ),
+    check(
+      'crm_tasks_assigned_role_check',
+      sql`${table.assignedRole} is null or ${table.assignedRole} in ('agent', 'staff', 'branch_manager', 'admin')`
+    ),
+    check(
+      'crm_tasks_create_reason_check',
+      sql`${table.createReasonCode} in ('manual', 'follow_up', 'support_handoff', 'assistance_review', 'data_quality')`
+    ),
+    check(
+      'crm_tasks_completion_reason_check',
+      sql`${table.completionReasonCode} is null or ${table.completionReasonCode} in ('resolved', 'no_longer_needed', 'duplicate', 'converted', 'manually_closed')`
+    ),
+    check(
+      'crm_tasks_cancellation_reason_check',
+      sql`${table.cancellationReasonCode} is null or ${table.cancellationReasonCode} in ('not_needed', 'duplicate', 'created_in_error', 'subject_closed')`
+    ),
+    check(
+      'crm_tasks_reopen_reason_check',
+      sql`${table.reopenReasonCode} is null or ${table.reopenReasonCode} in ('follow_up_required', 'incomplete', 'manually_reopened')`
+    ),
+    check('crm_tasks_lifecycle_version_check', sql`${table.lifecycleVersion} >= 1`),
+    check(
+      'crm_tasks_assignment_shape_check',
+      sql`
+        (${table.assignedKind} = 'unassigned' and ${table.assignedActorId} is null and ${table.assignedRole} is null and ${table.assignedTeamId} is null)
+        or (${table.assignedKind} = 'actor' and ${table.assignedActorId} is not null and ${table.assignedRole} is not null and ${table.assignedTeamId} is null)
+        or (${table.assignedKind} = 'role' and ${table.assignedActorId} is null and ${table.assignedRole} is not null and ${table.assignedTeamId} is null)
+        or (${table.assignedKind} = 'team' and ${table.assignedActorId} is null and ${table.assignedRole} is null and ${table.assignedTeamId} is not null)
+      `
+    ),
+  ]
+);
+
+export const crmTaskHistory = pgTable(
+  'crm_task_history',
+  {
+    id: text('id').primaryKey(),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    taskId: text('task_id').notNull(),
+    event: text('event').notNull(),
+    fromStatus: text('from_status'),
+    toStatus: text('to_status').notNull(),
+    reasonCode: text('reason_code').notNull(),
+    actorId: text('actor_id')
+      .notNull()
+      .references(() => user.id),
+    actorRole: text('actor_role').notNull(),
+    actorBranchId: text('actor_branch_id'),
+    occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  table => [
+    index('crm_task_history_tenant_task_occurred_idx').on(
+      table.tenantId,
+      table.taskId,
+      table.occurredAt
+    ),
+    foreignKey({
+      columns: [table.tenantId, table.taskId],
+      foreignColumns: [crmTasks.tenantId, crmTasks.id],
+      name: 'crm_task_history_tenant_task_fk',
+    }),
+    foreignKey({
+      columns: [table.tenantId, table.actorBranchId],
+      foreignColumns: [branches.tenantId, branches.id],
+      name: 'crm_task_history_tenant_actor_branch_fk',
+    }),
+    check(
+      'crm_task_history_event_check',
+      sql`${table.event} in ('created', 'assigned', 'reassigned', 'due_updated', 'started', 'completed', 'cancelled', 'reopened')`
+    ),
+    check(
+      'crm_task_history_from_status_check',
+      sql`${table.fromStatus} is null or ${table.fromStatus} in ('pending', 'in_progress', 'completed', 'cancelled')`
+    ),
+    check(
+      'crm_task_history_to_status_check',
+      sql`${table.toStatus} in ('pending', 'in_progress', 'completed', 'cancelled')`
+    ),
+    check(
+      'crm_task_history_reason_code_check',
+      sql`${table.reasonCode} in ('manual', 'follow_up', 'support_handoff', 'assistance_review', 'data_quality', 'manual_assignment', 'reassignment', 'workload_balance', 'due_date_changed', 'due_date_cleared', 'manual_start', 'resolved', 'no_longer_needed', 'duplicate', 'converted', 'manually_closed', 'not_needed', 'created_in_error', 'subject_closed', 'follow_up_required', 'incomplete', 'manually_reopened')`
+    ),
+    check(
+      'crm_task_history_actor_role_check',
+      sql`${table.actorRole} in ('member', 'agent', 'staff', 'branch_manager', 'admin')`
+    ),
+  ]
+);
+
 // Legacy leads table
 export const leads = pgTable('leads', {
   id: text('id').primaryKey(),

--- a/packages/database/test/critical-rls-tables.test.ts
+++ b/packages/database/test/critical-rls-tables.test.ts
@@ -10,7 +10,14 @@ type CriticalRlsRow = {
   relrowsecurity: boolean | null;
 };
 
-const CRITICAL_TABLES = ['claim', 'claim_messages', 'documents', 'user'] as const;
+const CRITICAL_TABLES = [
+  'claim',
+  'claim_messages',
+  'crm_task_history',
+  'crm_tasks',
+  'documents',
+  'user',
+] as const;
 
 test('critical tables keep row level security enabled', async t => {
   if (!process.env.DATABASE_URL) {

--- a/packages/database/test/rls-engaged.test.ts
+++ b/packages/database/test/rls-engaged.test.ts
@@ -7,7 +7,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 
-import { claims, user } from '../src/schema';
+import { claims, crmTaskHistory, crmTasks, user } from '../src/schema';
 
 const KS_TENANT_ID = 'tenant_ks';
 const MK_TENANT_ID = 'tenant_mk';
@@ -67,6 +67,7 @@ async function requireRlsPreconditions(
   requireIntegration: boolean,
   t: TestContext
 ): Promise<void> {
+  const requiredTables = ['claim', 'crm_tasks', 'crm_task_history'] as const;
   const [rlsEnabled] = await adminDb.execute<{ enabled: boolean }>(
     sql`select relrowsecurity as enabled from pg_class where relname = 'claim'`
   );
@@ -81,17 +82,49 @@ async function requireRlsPreconditions(
     return;
   }
 
-  const policies = await adminDb.execute<{ policyname: string }>(
-    sql`select policyname from pg_policies where schemaname = 'public' and tablename = 'claim' and policyname = 'tenant_isolation_claim'`
-  );
-  if (policies.length === 0) {
+  const tableRows = await adminDb.execute<{ relname: string; relrowsecurity: boolean }>(sql`
+    select c.relname, c.relrowsecurity
+    from pg_class c
+    join pg_namespace n
+      on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relkind = 'r'
+      and c.relname in ('claim', 'crm_tasks', 'crm_task_history')
+  `);
+  const enabledTables = new Map(tableRows.map(row => [row.relname, row.relrowsecurity]));
+  const missingOrDisabled = requiredTables.filter(table => enabledTables.get(table) !== true);
+  if (missingOrDisabled.length > 0) {
     await adminSql.end({ timeout: 5 });
     if (requireIntegration) {
       assert.fail(
-        'RLS test requires tenant_isolation_claim policy when REQUIRE_RLS_INTEGRATION=1.'
+        `RLS test requires CRM task tables with RLS enabled when REQUIRE_RLS_INTEGRATION=1: ${missingOrDisabled.join(', ')}`
       );
     }
-    t.skip('tenant_isolation_claim policy is not present in current database');
+    t.skip(`CRM task RLS tables are not ready: ${missingOrDisabled.join(', ')}`);
+    return;
+  }
+
+  const policies = await adminDb.execute<{ policyname: string }>(
+    sql`
+      select policyname
+      from pg_policies
+      where schemaname = 'public'
+        and (
+          (tablename = 'claim' and policyname = 'tenant_isolation_claim')
+          or (tablename = 'crm_tasks' and policyname = 'tenant_isolation_crm_tasks')
+          or (tablename = 'crm_task_history' and policyname = 'tenant_isolation_crm_task_history')
+        )
+    `
+  );
+  if (policies.length !== requiredTables.length) {
+    await adminSql.end({ timeout: 5 });
+    if (requireIntegration) {
+      assert.fail(
+        'RLS test requires tenant-isolation policies for claim, crm_tasks, and crm_task_history when REQUIRE_RLS_INTEGRATION=1.'
+      );
+    }
+    t.skip('tenant-isolation policy set for claim/crm task tables is not present');
+    return;
   }
 }
 
@@ -189,6 +222,8 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
   );
   await adminDb.execute(sql.raw(`grant usage on schema public to "${TEST_DB_ROLE}"`));
   await adminDb.execute(sql.raw(`grant select on table "claim" to "${TEST_DB_ROLE}"`));
+  await adminDb.execute(sql.raw(`grant select on table "crm_tasks" to "${TEST_DB_ROLE}"`));
+  await adminDb.execute(sql.raw(`grant select on table "crm_task_history" to "${TEST_DB_ROLE}"`));
   const [{ currentUser }] = await adminDb.execute<{ currentUser: string }>(
     sql`select current_user as "currentUser"`
   );
@@ -197,14 +232,17 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
   const ksUserId = uniqueId('rls_user_ks');
   const mkUserId = uniqueId('rls_user_mk');
   const claimId = uniqueId('rls_claim_ks');
+  const taskId = uniqueId('rls_task_ks');
+  const historyId = uniqueId('rls_task_history_ks');
   const now = new Date();
   let rlsTestEnv: ReturnType<typeof applyRlsTestConnectionEnv> | null = null;
   let dbAdmin: DbModule['dbAdmin'] | null = null;
+  let dbRls: DbModule['dbRls'] | null = null;
   let withTenantContext: TenantModule['withTenantContext'] | null = null;
 
   try {
     rlsTestEnv = applyRlsTestConnectionEnv(process.env.DATABASE_URL);
-    [{ dbAdmin }, { withTenantContext }] = await Promise.all([
+    [{ dbAdmin, dbRls }, { withTenantContext }] = await Promise.all([
       import('../src/db'),
       import('../src/tenant'),
     ]);
@@ -245,6 +283,42 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
       origin: 'portal',
     });
 
+    await dbAdmin.insert(crmTasks).values({
+      assignedActorId: ksUserId,
+      assignedBranchId: null,
+      assignedKind: 'actor',
+      assignedRole: 'agent',
+      assignedTeamId: null,
+      assignedTenantId: KS_TENANT_ID,
+      branchId: null,
+      createReasonCode: 'manual',
+      createdAt: now,
+      createdById: ksUserId,
+      createdByRole: 'admin',
+      dueAt: null,
+      id: taskId,
+      idempotencyKey: null,
+      priority: 'normal',
+      status: 'pending',
+      subjectId: 'rls-subject',
+      subjectKind: 'lead',
+      tenantId: KS_TENANT_ID,
+      updatedAt: now,
+    });
+
+    await dbAdmin.insert(crmTaskHistory).values({
+      actorId: ksUserId,
+      actorRole: 'admin',
+      event: 'created',
+      fromStatus: null,
+      id: historyId,
+      occurredAt: now,
+      reasonCode: 'manual',
+      taskId,
+      tenantId: KS_TENANT_ID,
+      toStatus: 'pending',
+    });
+
     const [mkRlsReceipt] = await withTenantContext({ tenantId: MK_TENANT_ID }, async tx => {
       return tx.execute<RlsRuntimeReceipt>(sql`
         select
@@ -282,6 +356,22 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
 
     assert.equal(mkRows.length, 0, 'tenant_mk must not see tenant_ks claim row');
 
+    const unsetTaskRows = await dbRls
+      .select({ id: crmTasks.id })
+      .from(crmTasks)
+      .where(and(eq(crmTasks.id, taskId), eq(crmTasks.tenantId, KS_TENANT_ID)));
+    assert.equal(unsetTaskRows.length, 0, 'crm_tasks must return zero rows with tenant GUC unset');
+
+    const unsetHistoryRows = await dbRls
+      .select({ id: crmTaskHistory.id })
+      .from(crmTaskHistory)
+      .where(and(eq(crmTaskHistory.id, historyId), eq(crmTaskHistory.tenantId, KS_TENANT_ID)));
+    assert.equal(
+      unsetHistoryRows.length,
+      0,
+      'crm_task_history must return zero rows with tenant GUC unset'
+    );
+
     const ksRows = await withTenantContext({ tenantId: KS_TENANT_ID }, async tx => {
       return tx
         .select({ id: claims.id })
@@ -290,8 +380,19 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
     });
 
     assert.equal(ksRows.length, 1, 'tenant_ks must see its own claim row');
+
+    const ksTaskRows = await withTenantContext({ tenantId: KS_TENANT_ID }, async tx => {
+      return tx
+        .select({ id: crmTasks.id })
+        .from(crmTasks)
+        .where(and(eq(crmTasks.id, taskId), eq(crmTasks.tenantId, KS_TENANT_ID)));
+    });
+
+    assert.equal(ksTaskRows.length, 1, 'tenant_ks must see its own CRM task row');
   } finally {
     if (dbAdmin) {
+      await dbAdmin.delete(crmTaskHistory).where(eq(crmTaskHistory.id, historyId));
+      await dbAdmin.delete(crmTasks).where(eq(crmTasks.id, taskId));
       await dbAdmin.delete(claims).where(eq(claims.id, claimId));
       await dbAdmin.delete(user).where(eq(user.id, ksUserId));
       await dbAdmin.delete(user).where(eq(user.id, mkUserId));

--- a/packages/domain-crm/src/tasks/index.test.ts
+++ b/packages/domain-crm/src/tasks/index.test.ts
@@ -119,6 +119,7 @@ describe('CRM task domain contracts', () => {
       dueAt: '2026-05-21T07:30:00.000Z',
       branchId: 'branch-1',
       idempotencyKey: 'crm24-create-1',
+      lifecycleVersion: 1,
       priority: 'normal',
       status: 'pending',
       subjectReference: { id: 'lead-1', kind: 'lead' },
@@ -320,9 +321,12 @@ describe('CRM task domain contracts', () => {
     );
 
     expect(started.status).toBe('in_progress');
+    expect(started.lifecycleVersion).toBe(2);
     expect(completed.status).toBe('completed');
+    expect(completed.lifecycleVersion).toBe(3);
     expect(completed.completedAt).toBe('2026-05-20T14:00:00.000Z');
     expect(reopened.status).toBe('in_progress');
+    expect(reopened.lifecycleVersion).toBe(4);
     expect(reopened.completedAt).toBeNull();
     expect(reopened.history.map(entry => entry.event)).toEqual([
       'created',

--- a/packages/domain-crm/src/tasks/repository.ts
+++ b/packages/domain-crm/src/tasks/repository.ts
@@ -12,6 +12,7 @@ export interface CrmTaskRepository {
   appendTaskHistory(params: {
     actor: CrmActorContext;
     entry: CrmTaskHistoryEntry;
+    expectedLifecycleVersion: number;
     taskId: string;
   }): Promise<CrmTask>;
   findTaskById(params: { actor: CrmActorContext; taskId: string }): Promise<CrmTask | null>;
@@ -19,9 +20,30 @@ export interface CrmTaskRepository {
     actor: CrmActorContext;
     idempotencyKey: string;
   }): Promise<CrmTask | null>;
-  saveTask(params: { actor: CrmActorContext; task: CrmTask }): Promise<CrmTask>;
+  saveTask(params: {
+    actor: CrmActorContext;
+    expectedLifecycleVersion?: number;
+    task: CrmTask;
+  }): Promise<CrmTask>;
   validateSubjectReference?(params: {
     actor: CrmActorContext;
     subjectReference: CrmTaskSubjectReference;
   }): Promise<CrmTaskSubjectVisibility>;
+}
+
+export type CrmTaskRepositoryFailureReason =
+  | 'idempotency_conflict'
+  | 'lifecycle_conflict'
+  | 'subject_not_found'
+  | 'subject_not_visible'
+  | 'subject_proof_missing';
+
+export class CrmTaskRepositoryFailure extends Error {
+  readonly reason: CrmTaskRepositoryFailureReason;
+
+  constructor(reason: CrmTaskRepositoryFailureReason) {
+    super(`CRM task repository rejected write: ${reason}`);
+    this.name = 'CrmTaskRepositoryFailure';
+    this.reason = reason;
+  }
 }

--- a/packages/domain-crm/src/tasks/state.ts
+++ b/packages/domain-crm/src/tasks/state.ts
@@ -400,6 +400,7 @@ function applyTransition(args: {
         : args.completionReasonCode,
     dueAt: args.dueAt === undefined ? args.task.dueAt : args.dueAt,
     history: [...args.task.history, entry],
+    lifecycleVersion: args.task.lifecycleVersion + 1,
     reopenedAt: args.reopenedAt === undefined ? args.task.reopenedAt : args.reopenedAt,
     reopenReasonCode:
       args.reopenReasonCode === undefined ? args.task.reopenReasonCode : args.reopenReasonCode,
@@ -515,6 +516,7 @@ export function createCrmTask(
     dueAt,
     history: [historyEntry(input.actor, createTransition)],
     idempotencyKey: input.idempotencyKey ?? null,
+    lifecycleVersion: 1,
     priority: input.priority,
     reopenedAt: null,
     reopenReasonCode: null,

--- a/packages/domain-crm/src/tasks/types.ts
+++ b/packages/domain-crm/src/tasks/types.ts
@@ -154,6 +154,7 @@ export type CrmTask = {
   readonly dueAt: string | null;
   readonly history: readonly CrmTaskHistoryEntry[];
   readonly idempotencyKey: string | null;
+  readonly lifecycleVersion: number;
   readonly priority: CrmTaskPriority;
   readonly reopenedAt: string | null;
   readonly reopenReasonCode: CrmTaskReopenReasonCode | null;

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 29390000,
-  "maxTrackedFiles": 3780,
+  "maxTrackedBytes": 29430000,
+  "maxTrackedFiles": 3785,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
-    "large support/generated-ish": 13850000,
+    "large support/generated-ish": 13865000,
     "source/scripts": 6230000,
     "tests/e2e": 4194304,
     "docs/text": 3745000,


### PR DESCRIPTION
## Summary
- add CRM task persistence tables, migration, constraints, indexes, tenant RLS, and RLS integration coverage
- extend domain CRM task contracts with lifecycle versions and repository conflict/fail-closed reasons
- add the web CRM task repository adapter with actor-derived tenant/branch/subject visibility checks, idempotency replay, CAS lifecycle writes, and focused tests

## Verification
- pnpm --filter @interdomestik/web test:unit -- --run src/adapters/crm/task-repository.test.ts
- pnpm --filter @interdomestik/web type-check
- pnpm security:guard
- pnpm pr:verify
- pnpm e2e:gate (first run hit existing support-handoff strict-locator flake; clean rerun passed 128 passed / 4 skipped)
- interdomestik_qa.scope_audit
- Codex Security diff scan: /tmp/codex-security-scans/interdomestik-crystal-home/c40c25ea_20260521T0705Z/report.md

## Notes
- No proxy, canonical route, UI, auth/tenancy, scheduler, outbox, AI, README, AGENTS, or architecture-doc changes.
- Reviewer subagents were started but did not return findings after repeated waits; closed before PR packaging.
- Do not merge yet.