### PR TITLE
test: deduplicate admin claim status tests

### DIFF
--- a/packages/domain-claims/src/admin-claims/update-status.payment-auth.test.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.payment-auth.test.ts
@@ -1,58 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-  agreementFrom: vi.fn(),
-  agreementLimit: vi.fn(),
-  agreementWhere: vi.fn(),
-  claimFrom: vi.fn(),
-  claimLeftJoin: vi.fn(),
-  claimWhere: vi.fn(),
-  dbSelect: vi.fn(),
-  dbUpdate: vi.fn(),
-  transitionClaimStatus: vi.fn(),
-  withTenant: vi.fn((tenantId, tenantColumn, condition) => ({ tenantId, tenantColumn, condition })),
-}));
-
-mocks.claimLeftJoin.mockReturnValue({ where: mocks.claimWhere });
-mocks.claimFrom.mockReturnValue({ leftJoin: mocks.claimLeftJoin });
-mocks.agreementWhere.mockReturnValue({ limit: mocks.agreementLimit });
-mocks.agreementFrom.mockReturnValue({ where: mocks.agreementWhere });
-mocks.dbSelect.mockImplementation((fields: { paymentAuthorizationState?: unknown }) =>
-  fields.paymentAuthorizationState ? { from: mocks.agreementFrom } : { from: mocks.claimFrom }
-);
-
-vi.mock('@interdomestik/database', () => ({
-  db: {
-    select: mocks.dbSelect,
-    update: mocks.dbUpdate,
-  },
-  claimEscalationAgreements: {
-    claimId: 'claim_escalation_agreements.claim_id',
-    paymentAuthorizationState: 'claim_escalation_agreements.payment_authorization_state',
-    tenantId: 'claim_escalation_agreements.tenant_id',
-  },
-  claims: { id: 'claims.id', tenantId: 'claims.tenant_id', userId: 'claims.user_id' },
-  user: { id: 'user.id', email: 'user.email' },
-  eq: vi.fn((left, right) => ({ left, right })),
-}));
-
-vi.mock('@interdomestik/database/tenant-security', () => ({
-  withTenant: mocks.withTenant,
-}));
-
-vi.mock('@interdomestik/shared-auth', () => ({
-  ensureTenantId: vi.fn(() => 'tenant-1'),
-}));
-
-vi.mock('../claims/transition', () => ({
-  transitionClaimStatus: mocks.transitionClaimStatus,
-}));
+import { adminSession, getUpdateStatusMocks } from './update-status.test-support';
 
 import { updateClaimStatusCore } from './update-status';
 
-const adminSession = {
-  user: { id: 'admin-1', role: 'tenant_admin', tenantId: 'tenant-1' },
-} as never;
+const mocks = getUpdateStatusMocks();
 
 describe('admin updateClaimStatusCore payment authorization', () => {
   beforeEach(() => {

--- a/packages/domain-claims/src/admin-claims/update-status.test-support.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test-support.ts
@@ -1,0 +1,88 @@
+import { vi } from 'vitest';
+
+type MockFunction = ReturnType<typeof vi.fn>;
+
+type UpdateStatusMocks = {
+  agreementFrom: MockFunction;
+  agreementLimit: MockFunction;
+  agreementWhere: MockFunction;
+  claimFrom: MockFunction;
+  claimLeftJoin: MockFunction;
+  claimWhere: MockFunction;
+  dbSelect: MockFunction;
+  dbUpdate: MockFunction;
+  transitionClaimStatus: MockFunction;
+  withTenant: MockFunction;
+};
+
+const updateStatusMocks: UpdateStatusMocks = vi.hoisted(() => ({
+  agreementFrom: vi.fn(),
+  agreementLimit: vi.fn(),
+  agreementWhere: vi.fn(),
+  claimFrom: vi.fn(),
+  claimLeftJoin: vi.fn(),
+  claimWhere: vi.fn(),
+  dbSelect: vi.fn(),
+  dbUpdate: vi.fn(),
+  transitionClaimStatus: vi.fn(),
+  withTenant: vi.fn((tenantId, tenantColumn, condition) => ({ tenantId, tenantColumn, condition })),
+}));
+
+updateStatusMocks.claimLeftJoin.mockReturnValue({ where: updateStatusMocks.claimWhere });
+updateStatusMocks.claimFrom.mockReturnValue({ leftJoin: updateStatusMocks.claimLeftJoin });
+updateStatusMocks.agreementWhere.mockReturnValue({ limit: updateStatusMocks.agreementLimit });
+updateStatusMocks.agreementFrom.mockReturnValue({ where: updateStatusMocks.agreementWhere });
+updateStatusMocks.dbSelect.mockImplementation((fields: { paymentAuthorizationState?: unknown }) =>
+  fields.paymentAuthorizationState
+    ? { from: updateStatusMocks.agreementFrom }
+    : { from: updateStatusMocks.claimFrom }
+);
+
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    select: updateStatusMocks.dbSelect,
+    update: updateStatusMocks.dbUpdate,
+  },
+  claimEscalationAgreements: {
+    claimId: 'claim_escalation_agreements.claim_id',
+    paymentAuthorizationState: 'claim_escalation_agreements.payment_authorization_state',
+    tenantId: 'claim_escalation_agreements.tenant_id',
+  },
+  claims: { id: 'claims.id', tenantId: 'claims.tenant_id', userId: 'claims.user_id' },
+  user: { id: 'user.id', email: 'user.email' },
+  eq: vi.fn((left, right) => ({ left, right })),
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: updateStatusMocks.withTenant,
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: vi.fn(() => 'tenant-1'),
+}));
+
+vi.mock('../claims/transition', () => ({
+  transitionClaimStatus: updateStatusMocks.transitionClaimStatus,
+}));
+
+export const adminSession = {
+  user: { id: 'admin-1', role: 'tenant_admin', tenantId: 'tenant-1' },
+} as never;
+
+export const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
+
+export function mockClaim(status: string): void {
+  updateStatusMocks.claimWhere.mockResolvedValueOnce([
+    {
+      id: 'claim-1',
+      title: 'Claim',
+      status,
+      userId: 'member-1',
+      userEmail: 'member@example.com',
+    },
+  ]);
+}
+
+export function getUpdateStatusMocks(): UpdateStatusMocks {
+  return updateStatusMocks;
+}

