### PR TITLE
ARCH-M0-13 route agent claim status writer through transition command

### DIFF
--- a/apps/web/src/actions/agent-claims.test.ts
+++ b/apps/web/src/actions/agent-claims.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock variables must be defined before vi.mock is called
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   dbUpdate: vi.fn(),
   dbSelect: vi.fn(),
+  txUpdateReturning: vi.fn(),
+  txInsertValues: vi.fn(),
   dbQueryUser: vi.fn(),
   dbQueryClaims: vi.fn(),
 }));
@@ -34,7 +35,9 @@ vi.mock('@interdomestik/database', () => ({
     staffId: { name: 'staffId' },
     userId: { name: 'userId' },
     title: { name: 'title' },
+    lifecycleVersion: { name: 'lifecycleVersion' },
   },
+  claimStageHistory: {},
   user: { id: { name: 'id' }, tenantId: { name: 'tenantId' }, email: { name: 'email' } },
   db: {
     select: () => ({
@@ -47,6 +50,27 @@ vi.mock('@interdomestik/database', () => ({
     update: () => ({
       set: () => ({ where: mocks.dbUpdate }),
     }),
+    transaction: async <T>(callback: (tx: unknown) => T) =>
+      callback({
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: () =>
+                Promise.resolve([{ id: 'claim-1', lifecycleVersion: 1, status: 'submitted' }]),
+            }),
+          }),
+        }),
+        update: () => ({
+          set: () => ({
+            where: () => ({
+              returning: mocks.txUpdateReturning,
+            }),
+          }),
+        }),
+        insert: () => ({
+          values: mocks.txInsertValues,
+        }),
+      }),
     query: {
       user: {
         findFirst: () => mocks.dbQueryUser(),
@@ -58,6 +82,7 @@ vi.mock('@interdomestik/database', () => ({
   },
   and: vi.fn(),
   eq: vi.fn(),
+  sql: vi.fn(),
 }));
 
 vi.mock('next/cache', () => ({
@@ -77,39 +102,12 @@ describe('Staff Claims Actions', () => {
   });
 
   describe('updateClaimStatus', () => {
-    it('should throw if user is not authenticated', async () => {
-      mocks.getSession.mockResolvedValue(null);
-      mocks.getSession.mockResolvedValue(null);
-      await expect(updateClaimStatus('claim-1', 'resolved')).resolves.toEqual({
-        success: false,
-        error: 'Unauthorized',
-      });
-    });
-
-    it('should throw if user is a regular member', async () => {
-      mocks.getSession.mockResolvedValue({
-        user: { id: 'user-1', role: 'user', tenantId: 'tenant_mk' },
-      });
-      await expect(updateClaimStatus('claim-1', 'resolved')).resolves.toEqual({
-        success: false,
-        error: 'Unauthorized',
-      });
-    });
-
-    it('should throw if user role is user (not staff/admin)', async () => {
-      mocks.getSession.mockResolvedValue({
-        user: { id: 'user-1', role: 'user', tenantId: 'tenant_mk' },
-      });
-      await expect(updateClaimStatus('claim-1', 'resolved')).resolves.toEqual({
-        success: false,
-        error: 'Unauthorized',
-      });
-    });
-
-    it('should throw if user role is agent (sales only)', async () => {
-      mocks.getSession.mockResolvedValue({
-        user: { id: 'agent-1', role: 'agent', tenantId: 'tenant_mk' },
-      });
+    it.each([
+      ['unauthenticated user', null],
+      ['regular member', { user: { id: 'user-1', role: 'user', tenantId: 'tenant_mk' } }],
+      ['sales agent', { user: { id: 'agent-1', role: 'agent', tenantId: 'tenant_mk' } }],
+    ])('should reject %s status updates', async (_label, session) => {
+      mocks.getSession.mockResolvedValue(session);
       await expect(updateClaimStatus('claim-1', 'resolved')).resolves.toEqual({
         success: false,
         error: 'Unauthorized',
@@ -130,11 +128,12 @@ describe('Staff Claims Actions', () => {
           userEmail: 'user@test.com',
         },
       ]);
-      mocks.dbUpdate.mockResolvedValue(undefined);
+      mocks.txUpdateReturning.mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 2 }]);
+      mocks.txInsertValues.mockResolvedValue(undefined);
 
       await updateClaimStatus('claim-1', 'verification');
 
-      expect(mocks.dbUpdate).toHaveBeenCalled();
+      expect(mocks.txUpdateReturning).toHaveBeenCalled();
     });
 
     it('should allow admin to update claim status', async () => {
@@ -150,11 +149,12 @@ describe('Staff Claims Actions', () => {
           userEmail: 'user@test.com',
         },
       ]);
-      mocks.dbUpdate.mockResolvedValue(undefined);
+      mocks.txUpdateReturning.mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 2 }]);
+      mocks.txInsertValues.mockResolvedValue(undefined);
 
       await updateClaimStatus('claim-1', 'resolved');
 
-      expect(mocks.dbUpdate).toHaveBeenCalled();
+      expect(mocks.txUpdateReturning).toHaveBeenCalled();
     });
   });
 

--- a/packages/domain-claims/src/agent-claims/update-status.test.ts
+++ b/packages/domain-claims/src/agent-claims/update-status.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { updateClaimStatusCore } from './update-status';
+
+const mocks = vi.hoisted(() => {
+  const claimWhere = vi.fn();
+  const claimLeftJoin = vi.fn(() => ({ where: claimWhere }));
+  const claimFrom = vi.fn(() => ({ leftJoin: claimLeftJoin }));
+  return {
+    claimWhere,
+    dbSelect: vi.fn(() => ({ from: claimFrom })),
+    dbUpdate: vi.fn(),
+    getPaymentAuthorizationState: vi.fn(),
+    transitionClaimStatus: vi.fn(),
+    withTenant: vi.fn((tenantId, tenantColumn, condition) => ({
+      condition,
+      tenantColumn,
+      tenantId,
+    })),
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  claims: {
+    id: 'claims.id',
+    staffId: 'claims.staff_id',
+    status: 'claims.status',
+    tenantId: 'claims.tenant_id',
+    title: 'claims.title',
+    userId: 'claims.user_id',
+  },
+  db: {
+    select: mocks.dbSelect,
+    update: mocks.dbUpdate,
+  },
+  eq: vi.fn((left, right) => ({ left, right })),
+  user: { email: 'user.email', id: 'user.id' },
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: vi.fn(() => 'tenant-1'),
+}));
+
+vi.mock('../claims/transition', () => ({
+  transitionClaimStatus: mocks.transitionClaimStatus,
+}));
+
+vi.mock('../admin-claims/payment-authorization', () => ({
+  getPaymentAuthorizationState: mocks.getPaymentAuthorizationState,
+}));
+
+const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
+const staffSession = { user: { id: 'staff-1', role: 'staff', tenantId: 'tenant-1' } } as never;
+
+function mockClaim(status: string) {
+  mocks.claimWhere.mockResolvedValueOnce([
+    {
+      id: 'claim-1',
+      staffId: 'staff-1',
+      status,
+      title: 'Claim',
+      userEmail: 'member@example.com',
+      userId: 'member-1',
+    },
+  ]);
+}
+
+function runStatusUpdate(deps = {}, newStatus = 'verification') {
+  return updateClaimStatusCore(
+    {
+      claimId: 'claim-1',
+      newStatus,
+      requestHeaders,
+      session: staffSession,
+    },
+    deps
+  );
+}
+
+describe('agent updateClaimStatusCore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.transitionClaimStatus.mockResolvedValue({
+      success: true,
+      fromStatus: 'submitted',
+      lifecycleVersion: 2,
+      status: 'negotiation',
+    });
+  });
+
+  it('routes agent status changes through the transition command', async () => {
+    const logAuditEvent = vi.fn();
+    const notifyStatusChanged = vi.fn().mockResolvedValue(undefined);
+    mockClaim('submitted');
+    mocks.getPaymentAuthorizationState.mockResolvedValueOnce('authorized');
+
+    const result = await runStatusUpdate({ logAuditEvent, notifyStatusChanged }, 'negotiation');
+
+    expect(result).toEqual({ success: true, error: undefined });
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(mocks.transitionClaimStatus).toHaveBeenCalledWith({
+      actor: { id: 'staff-1', role: 'staff' },
+      claimId: 'claim-1',
+      paymentAuthorizationState: 'authorized',
+      tenantId: 'tenant-1',
+      toStatus: 'negotiation',
+    });
+    expect(logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'staff-1',
+        action: 'claim.status_changed',
+        entityId: 'claim-1',
+        headers: requestHeaders,
+        metadata: { oldStatus: 'submitted', newStatus: 'negotiation' },
+        tenantId: 'tenant-1',
+      })
+    );
+    await vi.waitFor(() =>
+      expect(notifyStatusChanged).toHaveBeenCalledWith(
+        'member-1',
+        'member@example.com',
+        { id: 'claim-1', title: 'Claim' },
+        'submitted',
+        'negotiation'
+      )
+    );
+  });
+
+  it.each([
+    ['transition_rejected', 'Invalid status transition'],
+    ['invalid_current_status', 'Invalid current claim status'],
+  ])('surfaces %s without audit or notification side effects', async (error, expectedError) => {
+    const logAuditEvent = vi.fn();
+    const notifyStatusChanged = vi.fn();
+    mockClaim('evaluation');
+    mocks.transitionClaimStatus.mockResolvedValueOnce({ success: false, error });
+
+    const result = await runStatusUpdate({ logAuditEvent, notifyStatusChanged });
+
+    expect(result).toEqual({ success: false, error: expectedError, data: undefined });
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(logAuditEvent).not.toHaveBeenCalled();
+    expect(notifyStatusChanged).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-claims/src/agent-claims/update-status.ts
+++ b/packages/domain-claims/src/agent-claims/update-status.ts
@@ -3,7 +3,9 @@ import { withTenant } from '@interdomestik/database/tenant-security';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 
 import type { ActionResult, ClaimsDeps, ClaimsSession } from '../claims/types';
+import { transitionClaimStatus } from '../claims/transition';
 import { claimStatusSchema } from '../validators/claims';
+import { getPaymentAuthorizationState } from '../admin-claims/payment-authorization';
 
 function isStaff(role: string | null | undefined) {
   return role === 'staff';
@@ -11,6 +13,18 @@ function isStaff(role: string | null | undefined) {
 
 function isStaffOrAdmin(role: string | null | undefined) {
   return role === 'staff' || role === 'admin';
+}
+
+function transitionFailureMessage(error: string): string {
+  if (error === 'claim_not_found') {
+    return 'Claim not found';
+  }
+
+  if (error === 'invalid_current_status') {
+    return 'Invalid current claim status';
+  }
+
+  return 'Invalid status transition';
 }
 
 export async function updateClaimStatusCore(
@@ -59,13 +73,30 @@ export async function updateClaimStatusCore(
     return { success: false, error: 'Access denied', data: undefined };
   }
 
-  const oldStatus = claimWithUser.status || 'draft';
+  const paymentAuthorizationState = await getPaymentAuthorizationState({
+    claimId,
+    status,
+    tenantId,
+  });
 
-  // Update status
-  await db
-    .update(claims)
-    .set({ status: status })
-    .where(withTenant(tenantId, claims.tenantId, eq(claims.id, claimId)));
+  const transitionResult = await transitionClaimStatus({
+    actor: { id: session.user.id, role: session.user.role ?? null },
+    claimId,
+    ...(paymentAuthorizationState !== undefined ? { paymentAuthorizationState } : {}),
+    tenantId,
+    toStatus: status,
+  });
+
+  if (!transitionResult.success) {
+    return {
+      success: false,
+      error: transitionFailureMessage(transitionResult.error),
+      data: undefined,
+    };
+  }
+
+  const oldStatus = transitionResult.fromStatus;
+  const persistedStatus = transitionResult.status;
 
   if (deps.logAuditEvent) {
     await deps.logAuditEvent({
@@ -77,7 +108,7 @@ export async function updateClaimStatusCore(
       entityId: claimId,
       metadata: {
         oldStatus,
-        newStatus: status,
+        newStatus: persistedStatus,
       },
       headers: requestHeaders,
     });
@@ -87,7 +118,7 @@ export async function updateClaimStatusCore(
   if (
     claimWithUser.userId &&
     claimWithUser.userEmail &&
-    oldStatus !== status &&
+    oldStatus !== persistedStatus &&
     deps.notifyStatusChanged
   ) {
     Promise.resolve(
@@ -96,7 +127,7 @@ export async function updateClaimStatusCore(
         claimWithUser.userEmail,
         { id: claimWithUser.id, title: claimWithUser.title },
         oldStatus,
-        status
+        persistedStatus
       )
     ).catch((err: Error) => console.error('Failed to send status notification:', err));
   }

--- a/scripts/check-claim-status-writers.mjs
+++ b/scripts/check-claim-status-writers.mjs
@@ -32,7 +32,6 @@ export const CLAIM_STATUS_WRITER_ALLOWLIST = new Set([
   'packages/database/src/seed-golden/claims.ts',
   'packages/database/src/seed-packs/ks-workflow-pack.ts',
   'packages/database/test/rls-engaged.test.ts',
-  'packages/domain-claims/src/agent-claims/update-status.ts',
   'packages/domain-claims/src/claims/create.ts',
   'packages/domain-claims/src/claims/draft.ts',
   'packages/domain-claims/src/claims/status.ts',
@@ -50,14 +49,26 @@ export const CLAIM_STATUS_WRITER_ALLOWLIST = new Set([
 const CLAIMS_REF = String.raw`(?:schema\.)?claims`;
 const STATUS_UPDATE_PATTERNS = [
   // Drizzle updates with status in set
-  new RegExp(String.raw`\.update\(\s*${CLAIMS_REF}\s*\)[\s\S]{0,1200}\.set\(\s*\{[\s\S]{0,800}\bstatus\b`, 'u'),
-  new RegExp(String.raw`\.update\(\s*${CLAIMS_REF}\s*\)[\s\S]{0,1200}\.set\(\s*updateData\s*\)`, 'u'),
+  new RegExp(
+    String.raw`\.update\(\s*${CLAIMS_REF}\s*\)[\s\S]{0,1200}\.set\(\s*\{[\s\S]{0,800}\bstatus\b`,
+    'u'
+  ),
+  new RegExp(
+    String.raw`\.update\(\s*${CLAIMS_REF}\s*\)[\s\S]{0,1200}\.set\(\s*updateData\s*\)`,
+    'u'
+  ),
   // Drizzle inserts with status
-  new RegExp(String.raw`\.insert\(\s*${CLAIMS_REF}\s*\)[\s\S]{0,1400}\.values\(\s*\{[\s\S]{0,1000}\bstatus\s*:`, 'u'),
-  new RegExp(String.raw`\.insert\(\s*${CLAIMS_REF}\s*\)[\s\S]{0,1800}\.onConflictDoUpdate\([\s\S]{0,900}\bstatus\s*:`, 'u'),
+  new RegExp(
+    String.raw`\.insert\(\s*${CLAIMS_REF}\s*\)[\s\S]{0,1400}\.values\(\s*\{[\s\S]{0,1000}\bstatus\s*:`,
+    'u'
+  ),
+  new RegExp(
+    String.raw`\.insert\(\s*${CLAIMS_REF}\s*\)[\s\S]{0,1800}\.onConflictDoUpdate\([\s\S]{0,900}\bstatus\s*:`,
+    'u'
+  ),
   // Raw SQL updates/inserts
-  /UPDATE\s+claims\s+SET\s+[\s\S]{0,150}\bstatus\b/ui,
-  /INSERT\s+INTO\s+claims\s+[\s\S]{0,250}\bstatus\b/ui,
+  /UPDATE\s+claims\s+SET\s+[\s\S]{0,150}\bstatus\b/iu,
+  /INSERT\s+INTO\s+claims\s+[\s\S]{0,250}\bstatus\b/iu,
 ];
 
 function toPosix(value) {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 31039555,
-  "maxTrackedFiles": 3871,
+  "maxTrackedBytes": 31044897,
+  "maxTrackedFiles": 3872,
   "maxLargestFileBytes": 1048576,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 14300000,
-    "source/scripts": 6409578,
-    "tests/e2e": 4219785,
+    "source/scripts": 6410451,
+    "tests/e2e": 4221149,
     "docs/text": 4471381,
     "config/data/messages": 1572864,
     "other": 1048576


### PR DESCRIPTION
## Summary
- Route `packages/domain-claims/src/agent-claims/update-status.ts` through `transitionClaimStatus()` while preserving agent API behavior, assignment checks, audit metadata, notification behavior, and transition rejection mapping.
- Add focused agent writer tests for command success and transition rejection.
- Remove the package agent writer from the direct claim-status writer allowlist and update repo-size budgets for the measured scoped increase.

## Verification
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/agent-claims/update-status.test.ts`
- `node --test scripts/ci/claim-status-writer-guard.test.mjs`
- `pnpm --filter @interdomestik/domain-claims type-check`
- `pnpm --filter @interdomestik/domain-claims test:unit`
- `pnpm --filter @interdomestik/web test:unit --run src/actions/agent-claims.test.ts`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm exec prettier --check apps/web/src/actions/agent-claims.test.ts packages/domain-claims/src/agent-claims/update-status.ts packages/domain-claims/src/agent-claims/update-status.test.ts scripts/check-claim-status-writers.mjs scripts/repo-size-budget.json`
- `git diff --check`
- `pnpm repo:size:check`
- MCP `scope_audit`
- MCP `security_guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`

Notes: MCP `pr_verify` was attempted first and timed out after 120s, so the shell fallback `pnpm pr:verify` was used and passed. The Codex Security diff-scan callable was not exposed by tool discovery; fallback coverage was MCP `security_guard` plus diff-scoped sidecar security review, both clean.