### PR TITLE
feat: add CRM task runtime boundary

### DIFF
--- a/apps/web/src/actions/crm-tasks.core.test.ts
+++ b/apps/web/src/actions/crm-tasks.core.test.ts
@@ -1,0 +1,647 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/adapters/crm/task-repository', () => ({
+  crmTaskRepository: {},
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: hoisted.revalidatePath,
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: () => 'task-1',
+}));
+
+import {
+  CrmTaskRepositoryFailure,
+  type CrmTask,
+  type CrmTaskRepository,
+} from '@interdomestik/domain-crm/tasks';
+
+import {
+  assignCrmTaskCore,
+  cancelCrmTaskCore,
+  completeCrmTaskCore,
+  createCrmTaskCore,
+  readCrmTaskCore,
+  reopenCrmTaskCore,
+  startCrmTaskCore,
+  updateCrmTaskDueAtCore,
+} from './crm-tasks.core';
+
+const TEST_NOW = '2026-05-21T10:00:00.000Z';
+const LOCALES = ['sq', 'en', 'sr', 'mk'] as const;
+
+function session(overrides: Record<string, unknown> = {}) {
+  return {
+    user: {
+      branchId: 'branch-1',
+      id: 'agent-1',
+      role: 'agent',
+      tenantId: 'tenant-1',
+      ...overrides,
+    },
+  };
+}
+
+function task(overrides: Partial<CrmTask> = {}): CrmTask {
+  return {
+    assignedTo: { kind: 'unassigned' },
+    branchId: 'branch-1',
+    cancelledAt: null,
+    cancellationReasonCode: null,
+    completedAt: null,
+    completionReasonCode: null,
+    createReasonCode: 'manual',
+    createdAt: TEST_NOW,
+    createdBy: {
+      actorId: 'agent-1',
+      branchId: 'branch-1',
+      role: 'agent',
+      tenantId: 'tenant-1',
+    },
+    dueAt: null,
+    history: [
+      {
+        actor: {
+          actorId: 'agent-1',
+          branchId: 'branch-1',
+          role: 'agent',
+          tenantId: 'tenant-1',
+        },
+        event: 'created',
+        fromStatus: null,
+        reasonCode: 'manual',
+        timestamp: TEST_NOW,
+        toStatus: 'pending',
+      },
+    ],
+    idempotencyKey: 'idem-1',
+    lifecycleVersion: 1,
+    priority: 'normal',
+    reopenedAt: null,
+    reopenReasonCode: null,
+    status: 'pending',
+    subjectReference: { id: 'lead-1', kind: 'lead' },
+    taskId: 'task-1',
+    tenantId: 'tenant-1',
+    updatedAt: TEST_NOW,
+    ...overrides,
+  };
+}
+
+function repository(overrides: Partial<CrmTaskRepository> = {}) {
+  return {
+    appendTaskHistory: vi.fn(),
+    findTaskById: vi.fn(),
+    findTaskByIdempotencyKey: vi.fn().mockResolvedValue(null),
+    saveTask: vi.fn(async ({ task: saved }) => saved),
+    validateSubjectReference: vi.fn().mockResolvedValue({
+      branchId: 'branch-1',
+      tenantId: 'tenant-1',
+      visible: true,
+    }),
+    ...overrides,
+  } satisfies CrmTaskRepository;
+}
+
+function deps(repo = repository()) {
+  return {
+    audit: vi.fn().mockResolvedValue(undefined),
+    now: () => TEST_NOW,
+    rateLimit: vi.fn().mockResolvedValue({ limited: false }),
+    repository: repo,
+    revalidate: vi.fn(),
+    taskId: () => 'task-1',
+  };
+}
+
+function createInput() {
+  return {
+    assignedTo: { kind: 'unassigned' } as const,
+    createReasonCode: 'manual' as const,
+    idempotencyKey: 'idem-1',
+    priority: 'normal' as const,
+    subjectReference: { id: 'lead-1', kind: 'lead' as const },
+    taskId: 'task-1',
+  };
+}
+
+describe('CRM task core boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fails closed for missing sessions before repository access', async () => {
+    const repo = repository();
+    const d = deps(repo);
+
+    const result = await readCrmTaskCore({
+      deps: d,
+      session: null,
+      taskId: 'task-1',
+    });
+
+    expect(result).toEqual({ outcome: 'unauthorized', reason: 'missing_session' });
+    expect(repo.findTaskById).not.toHaveBeenCalled();
+    expect(d.rateLimit).not.toHaveBeenCalled();
+  });
+
+  it('maps member task mutations to forbidden role scope', async () => {
+    const repo = repository();
+    const d = deps(repo);
+
+    const result = await createCrmTaskCore({
+      deps: d,
+      input: createInput(),
+      requestHeaders: new Headers({ 'user-agent': 'Vitest' }),
+      session: session({ role: 'member' }),
+    });
+
+    expect(result).toEqual({ outcome: 'forbidden', reason: 'role_scope' });
+    expect(d.rateLimit).not.toHaveBeenCalled();
+    expect(repo.validateSubjectReference).not.toHaveBeenCalled();
+    expect(repo.saveTask).not.toHaveBeenCalled();
+    expect(d.audit).not.toHaveBeenCalled();
+    expect(d.revalidate).not.toHaveBeenCalled();
+  });
+
+  it('creates a task with subject proof, audit metadata, and locale CRM revalidation', async () => {
+    const repo = repository();
+    const d = deps(repo);
+
+    const result = await createCrmTaskCore({
+      deps: d,
+      input: createInput(),
+      requestHeaders: new Headers({ 'x-forwarded-for': '127.0.0.1' }),
+      session: session(),
+    });
+
+    expect(result.outcome).toBe('success');
+    expect(repo.validateSubjectReference).toHaveBeenCalledWith({
+      actor: expect.objectContaining({
+        actorId: 'agent-1',
+        role: 'agent',
+        scope: expect.objectContaining({ branchId: 'branch-1' }),
+        tenantId: 'tenant-1',
+      }),
+      subjectReference: { id: 'lead-1', kind: 'lead' },
+    });
+    expect(repo.saveTask).toHaveBeenCalledWith({
+      actor: expect.objectContaining({ actorId: 'agent-1', tenantId: 'tenant-1' }),
+      task: expect.objectContaining({
+        branchId: 'branch-1',
+        idempotencyKey: 'idem-1',
+        subjectReference: { id: 'lead-1', kind: 'lead' },
+      }),
+    });
+    expect(d.audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'crm.task.created',
+        actorId: 'agent-1',
+        actorRole: 'agent',
+        entityId: 'task-1',
+        entityType: 'crm_task',
+        metadata: {
+          event: 'created',
+          fromStatus: null,
+          operation: 'created',
+          reasonCode: 'manual',
+          replay: false,
+          subjectKind: 'lead',
+          toStatus: 'pending',
+        },
+        tenantId: 'tenant-1',
+      })
+    );
+    for (const locale of LOCALES) {
+      expect(d.revalidate).toHaveBeenCalledWith(`/${locale}/agent/crm`);
+      expect(d.revalidate).toHaveBeenCalledWith(`/${locale}/staff/crm`);
+      expect(d.revalidate).toHaveBeenCalledWith(`/${locale}/admin/crm`);
+    }
+    expect(JSON.stringify(vi.mocked(d.audit).mock.calls)).not.toContain('Sensitive lead note');
+  });
+
+  it('returns idempotent replay for an equivalent create without saving or revalidating', async () => {
+    const existing = task();
+    const repo = repository({
+      findTaskByIdempotencyKey: vi.fn().mockResolvedValue(existing),
+    });
+    const d = deps(repo);
+
+    const result = await createCrmTaskCore({
+      deps: d,
+      input: createInput(),
+      session: session(),
+    });
+
+    expect(result).toEqual({
+      outcome: 'idempotent_replay',
+      reason: 'idempotent_replay',
+      task: existing,
+    });
+    expect(repo.saveTask).not.toHaveBeenCalled();
+    expect(d.revalidate).not.toHaveBeenCalled();
+    expect(d.audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'crm.task.created',
+        metadata: expect.objectContaining({
+          fromStatus: null,
+          reasonCode: 'manual',
+          replay: true,
+          toStatus: 'pending',
+        }),
+      })
+    );
+  });
+
+  it.each(['tenant_admin', 'super_admin'] as const)(
+    'normalizes %s sessions to the admin CRM actor for reads',
+    async role => {
+      const existing = task({ branchId: 'branch-2' });
+      const repo = repository({
+        findTaskById: vi.fn().mockResolvedValue(existing),
+      });
+
+      const result = await readCrmTaskCore({
+        deps: deps(repo),
+        session: session({ branchId: null, role }),
+        taskId: 'task-1',
+      });
+
+      expect(result).toEqual({ outcome: 'success', task: existing });
+      expect(repo.findTaskById).toHaveBeenCalledWith({
+        actor: expect.objectContaining({
+          actorId: 'agent-1',
+          role: 'admin',
+          scope: expect.objectContaining({ branchId: null, staffId: 'agent-1' }),
+          tenantId: 'tenant-1',
+        }),
+        taskId: 'task-1',
+      });
+    }
+  );
+
+  it('normalizes tenant_admin sessions to the admin CRM actor for mutations', async () => {
+    const existing = task({ branchId: 'branch-2', updatedAt: '2026-05-21T09:59:00.000Z' });
+    const repo = repository({
+      findTaskById: vi.fn().mockResolvedValue(existing),
+    });
+    const d = deps(repo);
+
+    const result = await updateCrmTaskDueAtCore({
+      deps: d,
+      input: {
+        dueAt: '2026-05-22T10:00:00.000Z',
+        expectedLifecycleVersion: 1,
+        reasonCode: 'due_date_changed',
+        taskId: 'task-1',
+      },
+      session: session({ branchId: null, role: 'tenant_admin' }),
+    });
+
+    expect(result.outcome).toBe('success');
+    expect(repo.saveTask).toHaveBeenCalledWith({
+      actor: expect.objectContaining({
+        actorId: 'agent-1',
+        role: 'admin',
+        scope: expect.objectContaining({ branchId: null, staffId: 'agent-1' }),
+        tenantId: 'tenant-1',
+      }),
+      expectedLifecycleVersion: 1,
+      task: expect.objectContaining({
+        dueAt: '2026-05-22T10:00:00.000Z',
+        lifecycleVersion: 2,
+      }),
+    });
+  });
+
+  it('short-circuits rate-limited mutations before repository writes', async () => {
+    const repo = repository();
+    const d = deps(repo);
+    d.rateLimit.mockResolvedValue({
+      error: 'Too many requests',
+      limited: true,
+      retryAfter: 42,
+      status: 429,
+    });
+
+    const result = await createCrmTaskCore({
+      deps: d,
+      input: createInput(),
+      session: session(),
+    });
+
+    expect(result).toEqual({
+      outcome: 'rate_limited',
+      reason: 'rate_limited',
+      retryAfter: 42,
+    });
+    expect(repo.validateSubjectReference).not.toHaveBeenCalled();
+    expect(repo.saveTask).not.toHaveBeenCalled();
+    expect(d.audit).not.toHaveBeenCalled();
+  });
+
+  it('maps lifecycle repository conflicts to conflict without audit or revalidation', async () => {
+    const existing = task({ updatedAt: '2026-05-21T09:59:00.000Z' });
+    const repo = repository({
+      findTaskById: vi.fn().mockResolvedValue(existing),
+      saveTask: vi.fn().mockRejectedValue(new CrmTaskRepositoryFailure('lifecycle_conflict')),
+    });
+    const d = deps(repo);
+
+    const result = await startCrmTaskCore({
+      deps: d,
+      input: { expectedLifecycleVersion: 1, reasonCode: 'manual_start', taskId: 'task-1' },
+      session: session(),
+    });
+
+    expect(result).toEqual({ outcome: 'conflict', reason: 'lifecycle_conflict' });
+    expect(d.audit).not.toHaveBeenCalled();
+    expect(d.revalidate).not.toHaveBeenCalled();
+  });
+
+  it('maps absent scoped reads to not_found', async () => {
+    const repo = repository({
+      findTaskById: vi.fn().mockResolvedValue(null),
+    });
+
+    await expect(
+      readCrmTaskCore({
+        deps: deps(repo),
+        session: session(),
+        taskId: 'task-1',
+      })
+    ).resolves.toEqual({ outcome: 'not_found', reason: 'task_not_found' });
+  });
+
+  it('saves assignment mutations with the expected lifecycle version', async () => {
+    const existing = task({ updatedAt: '2026-05-21T09:59:00.000Z' });
+    const repo = repository({
+      findTaskById: vi.fn().mockResolvedValue(existing),
+    });
+    const d = deps(repo);
+
+    const result = await assignCrmTaskCore({
+      deps: d,
+      input: {
+        assignedTo: {
+          actorId: 'agent-1',
+          branchId: 'branch-1',
+          kind: 'actor',
+          role: 'agent',
+          tenantId: 'tenant-1',
+        },
+        expectedLifecycleVersion: 1,
+        reasonCode: 'manual_assignment',
+        taskId: 'task-1',
+      },
+      session: session(),
+    });
+
+    expect(result.outcome).toBe('success');
+    expect(repo.saveTask).toHaveBeenCalledWith({
+      actor: expect.objectContaining({ actorId: 'agent-1', tenantId: 'tenant-1' }),
+      expectedLifecycleVersion: 1,
+      task: expect.objectContaining({ lifecycleVersion: 2, status: 'pending' }),
+    });
+  });
+
+  it.each([
+    {
+      expectedTask: {
+        dueAt: '2026-05-22T10:00:00.000Z',
+        lifecycleVersion: 2,
+        status: 'pending',
+      },
+      expectedTransition: {
+        event: 'due_updated',
+        fromStatus: 'pending',
+        reasonCode: 'due_date_changed',
+        toStatus: 'pending',
+      },
+      input: {
+        dueAt: '2026-05-22T10:00:00.000Z',
+        expectedLifecycleVersion: 7,
+        reasonCode: 'due_date_changed',
+        taskId: 'task-1',
+      },
+      mutate: updateCrmTaskDueAtCore,
+      name: 'due date updates',
+      sourceTask: task({ updatedAt: '2026-05-21T09:59:00.000Z' }),
+    },
+    {
+      expectedTask: {
+        completedAt: TEST_NOW,
+        completionReasonCode: 'resolved',
+        lifecycleVersion: 4,
+        status: 'completed',
+      },
+      expectedTransition: {
+        event: 'completed',
+        fromStatus: 'in_progress',
+        reasonCode: 'resolved',
+        toStatus: 'completed',
+      },
+      input: {
+        expectedLifecycleVersion: 3,
+        reasonCode: 'resolved',
+        taskId: 'task-1',
+      },
+      mutate: completeCrmTaskCore,
+      name: 'completion',
+      sourceTask: task({
+        lifecycleVersion: 3,
+        status: 'in_progress',
+        updatedAt: '2026-05-21T09:59:00.000Z',
+      }),
+    },
+    {
+      expectedTask: {
+        cancellationReasonCode: 'created_in_error',
+        cancelledAt: TEST_NOW,
+        lifecycleVersion: 6,
+        status: 'cancelled',
+      },
+      expectedTransition: {
+        event: 'cancelled',
+        fromStatus: 'pending',
+        reasonCode: 'created_in_error',
+        toStatus: 'cancelled',
+      },
+      input: {
+        expectedLifecycleVersion: 5,
+        reasonCode: 'created_in_error',
+        taskId: 'task-1',
+      },
+      mutate: cancelCrmTaskCore,
+      name: 'cancellation',
+      sourceTask: task({
+        lifecycleVersion: 5,
+        updatedAt: '2026-05-21T09:59:00.000Z',
+      }),
+    },
+    {
+      expectedTask: {
+        completedAt: null,
+        completionReasonCode: null,
+        lifecycleVersion: 10,
+        reopenedAt: TEST_NOW,
+        reopenReasonCode: 'follow_up_required',
+        status: 'in_progress',
+      },
+      expectedTransition: {
+        event: 'reopened',
+        fromStatus: 'completed',
+        reasonCode: 'follow_up_required',
+        toStatus: 'in_progress',
+      },
+      input: {
+        expectedLifecycleVersion: 9,
+        reasonCode: 'follow_up_required',
+        taskId: 'task-1',
+      },
+      mutate: reopenCrmTaskCore,
+      name: 'reopen',
+      sourceTask: task({
+        completedAt: '2026-05-21T09:30:00.000Z',
+        completionReasonCode: 'resolved',
+        lifecycleVersion: 9,
+        status: 'completed',
+        updatedAt: '2026-05-21T09:59:00.000Z',
+      }),
+    },
+  ] as const)('persists expected lifecycle version and transition for $name', async scenario => {
+    const repo = repository({
+      findTaskById: vi.fn().mockResolvedValue(scenario.sourceTask),
+    });
+    const d = deps(repo);
+
+    const mutate = scenario.mutate as (params: {
+      readonly deps: typeof d;
+      readonly input: typeof scenario.input;
+      readonly session: ReturnType<typeof session>;
+    }) => ReturnType<typeof updateCrmTaskDueAtCore>;
+    const result = await mutate({
+      deps: d,
+      input: scenario.input,
+      session: session(),
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'success',
+      transition: scenario.expectedTransition,
+    });
+    expect(repo.saveTask).toHaveBeenCalledWith({
+      actor: expect.objectContaining({ actorId: 'agent-1', tenantId: 'tenant-1' }),
+      expectedLifecycleVersion: scenario.input.expectedLifecycleVersion,
+      task: expect.objectContaining(scenario.expectedTask),
+    });
+    expect(d.audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: `crm.task.${scenario.expectedTransition.event}`,
+        metadata: expect.objectContaining({
+          event: scenario.expectedTransition.event,
+          fromStatus: scenario.expectedTransition.fromStatus,
+          operation: scenario.expectedTransition.event,
+          reasonCode: scenario.expectedTransition.reasonCode,
+          replay: false,
+          toStatus: scenario.expectedTransition.toStatus,
+        }),
+      })
+    );
+  });
+
+  it.each([
+    {
+      existingTask: task({
+        dueAt: '2026-05-22T10:00:00.000Z',
+        updatedAt: '2026-05-21T09:59:00.000Z',
+      }),
+      expectedEvent: 'due_updated',
+      expectedFromStatus: null,
+      input: {
+        dueAt: '2026-05-22T10:00:00.000Z',
+        expectedLifecycleVersion: 1,
+        reasonCode: 'due_date_changed',
+        taskId: 'task-1',
+      },
+      mutate: updateCrmTaskDueAtCore,
+      name: 'due date updates',
+    },
+    {
+      existingTask: task({
+        completedAt: TEST_NOW,
+        completionReasonCode: 'resolved',
+        status: 'completed',
+        updatedAt: '2026-05-21T09:59:00.000Z',
+      }),
+      expectedEvent: 'completed',
+      expectedFromStatus: null,
+      input: {
+        expectedLifecycleVersion: 1,
+        reasonCode: 'resolved',
+        taskId: 'task-1',
+      },
+      mutate: completeCrmTaskCore,
+      name: 'completion',
+    },
+    {
+      existingTask: task({
+        cancellationReasonCode: 'created_in_error',
+        cancelledAt: TEST_NOW,
+        status: 'cancelled',
+        updatedAt: '2026-05-21T09:59:00.000Z',
+      }),
+      expectedEvent: 'cancelled',
+      expectedFromStatus: null,
+      input: {
+        expectedLifecycleVersion: 1,
+        reasonCode: 'created_in_error',
+        taskId: 'task-1',
+      },
+      mutate: cancelCrmTaskCore,
+      name: 'cancellation',
+    },
+  ] as const)('audits $name idempotent replays with fallback events', async scenario => {
+    const repo = repository({
+      findTaskById: vi.fn().mockResolvedValue(scenario.existingTask),
+    });
+    const d = deps(repo);
+
+    const mutate = scenario.mutate as (params: {
+      readonly deps: typeof d;
+      readonly input: typeof scenario.input;
+      readonly session: ReturnType<typeof session>;
+    }) => ReturnType<typeof updateCrmTaskDueAtCore>;
+    const result = await mutate({
+      deps: d,
+      input: scenario.input,
+      session: session(),
+    });
+
+    expect(result).toEqual({
+      outcome: 'idempotent_replay',
+      reason: 'idempotent_replay',
+      task: scenario.existingTask,
+    });
+    expect(repo.saveTask).not.toHaveBeenCalled();
+    expect(d.audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: `crm.task.${scenario.expectedEvent}`,
+        metadata: expect.objectContaining({
+          event: scenario.expectedEvent,
+          fromStatus: scenario.expectedFromStatus,
+          operation: scenario.expectedEvent,
+          reasonCode: null,
+          replay: true,
+          toStatus: scenario.existingTask.status,
+        }),
+      })
+    );
+  });
+});

