### PR TITLE
ARCH-M0-12: route admin claim status through transition command

### DIFF
--- a/packages/domain-claims/src/admin-claims/payment-authorization.ts
+++ b/packages/domain-claims/src/admin-claims/payment-authorization.ts
@@ -1,0 +1,32 @@
+import { claimEscalationAgreements, db, eq } from '@interdomestik/database';
+import { withTenant } from '@interdomestik/database/tenant-security';
+
+import type { PaymentAuthorizationState } from '../staff-claims/types';
+
+const paymentGatedStatuses = new Set<string>(['negotiation', 'court']);
+
+export async function getPaymentAuthorizationState(params: {
+  claimId: string;
+  status: string;
+  tenantId: string;
+}): Promise<PaymentAuthorizationState | null | undefined> {
+  if (!paymentGatedStatuses.has(params.status)) {
+    return undefined;
+  }
+
+  const [agreement] = await db
+    .select({
+      paymentAuthorizationState: claimEscalationAgreements.paymentAuthorizationState,
+    })
+    .from(claimEscalationAgreements)
+    .where(
+      withTenant(
+        params.tenantId,
+        claimEscalationAgreements.tenantId,
+        eq(claimEscalationAgreements.claimId, params.claimId)
+      )
+    )
+    .limit(1);
+
+  return agreement?.paymentAuthorizationState ?? null;
+}

--- a/packages/domain-claims/src/admin-claims/update-status.payment-auth.test.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.payment-auth.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  agreementFrom: vi.fn(),
+  agreementLimit: vi.fn(),
+  agreementWhere: vi.fn(),
+  claimFrom: vi.fn(),
+  claimLeftJoin: vi.fn(),
+  claimWhere: vi.fn(),
+  dbSelect: vi.fn(),
+  dbUpdate: vi.fn(),
+  transitionClaimStatus: vi.fn(),
+  withTenant: vi.fn((tenantId, tenantColumn, condition) => ({ tenantId, tenantColumn, condition })),
+}));
+
+mocks.claimLeftJoin.mockReturnValue({ where: mocks.claimWhere });
+mocks.claimFrom.mockReturnValue({ leftJoin: mocks.claimLeftJoin });
+mocks.agreementWhere.mockReturnValue({ limit: mocks.agreementLimit });
+mocks.agreementFrom.mockReturnValue({ where: mocks.agreementWhere });
+mocks.dbSelect.mockImplementation((fields: { paymentAuthorizationState?: unknown }) =>
+  fields.paymentAuthorizationState ? { from: mocks.agreementFrom } : { from: mocks.claimFrom }
+);
+
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    select: mocks.dbSelect,
+    update: mocks.dbUpdate,
+  },
+  claimEscalationAgreements: {
+    claimId: 'claim_escalation_agreements.claim_id',
+    paymentAuthorizationState: 'claim_escalation_agreements.payment_authorization_state',
+    tenantId: 'claim_escalation_agreements.tenant_id',
+  },
+  claims: { id: 'claims.id', tenantId: 'claims.tenant_id', userId: 'claims.user_id' },
+  user: { id: 'user.id', email: 'user.email' },
+  eq: vi.fn((left, right) => ({ left, right })),
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: vi.fn(() => 'tenant-1'),
+}));
+
+vi.mock('../claims/transition', () => ({
+  transitionClaimStatus: mocks.transitionClaimStatus,
+}));
+
+import { updateClaimStatusCore } from './update-status';
+
+const adminSession = {
+  user: { id: 'admin-1', role: 'tenant_admin', tenantId: 'tenant-1' },
+} as never;
+
+describe('admin updateClaimStatusCore payment authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.claimWhere.mockResolvedValue([
+      {
+        id: 'claim-1',
+        title: 'Claim',
+        status: 'evaluation',
+        userId: 'member-1',
+        userEmail: 'member@example.com',
+      },
+    ]);
+    mocks.agreementLimit.mockResolvedValue([{ paymentAuthorizationState: 'authorized' }]);
+    mocks.transitionClaimStatus.mockResolvedValue({
+      success: true,
+      fromStatus: 'evaluation',
+      lifecycleVersion: 2,
+      status: 'negotiation',
+    });
+  });
+
+  it('passes payment authorization state into payment-gated admin transitions', async () => {
+    await updateClaimStatusCore({
+      claimId: 'claim-1',
+      newStatus: 'negotiation',
+      session: adminSession,
+      requestHeaders: new Headers(),
+    });
+
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(mocks.agreementLimit).toHaveBeenCalledWith(1);
+    expect(mocks.transitionClaimStatus).toHaveBeenCalledWith({
+      actor: { id: 'admin-1', role: 'tenant_admin' },
+      claimId: 'claim-1',
+      paymentAuthorizationState: 'authorized',
+      tenantId: 'tenant-1',
+      toStatus: 'negotiation',
+    });
+  });
+});