--- a/packages/domain-claims/src/admin-claims/update-status.test.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test.ts
@@ -1,61 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-  selectWhere: vi.fn(),
-  selectLeftJoin: vi.fn(),
-  selectFrom: vi.fn(),
-  dbSelect: vi.fn(),
-  dbUpdate: vi.fn(),
-  transitionClaimStatus: vi.fn(),
-  withTenant: vi.fn((tenantId, tenantColumn, condition) => ({ tenantId, tenantColumn, condition })),
-}));
-
-mocks.selectLeftJoin.mockReturnValue({ where: mocks.selectWhere });
-mocks.selectFrom.mockReturnValue({ leftJoin: mocks.selectLeftJoin });
-mocks.dbSelect.mockReturnValue({ from: mocks.selectFrom });
-
-vi.mock('@interdomestik/database', () => ({
-  db: {
-    select: mocks.dbSelect,
-    update: mocks.dbUpdate,
-  },
-  claims: { id: 'claims.id', tenantId: 'claims.tenant_id', userId: 'claims.user_id' },
-  claimEscalationAgreements: {},
-  user: { id: 'user.id', email: 'user.email' },
-  eq: vi.fn((left, right) => ({ left, right })),
-}));
-
-vi.mock('@interdomestik/database/tenant-security', () => ({
-  withTenant: mocks.withTenant,
-}));
-
-vi.mock('@interdomestik/shared-auth', () => ({
-  ensureTenantId: vi.fn(() => 'tenant-1'),
-}));
-
-vi.mock('../claims/transition', () => ({
-  transitionClaimStatus: mocks.transitionClaimStatus,
-}));
+import {
+  adminSession,
+  getUpdateStatusMocks,
+  mockClaim,
+  requestHeaders,
+} from './update-status.test-support';
 
 import { updateClaimStatusCore } from './update-status';
 
-const adminSession = {
-  user: { id: 'admin-1', role: 'tenant_admin', tenantId: 'tenant-1' },
-} as never;
-
-const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
-
-function mockClaim(status: string) {
-  mocks.selectWhere.mockResolvedValueOnce([
-    {
-      id: 'claim-1',
-      title: 'Claim',
-      status,
-      userId: 'member-1',
-      userEmail: 'member@example.com',
-    },
-  ]);
-}
+const mocks = getUpdateStatusMocks();
 
 function runStatusUpdate(
   newStatus: Parameters<typeof updateClaimStatusCore>[0]['newStatus'],
@@ -90,7 +44,7 @@ describe('admin updateClaimStatusCore', () => {
     expect(mocks.transitionClaimStatus).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
-    mocks.selectWhere.mockResolvedValueOnce([]);
+    mocks.claimWhere.mockResolvedValueOnce([]);
 
     await expect(runStatusUpdate('resolved')).rejects.toThrow('Claim not found');
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "maxTrackedBytes": 31032139,
-  "maxTrackedFiles": 3869,
+  "maxTrackedFiles": 3870,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 14300000,
-    "source/scripts": 6406865,
+    "source/scripts": 6409578,
     "tests/e2e": 4219785,
     "docs/text": 4466100,
     "config/data/messages": 1572864,


### PR DESCRIPTION
Follow-up to PR #905 after SonarCloud reported new duplicated lines in the admin claim-status adoption tests.\n\nChanges:\n- Extract shared admin claim status test mocks into update-status.test-support.ts.\n- Keep success/rejection/payment-authorization assertions unchanged.\n- Adjust repo-size file/category budgets narrowly to actual + headroom.\n\nVerification:\n- pnpm --filter @interdomestik/domain-claims test:unit --run src/admin-claims/update-status.test.ts src/admin-claims/update-status.payment-auth.test.ts src/claims/transition.test.ts src/claims/transition-guard.test.ts\n- node scripts/repo-size-audit.mjs --check --json --top=2\n- MCP interdomestik_qa.security_guard\n- Earlier local full gates on identical final tree: pnpm pr:verify; pnpm e2e:gate (MCP e2e_gate blocked by timeout: timed out awaiting tools/call after 120s)