### PR TITLE
P41-UX03 Admin/Ops Filter Wrapping Hardening

### DIFF
--- a/apps/web/src/components/admin/claims/claims-filters.test.tsx
+++ b/apps/web/src/components/admin/claims/claims-filters.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { ComponentProps, PropsWithChildren } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OPS_TEST_IDS } from '@/components/ops/testids';
 import { AdminClaimsFilters } from './claims-filters';
 
 // Mock next/navigation - the component imports useRouter, usePathname, useSearchParams from here
@@ -23,6 +24,7 @@ vi.mock('next-intl', () => ({
       'sections.resolved': 'Closed',
       'filters.unassigned_only': 'Unassigned',
       'filters.assigned_to_me': 'Assigned to me',
+      'filters.assignment_label': 'Assignment',
       'filters.origin_label': 'Origin',
       'filters.origin_all': 'All origins',
       'filters.origin_diaspora': 'Diaspora / Green Card',
@@ -38,6 +40,7 @@ vi.mock('next-intl', () => ({
 vi.mock('@interdomestik/ui', () => ({
   Button: ({
     children,
+    asChild: _asChild,
     ...props
   }: PropsWithChildren<ComponentProps<'button'> & { asChild?: boolean }>) => (
     <button {...props}>{children}</button>
@@ -181,5 +184,13 @@ describe('AdminClaimsFilters', () => {
     fireEvent.click(screen.getByTestId('assigned-filter-unassigned'));
 
     expect(screen.getByPlaceholderText('Search...')).toBeDisabled();
+  });
+
+  it('labels assignment controls and preserves wrapping classes for filter groups', () => {
+    render(<AdminClaimsFilters />);
+
+    expect(screen.getByTestId(OPS_TEST_IDS.FILTERS.ACTIONS)).toHaveClass('flex-wrap');
+    expect(screen.getByRole('group', { name: 'Assignment' })).toHaveClass('flex-wrap');
+    expect(screen.getByRole('group', { name: 'Origin' })).toHaveClass('flex-wrap');
   });
 });

--- a/apps/web/src/components/admin/claims/claims-filters.tsx
+++ b/apps/web/src/components/admin/claims/claims-filters.tsx
@@ -182,8 +182,12 @@ export function AdminClaimsFilters() {
         isPending={isNavigationPending}
         searchDisabled={pendingKind === 'filter'}
         rightActions={
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="flex bg-black/20 p-1 rounded-lg border border-white/5">
+          <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto">
+            <div
+              className="flex max-w-full flex-wrap bg-black/20 p-1 rounded-lg border border-white/5"
+              role="group"
+              aria-label={tAdmin('filters.assignment_label')}
+            >
               {assignmentOptions.map(option => {
                 const isActive = currentAssignment === option.value;
                 const isInert = isNavigationPending || isActive;
@@ -210,7 +214,8 @@ export function AdminClaimsFilters() {
               })}
             </div>
             <div
-              className="flex bg-black/20 p-1 rounded-lg border border-white/5"
+              className="flex max-w-full flex-wrap bg-black/20 p-1 rounded-lg border border-white/5"
+              role="group"
               aria-label={tAdmin('filters.origin_label')}
             >
               {diasporaOptions.map(option => {

--- a/apps/web/src/components/ops/OpsFiltersBar.test.tsx
+++ b/apps/web/src/components/ops/OpsFiltersBar.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { ComponentProps, PropsWithChildren } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { OpsFiltersBar } from './OpsFiltersBar';
+import { OPS_TEST_IDS } from './testids';
 
 vi.mock('@interdomestik/ui', () => ({
   Button: ({
@@ -57,5 +58,78 @@ describe('OpsFiltersBar', () => {
 
     fireEvent.click(screen.getByTestId('ops-tab-active'));
     expect(onTabChange).toHaveBeenCalledWith('active');
+  });
+
+  it('renders the structural wrapping contract for tabs, search, and actions', () => {
+    render(
+      <OpsFiltersBar
+        tabs={tabs}
+        activeTab="all"
+        onTabChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Search..."
+        rightActions={<div data-testid="right-actions">Actions</div>}
+      />
+    );
+
+    expect(screen.getByTestId(OPS_TEST_IDS.FILTERS.TABS)).toHaveClass('flex-wrap');
+    expect(screen.getByTestId(OPS_TEST_IDS.FILTERS.TABS)).toHaveClass('w-full');
+    expect(screen.getByTestId(OPS_TEST_IDS.FILTERS.ACTIONS)).toHaveClass('flex-wrap');
+    expect(screen.getByTestId(OPS_TEST_IDS.FILTERS.ACTIONS)).toHaveClass('w-full');
+    expect(screen.getByTestId(OPS_TEST_IDS.FILTERS.SEARCH_GROUP)).toHaveClass('min-w-0');
+  });
+
+  it('keeps active link tabs inert without removing their href', () => {
+    const onTabChange = vi.fn();
+
+    render(
+      <OpsFiltersBar
+        tabs={[
+          { id: 'all', label: 'All', href: '/ops?tab=all' },
+          { id: 'active', label: 'Active', href: '/ops?tab=active' },
+        ]}
+        activeTab="all"
+        onTabChange={onTabChange}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Search..."
+      />
+    );
+
+    const activeTab = screen.getByTestId('ops-tab-all');
+    expect(activeTab).toHaveAttribute('href', '/ops?tab=all');
+    expect(activeTab).toHaveAttribute('aria-disabled', 'true');
+    expect(activeTab).toHaveAttribute('tabindex', '-1');
+
+    fireEvent.click(activeTab);
+    expect(onTabChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps pending link tabs inert without removing their href', () => {
+    const onTabChange = vi.fn();
+
+    render(
+      <OpsFiltersBar
+        tabs={[
+          { id: 'all', label: 'All', href: '/ops?tab=all' },
+          { id: 'active', label: 'Active', href: '/ops?tab=active' },
+        ]}
+        activeTab="all"
+        onTabChange={onTabChange}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Search..."
+        isPending
+      />
+    );
+
+    const inactivePendingTab = screen.getByTestId('ops-tab-active');
+    expect(inactivePendingTab).toHaveAttribute('href', '/ops?tab=active');
+    expect(inactivePendingTab).toHaveAttribute('aria-disabled', 'true');
+    expect(inactivePendingTab).toHaveAttribute('tabindex', '-1');
+
+    fireEvent.click(inactivePendingTab);
+    expect(onTabChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/ops/OpsFiltersBar.tsx
+++ b/apps/web/src/components/ops/OpsFiltersBar.tsx
@@ -54,7 +54,10 @@ export function OpsFiltersBar({
 
   return (
     <div className={containerClasses} data-testid={OPS_TEST_IDS.FILTERS.BAR}>
-      <div className="flex gap-2">
+      <div
+        className="flex w-full flex-wrap gap-2 sm:w-auto"
+        data-testid={OPS_TEST_IDS.FILTERS.TABS}
+      >
         {tabs.map(tab => {
           const isActive = tab.id === activeTab;
 
@@ -116,8 +119,14 @@ export function OpsFiltersBar({
           );
         })}
       </div>
-      <div className="flex w-full sm:w-auto items-center gap-3">
-        <div className="relative w-full sm:w-auto sm:min-w-[280px]">
+      <div
+        className="flex w-full flex-wrap items-center gap-3 sm:w-auto"
+        data-testid={OPS_TEST_IDS.FILTERS.ACTIONS}
+      >
+        <div
+          className="relative w-full min-w-0 sm:w-auto sm:min-w-[280px]"
+          data-testid={OPS_TEST_IDS.FILTERS.SEARCH_GROUP}
+        >
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
             type="search"

--- a/apps/web/src/components/ops/testids.ts
+++ b/apps/web/src/components/ops/testids.ts
@@ -20,6 +20,9 @@ export const OPS_TEST_IDS = {
   },
   FILTERS: {
     BAR: 'ops-filters-bar',
+    TABS: 'ops-filters-tabs',
+    ACTIONS: 'ops-filters-actions',
+    SEARCH_GROUP: 'ops-filters-search-group',
     TAB: (id: string) => `ops-tab-${id}`,
     SEARCH: 'ops-search-input',
   },

--- a/apps/web/src/messages/en/admin-claims.json
+++ b/apps/web/src/messages/en/admin-claims.json
@@ -88,6 +88,7 @@
         "assigned_only": "Assigned",
         "unassigned_only": "Unassigned",
         "assigned_to_me": "Assigned to me",
+        "assignment_label": "Assignment",
         "origin_label": "Origin",
         "origin_all": "All origins",
         "origin_diaspora": "Diaspora / Green Card",

--- a/apps/web/src/messages/mk/admin-claims.json
+++ b/apps/web/src/messages/mk/admin-claims.json
@@ -89,6 +89,7 @@
         "assigned_only": "Назначени",
         "unassigned_only": "Неназначени",
         "assigned_to_me": "Назначени на мене",
+        "assignment_label": "Назначување",
         "origin_label": "Потекло",
         "origin_all": "Сите потекла",
         "origin_diaspora": "Дијаспора / Зелен картон",

--- a/apps/web/src/messages/sq/admin-claims.json
+++ b/apps/web/src/messages/sq/admin-claims.json
@@ -91,6 +91,7 @@
         "assigned_only": "Të caktuara",
         "unassigned_only": "Të pacaktuara",
         "assigned_to_me": "Të caktuara për mua",
+        "assignment_label": "Shpërndarja",
         "handler_label": "Përpunon",
         "origin_label": "Origjina",
         "origin_all": "Të gjitha origjinat",

--- a/apps/web/src/messages/sr/admin-claims.json
+++ b/apps/web/src/messages/sr/admin-claims.json
@@ -89,6 +89,7 @@
         "assigned_only": "Dodeljeno",
         "unassigned_only": "Nedodeljeno",
         "assigned_to_me": "Dodeljeno meni",
+        "assignment_label": "Dodela",
         "origin_label": "Poreklo",
         "origin_all": "Sva porekla",
         "origin_diaspora": "Dijaspora / Zeleni karton",


### PR DESCRIPTION
## Summary
- Hardened shared ops/admin filter bars so tabs, search, and action groups wrap predictably on narrow widths.
- Added stable filter wrapper test ids and accessible grouped labels for admin claim assignment/origin segmented controls.
- Added active-locale copy for the new assignment group label across en/sq/sr/mk.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/components/ops/OpsFiltersBar.test.tsx src/components/admin/claims/claims-filters.test.tsx` (17 tests)
- `pnpm --filter @interdomestik/web test:unit --run src/features/agent/leads/components/AgentLeadsProPage.test.tsx`
- `pnpm i18n:check && pnpm i18n:purity:check`
- targeted Playwright admin claims filters proof (4 tests)
- Playwright MCP browser proof at 390/1024/1440 viewports
- `git diff --check`
- Interdomestik scope audit and `security:guard`
- `pnpm ci:local:quick`
- `pnpm e2e:gate` (128 passed, 4 skipped)
- `pnpm pr:verify` (passed, including gate and smoke)

## Review Notes
- Subagent spawn was blocked by runtime thread limit: `collab spawn failed: agent thread limit reached`.
- Sonnet via Copilot review found no blockers; one hardening note about raw test-id usage was fixed before PR.

## Residual Risk
- Existing admin shell/page-level mobile horizontal overflow at 390px remains outside P41-UX03 scope; the filter controls themselves wrap and remain labeled.
- A first `ci:local:pr` Docker RLS lane hit a local precondition with missing migrated tables; explicit local gate contracts passed after local DB reset.