--- a/apps/web/src/actions/crm-tasks.core.ts
+++ b/apps/web/src/actions/crm-tasks.core.ts
@@ -1,0 +1,571 @@
+import { ensureTenantId, type SessionWithTenant } from '@interdomestik/shared-auth';
+import {
+  CRM_ACTOR_ROLES,
+  type CrmActorContext,
+  type CrmActorRole,
+} from '@interdomestik/domain-crm/context';
+import {
+  CrmTaskRepositoryFailure,
+  assignCrmTask,
+  cancelCrmTask,
+  completeCrmTask,
+  createCrmTask,
+  reopenCrmTask,
+  startCrmTask,
+  updateCrmTaskDueAt,
+  type CrmTask,
+  type CrmTaskAssignmentReasonCode,
+  type CrmTaskAssignmentTarget,
+  type CrmTaskCancellationReasonCode,
+  type CrmTaskCompletionReasonCode,
+  type CrmTaskCreateReasonCode,
+  type CrmTaskDueReasonCode,
+  type CrmTaskMutationDenialReason,
+  type CrmTaskMutationResult,
+  type CrmTaskPriority,
+  type CrmTaskReopenReasonCode,
+  type CrmTaskRepository,
+  type CrmTaskStartReasonCode,
+  type CrmTaskSubjectReference,
+  type CrmTaskTransition,
+} from '@interdomestik/domain-crm/tasks';
+import { nanoid } from 'nanoid';
+import { revalidatePath } from 'next/cache';
+
+import { crmTaskRepository } from '@/adapters/crm/task-repository';
+import { LOCALES } from '@/i18n/locales';
+import { logAuditEvent, type AuditEvent } from '@/lib/audit';
+import { enforceRateLimitForAction } from '@/lib/rate-limit';
+import type { RateLimitResult } from '@/lib/rate-limit.core';
+
+export type CrmTaskBoundaryOutcome =
+  | 'success'
+  | 'idempotent_replay'
+  | 'not_found'
+  | 'forbidden'
+  | 'conflict'
+  | 'invalid_input'
+  | 'rate_limited'
+  | 'unauthorized'
+  | 'repository_failure';
+
+export type CrmTaskBoundaryResult =
+  | {
+      readonly outcome: 'success';
+      readonly task: CrmTask;
+      readonly transition?: CrmTaskTransition | null;
+    }
+  | {
+      readonly outcome: 'idempotent_replay';
+      readonly reason: 'idempotent_replay';
+      readonly task: CrmTask;
+    }
+  | {
+      readonly outcome: Exclude<
+        CrmTaskBoundaryOutcome,
+        'success' | 'idempotent_replay' | 'rate_limited'
+      >;
+      readonly reason: string;
+    }
+  | {
+      readonly outcome: 'rate_limited';
+      readonly reason: 'rate_limited';
+      readonly retryAfter?: number;
+    };
+
+export type CreateCrmTaskCoreInput = {
+  readonly assignedTo: CrmTaskAssignmentTarget;
+  readonly createReasonCode?: CrmTaskCreateReasonCode;
+  readonly dueAt?: string | null;
+  readonly idempotencyKey: string;
+  readonly priority: CrmTaskPriority;
+  readonly subjectReference: CrmTaskSubjectReference;
+  readonly taskId?: string | null;
+};
+
+export type AssignCrmTaskCoreInput = {
+  readonly assignedTo: CrmTaskAssignmentTarget;
+  readonly expectedLifecycleVersion: number;
+  readonly reasonCode: CrmTaskAssignmentReasonCode;
+  readonly taskId: string;
+};
+
+export type UpdateCrmTaskDueAtCoreInput = {
+  readonly dueAt: string | null;
+  readonly expectedLifecycleVersion: number;
+  readonly reasonCode: CrmTaskDueReasonCode;
+  readonly taskId: string;
+};
+
+export type StartCrmTaskCoreInput = {
+  readonly expectedLifecycleVersion: number;
+  readonly reasonCode?: CrmTaskStartReasonCode;
+  readonly taskId: string;
+};
+
+export type CompleteCrmTaskCoreInput = {
+  readonly expectedLifecycleVersion: number;
+  readonly reasonCode: CrmTaskCompletionReasonCode;
+  readonly taskId: string;
+};
+
+export type CancelCrmTaskCoreInput = {
+  readonly expectedLifecycleVersion: number;
+  readonly reasonCode: CrmTaskCancellationReasonCode;
+  readonly taskId: string;
+};
+
+export type ReopenCrmTaskCoreInput = {
+  readonly expectedLifecycleVersion: number;
+  readonly reasonCode: CrmTaskReopenReasonCode;
+  readonly taskId: string;
+};
+
+type CrmTaskCoreDeps = {
+  readonly audit?: (event: AuditEvent) => Promise<void>;
+  readonly now?: () => string;
+  readonly rateLimit?: typeof enforceRateLimitForAction;
+  readonly repository?: CrmTaskRepository;
+  readonly revalidate?: typeof revalidatePath;
+  readonly taskId?: () => string;
+};
+
+type CoreParams = {
+  readonly deps?: CrmTaskCoreDeps;
+  readonly requestHeaders?: Headers;
+  readonly session: SessionWithTenant;
+};
+
+type MutationContext =
+  | {
+      readonly actor: CrmActorContext;
+      readonly deps: Required<CrmTaskCoreDeps>;
+      readonly requestHeaders: Headers;
+    }
+  | CrmTaskBoundaryResult;
+
+const MUTATION_LIMIT = 30;
+const MUTATION_WINDOW_SECONDS = 60;
+const CRM_TASK_REVALIDATION_PATHS = ['/agent/crm', '/staff/crm', '/admin/crm'] as const;
+
+const defaultDeps: Required<CrmTaskCoreDeps> = {
+  audit: logAuditEvent,
+  now: () => new Date().toISOString(),
+  rateLimit: enforceRateLimitForAction,
+  repository: crmTaskRepository,
+  revalidate: revalidatePath,
+  taskId: nanoid,
+};
+
+function mergeDeps(deps?: CrmTaskCoreDeps): Required<CrmTaskCoreDeps> {
+  return { ...defaultDeps, ...deps };
+}
+
+function failure(
+  outcome: Exclude<CrmTaskBoundaryOutcome, 'success' | 'idempotent_replay' | 'rate_limited'>,
+  reason: string
+): CrmTaskBoundaryResult {
+  return { outcome, reason };
+}
+
+function isCrmActorRole(role: unknown): role is CrmActorRole {
+  return typeof role === 'string' && (CRM_ACTOR_ROLES as readonly string[]).includes(role);
+}
+
+function normalizeCrmActorRole(role: unknown): CrmActorRole | null {
+  if (role === 'tenant_admin' || role === 'super_admin') return 'admin';
+  return isCrmActorRole(role) ? role : null;
+}
+
+function createActorContext(session: SessionWithTenant): CrmActorContext | CrmTaskBoundaryResult {
+  if (!session?.user?.id) return failure('unauthorized', 'missing_session');
+
+  let tenantId: string;
+  try {
+    tenantId = ensureTenantId(session);
+  } catch {
+    return failure('unauthorized', 'missing_session');
+  }
+
+  const role = normalizeCrmActorRole(session.user.role);
+  if (!role) return failure('forbidden', 'role_scope');
+  if (role === 'member') return failure('forbidden', 'role_scope');
+
+  return {
+    actorId: session.user.id,
+    role,
+    scope: {
+      agentId: session.user.agentId ?? (role === 'agent' ? session.user.id : null),
+      branchId: session.user.branchId ?? null,
+      memberId: null,
+      staffId:
+        role === 'staff' || role === 'branch_manager' || role === 'admin' ? session.user.id : null,
+    },
+    tenantId,
+  };
+}
+
+function isBoundaryResult(value: MutationContext): value is CrmTaskBoundaryResult {
+  return 'outcome' in value;
+}
+
+function mapDomainDenial(reason: CrmTaskMutationDenialReason): CrmTaskBoundaryResult {
+  if (reason === 'subject_not_found') return failure('not_found', reason);
+  if (
+    reason === 'terminal_state' ||
+    reason === 'unsupported_transition' ||
+    reason === 'duplicate_idempotency_conflict'
+  ) {
+    return failure('conflict', reason);
+  }
+  if (reason === 'non_monotonic_timestamp' || reason.startsWith('invalid_')) {
+    return failure('invalid_input', reason);
+  }
+  return failure('forbidden', reason);
+}
+
+function mapRepositoryFailure(error: unknown): CrmTaskBoundaryResult {
+  if (!(error instanceof CrmTaskRepositoryFailure)) {
+    return failure('repository_failure', 'repository_failure');
+  }
+  if (error.reason === 'idempotency_conflict' || error.reason === 'lifecycle_conflict') {
+    return failure('conflict', error.reason);
+  }
+  if (error.reason === 'subject_not_found') return failure('not_found', error.reason);
+  return failure('forbidden', error.reason);
+}
+
+function mapRateLimit(limit: RateLimitResult): CrmTaskBoundaryResult | null {
+  if (!limit.limited) return null;
+  return {
+    outcome: 'rate_limited',
+    reason: 'rate_limited',
+    retryAfter: limit.retryAfter,
+  };
+}
+
+async function createMutationContext(params: CoreParams): Promise<MutationContext> {
+  const actor = createActorContext(params.session);
+  if ('outcome' in actor) return actor;
+
+  const deps = mergeDeps(params.deps);
+  const requestHeaders = params.requestHeaders ?? new Headers();
+  const limit = await deps.rateLimit({
+    headers: requestHeaders,
+    keySuffix: actor.actorId,
+    limit: MUTATION_LIMIT,
+    name: 'action:crm-tasks',
+    productionSensitive: true,
+    windowSeconds: MUTATION_WINDOW_SECONDS,
+  });
+  const rateLimited = mapRateLimit(limit);
+  if (rateLimited) return rateLimited;
+
+  return { actor, deps, requestHeaders };
+}
+
+function revalidateCrmTaskPaths(deps: Required<CrmTaskCoreDeps>): void {
+  for (const locale of LOCALES) {
+    for (const path of CRM_TASK_REVALIDATION_PATHS) {
+      deps.revalidate(`/${locale}${path}`);
+    }
+  }
+}
+
+function findTaskHistoryTransition(
+  task: CrmTask,
+  event: CrmTaskTransition['event']
+): CrmTaskTransition | null {
+  for (const entry of [...task.history].reverse()) {
+    if (entry.event !== event) continue;
+    return {
+      event: entry.event,
+      fromStatus: entry.fromStatus,
+      reasonCode: entry.reasonCode,
+      timestamp: entry.timestamp,
+      toStatus: entry.toStatus,
+    };
+  }
+  return null;
+}
+
+async function auditTaskMutation(params: {
+  actor: CrmActorContext;
+  deps: Required<CrmTaskCoreDeps>;
+  replay: boolean;
+  requestHeaders: Headers;
+  task: CrmTask;
+  transition: CrmTaskTransition | null;
+  fallbackEvent: CrmTaskTransition['event'];
+}): Promise<void> {
+  const event = params.transition?.event ?? params.fallbackEvent;
+  const transition = params.transition ?? findTaskHistoryTransition(params.task, event);
+  await params.deps.audit({
+    action: `crm.task.${event}`,
+    actorId: params.actor.actorId,
+    actorRole: params.actor.role,
+    entityId: params.task.taskId,
+    entityType: 'crm_task',
+    headers: params.requestHeaders,
+    metadata: {
+      event,
+      fromStatus: transition?.fromStatus ?? null,
+      operation: event,
+      reasonCode: transition?.reasonCode ?? null,
+      replay: params.replay,
+      subjectKind: params.task.subjectReference.kind,
+      toStatus: transition?.toStatus ?? params.task.status,
+    },
+    tenantId: params.actor.tenantId,
+  });
+}
+
+async function persistMutation(params: {
+  actor: CrmActorContext;
+  deps: Required<CrmTaskCoreDeps>;
+  expectedLifecycleVersion: number;
+  fallbackEvent: CrmTaskTransition['event'];
+  requestHeaders: Headers;
+  result: CrmTaskMutationResult;
+}): Promise<CrmTaskBoundaryResult> {
+  if (!params.result.success) return mapDomainDenial(params.result.reason);
+
+  if (params.result.idempotent) {
+    await auditTaskMutation({
+      actor: params.actor,
+      deps: params.deps,
+      fallbackEvent: params.fallbackEvent,
+      replay: true,
+      requestHeaders: params.requestHeaders,
+      task: params.result.task,
+      transition: null,
+    });
+    return { outcome: 'idempotent_replay', reason: 'idempotent_replay', task: params.result.task };
+  }
+
+  try {
+    const task = await params.deps.repository.saveTask({
+      actor: params.actor,
+      expectedLifecycleVersion: params.expectedLifecycleVersion,
+      task: params.result.task,
+    });
+    await auditTaskMutation({
+      actor: params.actor,
+      deps: params.deps,
+      fallbackEvent: params.fallbackEvent,
+      replay: false,
+      requestHeaders: params.requestHeaders,
+      task,
+      transition: params.result.transition,
+    });
+    revalidateCrmTaskPaths(params.deps);
+    return { outcome: 'success', task, transition: params.result.transition };
+  } catch (error) {
+    return mapRepositoryFailure(error);
+  }
+}
+
+async function runExistingTaskMutation(
+  params: CoreParams & {
+    readonly fallbackEvent: CrmTaskTransition['event'];
+    readonly input: { readonly expectedLifecycleVersion: number; readonly taskId: string };
+    readonly mutate: (
+      task: CrmTask,
+      actor: CrmActorContext,
+      deps: Required<CrmTaskCoreDeps>
+    ) => CrmTaskMutationResult;
+  }
+): Promise<CrmTaskBoundaryResult> {
+  const context = await createMutationContext(params);
+  if (isBoundaryResult(context)) return context;
+
+  try {
+    const task = await context.deps.repository.findTaskById({
+      actor: context.actor,
+      taskId: params.input.taskId,
+    });
+    if (!task) return failure('not_found', 'task_not_found');
+
+    const result = params.mutate(task, context.actor, context.deps);
+    return persistMutation({
+      actor: context.actor,
+      deps: context.deps,
+      expectedLifecycleVersion: params.input.expectedLifecycleVersion,
+      fallbackEvent: params.fallbackEvent,
+      requestHeaders: context.requestHeaders,
+      result,
+    });
+  } catch (error) {
+    return mapRepositoryFailure(error);
+  }
+}
+
+export async function readCrmTaskCore(
+  params: CoreParams & { readonly taskId: string }
+): Promise<CrmTaskBoundaryResult> {
+  const actor = createActorContext(params.session);
+  if ('outcome' in actor) return actor;
+
+  const deps = mergeDeps(params.deps);
+  try {
+    const task = await deps.repository.findTaskById({ actor, taskId: params.taskId });
+    if (!task) return failure('not_found', 'task_not_found');
+    return { outcome: 'success', task };
+  } catch (error) {
+    return mapRepositoryFailure(error);
+  }
+}
+
+export async function createCrmTaskCore(
+  params: CoreParams & { readonly input: CreateCrmTaskCoreInput }
+): Promise<CrmTaskBoundaryResult> {
+  const context = await createMutationContext(params);
+  if (isBoundaryResult(context)) return context;
+
+  const { actor, deps, requestHeaders } = context;
+  const { input } = params;
+
+  if (!deps.repository.validateSubjectReference) {
+    return failure('forbidden', 'subject_proof_missing');
+  }
+
+  try {
+    const subjectProof = await deps.repository.validateSubjectReference({
+      actor,
+      subjectReference: input.subjectReference,
+    });
+    if (!subjectProof.visible) return mapDomainDenial(subjectProof.reason);
+
+    const existingTask = await deps.repository.findTaskByIdempotencyKey({
+      actor,
+      idempotencyKey: input.idempotencyKey,
+    });
+    const result = createCrmTask(
+      {
+        actor,
+        assignedTo: input.assignedTo,
+        createReasonCode: input.createReasonCode,
+        dueAt: input.dueAt,
+        existingTask,
+        idempotencyKey: input.idempotencyKey,
+        priority: input.priority,
+        subjectProof: {
+          branchId: subjectProof.branchId ?? null,
+          subjectReference: input.subjectReference,
+          tenantId: subjectProof.tenantId,
+        },
+        subjectReference: input.subjectReference,
+        taskId: input.taskId,
+        tenantId: actor.tenantId,
+      },
+      { now: deps.now, taskId: deps.taskId }
+    );
+
+    if (!result.success) return mapDomainDenial(result.reason);
+
+    if (result.idempotent) {
+      await auditTaskMutation({
+        actor,
+        deps,
+        fallbackEvent: 'created',
+        replay: true,
+        requestHeaders,
+        task: result.task,
+        transition: null,
+      });
+      return { outcome: 'idempotent_replay', reason: 'idempotent_replay', task: result.task };
+    }
+
+    const task = await deps.repository.saveTask({ actor, task: result.task });
+    const replay = task.taskId !== result.task.taskId;
+    await auditTaskMutation({
+      actor,
+      deps,
+      fallbackEvent: 'created',
+      replay,
+      requestHeaders,
+      task,
+      transition: replay ? null : result.transition,
+    });
+    if (replay) return { outcome: 'idempotent_replay', reason: 'idempotent_replay', task };
+
+    revalidateCrmTaskPaths(deps);
+    return { outcome: 'success', task, transition: result.transition };
+  } catch (error) {
+    return mapRepositoryFailure(error);
+  }
+}
+
+export async function assignCrmTaskCore(
+  params: CoreParams & { readonly input: AssignCrmTaskCoreInput }
+): Promise<CrmTaskBoundaryResult> {
+  return runExistingTaskMutation({
+    ...params,
+    fallbackEvent: 'assigned',
+    mutate: (task, actor, deps) =>
+      assignCrmTask(
+        task,
+        { actor, assignedTo: params.input.assignedTo, reasonCode: params.input.reasonCode },
+        { now: deps.now }
+      ),
+  });
+}
+
+export async function updateCrmTaskDueAtCore(
+  params: CoreParams & { readonly input: UpdateCrmTaskDueAtCoreInput }
+): Promise<CrmTaskBoundaryResult> {
+  return runExistingTaskMutation({
+    ...params,
+    fallbackEvent: 'due_updated',
+    mutate: (task, actor, deps) =>
+      updateCrmTaskDueAt(
+        task,
+        { actor, dueAt: params.input.dueAt, reasonCode: params.input.reasonCode },
+        { now: deps.now }
+      ),
+  });
+}
+
+export async function startCrmTaskCore(
+  params: CoreParams & { readonly input: StartCrmTaskCoreInput }
+): Promise<CrmTaskBoundaryResult> {
+  return runExistingTaskMutation({
+    ...params,
+    fallbackEvent: 'started',
+    mutate: (task, actor, deps) =>
+      startCrmTask(task, { actor, reasonCode: params.input.reasonCode }, { now: deps.now }),
+  });
+}
+
+export async function completeCrmTaskCore(
+  params: CoreParams & { readonly input: CompleteCrmTaskCoreInput }
+): Promise<CrmTaskBoundaryResult> {
+  return runExistingTaskMutation({
+    ...params,
+    fallbackEvent: 'completed',
+    mutate: (task, actor, deps) =>
+      completeCrmTask(task, { actor, reasonCode: params.input.reasonCode }, { now: deps.now }),
+  });
+}
+
+export async function cancelCrmTaskCore(
+  params: CoreParams & { readonly input: CancelCrmTaskCoreInput }
+): Promise<CrmTaskBoundaryResult> {
+  return runExistingTaskMutation({
+    ...params,
+    fallbackEvent: 'cancelled',
+    mutate: (task, actor, deps) =>
+      cancelCrmTask(task, { actor, reasonCode: params.input.reasonCode }, { now: deps.now }),
+  });
+}
+
+export async function reopenCrmTaskCore(
+  params: CoreParams & { readonly input: ReopenCrmTaskCoreInput }
+): Promise<CrmTaskBoundaryResult> {
+  return runExistingTaskMutation({
+    ...params,
+    fallbackEvent: 'reopened',
+    mutate: (task, actor, deps) =>
+      reopenCrmTask(task, { actor, reasonCode: params.input.reasonCode }, { now: deps.now }),
+  });
+}

