### PR TITLE
feat: harden member dashboard hierarchy

### DIFF
--- a/apps/web/e2e/gate/member-home-cta.spec.ts
+++ b/apps/web/e2e/gate/member-home-cta.spec.ts
@@ -3,6 +3,11 @@ import { routes } from '../routes';
 import { gotoApp } from '../utils/navigation';
 
 const MEMBER_HOME_MARKER_TIMEOUT_MS = 30000;
+const DASHBOARD_HIERARCHY_VIEWPORTS = [
+  { name: 'mobile', width: 390, height: 844 },
+  { name: 'dense desktop', width: 1024, height: 768 },
+  { name: 'standard desktop', width: 1440, height: 900 },
+] as const;
 
 test.describe('Strict Gate: Member Home Crystal UI', () => {
   test('Member can navigate via the 4 Crystal CTAs', async ({
@@ -105,4 +110,56 @@ test.describe('Strict Gate: Member Home Crystal UI', () => {
       '/member/membership'
     );
   });
+
+  for (const viewport of DASHBOARD_HIERARCHY_VIEWPORTS) {
+    test(`Member dashboard hierarchy stays task-first at ${viewport.name}`, async ({
+      authenticatedPage: page,
+    }, testInfo) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await gotoApp(page, routes.member(test.info()), testInfo, {
+        marker: 'member-dashboard-ready',
+        markerTimeoutMs: MEMBER_HOME_MARKER_TIMEOUT_MS,
+      });
+
+      const dashboard = page.getByTestId('member-dashboard-ready').first();
+      const priorityRegion = dashboard.getByTestId('member-dashboard-priority-region');
+      const secondaryRegion = dashboard.getByTestId('member-dashboard-secondary-region');
+
+      await expect(dashboard).toBeVisible();
+      await expect(priorityRegion).toBeVisible();
+      await expect(secondaryRegion).toBeVisible();
+      await expect(dashboard.getByTestId('dashboard-heading')).toBeVisible();
+      await expect(dashboard.getByTestId('member-primary-actions')).toBeVisible();
+
+      const priorityPrecedesSecondary = await dashboard.evaluate(element => {
+        const priority = element.querySelector('[data-testid="member-dashboard-priority-region"]');
+        const secondary = element.querySelector(
+          '[data-testid="member-dashboard-secondary-region"]'
+        );
+
+        return Boolean(
+          priority &&
+          secondary &&
+          priority.compareDocumentPosition(secondary) & Node.DOCUMENT_POSITION_FOLLOWING
+        );
+      });
+      expect(priorityPrecedesSecondary).toBe(true);
+
+      const dashboardHasHorizontalOverflow = await dashboard.evaluate(
+        element => element.scrollWidth > element.clientWidth + 1
+      );
+      expect(dashboardHasHorizontalOverflow).toBe(false);
+
+      const firstServiceCardClass = await dashboard
+        .getByTestId('member-service-ecosystem-card')
+        .first()
+        .getAttribute('class');
+      expect(firstServiceCardClass ?? '').not.toContain('cursor-pointer');
+      expect(firstServiceCardClass ?? '').not.toContain('hover:-translate-y-1');
+      expect(firstServiceCardClass ?? '').not.toContain('hover:shadow-xl');
+      await expect(
+        dashboard.getByRole('button', { name: /explore|истражи|eksploro|istraži/i })
+      ).toHaveCount(0);
+    });
+  }
 });

--- a/apps/web/src/components/dashboard/matte-anchor-card.tsx
+++ b/apps/web/src/components/dashboard/matte-anchor-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Link } from '@/i18n/routing';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import {
   AlertCircle,
   ClipboardList,
@@ -33,6 +33,7 @@ interface MatteAnchorCardProps {
   iconName: string;
   href: string;
   colorClassName?: string;
+  compact?: boolean;
   testId?: string;
 }
 
@@ -42,33 +43,43 @@ export function MatteAnchorCard({
   iconName,
   href,
   colorClassName = 'from-slate-900 to-slate-800',
+  compact = false,
   testId,
 }: MatteAnchorCardProps) {
   const Icon = ICON_MAP[iconName] || AlertCircle;
+  const shouldReduceMotion = useReducedMotion();
+  const hoverOffset = compact ? -3 : -8;
 
   return (
     <motion.div
-      whileHover={{ y: -8 }}
+      whileHover={shouldReduceMotion ? undefined : { y: hoverOffset }}
       transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-      className="group relative h-full"
+      className="group relative h-full min-w-0"
     >
-      <Link href={href} className="block h-full" data-testid={testId}>
+      <Link href={href} className="block h-full min-w-0" data-testid={testId}>
         <div
           className={`
-          relative h-full p-8 rounded-[2.5rem] bg-gradient-to-br ${colorClassName}
-          border border-white/10 overflow-hidden transition-all duration-500
-          shadow-[0_10px_15px_-3px_rgba(0,0,0,0.4),0_20px_25px_-5px_rgba(0,0,0,0.1)]
-          group-hover:shadow-[0_40px_60px_-15px_rgba(0,0,0,0.5),0_10px_15px_-3px_rgba(0,0,0,0.4)]
+          relative h-full min-w-0 bg-gradient-to-br ${colorClassName}
+          border border-white/10 overflow-hidden motion-safe:transition-shadow motion-safe:duration-300
+          ${
+            compact
+              ? 'rounded-2xl p-5 shadow-[0_8px_14px_-8px_rgba(0,0,0,0.45)] group-hover:shadow-[0_16px_24px_-14px_rgba(0,0,0,0.5)]'
+              : 'rounded-[2.5rem] p-8 shadow-[0_10px_15px_-3px_rgba(0,0,0,0.4),0_20px_25px_-5px_rgba(0,0,0,0.1)] group-hover:shadow-[0_40px_60px_-15px_rgba(0,0,0,0.5),0_10px_15px_-3px_rgba(0,0,0,0.4)]'
+          }
         `}
         >
-          <div className="bg-white/10 p-4 rounded-2xl w-fit mb-6">
-            <Icon className="w-7 h-7 text-white" />
+          <div className={`mb-5 w-fit rounded-2xl bg-white/10 ${compact ? 'p-3' : 'p-4'}`}>
+            <Icon className={`${compact ? 'h-5 w-5' : 'h-7 w-7'} text-white`} />
           </div>
-          <div className="mt-auto">
-            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-white/60 mb-1">
+          <div className="mt-auto min-w-0">
+            <p className="mb-1 break-words text-[10px] font-black uppercase tracking-[0.16em] text-white/70">
               {description}
             </p>
-            <span className="text-2xl font-black text-white leading-tight block">{label}</span>
+            <span
+              className={`block break-words font-black leading-tight text-white ${compact ? 'text-lg' : 'text-2xl'}`}
+            >
+              {label}
+            </span>
           </div>
         </div>
       </Link>

--- a/apps/web/src/components/dashboard/member-dashboard-view.test.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import type { MemberDashboardData } from '@interdomestik/domain-member';
@@ -52,6 +52,8 @@ guidance_membership_cta|Активирај членство`
 
 const translationMap: Record<string, string> = {
   'dashboard.member_landing.page_title': 'Панел за членови',
+  'dashboard.member_landing.priority_region_label': 'Главни задачи',
+  'dashboard.member_landing.secondary_region_label': 'Дополнителни услуги и бенефиции',
   'dashboard.member_landing.more_services': 'Повеќе услуги',
   'dashboard.member_landing.hero_greeting': 'Добредојде',
   'dashboard.member_landing.hero_subtitle_active':
@@ -206,11 +208,31 @@ vi.mock('@/lib/roles.core', () => ({
 }));
 
 vi.mock('@interdomestik/ui', () => ({
-  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
-  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  CardHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  CardTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Button: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <button className={className}>{children}</button>
+  ),
+  Card: ({
+    children,
+    className,
+    'data-testid': testId,
+  }: {
+    children: ReactNode;
+    className?: string;
+    'data-testid'?: string;
+  }) => (
+    <div className={className} data-testid={testId}>
+      {children}
+    </div>
+  ),
+  CardContent: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  CardHeader: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  CardTitle: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
 }));
 
 import { MemberDashboardView } from './member-dashboard-view';
@@ -266,6 +288,7 @@ describe('MemberDashboardView MK localization', () => {
     expect(screen.queryByText('Your membership is not active yet.')).not.toBeInTheDocument();
     expect(screen.queryByText('Live Protection')).not.toBeInTheDocument();
     expect(screen.queryByText('Explore All')).not.toBeInTheDocument();
+    expect(screen.queryByText('Истражи ги сите')).not.toBeInTheDocument();
     expect(
       screen.queryByText('dashboard.member_landing.card_member_support')
     ).not.toBeInTheDocument();
@@ -274,6 +297,59 @@ describe('MemberDashboardView MK localization', () => {
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('member-guidance-panel')).toBeInTheDocument();
     expect(screen.getByText('Вашиот најважен следен чекор')).toBeInTheDocument();
+  });
+
+  it('renders a named task-first region before secondary services', async () => {
+    const tree = await MemberDashboardView({
+      data: makeData(),
+      locale: 'mk',
+    });
+
+    render(tree);
+
+    const priorityRegion = screen.getByRole('region', { name: 'Главни задачи' });
+    const secondaryRegion = screen.getByRole('region', {
+      name: 'Дополнителни услуги и бенефиции',
+    });
+    const heading = screen.getByTestId('dashboard-heading');
+
+    expect(priorityRegion).toHaveAttribute('data-testid', 'member-dashboard-priority-region');
+    expect(secondaryRegion).toHaveAttribute('data-testid', 'member-dashboard-secondary-region');
+    expect(priorityRegion).toContainElement(heading);
+    expect(within(priorityRegion).getByTestId('member-primary-actions')).toBeInTheDocument();
+    expect(
+      priorityRegion.compareDocumentPosition(secondaryRegion) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('keeps the secondary service cards static and non-interactive', async () => {
+    const tree = await MemberDashboardView({
+      data: makeData(),
+      locale: 'mk',
+    });
+
+    render(tree);
+
+    expect(screen.queryByRole('button', { name: /Истражи/i })).not.toBeInTheDocument();
+    for (const card of screen.getAllByTestId('member-service-ecosystem-card')) {
+      expect(card.className).not.toContain('cursor-pointer');
+      expect(card.className).not.toContain('hover:-translate-y-1');
+      expect(card.className).not.toContain('hover:shadow-xl');
+    }
+  });
+
+  it('preserves the combined no-claim orientation and empty state in the task-first region', async () => {
+    const tree = await MemberDashboardView({
+      data: makeData(),
+      locale: 'mk',
+    });
+
+    render(tree);
+
+    const priorityRegion = screen.getByRole('region', { name: 'Главни задачи' });
+
+    expect(within(priorityRegion).getByTestId('member-orientation-card')).toBeInTheDocument();
+    expect(within(priorityRegion).getByTestId('member-empty-state')).toBeInTheDocument();
   });
 
   it('surfaces activation CTAs before claim-centric actions for unpaid members', async () => {

--- a/apps/web/src/components/dashboard/member-dashboard-view/command-center-card.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/command-center-card.tsx
@@ -13,53 +13,59 @@ export function CommandCenterCard({
   tLanding: DashboardTranslator;
 }>) {
   return (
-    <Card className="lg:col-span-2 overflow-hidden rounded-[2rem] border border-slate-200/80 bg-slate-950 text-white shadow-lg dark:border-white/10">
+    <Card className="min-w-0 overflow-hidden rounded-[2rem] border border-slate-200/80 bg-slate-950 text-white shadow-lg dark:border-white/10 lg:col-span-2">
       <CardHeader className="relative border-b border-white/10 p-8 pb-4">
-        <div className="flex items-center justify-between gap-4">
-          <CardTitle className="flex items-center gap-3 text-lg font-display font-black">
-            <div className="rounded-lg bg-sky-500 p-2">
+        <div className="flex min-w-0 flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+          <CardTitle className="flex min-w-0 items-center gap-3 break-words text-lg font-display font-black">
+            <div className="shrink-0 rounded-lg bg-sky-500 p-2">
               <Phone className="h-5 w-5 text-white" />
             </div>
             {tLanding('command_center_title')}
           </CardTitle>
-          <div className="rounded-full border border-sky-400/30 bg-sky-400/10 px-3 py-1 text-[10px] font-black tracking-widest text-sky-300">
+          <div className="w-fit max-w-full break-words rounded-full border border-sky-400/30 bg-sky-400/10 px-3 py-1 text-[10px] font-black tracking-widest text-sky-300">
             {tLanding('priority_line_active')}
           </div>
         </div>
       </CardHeader>
 
-      <div className="relative flex flex-col gap-8 p-8 sm:p-10">
-        <div className="grid gap-6 sm:grid-cols-2">
-          <div className="space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
-            <div className="text-[10px] font-black uppercase tracking-[0.2em] text-sky-300">
+      <div className="relative flex min-w-0 flex-col gap-8 p-8 sm:p-10">
+        <div className="grid min-w-0 gap-6 sm:grid-cols-2">
+          <div className="min-w-0 space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
+            <div className="break-words text-[10px] font-black uppercase tracking-[0.2em] text-sky-300">
               {tLanding('support_phone_label')}
             </div>
-            <a href={contacts.telHref} className="block text-3xl font-display font-black">
+            <a
+              href={contacts.telHref}
+              className="block break-words text-2xl font-display font-black sm:text-3xl"
+            >
               {contacts.phoneDisplay}
             </a>
-            <div className="flex items-center gap-2 text-xs text-slate-400">
-              <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
-              <span>
+            <div className="flex min-w-0 items-center gap-2 text-xs text-slate-400">
+              <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-green-500" />
+              <span className="min-w-0 break-words">
                 {tLanding('available_now_avg_response', {
                   seconds: tLanding('response_value'),
                 })}
               </span>
             </div>
           </div>
-          <div className="space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
-            <div className="text-[10px] font-black uppercase tracking-[0.2em] text-sky-300">
+          <div className="min-w-0 space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
+            <div className="break-words text-[10px] font-black uppercase tracking-[0.2em] text-sky-300">
               {tLanding('support_whatsapp_label')}
             </div>
-            <a href={contacts.whatsappHref} className="block text-3xl font-display font-black">
+            <a
+              href={contacts.whatsappHref}
+              className="block break-words text-2xl font-display font-black sm:text-3xl"
+            >
               WhatsApp
             </a>
-            <div className="flex items-center gap-2 text-xs text-slate-400">
-              <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
-              <span>{tLanding('support_whatsapp_value')}</span>
+            <div className="flex min-w-0 items-center gap-2 text-xs text-slate-400">
+              <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-green-500" />
+              <span className="min-w-0 break-words">{tLanding('support_whatsapp_value')}</span>
             </div>
           </div>
         </div>
-        <p className="max-w-2xl text-sm leading-relaxed text-slate-300">
+        <p className="max-w-2xl break-words text-sm leading-relaxed text-slate-300">
           {tLanding('command_center_body')}
         </p>
       </div>

--- a/apps/web/src/components/dashboard/member-dashboard-view/dashboard-hero.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/dashboard-hero.tsx
@@ -22,64 +22,60 @@ export function DashboardHero({
   validThru: string;
 }>) {
   return (
-    <div className="relative overflow-hidden rounded-[2rem] border border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-sky-50/70 p-8 shadow-xl sm:p-10 dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-slate-900">
-      <div className="relative z-10 flex flex-col lg:flex-row lg:items-center justify-between gap-12">
-        <div className="flex flex-col gap-8 max-w-xl">
-          <div className="space-y-4">
-            <div className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-4 py-1.5 text-sky-700 shadow-sm dark:border-sky-400/20 dark:bg-sky-400/10 dark:text-sky-300">
+    <div className="relative min-w-0 max-w-full overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm sm:p-6 dark:border-white/10 dark:bg-slate-950/60">
+      <div className="relative z-10 flex min-w-0 flex-col justify-between gap-6 lg:flex-row lg:items-center">
+        <div className="flex min-w-0 max-w-xl flex-col gap-5">
+          <div className="space-y-3">
+            <div className="inline-flex max-w-full items-center gap-2 rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-sky-700 dark:border-sky-400/20 dark:bg-sky-400/10 dark:text-sky-300">
               <div
-                className={`flex h-2 w-2 rounded-full ${isActive ? 'bg-emerald-500' : 'bg-amber-500'}`}
+                className={`flex h-2 w-2 shrink-0 rounded-full ${isActive ? 'bg-emerald-500' : 'bg-amber-500'}`}
               />
-              <span
-                className="text-[10px] font-black uppercase tracking-[0.2em]"
-                data-testid="dashboard-heading"
-              >
+              <span className="min-w-0 break-words text-[10px] font-black uppercase tracking-[0.16em]">
                 {tLanding('page_title')}
               </span>
             </div>
 
-            <h1 className="text-4xl font-display font-black tracking-tight text-slate-950 md:text-6xl dark:text-white">
+            <h3 className="break-words text-2xl font-display font-black tracking-tight text-slate-950 md:text-3xl dark:text-white">
               {tLanding('hero_greeting')},
-              <br />
-              <span className="bg-gradient-to-r from-sky-600 to-blue-700 bg-clip-text text-transparent italic">
+              <span className="ml-2 break-words text-sky-700 dark:text-sky-300">
                 {userName.split(' ')[0]}
               </span>
-            </h1>
-            <p className="text-lg font-medium leading-relaxed text-slate-600 dark:text-slate-300">
+            </h3>
+            <p className="break-words text-sm font-medium leading-relaxed text-slate-600 dark:text-slate-300 sm:text-base">
               {heroSubtitle}
             </p>
           </div>
 
-          <div className="flex flex-wrap gap-4">
-            <div className="flex items-center gap-3 rounded-2xl border border-slate-200/80 bg-white/90 px-5 py-3 shadow-sm dark:border-white/10 dark:bg-white/5">
-              <ShieldCheck className="w-5 h-5 text-emerald-500" />
-              <div className="flex flex-col">
-                <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+          <div className="flex min-w-0 flex-wrap gap-3">
+            <div className="flex min-w-0 max-w-full items-center gap-3 rounded-xl border border-slate-200/80 bg-slate-50 px-4 py-3 dark:border-white/10 dark:bg-white/5">
+              <ShieldCheck className="h-5 w-5 shrink-0 text-emerald-500" />
+              <div className="flex min-w-0 flex-col">
+                <span className="break-words text-[10px] font-bold uppercase text-slate-500 dark:text-slate-400">
                   {tLanding('status_label')}
                 </span>
-                <span className="text-sm font-black uppercase tracking-tighter text-slate-950 dark:text-white">
+                <span className="break-words text-sm font-black uppercase text-slate-950 dark:text-white">
                   {supportStatusLabel}
                 </span>
               </div>
             </div>
-            <div className="flex items-center gap-3 rounded-2xl border border-slate-200/80 bg-white/90 px-5 py-3 shadow-sm dark:border-white/10 dark:bg-white/5">
-              <Headphones className="w-5 h-5 text-sky-600 dark:text-sky-400" />
-              <div className="flex flex-col">
-                <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+            <div className="flex min-w-0 max-w-full items-center gap-3 rounded-xl border border-slate-200/80 bg-slate-50 px-4 py-3 dark:border-white/10 dark:bg-white/5">
+              <Headphones className="h-5 w-5 shrink-0 text-sky-600 dark:text-sky-400" />
+              <div className="flex min-w-0 flex-col">
+                <span className="break-words text-[10px] font-bold uppercase text-slate-500 dark:text-slate-400">
                   {tLanding('response_label')}
                 </span>
-                <span className="text-sm font-black uppercase tracking-tighter text-slate-950 dark:text-white">
+                <span className="break-words text-sm font-black uppercase text-slate-950 dark:text-white">
                   {tLanding('response_value')}
                 </span>
               </div>
             </div>
-            <div className="flex items-center gap-3 rounded-2xl border border-slate-200/80 bg-white/90 px-5 py-3 shadow-sm dark:border-white/10 dark:bg-white/5">
-              <Zap className="w-5 h-5 text-amber-500" />
-              <div className="flex flex-col">
-                <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+            <div className="flex min-w-0 max-w-full items-center gap-3 rounded-xl border border-slate-200/80 bg-slate-50 px-4 py-3 dark:border-white/10 dark:bg-white/5">
+              <Zap className="h-5 w-5 shrink-0 text-amber-500" />
+              <div className="flex min-w-0 flex-col">
+                <span className="break-words text-[10px] font-bold uppercase text-slate-500 dark:text-slate-400">
                   {tLanding('card_ready_label')}
                 </span>
-                <span className="text-sm font-black uppercase tracking-tighter text-slate-950 dark:text-white">
+                <span className="break-words text-sm font-black uppercase text-slate-950 dark:text-white">
                   {tLanding('card_ready_value')}
                 </span>
               </div>
@@ -87,7 +83,7 @@ export function DashboardHero({
           </div>
         </div>
 
-        <div className="flex-shrink-0 animate-in fade-in zoom-in-95 duration-1000 delay-300">
+        <div className="min-w-0 max-w-full flex-shrink-0 motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-95 motion-safe:duration-700 lg:max-w-[460px]">
           <DigitalIDCard
             name={userName}
             memberNumber={memberNumber || 'PENDING'}

--- a/apps/web/src/components/dashboard/member-dashboard-view/diaspora-ribbon.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/diaspora-ribbon.tsx
@@ -13,32 +13,37 @@ export function DiasporaRibbon({
   tLanding: DashboardTranslator;
 }>) {
   return (
-    <div className="relative group cursor-pointer" data-testid="diaspora-ribbon">
-      <div className="relative rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm transition-all duration-300 hover:border-sky-200 dark:border-white/10 dark:bg-slate-950/60">
-        <div className="flex items-center gap-5">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-sky-50 text-sky-700 dark:bg-sky-400/10 dark:text-sky-300">
-            <Globe className="w-7 h-7" />
+    <div className="group relative min-w-0 max-w-full cursor-pointer" data-testid="diaspora-ribbon">
+      <div className="relative min-w-0 rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm transition-all duration-300 hover:border-sky-200 dark:border-white/10 dark:bg-slate-950/60">
+        <div className="flex min-w-0 flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex min-w-0 items-start gap-5">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-sky-50 text-sky-700 dark:bg-sky-400/10 dark:text-sky-300">
+              <Globe className="h-7 w-7" />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <h3 className="break-words text-lg font-display font-bold text-foreground">
+                {t('diaspora_ribbon.text')}
+              </h3>
+              <p className="break-words text-sm leading-relaxed text-muted-foreground">
+                {tLanding('diaspora_description')}
+              </p>
+            </div>
           </div>
-          <div className="space-y-1">
-            <h3 className="text-lg font-display font-bold text-foreground">
-              {t('diaspora_ribbon.text')}
-            </h3>
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              {tLanding('diaspora_description')}
-            </p>
-          </div>
+          <Button
+            asChild
+            size="lg"
+            className="group/btn w-full min-w-0 rounded-2xl px-8 shadow-sm transition-all active:scale-95 sm:w-auto"
+            data-testid="diaspora-ribbon-cta"
+          >
+            <Link
+              href="/member/diaspora"
+              className="flex min-w-0 items-center justify-center gap-3"
+            >
+              <span className="min-w-0 break-words font-bold">{t('diaspora_ribbon.cta')}</span>
+              <ArrowRight className="h-5 w-5 shrink-0 transition-transform duration-300 group-hover/btn:translate-x-1.5" />
+            </Link>
+          </Button>
         </div>
-        <Button
-          asChild
-          size="lg"
-          className="rounded-2xl px-8 group/btn shadow-sm transition-all active:scale-95"
-          data-testid="diaspora-ribbon-cta"
-        >
-          <Link href="/member/diaspora" className="flex items-center gap-3">
-            <span className="font-bold">{t('diaspora_ribbon.cta')}</span>
-            <ArrowRight className="w-5 h-5 group-hover/btn:translate-x-1.5 transition-transform duration-300" />
-          </Link>
-        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/components/dashboard/member-dashboard-view/index.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/index.tsx
@@ -78,45 +78,67 @@ export async function MemberDashboardView({ data, locale }: Readonly<MemberDashb
     : tLanding('hero_subtitle_inactive');
 
   return (
-    <div className="space-y-10 pb-10" data-testid="member-dashboard-ready">
-      <MemberHeader name={member.name} membershipNumber={member.membershipNumber} />
-      <PrimaryActions locale={locale} />
-      <MemberGuidancePanel
-        activeClaim={activeClaim}
-        hasNoClaims={hasNoClaims}
-        isActive={isActive}
-        supportHref={supportHref}
-        tLanding={tLanding}
-        validThru={validThru}
-      />
-      {hasNoClaims ? (
-        <OrientationCard orientationHref={orientationHref} tLanding={tLanding} />
-      ) : null}
-
-      {activeClaim ? (
-        <ActiveClaimFocus
-          claimNumber={activeClaim.claimNumber}
-          locale={locale}
-          status={activeClaim.status}
-          stageLabel={activeClaim.stageLabel}
-          stageKey={activeClaim.stageKey}
-          updatedAt={activeClaim.updatedAt}
-          nextMemberAction={
-            activeClaim.requiresMemberAction ? activeClaim.nextMemberAction : undefined
-          }
+    <div className="min-w-0 max-w-full space-y-10 pb-10" data-testid="member-dashboard-ready">
+      <section
+        aria-labelledby="member-dashboard-priority-heading"
+        className="min-w-0 space-y-5"
+        data-testid="member-dashboard-priority-region"
+      >
+        <div className="min-w-0 space-y-3">
+          <MemberHeader name={member.name} membershipNumber={member.membershipNumber} />
+          <h2
+            id="member-dashboard-priority-heading"
+            className="break-words text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+            data-testid="dashboard-heading"
+          >
+            {tLanding('priority_region_label')}
+          </h2>
+        </div>
+        <PrimaryActions locale={locale} />
+        <MemberGuidancePanel
+          activeClaim={activeClaim}
+          hasNoClaims={hasNoClaims}
+          isActive={isActive}
+          supportHref={supportHref}
+          tLanding={tLanding}
+          validThru={validThru}
         />
-      ) : null}
+        {hasNoClaims ? (
+          <OrientationCard orientationHref={orientationHref} tLanding={tLanding} />
+        ) : null}
 
-      {hasNoClaims ? <MemberEmptyState locale={locale} /> : null}
+        {activeClaim ? (
+          <ActiveClaimFocus
+            claimNumber={activeClaim.claimNumber}
+            locale={locale}
+            status={activeClaim.status}
+            stageLabel={activeClaim.stageLabel}
+            stageKey={activeClaim.stageKey}
+            updatedAt={activeClaim.updatedAt}
+            nextMemberAction={
+              activeClaim.requiresMemberAction ? activeClaim.nextMemberAction : undefined
+            }
+          />
+        ) : null}
 
-      <SupportLink href={supportHref} />
+        {hasNoClaims ? <MemberEmptyState locale={locale} /> : null}
 
-      {shouldShowActivationPanel ? <ActivationPanel tLanding={tLanding} /> : null}
+        <SupportLink href={supportHref} />
 
-      <section className="space-y-6">
-        <div className="flex items-center justify-between px-1">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            {tLanding('more_services')}
+        {shouldShowActivationPanel ? <ActivationPanel tLanding={tLanding} /> : null}
+      </section>
+
+      <section
+        aria-labelledby="member-dashboard-secondary-heading"
+        className="min-w-0 space-y-6"
+        data-testid="member-dashboard-secondary-region"
+      >
+        <div className="flex min-w-0 items-center justify-between px-1">
+          <h2
+            id="member-dashboard-secondary-heading"
+            className="min-w-0 break-words text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            {tLanding('secondary_region_label')}
           </h2>
         </div>
 
@@ -134,8 +156,8 @@ export async function MemberDashboardView({ data, locale }: Readonly<MemberDashb
         <DiasporaRibbon t={t} tLanding={tLanding} />
 
         {/* Action Center - Primary Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-2 space-y-8">
+        <div className="grid min-w-0 grid-cols-1 gap-8 lg:grid-cols-3">
+          <div className="min-w-0 space-y-8 lg:col-span-2">
             <MemberActionGrid t={t} tLanding={tLanding} />
           </div>
 
@@ -145,7 +167,7 @@ export async function MemberDashboardView({ data, locale }: Readonly<MemberDashb
         {/* Secondary Service Tiles - Glass Grid */}
         <ServiceEcosystemGrid t={t} tLanding={tLanding} />
 
-        <div className="grid gap-8 lg:grid-cols-3">
+        <div className="grid min-w-0 gap-8 lg:grid-cols-3">
           <CommandCenterCard contacts={contacts} tLanding={tLanding} />
 
           <ReferralStatusColumn

--- a/apps/web/src/components/dashboard/member-dashboard-view/member-action-grid.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/member-action-grid.tsx
@@ -54,6 +54,7 @@ export function MemberActionGrid({
           description={action.description}
           colorClassName={action.color}
           testId={`home-cta-${action.id}`}
+          compact
         />
       ))}
     </HomeGrid>

--- a/apps/web/src/components/dashboard/member-dashboard-view/referral-status-column.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/referral-status-column.tsx
@@ -16,23 +16,25 @@ export function ReferralStatusColumn({
   tLanding: DashboardTranslator;
 }>) {
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex min-w-0 flex-col gap-8">
       <ReferralCard isAgent={isAgentRole} />
-      <Card className="relative overflow-hidden rounded-[2rem] border border-slate-200/80 bg-white p-8 shadow-sm dark:border-white/10 dark:bg-slate-950/60">
-        <div className="relative space-y-5">
-          <div className="flex items-center gap-4">
-            <div className="rounded-2xl bg-sky-50 p-3 dark:bg-sky-400/10">
-              <LayoutDashboard className="w-6 h-6 text-sky-700 dark:text-sky-300" />
+      <Card className="relative min-w-0 overflow-hidden rounded-[2rem] border border-slate-200/80 bg-white p-8 shadow-sm dark:border-white/10 dark:bg-slate-950/60">
+        <div className="relative min-w-0 space-y-5">
+          <div className="flex min-w-0 items-center gap-4">
+            <div className="shrink-0 rounded-2xl bg-sky-50 p-3 dark:bg-sky-400/10">
+              <LayoutDashboard className="h-6 w-6 text-sky-700 dark:text-sky-300" />
             </div>
-            <h3 className="text-lg font-display font-black text-foreground">
+            <h3 className="min-w-0 break-words text-lg font-display font-black text-foreground">
               {tLanding('status_insight_title')}
             </h3>
           </div>
-          <p className="text-sm font-medium leading-relaxed text-muted-foreground">
+          <p className="break-words text-sm font-medium leading-relaxed text-muted-foreground">
             {tLanding('status_insight_body')}
           </p>
-          <Button variant="secondary" asChild className="w-full rounded-xl font-bold">
-            <Link href={supportHref}>{tLanding('review_security_parameters')}</Link>
+          <Button variant="secondary" asChild className="w-full min-w-0 rounded-xl font-bold">
+            <Link href={supportHref} className="min-w-0 break-words">
+              {tLanding('review_security_parameters')}
+            </Link>
           </Button>
         </div>
       </Card>

--- a/apps/web/src/components/dashboard/member-dashboard-view/service-ecosystem-grid.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/service-ecosystem-grid.tsx
@@ -1,5 +1,5 @@
-import { Button, Card, CardContent } from '@interdomestik/ui';
-import { ArrowRight, FileText, Headphones, HeartPulse, ShieldCheck } from 'lucide-react';
+import { Card, CardContent } from '@interdomestik/ui';
+import { FileText, Headphones, HeartPulse, ShieldCheck } from 'lucide-react';
 
 import type { DashboardTranslator } from './types';
 
@@ -11,20 +11,13 @@ export function ServiceEcosystemGrid({
   tLanding: DashboardTranslator;
 }>) {
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between px-1">
-        <h2 className="text-xl font-display font-black tracking-tight">
+    <div className="min-w-0 space-y-6">
+      <div className="flex min-w-0 items-center justify-between px-1">
+        <h2 className="min-w-0 break-words text-xl font-display font-black tracking-tight">
           {tLanding('system_ecosystem')}
         </h2>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-xs font-bold uppercase tracking-widest text-muted-foreground hover:text-primary"
-        >
-          {tLanding('explore_all')} <ArrowRight className="ml-2 w-3 h-3" />
-        </Button>
       </div>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-5">
+      <div className="grid min-w-0 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {[
           {
             key: 'property_damage',
@@ -34,24 +27,24 @@ export function ServiceEcosystemGrid({
           { key: 'health_safety', icon: HeartPulse, desc: tLanding('health_safety_desc') },
           { key: 'my_documents', icon: FileText, desc: tLanding('my_documents_desc') },
           { key: 'contact_center', icon: Headphones, desc: tLanding('contact_center_desc') },
-        ].map((cat, i) => (
+        ].map(cat => (
           <Card
             key={cat.key}
-            className="group relative overflow-hidden bg-white/50 dark:bg-white/5 backdrop-blur-sm hover:bg-white dark:hover:bg-white/10 transition-all duration-500 cursor-pointer border-slate-200/60 dark:border-white/10 shadow-sm hover:shadow-xl hover:-translate-y-1 animate-in fade-in slide-in-from-bottom-4"
-            style={{ animationDelay: `${(i + 4) * 100}ms` }}
+            className="relative min-w-0 overflow-hidden border-slate-200/60 bg-white/70 shadow-sm dark:border-white/10 dark:bg-white/5"
+            data-testid="member-service-ecosystem-card"
           >
-            <CardContent className="p-7 flex flex-col items-center text-center gap-4">
+            <CardContent className="flex flex-col items-center gap-4 p-6 text-center">
               <div className="relative">
-                <div className="absolute inset-0 bg-primary/20 rounded-2xl blur group-hover:blur-md transition-all duration-500" />
-                <div className="relative w-14 h-14 rounded-2xl bg-primary/5 dark:bg-primary/10 flex items-center justify-center text-primary group-hover:bg-primary group-hover:text-white transition-all duration-500">
-                  <cat.icon className="w-7 h-7" />
+                <div className="absolute inset-0 rounded-2xl bg-primary/10 blur" />
+                <div className="relative flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/5 text-primary dark:bg-primary/10">
+                  <cat.icon className="h-6 w-6" />
                 </div>
               </div>
-              <div className="space-y-1.5">
-                <span className="text-sm font-bold block group-hover:text-primary transition-colors">
+              <div className="min-w-0 space-y-1.5">
+                <span className="block break-words text-sm font-bold">
                   {t(`categories.${cat.key}`)}
                 </span>
-                <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                <p className="break-words text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                   {cat.desc}
                 </p>
               </div>

--- a/apps/web/src/components/dashboard/member-dashboard-view/support-readiness-card.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/support-readiness-card.tsx
@@ -15,19 +15,21 @@ export function SupportReadinessCard({
   tLanding: DashboardTranslator;
 }>) {
   return (
-    <Card className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-white shadow-sm dark:border-white/10 dark:bg-slate-950/60">
-      <CardHeader className="p-8 pb-4">
-        <CardTitle className="flex items-center gap-2 text-sm font-black uppercase tracking-[0.2em] text-sky-700 dark:text-sky-300">
-          <Headphones className="w-4 h-4" />
+    <Card className="min-w-0 overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm dark:border-white/10 dark:bg-slate-950/60">
+      <CardHeader className="p-6 pb-3">
+        <CardTitle className="flex min-w-0 items-center gap-2 break-words text-sm font-black uppercase tracking-[0.16em] text-sky-700 dark:text-sky-300">
+          <Headphones className="h-4 w-4 shrink-0" />
           {tLanding('support_panel_title')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-8 pt-0 space-y-8">
-        <div className="space-y-6">
+      <CardContent className="space-y-6 p-6 pt-0">
+        <div className="space-y-5">
           <div className="space-y-2">
-            <div className="flex items-center justify-between text-[10px] font-black uppercase tracking-widest text-muted-foreground">
-              <span>{tLanding('support_readiness_label')}</span>
-              <span className={isActive ? 'text-emerald-500' : 'text-amber-500'}>
+            <div className="flex min-w-0 flex-wrap items-center justify-between gap-2 text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+              <span className="min-w-0 break-words">{tLanding('support_readiness_label')}</span>
+              <span
+                className={`min-w-0 break-words ${isActive ? 'text-emerald-500' : 'text-amber-500'}`}
+              >
                 {isActive
                   ? tLanding('support_readiness_active')
                   : tLanding('support_readiness_pending')}
@@ -35,7 +37,7 @@ export function SupportReadinessCard({
             </div>
             <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-white/5">
               <div
-                className={`h-full transition-all duration-1000 ${
+                className={`h-full motion-safe:transition-all motion-safe:duration-700 ${
                   isActive ? 'bg-emerald-500' : 'bg-amber-500'
                 }`}
                 style={{ width: isActive ? '100%' : '65%' }}
@@ -43,20 +45,20 @@ export function SupportReadinessCard({
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div className="rounded-3xl border border-slate-100 bg-slate-50 p-4 dark:border-white/5 dark:bg-white/5">
-              <span className="mb-1 block text-[9px] font-bold uppercase tracking-widest text-muted-foreground">
+          <div className="grid min-w-0 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+            <div className="min-w-0 rounded-2xl border border-slate-100 bg-slate-50 p-4 dark:border-white/5 dark:bg-white/5">
+              <span className="mb-1 block break-words text-[9px] font-bold uppercase tracking-widest text-muted-foreground">
                 {tLanding('support_channel_label')}
               </span>
-              <span className="text-xl font-display font-black">
+              <span className="break-words text-base font-display font-black sm:text-lg">
                 {tLanding('support_channel_value')}
               </span>
             </div>
-            <div className="rounded-3xl border border-slate-100 bg-slate-50 p-4 dark:border-white/5 dark:bg-white/5">
-              <span className="mb-1 block text-[9px] font-bold uppercase tracking-widest text-muted-foreground">
+            <div className="min-w-0 rounded-2xl border border-slate-100 bg-slate-50 p-4 dark:border-white/5 dark:bg-white/5">
+              <span className="mb-1 block break-words text-[9px] font-bold uppercase tracking-widest text-muted-foreground">
                 {tLanding('support_window_label')}
               </span>
-              <span className="text-xl font-display font-black">
+              <span className="break-words text-base font-display font-black sm:text-lg">
                 {tLanding('support_window_value')}
               </span>
             </div>
@@ -64,7 +66,7 @@ export function SupportReadinessCard({
         </div>
 
         <div className="space-y-4">
-          <h4 className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+          <h4 className="break-words text-[10px] font-black uppercase tracking-widest text-muted-foreground">
             {tLanding('support_highlights_title')}
           </h4>
           <div className="space-y-3">
@@ -73,9 +75,9 @@ export function SupportReadinessCard({
               tLanding('support_highlight_two'),
               tLanding('support_highlight_three'),
             ].map(item => (
-              <div key={item} className="flex items-center justify-between">
-                <span className="text-xs font-bold">{item}</span>
-                <div className="flex items-center gap-2">
+              <div key={item} className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+                <span className="min-w-0 break-words text-xs font-bold">{item}</span>
+                <div className="flex shrink-0 items-center gap-2">
                   <div className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
                   <span className="text-[10px] font-mono text-muted-foreground">
                     {tLanding('online_now')}
@@ -89,11 +91,11 @@ export function SupportReadinessCard({
         <Button
           asChild
           variant="outline"
-          className="w-full rounded-2xl border-sky-200 font-bold transition-all hover:border-sky-300 hover:bg-sky-50 dark:border-sky-400/20 dark:hover:bg-sky-400/5"
+          className="w-full min-w-0 rounded-2xl border-sky-200 font-bold motion-safe:transition-colors hover:border-sky-300 hover:bg-sky-50 dark:border-sky-400/20 dark:hover:bg-sky-400/5"
         >
-          <Link href={supportHref} className="flex items-center justify-center gap-2">
-            <span>{tLanding('support_panel_cta')}</span>
-            <ArrowRight className="w-4 h-4 transition-transform" />
+          <Link href={supportHref} className="flex min-w-0 items-center justify-center gap-2">
+            <span className="min-w-0 break-words">{tLanding('support_panel_cta')}</span>
+            <ArrowRight className="h-4 w-4 shrink-0" />
           </Link>
         </Button>
       </CardContent>

--- a/apps/web/src/components/member/referral-card.tsx
+++ b/apps/web/src/components/member/referral-card.tsx
@@ -127,9 +127,9 @@ export function ReferralCard({ isAgent: _isAgent }: Readonly<ReferralCardProps>)
 
   if (isLoading) {
     return (
-      <Card>
+      <Card className="min-w-0">
         <CardHeader>
-          <CardTitle className="text-sm font-medium">{t('title')}</CardTitle>
+          <CardTitle className="break-words text-sm font-medium">{t('title')}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
           <Skeleton className="h-10 w-full" />
@@ -145,15 +145,15 @@ export function ReferralCard({ isAgent: _isAgent }: Readonly<ReferralCardProps>)
 
   if (error || !data) {
     return (
-      <Card className="border-destructive/50">
+      <Card className="min-w-0 border-destructive/50">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-sm font-medium text-destructive">
-            <AlertCircle className="h-4 w-4" />
+          <CardTitle className="flex min-w-0 items-center gap-2 break-words text-sm font-medium text-destructive">
+            <AlertCircle className="h-4 w-4 shrink-0" />
             {t('loadError')}
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">{error}</p>
+          <p className="break-words text-sm text-muted-foreground">{error}</p>
         </CardContent>
       </Card>
     );
@@ -163,23 +163,23 @@ export function ReferralCard({ isAgent: _isAgent }: Readonly<ReferralCardProps>)
   const currency = data.stats.rewardsCurrency || data.settings.currencyCode;
 
   return (
-    <Card>
+    <Card className="min-w-0">
       <CardHeader className="space-y-2">
-        <CardTitle className="flex items-center gap-2 text-base font-semibold">
-          <Gift className="h-4 w-4 text-primary" />
+        <CardTitle className="flex min-w-0 items-center gap-2 break-words text-base font-semibold">
+          <Gift className="h-4 w-4 shrink-0 text-primary" />
           {t('title')}
         </CardTitle>
-        <p className="text-sm text-muted-foreground">{t('description')}</p>
+        <p className="break-words text-sm text-muted-foreground">{t('description')}</p>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex flex-col gap-2 sm:flex-row">
+        <div className="flex min-w-0 flex-col gap-2 sm:flex-row">
           <Input
             value={data.link}
             readOnly
-            className="font-mono text-sm"
+            className="min-w-0 font-mono text-sm"
             onClick={event => event.currentTarget.select()}
           />
-          <div className="flex gap-2">
+          <div className="flex shrink-0 gap-2">
             <Button
               type="button"
               variant="outline"
@@ -205,35 +205,43 @@ export function ReferralCard({ isAgent: _isAgent }: Readonly<ReferralCardProps>)
           </div>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-lg border bg-muted/30 p-3">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">{t('friends')}</p>
+        <div className="grid min-w-0 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="min-w-0 rounded-lg border bg-muted/30 p-3">
+            <p className="break-words text-xs uppercase tracking-wide text-muted-foreground">
+              {t('friends')}
+            </p>
             <p className="mt-2 text-2xl font-semibold">{data.stats.totalReferred}</p>
           </div>
-          <div className="rounded-lg border bg-muted/30 p-3">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">{t('pending')}</p>
-            <p className="mt-2 text-2xl font-semibold">
+          <div className="min-w-0 rounded-lg border bg-muted/30 p-3">
+            <p className="break-words text-xs uppercase tracking-wide text-muted-foreground">
+              {t('pending')}
+            </p>
+            <p className="mt-2 break-words text-2xl font-semibold">
               {formatCurrency(data.stats.pendingRewards, currency)}
             </p>
           </div>
-          <div className="rounded-lg border bg-muted/30 p-3">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">{t('credited')}</p>
-            <p className="mt-2 text-2xl font-semibold">
+          <div className="min-w-0 rounded-lg border bg-muted/30 p-3">
+            <p className="break-words text-xs uppercase tracking-wide text-muted-foreground">
+              {t('credited')}
+            </p>
+            <p className="mt-2 break-words text-2xl font-semibold">
               {formatCurrency(data.stats.creditedRewards, currency)}
             </p>
           </div>
-          <div className="rounded-lg border bg-muted/30 p-3">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">{t('paid')}</p>
-            <p className="mt-2 text-2xl font-semibold">
+          <div className="min-w-0 rounded-lg border bg-muted/30 p-3">
+            <p className="break-words text-xs uppercase tracking-wide text-muted-foreground">
+              {t('paid')}
+            </p>
+            <p className="mt-2 break-words text-2xl font-semibold">
               {formatCurrency(data.stats.paidRewards, currency)}
             </p>
           </div>
         </div>
 
-        <div className="rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm text-muted-foreground">
-          <div className="flex items-start gap-2">
-            <Wallet className="mt-0.5 h-4 w-4 text-primary" />
-            <div className="space-y-1">
+        <div className="min-w-0 rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm text-muted-foreground">
+          <div className="flex min-w-0 items-start gap-2">
+            <Wallet className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            <div className="min-w-0 space-y-1 break-words">
               <p>{rewardSummary}</p>
               {data.settings.settlementMode === 'credit_or_payout' ? (
                 <p>

--- a/apps/web/src/messages/en/dashboard.json
+++ b/apps/web/src/messages/en/dashboard.json
@@ -62,6 +62,8 @@
       "account_error_cta": "Get assistance",
       "unavailable_short": "N/A",
       "help_label": "Need help?",
+      "priority_region_label": "Primary tasks",
+      "secondary_region_label": "Additional services and benefits",
       "more_services": "More services",
       "diaspora_description": "Specialized support network for members across Europe and beyond.",
       "cta_incident_kicker": "SOS",

--- a/apps/web/src/messages/mk/dashboard.json
+++ b/apps/web/src/messages/mk/dashboard.json
@@ -62,6 +62,8 @@
       "account_error_cta": "Побарај помош",
       "unavailable_short": "Н/Д",
       "help_label": "Ви треба помош?",
+      "priority_region_label": "Главни задачи",
+      "secondary_region_label": "Дополнителни услуги и бенефиции",
       "more_services": "Повеќе услуги",
       "diaspora_description": "Специјализирана мрежа за поддршка за членови низ Европа и пошироко.",
       "cta_incident_kicker": "ИТНО",

--- a/apps/web/src/messages/sq/dashboard.json
+++ b/apps/web/src/messages/sq/dashboard.json
@@ -62,6 +62,8 @@
       "account_error_cta": "Merr ndihmë",
       "unavailable_short": "Nuk ka",
       "help_label": "Keni nevojë për ndihmë?",
+      "priority_region_label": "Detyrat kryesore",
+      "secondary_region_label": "Shërbime dhe përfitime shtesë",
       "more_services": "Më shumë shërbime",
       "diaspora_description": "Rrjet i specializuar mbështetjeje për anëtarët në Evropë dhe më gjerë.",
       "cta_incident_kicker": "URGJENT",

--- a/apps/web/src/messages/sr/dashboard.json
+++ b/apps/web/src/messages/sr/dashboard.json
@@ -62,6 +62,8 @@
       "account_error_cta": "Zatraži pomoć",
       "unavailable_short": "Nema",
       "help_label": "Potrebna vam je pomoć?",
+      "priority_region_label": "Glavni zadaci",
+      "secondary_region_label": "Dodatne usluge i pogodnosti",
       "more_services": "Više usluga",
       "diaspora_description": "Specijalizovana mreža podrške za članove širom Evrope i šire.",
       "cta_incident_kicker": "HITNO",


### PR DESCRIPTION
## Summary
- Promotes the member dashboard to a task-first visual hierarchy for P41-UX04.
- Adds explicit priority and secondary dashboard regions while preserving canonical member routing and readiness markers.
- Demotes the marketing hero into a secondary section, makes service ecosystem cards static, and keeps action cards compact.
- Adds locale copy and focused unit/E2E coverage across mobile, tablet, and desktop viewports.

## Verification
- `git diff --check`
- `pnpm repo:size:check`
- `pnpm --filter @interdomestik/web test:unit --run src/components/dashboard/member-dashboard-view.test.tsx 'src/components/dashboard/member-dashboard-v2.test.tsx' 'src/app/[locale]/(app)/member/page.test.tsx'`
- `pnpm i18n:check`
- `pnpm i18n:purity:check`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm --filter @interdomestik/web lint`
- `pnpm --filter @interdomestik/web test:e2e -- apps/web/e2e/gate/member-home-cta.spec.ts`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`

## Scope Guard
- No `apps/web/src/proxy.ts` edits.
- No route, auth, tenancy, schema, migration, Stripe, README, AGENTS, or architecture-doc changes.
