### PR TITLE
ARCH-M0-16 route draft cancellation through claim transitions

### DIFF
--- a/packages/domain-claims/src/claims/draft-cancellation.ts
+++ b/packages/domain-claims/src/claims/draft-cancellation.ts
@@ -1,0 +1,103 @@
+import { db } from '@interdomestik/database';
+import { withTenant } from '@interdomestik/database/tenant-security';
+import { ensureTenantId } from '@interdomestik/shared-auth';
+
+import { transitionClaimStatus } from './transition';
+import type { ClaimsDeps, ClaimsSession } from './types';
+
+function transitionFailureMessage(error: string): string {
+  if (error === 'claim_not_found') {
+    return 'Claim not found';
+  }
+
+  if (error === 'invalid_current_status') {
+    return 'Invalid current claim status';
+  }
+
+  return 'Invalid status transition';
+}
+
+async function loadTenantClaim(tenantId: string, claimId: string) {
+  return db.query.claims.findFirst({
+    where: (claimsTable, { eq }) =>
+      withTenant(tenantId, claimsTable.tenantId, eq(claimsTable.id, claimId)),
+  });
+}
+
+function cancellationAccessError(
+  claim: Awaited<ReturnType<typeof loadTenantClaim>>,
+  userId: string
+): string | null {
+  if (!claim) {
+    return 'Claim not found';
+  }
+
+  if (claim.userId !== userId) {
+    return 'Access denied';
+  }
+
+  if (claim.status === 'resolved' || claim.status === 'rejected') {
+    return 'Claim cannot be cancelled';
+  }
+
+  return null;
+}
+
+export async function cancelClaimCore(
+  params: {
+    session: ClaimsSession | null;
+    requestHeaders: Headers;
+    claimId: string;
+  },
+  deps: ClaimsDeps = {}
+) {
+  const { session, requestHeaders, claimId } = params;
+
+  if (!session) {
+    return { success: false, error: 'Unauthorized' };
+  }
+
+  const tenantId = ensureTenantId(session);
+  const accessError = cancellationAccessError(
+    await loadTenantClaim(tenantId, claimId),
+    session.user.id
+  );
+  if (accessError) {
+    return { success: false, error: accessError };
+  }
+
+  try {
+    const transitionResult = await transitionClaimStatus({
+      actor: { id: session.user.id, role: session.user.role ?? null },
+      claimId,
+      tenantId,
+      toStatus: 'rejected',
+    });
+
+    if (!transitionResult.success) {
+      return { success: false, error: transitionFailureMessage(transitionResult.error) };
+    }
+
+    await deps.logAuditEvent?.({
+      actorId: session.user.id,
+      actorRole: session.user.role,
+      tenantId,
+      action: 'claim.cancelled',
+      entityType: 'claim',
+      entityId: claimId,
+      metadata: {
+        oldStatus: transitionResult.fromStatus,
+        newStatus: transitionResult.status,
+      },
+      headers: requestHeaders,
+    });
+  } catch (error) {
+    console.error('Failed to cancel claim:', error);
+    return { success: false, error: 'Failed to cancel claim' };
+  }
+
+  await deps.revalidatePath?.('/member/claims');
+  await deps.revalidatePath?.(`/member/claims/${claimId}`);
+
+  return { success: true };
+}

