### PR TITLE
refactor: return action result from claim status

### DIFF
--- a/packages/domain-claims/src/claims/status.test.ts
+++ b/packages/domain-claims/src/claims/status.test.ts
@@ -48,7 +48,7 @@ describe('updateClaimStatusCore', () => {
       newStatus: 'submitted',
     });
 
-    expect(result).toEqual({ error: 'Claim not found' });
+    expect(result).toEqual({ success: false, error: 'Claim not found', data: undefined });
     expect(mocks.withTenant).toHaveBeenCalledWith(
       'tenant-1',
       'claims.tenant_id',
@@ -64,7 +64,7 @@ describe('updateClaimStatusCore', () => {
       newStatus: 'invalid-status',
     });
 
-    expect(result).toEqual({ error: 'Invalid status' });
+    expect(result).toEqual({ success: false, error: 'Invalid status', data: undefined });
   });
 
   it('rejects unauthorized user (member)', async () => {
@@ -75,7 +75,7 @@ describe('updateClaimStatusCore', () => {
       newStatus: 'submitted',
     });
 
-    expect(result).toEqual({ error: 'Unauthorized' });
+    expect(result).toEqual({ success: false, error: 'Unauthorized', data: undefined });
   });
 
   it('successfully updates status', async () => {
@@ -102,7 +102,7 @@ describe('updateClaimStatusCore', () => {
       }
     );
 
-    expect(result).toEqual({ success: true });
+    expect(result).toEqual({ success: true, error: undefined });
     expect(mocks.update).toHaveBeenCalled();
     expect(mocks.updateSet).toHaveBeenCalledWith({
       status: 'submitted',

--- a/packages/domain-claims/src/claims/status.ts
+++ b/packages/domain-claims/src/claims/status.ts
@@ -2,18 +2,7 @@ import { claims, db, eq } from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 
-import type { ClaimsDeps, ClaimsSession } from './types';
-
-const VALID_STATUSES = [
-  'draft',
-  'submitted',
-  'verification',
-  'evaluation',
-  'negotiation',
-  'court',
-  'resolved',
-  'rejected',
-] as const;
+import type { ActionResult, ClaimsDeps, ClaimsSession } from './types';
 
 import { claimStatusSchema } from '../validators/claims';
 
@@ -29,16 +18,16 @@ export async function updateClaimStatusCore(
     newStatus: string;
   },
   deps: ClaimsDeps = {}
-) {
+): Promise<ActionResult> {
   const { session, requestHeaders, claimId, newStatus } = params;
 
   if (!session || !isStaffOrAdmin(session.user.role ?? null)) {
-    return { error: 'Unauthorized' };
+    return { success: false, error: 'Unauthorized', data: undefined };
   }
 
   const parsed = claimStatusSchema.safeParse({ status: newStatus });
   if (!parsed.success) {
-    return { error: 'Invalid status' };
+    return { success: false, error: 'Invalid status', data: undefined };
   }
 
   // validated by safeParse above
@@ -53,7 +42,7 @@ export async function updateClaimStatusCore(
     });
 
     if (!claim) {
-      return { error: 'Claim not found' };
+      return { success: false, error: 'Claim not found', data: undefined };
     }
 
     const oldStatus = claim.status;
@@ -107,9 +96,9 @@ export async function updateClaimStatusCore(
       await deps.revalidatePath('/member/claims');
     }
 
-    return { success: true };
+    return { success: true, error: undefined };
   } catch (e) {
     console.error('Failed to update status:', e);
-    return { error: 'Failed to update status' };
+    return { success: false, error: 'Failed to update status', data: undefined };
   }
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -6,8 +6,8 @@
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 14300000,
-    "source/scripts": 6404812,
-    "tests/e2e": 4214981,
+    "source/scripts": 6404845,
+    "tests/e2e": 4215098,
     "docs/text": 4450000,
     "config/data/messages": 1572864,
     "other": 1048576


### PR DESCRIPTION
## Summary

- Convert `updateClaimStatusCore` to return the package `ActionResult` discriminated contract.
- Preserve existing caller-visible error strings and success behavior.
- Update focused status tests for the new result shape.
- Remove the unused local `VALID_STATUSES` tuple; `claimStatusSchema.safeParse` remains authoritative.
- Adjust exact repo-size budget bytes for the changed files only.

## Scope

Touched files:
- `packages/domain-claims/src/claims/status.ts`
- `packages/domain-claims/src/claims/status.test.ts`
- `scripts/repo-size-budget.json`

No changes to `apps/web/src/proxy.ts`, canonical routes, auth/session architecture, tenancy architecture, schemas, migrations, billing, README, AGENTS, or broad architecture docs.

## Verification

- `pnpm exec prettier --check packages/domain-claims/src/claims/status.ts packages/domain-claims/src/claims/status.test.ts scripts/repo-size-budget.json`
- `pnpm --filter @interdomestik/domain-claims test:unit -- claims/status.test.ts`
- `pnpm --filter @interdomestik/domain-claims type-check`
- `pnpm repo:size:check`
- `pnpm security:guard` via `interdomestik_qa.security_guard`
- `pnpm pr:verify` via shell fallback after `interdomestik_qa.pr_verify` timed out at 120s
- `pnpm e2e:gate` via shell fallback after `interdomestik_qa.e2e_gate` timed out at 120s
- `mcp__interdomestik_qa.scope_audit`: pass
- Static proof: no `return { error:` remains in `packages/domain-claims/src/claims/status.ts`
- Sonnet 4.6 review: PASS via Copilot CLI fallback after Claude CLI hung with no stdout/stderr

## Reviewer Notes

Pre-PR reviewer pool completed for security/auth/tenancy, performance/scalability, and maintainability/code quality. No blockers remained. One maintainability finding corrected the exact `tests/e2e` repo-size byte budget.

`pnpm ci:local:pr` was attempted for slice-runner parity. It failed in the local CI parity container at `pnpm db:rls:test:required` because the fresh `ci-postgres` did not have the D08 critical tables when the RLS lane ran. The script path invokes the RLS gate before its later migration step in `run_pilot_gate_p0`. The authoritative Phase C gates above passed outside that parity-container ordering issue.