--- a/apps/web/src/actions/crm-tasks.ts
+++ b/apps/web/src/actions/crm-tasks.ts
@@ -1,0 +1,69 @@
+'use server';
+
+import { headers } from 'next/headers';
+
+import { auth } from '@/lib/auth';
+
+import {
+  assignCrmTaskCore,
+  cancelCrmTaskCore,
+  completeCrmTaskCore,
+  createCrmTaskCore,
+  readCrmTaskCore,
+  reopenCrmTaskCore,
+  startCrmTaskCore,
+  updateCrmTaskDueAtCore,
+  type AssignCrmTaskCoreInput,
+  type CancelCrmTaskCoreInput,
+  type CompleteCrmTaskCoreInput,
+  type CreateCrmTaskCoreInput,
+  type ReopenCrmTaskCoreInput,
+  type StartCrmTaskCoreInput,
+  type UpdateCrmTaskDueAtCoreInput,
+} from './crm-tasks.core';
+
+async function getActionSession() {
+  const requestHeaders = await headers();
+  const session = await auth.api.getSession({ headers: requestHeaders });
+  return { requestHeaders, session };
+}
+
+export async function readCrmTaskAction(taskId: string) {
+  const { requestHeaders, session } = await getActionSession();
+  return readCrmTaskCore({ requestHeaders, session, taskId });
+}
+
+export async function createCrmTaskAction(input: CreateCrmTaskCoreInput) {
+  const { requestHeaders, session } = await getActionSession();
+  return createCrmTaskCore({ input, requestHeaders, session });
+}
+
+export async function assignCrmTaskAction(input: AssignCrmTaskCoreInput) {
+  const { requestHeaders, session } = await getActionSession();
+  return assignCrmTaskCore({ input, requestHeaders, session });
+}
+
+export async function updateCrmTaskDueAtAction(input: UpdateCrmTaskDueAtCoreInput) {
+  const { requestHeaders, session } = await getActionSession();
+  return updateCrmTaskDueAtCore({ input, requestHeaders, session });
+}
+
+export async function startCrmTaskAction(input: StartCrmTaskCoreInput) {
+  const { requestHeaders, session } = await getActionSession();
+  return startCrmTaskCore({ input, requestHeaders, session });
+}
+
+export async function completeCrmTaskAction(input: CompleteCrmTaskCoreInput) {
+  const { requestHeaders, session } = await getActionSession();
+  return completeCrmTaskCore({ input, requestHeaders, session });
+}
+
+export async function cancelCrmTaskAction(input: CancelCrmTaskCoreInput) {
+  const { requestHeaders, session } = await getActionSession();
+  return cancelCrmTaskCore({ input, requestHeaders, session });
+}
+
+export async function reopenCrmTaskAction(input: ReopenCrmTaskCoreInput) {
+  const { requestHeaders, session } = await getActionSession();
+  return reopenCrmTaskCore({ input, requestHeaders, session });
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "maxTrackedBytes": 29500000,
-  "maxTrackedFiles": 3785,
+  "maxTrackedFiles": 3790,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 13865000,
-    "source/scripts": 6230000,
+    "source/scripts": 6265000,
     "tests/e2e": 4194304,
     "docs/text": 3770000,
     "config/data/messages": 1572864,


### PR DESCRIPTION
## Summary
- Adds the CRM task runtime boundary server-action/core pair for read, create, assign, due-date, start, complete, cancel, and reopen operations.
- Maps repository and domain mutation denials to stable typed outcomes, with authenticated actor context, mutation rate limiting, structural audit events, and locale-aware CRM revalidation.
- Adds focused core tests and a narrow repo-size budget bump.

## Verification
- pnpm --filter @interdomestik/web type-check
- pnpm --filter @interdomestik/web test:unit --run src/actions/crm-tasks.core.test.ts
- git diff --check
- pnpm security:guard
- pnpm ci:local:quick
- pnpm e2e:gate
- pnpm pr:verify

## Notes
- No proxy, route, cron, UI, schema, migration, or canonical-route changes.
- Subagent review found the member-role boundary should fail before rate-limit/repository access; fixed and covered by test.
- First pr:verify attempt hit the expected Next build lock because it was accidentally run concurrently with e2e:gate; the sequential rerun passed.