### PR TITLE
test: classify claim initialization status writers

### DIFF
--- a/scripts/check-claim-status-writers.mjs
+++ b/scripts/check-claim-status-writers.mjs
@@ -25,21 +25,33 @@ const EXCLUDED_DIRS = new Set([
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
 
-export const CLAIM_STATUS_WRITER_ALLOWLIST = new Set([
+export const CLAIM_STATUS_TRANSITION_WRITERS = new Set([
+  'packages/domain-claims/src/claims/transition.ts',
+  'packages/domain-claims/src/staff-claims/update-status.ts',
+]);
+
+export const CLAIM_STATUS_INITIALIZATION_WRITERS = new Set([
+  'packages/domain-claims/src/claims/create.ts',
+  'packages/domain-claims/src/claims/submit.ts',
+]);
+
+export const CLAIM_STATUS_FIXTURE_WRITERS = new Set([
   'apps/web/e2e/gate/agent-workspace-claims-selection.spec.ts',
   'packages/database/src/seed-full/claims.ts',
   'packages/database/src/seed-golden/claims.ts',
   'packages/database/src/seed-packs/ks-workflow-pack.ts',
   'packages/database/test/rls-engaged.test.ts',
-  'packages/domain-claims/src/claims/create.ts',
-  'packages/domain-claims/src/claims/submit.ts',
-  'packages/domain-claims/src/claims/transition.ts',
-  'packages/domain-claims/src/staff-claims/update-status.ts',
   'scripts/ci/db-access-guard.test.mjs',
   'scripts/pilot/day1_multi_seeder.ts',
   'scripts/pilot/day1_run3_lifecycle.ts',
   'scripts/pilot/simulate_agent_claim.ts',
   'scripts/pilot/simulate_triage.ts',
+]);
+
+export const CLAIM_STATUS_WRITER_ALLOWLIST = new Set([
+  ...CLAIM_STATUS_TRANSITION_WRITERS,
+  ...CLAIM_STATUS_INITIALIZATION_WRITERS,
+  ...CLAIM_STATUS_FIXTURE_WRITERS,
 ]);
 
 const CLAIMS_REF = String.raw`(?:schema\.)?claims`;

--- a/scripts/ci/claim-status-writer-guard.test.mjs
+++ b/scripts/ci/claim-status-writer-guard.test.mjs
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
+  CLAIM_STATUS_FIXTURE_WRITERS,
+  CLAIM_STATUS_INITIALIZATION_WRITERS,
+  CLAIM_STATUS_TRANSITION_WRITERS,
   CLAIM_STATUS_WRITER_ALLOWLIST,
   containsClaimStatusWrite,
   findClaimStatusWriterViolations,
@@ -55,6 +61,58 @@ test('ignores claim status reads', () => {
     `),
     false
   );
+});
+
+test('classifies claim creation and submit as initial status writers', () => {
+  assert.deepEqual(
+    [...CLAIM_STATUS_INITIALIZATION_WRITERS].sort((a, b) => a.localeCompare(b)),
+    ['packages/domain-claims/src/claims/create.ts', 'packages/domain-claims/src/claims/submit.ts']
+  );
+  assert.equal(
+    CLAIM_STATUS_TRANSITION_WRITERS.has('packages/domain-claims/src/claims/create.ts'),
+    false
+  );
+  assert.equal(
+    CLAIM_STATUS_FIXTURE_WRITERS.has('packages/domain-claims/src/claims/submit.ts'),
+    false
+  );
+});
+
+test('initial status writers do not update existing claim statuses', () => {
+  for (const writer of CLAIM_STATUS_INITIALIZATION_WRITERS) {
+    const source = fs.readFileSync(path.join(process.cwd(), writer), 'utf8');
+    assert.equal(hasExistingClaimUpdate(source), false, `${writer} must remain an init writer`);
+  }
+});
+
+function hasExistingClaimUpdate(source) {
+  const compactSource = source.replaceAll(/\s+/gu, '');
+  return (
+    compactSource.includes('.update(claims)') ||
+    compactSource.includes('.update(schema.claims)') ||
+    compactSource.toUpperCase().includes('UPDATECLAIMSSET')
+  );
+}
+test('keeps unexpected post-create status writers outside the inventory', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-status-writer-'));
+  try {
+    const file = path.join(root, 'packages/domain-claims/src/claims/new-writer.ts');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      `
+        import { claims } from '@interdomestik/database';
+        export async function updateExistingClaim(tx, claimId) {
+          return tx.update(claims).set({ status: 'resolved' }).where(eq(claims.id, claimId));
+        }
+      `
+    );
+
+    const result = findClaimStatusWriterViolations(root);
+    assert.deepEqual(result.unexpected, ['packages/domain-claims/src/claims/new-writer.ts']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('repo inventory has no unlisted direct claims.status writers', () => {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 32441651,
+  "maxTrackedBytes": 32444097,
   "maxTrackedFiles": 3882,
   "maxLargestFileBytes": 2332723,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 15634927,
     "source/scripts": 6420000,
-    "tests/e2e": 4230000,
+    "tests/e2e": 4231199,
     "docs/text": 4503056,
     "config/data/messages": 1572864,
     "other": 1048576


### PR DESCRIPTION
## Summary
- Split the claim-status writer guard inventory into transition, initialization, and fixture writer sets while preserving the existing allowlist union.
- Classify claim create/submit as initial status writers, not post-create transition writers.
- Add guard tests proving create/submit remain initialization-only and that unexpected post-create `claims.status` writers are rejected.
- Update the exact repo-size budget for the script/test delta.

## Model Review
- Claude Sonnet 4.6 reviewed the implementation.
- Blockers: none.
- Applied hardening: guard-level proof that initialization writers do not update existing claim statuses.
- Rejected/covered: rename drift is already covered by the inventory `missing` assertion; runtime changes are not warranted because create/submit only initialize claim rows.

## Local Verification
- `pnpm exec node --test scripts/ci/claim-status-writer-guard.test.mjs`
- `pnpm repo:size:check`
- `pnpm exec node --test scripts/ci/repo-size-audit.test.mjs`
- `git diff --check`
- `pnpm check:architecture-boundaries`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate` (rerun passed after one transient Google Fonts DNS failure during the first build attempt)

## Scope Notes
- No runtime behavior changed.
- `apps/web/src/proxy.ts` untouched.
- Claim create/submit runtime files untouched; this slice only strengthens guard classification around them.