--- a/packages/domain-claims/src/admin-claims/update-status.test.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test.ts
@@ -5,17 +5,14 @@ const mocks = vi.hoisted(() => ({
   selectLeftJoin: vi.fn(),
   selectFrom: vi.fn(),
   dbSelect: vi.fn(),
-  updateWhere: vi.fn(),
-  updateSet: vi.fn(),
   dbUpdate: vi.fn(),
+  transitionClaimStatus: vi.fn(),
   withTenant: vi.fn((tenantId, tenantColumn, condition) => ({ tenantId, tenantColumn, condition })),
 }));
 
 mocks.selectLeftJoin.mockReturnValue({ where: mocks.selectWhere });
 mocks.selectFrom.mockReturnValue({ leftJoin: mocks.selectLeftJoin });
 mocks.dbSelect.mockReturnValue({ from: mocks.selectFrom });
-mocks.updateSet.mockReturnValue({ where: mocks.updateWhere });
-mocks.dbUpdate.mockReturnValue({ set: mocks.updateSet });
 
 vi.mock('@interdomestik/database', () => ({
   db: {
@@ -23,6 +20,7 @@ vi.mock('@interdomestik/database', () => ({
     update: mocks.dbUpdate,
   },
   claims: { id: 'claims.id', tenantId: 'claims.tenant_id', userId: 'claims.user_id' },
+  claimEscalationAgreements: {},
   user: { id: 'user.id', email: 'user.email' },
   eq: vi.fn((left, right) => ({ left, right })),
 }));
@@ -35,73 +33,116 @@ vi.mock('@interdomestik/shared-auth', () => ({
   ensureTenantId: vi.fn(() => 'tenant-1'),
 }));
 
+vi.mock('../claims/transition', () => ({
+  transitionClaimStatus: mocks.transitionClaimStatus,
+}));
+
 import { updateClaimStatusCore } from './update-status';
 
 const adminSession = {
   user: { id: 'admin-1', role: 'tenant_admin', tenantId: 'tenant-1' },
 } as never;
 
+const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
+
+function mockClaim(status: string) {
+  mocks.selectWhere.mockResolvedValueOnce([
+    {
+      id: 'claim-1',
+      title: 'Claim',
+      status,
+      userId: 'member-1',
+      userEmail: 'member@example.com',
+    },
+  ]);
+}
+
+function runStatusUpdate(
+  newStatus: Parameters<typeof updateClaimStatusCore>[0]['newStatus'],
+  deps = {}
+) {
+  return updateClaimStatusCore(
+    {
+      claimId: 'claim-1',
+      newStatus,
+      session: adminSession,
+      requestHeaders,
+    },
+    deps
+  );
+}
+
 describe('admin updateClaimStatusCore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.transitionClaimStatus.mockResolvedValue({
+      success: true,
+      fromStatus: 'verification',
+      lifecycleVersion: 2,
+      status: 'resolved',
+    });
   });
 
