### PR TITLE
ARCH-M0-04: Extract tenant leak assertion helper

### DIFF
--- a/apps/web/src/server/domains/claims/index.ts
+++ b/apps/web/src/server/domains/claims/index.ts
@@ -1,6 +1,7 @@
 // v2.0.0-ops — Admin Claims lifecycle hardening
 import * as Sentry from '@sentry/nextjs';
 import 'server-only';
+import { assertNoTenantLeak } from '../tenant-leak';
 import { ClaimsSession, ensureClaimsAccess } from './guards';
 import { mapClaimsToDto } from './mappers';
 import { getClaimsListQuery } from './queries';
@@ -36,19 +37,7 @@ export async function getClaimsListV2(
 
         // LEAK SENTINEL: Confirm result purity (Dev/Stage/Test check)
         // In production this might be expensive if many rows, but critical for multi-tenant safety.
-        if (rows.length > 0) {
-          const leakingRow = rows.find(r => r.claim.tenantId !== accessConfig.tenantId);
-          if (leakingRow) {
-            console.error('🚨 TENANT LEAK DETECTED', {
-              userTenant: accessConfig.tenantId,
-              leakedRowId: leakingRow.claim.id,
-              leakedRowTenant: leakingRow.claim.tenantId,
-            });
-            throw new Error(
-              `CRITICAL: Tenant Data Leak Detected! User ${accessConfig.tenantId} saw data from ${leakingRow.claim.tenantId}`
-            );
-          }
-        }
+        assertNoTenantLeak(rows, accessConfig.tenantId);
 
         return dto;
       } catch (error) {

--- a/apps/web/src/server/domains/tenant-leak.test.ts
+++ b/apps/web/src/server/domains/tenant-leak.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { assertNoTenantLeak, type TenantLeakAssertableRow } from './tenant-leak';
+
+function claimRow(id: string, tenantId: string): TenantLeakAssertableRow {
+  return {
+    claim: {
+      id,
+      tenantId,
+    },
+  };
+}
+
+describe('assertNoTenantLeak', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('allows rows that all belong to the requested tenant', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(() =>
+      assertNoTenantLeak(
+        [claimRow('claim-1', 'tenant-a'), claimRow('claim-2', 'tenant-a')],
+        'tenant-a'
+      )
+    ).not.toThrow();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws when a row belongs to another tenant', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(() =>
+      assertNoTenantLeak(
+        [claimRow('claim-1', 'tenant-a'), claimRow('claim-2', 'tenant-b')],
+        'tenant-a'
+      )
+    ).toThrow('CRITICAL: Tenant Data Leak Detected! User tenant-a saw data from tenant-b');
+    expect(errorSpy).toHaveBeenCalledWith('🚨 TENANT LEAK DETECTED', {
+      userTenant: 'tenant-a',
+      leakedRowId: 'claim-2',
+      leakedRowTenant: 'tenant-b',
+    });
+  });
+});

--- a/apps/web/src/server/domains/tenant-leak.ts
+++ b/apps/web/src/server/domains/tenant-leak.ts
@@ -1,0 +1,23 @@
+export interface TenantLeakAssertableRow {
+  claim: {
+    id: string;
+    tenantId: string | null;
+  };
+}
+
+export function assertNoTenantLeak(
+  rows: readonly TenantLeakAssertableRow[],
+  tenantId: string
+): void {
+  const leakingRow = rows.find(row => row.claim.tenantId !== tenantId);
+  if (!leakingRow) return;
+
+  console.error('🚨 TENANT LEAK DETECTED', {
+    userTenant: tenantId,
+    leakedRowId: leakingRow.claim.id,
+    leakedRowTenant: leakingRow.claim.tenantId,
+  });
+  throw new Error(
+    `CRITICAL: Tenant Data Leak Detected! User ${tenantId} saw data from ${leakingRow.claim.tenantId}`
+  );
+}

--- a/apps/web/src/server/domains/tenant-leak.ts
+++ b/apps/web/src/server/domains/tenant-leak.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 export interface TenantLeakAssertableRow {
   claim: {
     id: string;

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
   "maxTrackedBytes": 31000000,
-  "maxTrackedFiles": 3840,
+  "maxTrackedFiles": 3842,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 14300000,
     "source/scripts": 6400000,
-    "tests/e2e": 4196040,
+    "tests/e2e": 4197361,
     "docs/text": 4450000,
     "config/data/messages": 1572864,
     "other": 1048576


### PR DESCRIPTION
## Summary
- Extracts the existing claim-list tenant leak sentinel into `assertNoTenantLeak(rows, tenantId)` under the server domain boundary.
- Keeps the original console error payload and thrown error text for cross-tenant rows.
- Adds focused unit coverage for same-tenant pass-through and cross-tenant failure.
- Updates the repo-size budget for the two tracked files and test byte growth required by this slice.

## Scope
- T-004 / ARCH-M0-04 only.
- Does not apply the helper broadly to other domain list queries; that remains T-005.
- Does not touch `apps/web/src/proxy.ts`, canonical routes, auth/session architecture, tenancy architecture, schemas, migrations, billing, README, AGENTS, or architecture docs.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/server/domains/tenant-leak.test.ts`
- `pnpm --filter @interdomestik/web type-check`
- `git diff --check`
- `pnpm --filter @interdomestik/web lint`
- `pnpm repo:size:check`
- `pnpm test:ci:contracts`
- `pnpm security:guard`
- `pnpm pr:verify`

## E2E Gate Note
- Standalone `pnpm e2e:gate` was not run separately because this slice did not change a web flow, route, clarity marker, selector, or gate surface. `pnpm pr:verify` did run the PR E2E gate lane plus smoke tests successfully.
