### PR TITLE
fix(web): resolve member dashboard review issues

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/settings/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/settings/_core.entry.tsx
@@ -50,7 +50,7 @@ export default async function SettingsPage({ params }: SettingsPageProps) {
         {/* Left Column - Profile & Security */}
         <div className="space-y-8">
           {/* Profile Section */}
-          <section>
+          <section id="profile">
             <h3 className="text-lg font-medium mb-4">{t('profile.sectionTitle')}</h3>
             <Suspense fallback={<SettingsSkeleton />}>
               <ProfileForm
@@ -82,7 +82,7 @@ export default async function SettingsPage({ params }: SettingsPageProps) {
           </section>
 
           {/* Notifications Section */}
-          <section>
+          <section id="notifications">
             <h3 className="text-lg font-medium mb-4">{t('notifications.sectionTitle')}</h3>
             <Suspense fallback={<SettingsSkeleton />}>
               <NotificationSettings />

--- a/apps/web/src/components/dashboard/member-dashboard-view.test.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view.test.tsx
@@ -204,8 +204,17 @@ describe('MemberDashboardView assistance dashboard', () => {
     });
     render(tree);
 
+    const appHeader = within(screen.getByTestId('member-app-header'));
     expect(screen.getByTestId('member-app-header')).toHaveTextContent('Интердоместик ИДА');
     expect(screen.getByTestId('member-app-header')).toHaveTextContent('Полесно е заедно');
+    expect(appHeader.getByRole('link', { name: 'Известувања' })).toHaveAttribute(
+      'href',
+      '/mk/member/settings#notifications'
+    );
+    expect(appHeader.getByRole('link', { name: 'Членски профил' })).toHaveAttribute(
+      'href',
+      '/mk/member/settings#profile'
+    );
     expect(screen.getByTestId('member-welcome-status')).toHaveTextContent('Активно');
     expect(screen.getByTestId('member-welcome-status')).toHaveAttribute(
       'data-hero-state',
@@ -223,6 +232,15 @@ describe('MemberDashboardView assistance dashboard', () => {
     expect(screen.getByTestId('document-vault-summary')).toHaveTextContent('4');
     expect(screen.getByTestId('trust-strip')).toHaveTextContent('Центар за доверба');
     expect(screen.getByTestId('mobile-bottom-nav')).toHaveTextContent('Почетна');
+
+    const nextStepHeadingIds = screen
+      .getAllByTestId('next-step-card')
+      .map(card => card.getAttribute('aria-labelledby'));
+    expect(new Set(nextStepHeadingIds).size).toBe(nextStepHeadingIds.length);
+    for (const headingId of nextStepHeadingIds) {
+      expect(headingId).toBeTruthy();
+      expect(document.querySelectorAll(`[id="${headingId}"]`)).toHaveLength(1);
+    }
   });
 
   it('treats agent member-mode access as assistance/action, not visitor conversion', async () => {

--- a/apps/web/src/components/dashboard/member-dashboard-view/index.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/index.tsx
@@ -118,7 +118,7 @@ export async function MemberDashboardView({
       data-testid="member-dashboard-ready"
     >
       <div className="mx-auto flex max-w-[920px] flex-col gap-2 pb-[6.5rem] md:block md:space-y-4 md:pb-10">
-        <MemberTopBar isActive={hasAssistanceAccess} t={t} />
+        <MemberTopBar isActive={hasAssistanceAccess} locale={locale} t={t} />
 
         <div className="space-y-1.5 md:space-y-4" data-testid="member-dashboard-priority-region">
           <MemberHero hero={hero} isActive={hasAssistanceAccess} t={t} />
@@ -268,7 +268,15 @@ export async function getDashboardSupplementalData({
   ] as const;
 }
 
-function MemberTopBar({ isActive, t }: { isActive: boolean; t: DashboardTranslator }) {
+function MemberTopBar({
+  isActive,
+  locale,
+  t,
+}: {
+  isActive: boolean;
+  locale: string;
+  t: DashboardTranslator;
+}) {
   const brand = t('header.brand');
   const mobileBrand = brand.split(' ')[0] ?? brand;
 
@@ -298,20 +306,20 @@ function MemberTopBar({ isActive, t }: { isActive: boolean; t: DashboardTranslat
         <span className="hidden rounded-full border border-emerald-900/15 bg-white px-3 py-1.5 text-xs font-semibold text-emerald-900 shadow-sm sm:inline-flex">
           {isActive ? t('welcome.active') : t('welcome.inactive')}
         </span>
-        <button
-          type="button"
+        <a
+          href={`/${locale}/member/settings#notifications`}
           className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-transparent text-slate-800 transition hover:bg-emerald-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-900 focus-visible:ring-offset-2 md:h-11 md:w-11"
           aria-label={t('header.notifications')}
         >
           <Bell className="h-5 w-5" aria-hidden="true" />
-        </button>
-        <button
-          type="button"
+        </a>
+        <a
+          href={`/${locale}/member/settings#profile`}
           className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-transparent text-slate-800 transition hover:bg-emerald-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-900 focus-visible:ring-offset-2 md:h-11 md:w-11 md:hidden"
           aria-label={t('header.profile')}
         >
           <UserRound className="h-5 w-5" aria-hidden="true" />
-        </button>
+        </a>
       </div>
     </header>
   );

--- a/apps/web/src/components/dashboard/member-dashboard-view/next-step-card.tsx
+++ b/apps/web/src/components/dashboard/member-dashboard-view/next-step-card.tsx
@@ -17,9 +17,11 @@ type NextStepCardProps = {
 };
 
 export function NextStepCard({ compact = false, nextStep, t }: NextStepCardProps) {
+  const headingId = compact ? 'member-next-step-heading-compact' : 'member-next-step-heading';
+
   return (
     <section
-      aria-labelledby="member-next-step-heading"
+      aria-labelledby={headingId}
       className={
         compact
           ? 'relative rounded-[1.25rem] border border-emerald-900/10 bg-white p-3 shadow-md shadow-emerald-900/5'
@@ -48,7 +50,7 @@ export function NextStepCard({ compact = false, nextStep, t }: NextStepCardProps
             {t('nextStep.kicker')}
           </p>
           <h2
-            id="member-next-step-heading"
+            id={headingId}
             className={
               compact
                 ? 'mt-0.5 truncate text-sm font-extrabold tracking-tight text-slate-950'


### PR DESCRIPTION
## Scope

This PR has been rebased/rescoped onto current `main`. The original 46-file stale branch diff included proxy/auth/docs/gate/script churn that is no longer part of this PR. The useful member dashboard performance/Suspense/tenant-context work already exists on `main`.

This branch now contains only the remaining review fixes:

- convert the member dashboard top-bar notification/profile controls into real settings links
- add matching profile and notification anchors on member settings
- make desktop/compact `NextStepCard` headings unique for valid `aria-labelledby`
- add regression coverage for the links and duplicate-heading-id contract

## Review comment disposition

The stale screenshot/docs/proxy/auth/package/script hunks are gone due to the rescope. The other Copilot comments are either resolved by current-main code or by this commit.

## Verification

- `pnpm --filter @interdomestik/web test:unit --run src/components/dashboard/member-dashboard-view.test.tsx`
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(app)/member/settings/_core.entry.test.tsx'`
- `pnpm --filter @interdomestik/web lint`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm i18n:check`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`
- Codex Security diff scan: no findings