-  it('denies cross-tenant status update with no mutation', async () => {
-    mocks.selectWhere.mockResolvedValueOnce([]);
-
-    await expect(
-      updateClaimStatusCore(
-        {
-          claimId: 'claim-1',
-          newStatus: 'resolved',
-          session: adminSession,
-          requestHeaders: new Headers(),
-        },
-        {}
-      )
-    ).rejects.toThrow('Claim not found');
-
-    expect(mocks.dbUpdate).not.toHaveBeenCalled();
-  });
-
-  it('rejects invalid status fail-closed with no mutation', async () => {
-    await expect(
-      updateClaimStatusCore(
-        {
-          claimId: 'claim-1',
-          newStatus: 'not-a-real-status' as never,
-          session: adminSession,
-          requestHeaders: new Headers(),
-        },
-        {}
-      )
-    ).rejects.toThrow('Invalid status');
+  it('preserves invalid, cross-tenant, and no-op behavior before the command', async () => {
+    await expect(runStatusUpdate('not-a-real-status' as never)).rejects.toThrow('Invalid status');
 
     expect(mocks.dbSelect).not.toHaveBeenCalled();
-    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(mocks.transitionClaimStatus).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    mocks.selectWhere.mockResolvedValueOnce([]);
+
+    await expect(runStatusUpdate('resolved')).rejects.toThrow('Claim not found');
+
+    expect(mocks.transitionClaimStatus).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    mockClaim('resolved');
+
+    await runStatusUpdate('resolved');
+
+    expect(mocks.transitionClaimStatus).not.toHaveBeenCalled();
   });
 
-  it('status no-op does not execute update mutation', async () => {
-    mocks.selectWhere.mockResolvedValueOnce([
-      {
-        id: 'claim-1',
-        title: 'Claim',
-        status: 'resolved',
-        userId: 'member-1',
-        userEmail: 'member@example.com',
-      },
-    ]);
+  it('routes admin status changes through the transition command', async () => {
+    const logAuditEvent = vi.fn();
+    mockClaim('submitted');
 
-    await updateClaimStatusCore(
-      {
-        claimId: 'claim-1',
-        newStatus: 'resolved',
-        session: adminSession,
-        requestHeaders: new Headers(),
-      },
-      {}
-    );
+    await runStatusUpdate('resolved', { logAuditEvent });
 
     expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(mocks.transitionClaimStatus).toHaveBeenCalledWith({
+      actor: { id: 'admin-1', role: 'tenant_admin' },
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      toStatus: 'resolved',
+    });
+    expect(logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'admin-1',
+        action: 'claim.status_changed',
+        entityId: 'claim-1',
+        headers: requestHeaders,
+        metadata: { oldStatus: 'verification', newStatus: 'resolved' },
+      })
+    );
+  });
+
+  it('surfaces transition command rejection without audit or notification side effects', async () => {
+    const logAuditEvent = vi.fn();
+    const notifyStatusChanged = vi.fn();
+    mockClaim('evaluation');
+    mocks.transitionClaimStatus.mockResolvedValueOnce({
+      success: false,
+      error: 'transition_rejected',
+    });
+
+    await expect(
+      runStatusUpdate('resolved', { logAuditEvent, notifyStatusChanged })
+    ).rejects.toThrow('Invalid status transition');
+
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(logAuditEvent).not.toHaveBeenCalled();
+    expect(notifyStatusChanged).not.toHaveBeenCalled();
   });
 });

--- a/packages/domain-claims/src/admin-claims/update-status.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.ts
@@ -3,6 +3,8 @@ import { withTenant } from '@interdomestik/database/tenant-security';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 
 import type { ClaimsDeps, ClaimsSession } from '../claims/types';
+import { transitionClaimStatus } from '../claims/transition';
+import { getPaymentAuthorizationState } from './payment-authorization';
 
 type ClaimStatus =
   | 'draft'
@@ -72,14 +74,32 @@ export async function updateClaimStatusCore(
     return;
   }
 