--- a/packages/domain-claims/src/claims/draft.test.ts
+++ b/packages/domain-claims/src/claims/draft.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  dbUpdate: vi.fn(),
+  findFirst: vi.fn(),
+  transitionClaimStatus: vi.fn(),
+  withTenant: vi.fn(() => ({ scoped: true })),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  claimDocuments: {},
+  claims: {
+    id: 'claims.id',
+    tenantId: 'claims.tenant_id',
+  },
+  db: {
+    insert: vi.fn(),
+    query: { claims: { findFirst: mocks.findFirst } },
+    update: mocks.dbUpdate,
+  },
+  eq: vi.fn((left, right) => ({ left, right })),
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: vi.fn(() => 'tenant-1'),
+}));
+
+vi.mock('./transition', () => ({
+  transitionClaimStatus: mocks.transitionClaimStatus,
+}));
+
+import { cancelClaimCore } from './draft';
+
+const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
+const memberSession = { user: { id: 'member-1', role: 'member', tenantId: 'tenant-1' } } as never;
+
+function mockClaim(status = 'draft') {
+  mocks.findFirst.mockResolvedValueOnce({
+    id: 'claim-1',
+    status,
+    tenantId: 'tenant-1',
+    title: 'Claim',
+    userId: 'member-1',
+  });
+}
+
+function runCancel(deps = {}) {
+  return cancelClaimCore({ claimId: 'claim-1', requestHeaders, session: memberSession }, deps);
+}
+
+function sideEffectDeps() {
+  return {
+    logAuditEvent: vi.fn(),
+    revalidatePath: vi.fn(),
+  };
+}
+
+describe('cancelClaimCore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.transitionClaimStatus.mockResolvedValue({
+      success: true,
+      fromStatus: 'draft',
+      lifecycleVersion: 2,
+      status: 'rejected',
+    });
+  });
+
+  it('routes successful cancellation through the transition command', async () => {
+    const deps = sideEffectDeps();
+    mockClaim();
+
+    const result = await runCancel(deps);
+
+    expect(result).toEqual({ success: true });
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(mocks.transitionClaimStatus).toHaveBeenCalledWith({
+      actor: { id: 'member-1', role: 'member' },
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      toStatus: 'rejected',
+    });
+    expect(deps.logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'claim.cancelled',
+        actorId: 'member-1',
+        entityId: 'claim-1',
+        headers: requestHeaders,
+        metadata: { oldStatus: 'draft', newStatus: 'rejected' },
+        tenantId: 'tenant-1',
+      })
+    );
+    expect(deps.revalidatePath).toHaveBeenCalledWith('/member/claims');
+    expect(deps.revalidatePath).toHaveBeenCalledWith('/member/claims/claim-1');
+  });
+
+  it('surfaces transition rejection without audit or revalidation side effects', async () => {
+    const deps = sideEffectDeps();
+    mockClaim('submitted');
+    mocks.transitionClaimStatus.mockResolvedValueOnce({
+      success: false,
+      error: 'transition_rejected',
+    });
+
+    const result = await runCancel(deps);
+
+    expect(result).toEqual({ success: false, error: 'Invalid status transition' });
+    expect(mocks.transitionClaimStatus).toHaveBeenCalledWith({
+      actor: { id: 'member-1', role: 'member' },
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      toStatus: 'rejected',
+    });
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+    expect(deps.logAuditEvent).not.toHaveBeenCalled();
+    expect(deps.revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('preserves terminal-status cancellation rejection before transition', async () => {
+    mockClaim('resolved');
+
+    const result = await runCancel(sideEffectDeps());
+
+    expect(result).toEqual({ success: false, error: 'Claim cannot be cancelled' });
+    expect(mocks.transitionClaimStatus).not.toHaveBeenCalled();
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-claims/src/claims/draft.ts
+++ b/packages/domain-claims/src/claims/draft.ts
@@ -6,6 +6,8 @@ import { createClaimSchema, type CreateClaimValues } from '../validators/claims'
 import { buildClaimDocumentRows } from './documents';
 import type { ClaimsDeps, ClaimsSession } from './types';
 
+export { cancelClaimCore } from './draft-cancellation';
+
 export async function updateDraftClaimCore(
   params: {
     session: ClaimsSession | null;
@@ -93,75 +95,6 @@ export async function updateDraftClaimCore(
   } catch (error) {
     console.error('Failed to update claim:', error);
     return { success: false, error: 'Failed to update claim' };
-  }
-
-  if (deps.revalidatePath) {
-    await deps.revalidatePath('/member/claims');
-    await deps.revalidatePath(`/member/claims/${claimId}`);
-  }
-
-  return { success: true };
-}
-
-export async function cancelClaimCore(
-  params: {
-    session: ClaimsSession | null;
-    requestHeaders: Headers;
-    claimId: string;
-  },
-  deps: ClaimsDeps = {}
-) {
-  const { session, requestHeaders, claimId } = params;
-
-  if (!session) {
-    return { success: false, error: 'Unauthorized' };
-  }
-
-  const tenantId = ensureTenantId(session);
-  const claim = await db.query.claims.findFirst({
-    where: (claimsTable, { eq }) =>
-      withTenant(tenantId, claimsTable.tenantId, eq(claimsTable.id, claimId)),
-  });
-
-  if (!claim) {
-    return { success: false, error: 'Claim not found' };
-  }
-
-  if (claim.userId !== session.user.id) {
-    return { success: false, error: 'Access denied' };
-  }
-
-  if (claim.status === 'resolved' || claim.status === 'rejected') {
-    return { success: false, error: 'Claim cannot be cancelled' };
-  }
-
-  try {
-    await db
-      .update(claims)
-      .set({
-        status: 'rejected',
-        updatedAt: new Date(),
-      })
-      .where(withTenant(tenantId, claims.tenantId, eq(claims.id, claimId)));
-
-    if (deps.logAuditEvent) {
-      await deps.logAuditEvent({
-        actorId: session.user.id,
-        actorRole: session.user.role,
-        tenantId,
-        action: 'claim.cancelled',
-        entityType: 'claim',
-        entityId: claimId,
-        metadata: {
-          oldStatus: claim.status,
-          newStatus: 'rejected',
-        },
-        headers: requestHeaders,
-      });
-    }
-  } catch (error) {
-    console.error('Failed to cancel claim:', error);
-    return { success: false, error: 'Failed to cancel claim' };
   }
 
   if (deps.revalidatePath) {

--- a/scripts/check-claim-status-writers.mjs
+++ b/scripts/check-claim-status-writers.mjs
@@ -33,7 +33,6 @@ export const CLAIM_STATUS_WRITER_ALLOWLIST = new Set([
   'packages/database/src/seed-packs/ks-workflow-pack.ts',
   'packages/database/test/rls-engaged.test.ts',
   'packages/domain-claims/src/claims/create.ts',
-  'packages/domain-claims/src/claims/draft.ts',
   'packages/domain-claims/src/claims/submit.ts',
   'packages/domain-claims/src/claims/transition.ts',
   'packages/domain-claims/src/staff-claims/update-status.ts',

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 32404731,
-  "maxTrackedFiles": 3875,
+  "maxTrackedBytes": 32410000,
+  "maxTrackedFiles": 3877,
   "maxLargestFileBytes": 2319951,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 15622155,
-    "source/scripts": 6411904,
-    "tests/e2e": 4223473,
+    "source/scripts": 6412600,
+    "tests/e2e": 4225000,
     "docs/text": 4489981,
     "config/data/messages": 1572864,
     "other": 1048576


### PR DESCRIPTION
## Summary
- route member draft cancellation through transitionClaimStatus()
- preserve cancelClaimCore API behavior, member/tenant scoping, audit metadata, history/version behavior, and rejection mapping
- add focused success/rejection tests and update the claim-status writer guard
- adjust repo-size budget narrowly for the two focused files

## Verification
- pnpm --filter @interdomestik/domain-claims test:unit -- src/claims/draft.test.ts
- node scripts/check-claim-status-writers.mjs
- node --test scripts/ci/claim-status-writer-guard.test.mjs
- pnpm --filter @interdomestik/domain-claims type-check
- git diff --check
- pnpm repo:size:check
- node --test scripts/ci/repo-size-audit.test.mjs
- interdomestik_qa.scope_audit
- interdomestik_qa.security_guard
- pnpm ci:local:quick
- Codex Security diff scan: no reportable findings
- pnpm pr:verify
- pnpm e2e:gate (134 passed, 6 skipped)

## Notes
- pnpm ci:local:pr was attempted in Docker parity and reached the containerized Next build TypeScript phase after passing coverage/release/RLS prep, then exited 137 in the constrained Docker runtime. The required host gates above passed afterward.
- apps/web/src/proxy.ts and canonical routes were not changed.