-  // Update status
-  await db
-    .update(claims)
-    .set({
-      status: newStatus,
-      updatedAt: new Date(),
-    })
-    .where(withTenant(tenantId, claims.tenantId, eq(claims.id, claimId)));
+  const paymentAuthorizationState = await getPaymentAuthorizationState({
+    claimId,
+    status: newStatus,
+    tenantId,
+  });
+
+  const result = await transitionClaimStatus({
+    actor: { id: session.user.id, role: session.user.role ?? null },
+    claimId,
+    ...(paymentAuthorizationState !== undefined ? { paymentAuthorizationState } : {}),
+    tenantId,
+    toStatus: newStatus,
+  });
+
+  if (!result.success) {
+    if (result.error === 'claim_not_found') {
+      throw new Error('Claim not found');
+    }
+    if (result.error === 'transition_rejected') {
+      throw new Error('Invalid status transition');
+    }
+    throw new Error('Failed to update claim status');
+  }
+
+  const persistedOldStatus = result.fromStatus;
+  const persistedNewStatus = result.status;
 
   if (deps.logAuditEvent) {
     await deps.logAuditEvent({
@@ -89,23 +109,27 @@ export async function updateClaimStatusCore(
       entityType: 'claim',
       entityId: claimId,
       metadata: {
-        oldStatus,
-        newStatus,
+        oldStatus: persistedOldStatus,
+        newStatus: persistedNewStatus,
       },
       headers: requestHeaders,
     });
   }
 
   // Send notification to claim owner (fire-and-forget)
-  if (claimWithUser.userId && claimWithUser.userEmail && oldStatus !== newStatus) {
+  if (
+    claimWithUser.userId &&
+    claimWithUser.userEmail &&
+    persistedOldStatus !== persistedNewStatus
+  ) {
     if (deps.notifyStatusChanged) {
       Promise.resolve(
         deps.notifyStatusChanged(
           claimWithUser.userId,
           claimWithUser.userEmail,
           { id: claimWithUser.id, title: claimWithUser.title },
-          oldStatus,
-          newStatus
+          persistedOldStatus,
+          persistedNewStatus
         )
       ).catch((err: Error) => console.error('Failed to send status notification:', err));
     }

--- a/scripts/check-claim-status-writers.mjs
+++ b/scripts/check-claim-status-writers.mjs
@@ -32,7 +32,6 @@ export const CLAIM_STATUS_WRITER_ALLOWLIST = new Set([
   'packages/database/src/seed-golden/claims.ts',
   'packages/database/src/seed-packs/ks-workflow-pack.ts',
   'packages/database/test/rls-engaged.test.ts',
-  'packages/domain-claims/src/admin-claims/update-status.ts',
   'packages/domain-claims/src/agent-claims/update-status.ts',
   'packages/domain-claims/src/claims/create.ts',
   'packages/domain-claims/src/claims/draft.ts',

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 31025850,
-  "maxTrackedFiles": 3867,
+  "maxTrackedBytes": 31032139,
+  "maxTrackedFiles": 3869,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 14300000,
-    "source/scripts": 6405100,
-    "tests/e2e": 4215200,
+    "source/scripts": 6406865,
+    "tests/e2e": 4219785,
     "docs/text": 4466100,
     "config/data/messages": 1572864,
     "other": 1048576


### PR DESCRIPTION
## Summary
- routes `packages/domain-claims/src/admin-claims/update-status.ts` through `transitionClaimStatus()` while preserving admin API behavior, tenant scoping, actor context, lifecycle version behavior, history writes, and existing error strings where applicable
- adds focused admin writer tests for successful transition-command adoption and rejection handling
- removes the package admin writer from the direct claim-status writer allowlist and updates the repo-size budget to the measured post-slice values plus a narrow cushion

## Scope
- Tracker: T-002
- Slice: ARCH-M0-12
- Out of scope untouched: app-local admin ops writer, proxy/routes/auth/schema/migrations, broad docs/architecture changes

## Verification
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/admin-claims/update-status.test.ts`
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/admin-claims/update-status.test.ts src/claims/transition.test.ts src/claims/transition-guard.test.ts`
- `node scripts/check-claim-status-writers.mjs`
- `pnpm repo:size:check`
- `git diff --check`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate` (134 passed, 6 skipped)
- `interdomestik_qa.scope_audit` passed for the ARCH-M0-12 scope; forbidden paths unchanged

## Notes
- `interdomestik_qa.pr_verify` and `interdomestik_qa.e2e_gate` were attempted first and both timed out after 120s, so shell fallbacks were used per AGENTS.md MCP-first rules.
- Reviewer pool ran focused sidecar review; one stale-status side effect issue was found and fixed before gates.
