### PR TITLE
feat: append claim transition domain events

### DIFF
--- a/apps/web/src/actions/agent-claims.test.ts
+++ b/apps/web/src/actions/agent-claims.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/lib/audit', () => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   claims: {
     id: { name: 'id' },
     tenantId: { name: 'tenantId' },
@@ -92,7 +93,6 @@ vi.mock('next/cache', () => ({
 vi.mock('next/headers', () => ({
   headers: vi.fn(),
 }));
-
 import { notifyClaimAssigned } from '@/lib/notifications';
 import { assignClaim, updateClaimStatus } from './agent-claims';
 

--- a/apps/web/src/actions/claims.test.ts
+++ b/apps/web/src/actions/claims.test.ts
@@ -48,6 +48,7 @@ vi.mock('@interdomestik/database/claim-number', () => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   db: {
     insert: () => ({ values: mockDbInsert }),
     select: () => ({ from: () => ({ where: () => ({ limit: mockPaymentLimit }) }) }),
@@ -243,7 +244,6 @@ describe('Claim Actions', () => {
     it('applies tenant default branch when subscription has no branchId', async () => {
       mockGetSession.mockResolvedValue({ user: { id: 'user-123', tenantId: 'tenant_mk' } });
 
-      // Override the domain function mock, not the DB mock
       mockGetActiveSubscription.mockResolvedValueOnce({
         id: 'sub-1',
         userId: 'user-123',

--- a/packages/database/drizzle/0069_enable_domain_events_rls.sql
+++ b/packages/database/drizzle/0069_enable_domain_events_rls.sql
@@ -1,0 +1,15 @@
+ALTER TABLE public."domain_events" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'domain_events'
+      AND policyname = 'tenant_isolation_domain_events'
+  ) THEN
+    CREATE POLICY "tenant_isolation_domain_events" ON public."domain_events"
+      USING (tenant_id = current_setting('app.current_tenant_id', true)::text)
+      WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true)::text);
+  END IF;
+END $$;

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1780517640000,
       "tag": "0068_add_domain_events_outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1780525216296,
+      "tag": "0069_enable_domain_events_rls",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/domain-claims/src/claims/transition-events.test.ts
+++ b/packages/domain-claims/src/claims/transition-events.test.ts
@@ -1,0 +1,122 @@
+import { claimStageHistory, domainEvents } from '@interdomestik/database';
+import type { ClaimStatus } from '@interdomestik/database/constants';
+import { describe, expect, it } from 'vitest';
+
+import { transitionClaimStatusInTransaction, type TransitionTx } from './transition';
+
+type Row = Record<string, unknown>;
+type ClaimState = {
+  events: Row[];
+  histories: Row[];
+  lifecycleVersion: number;
+  status: ClaimStatus;
+};
+
+function makeParams() {
+  return {
+    actor: { id: 'staff-1', role: 'staff' },
+    claimId: 'claim-1',
+    correlationId: 'corr-1',
+    paymentAuthorizationState: 'authorized' as const,
+    tenantId: 'tenant-1',
+    toStatus: 'negotiation' as const,
+  };
+}
+
+function makeTx(state: ClaimState, failOn?: 'history' | 'event') {
+  const staged = { ...state, events: [...state.events], histories: [...state.histories] };
+  const tx = {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => [{ ...state, id: 'claim-1' }] }) }),
+    }),
+    update: () => ({
+      set: (values: Row) => ({
+        where: () => ({
+          returning: async () => {
+            if (typeof values.status === 'string') staged.status = values.status as ClaimStatus;
+            if ('lifecycleVersion' in values) staged.lifecycleVersion += 1;
+            return [{ id: 'claim-1', lifecycleVersion: staged.lifecycleVersion }];
+          },
+        }),
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (values: Row) => {
+        if (table === claimStageHistory) {
+          if (failOn === 'history') throw new Error('history failed');
+          staged.histories.push(values);
+        }
+        if (table === domainEvents) {
+          if (failOn === 'event') throw new Error('event failed');
+          staged.events.push(values);
+        }
+        return { returning: async () => [{ id: values.id }] };
+      },
+    }),
+  };
+  return { commit: () => Object.assign(state, staged), tx: tx as unknown as TransitionTx };
+}
+
+async function runTransaction(state: ClaimState, failOn?: 'history' | 'event') {
+  const { commit, tx } = makeTx(state, failOn);
+  const result = await transitionClaimStatusInTransaction(tx, makeParams());
+  commit();
+  return result;
+}
+
+describe('transitionClaimStatusInTransaction event atomicity', () => {
+  it('commits status, history, and exactly one event for a successful transition', async () => {
+    const state: ClaimState = {
+      events: [],
+      histories: [],
+      lifecycleVersion: 6,
+      status: 'evaluation',
+    };
+
+    await expect(runTransaction(state)).resolves.toMatchObject({ success: true });
+
+    expect(state.status).toBe('negotiation');
+    expect(state.lifecycleVersion).toBe(7);
+    expect(state.histories).toHaveLength(1);
+    expect(state.events).toHaveLength(1);
+    expect(state.events[0]).toEqual(
+      expect.objectContaining({
+        aggregateVersion: 7,
+        actorId: 'staff-1',
+        correlationId: 'corr-1',
+        entityId: 'claim-1',
+        entityType: 'claim',
+        eventName: 'claim.status_changed',
+        eventVersion: 1,
+        payload: { fromStatus: 'evaluation', toStatus: 'negotiation' },
+        tenantId: 'tenant-1',
+      })
+    );
+  });
+
+  it('rolls back status and history when event append fails', async () => {
+    const state: ClaimState = {
+      events: [],
+      histories: [],
+      lifecycleVersion: 6,
+      status: 'evaluation',
+    };
+
+    await expect(runTransaction(state, 'event')).rejects.toThrow('event failed');
+
+    expect(state).toEqual({ events: [], histories: [], lifecycleVersion: 6, status: 'evaluation' });
+  });
+
+  it('does not commit status or event when history insert fails', async () => {
+    const state: ClaimState = {
+      events: [],
+      histories: [],
+      lifecycleVersion: 6,
+      status: 'evaluation',
+    };
+
+    await expect(runTransaction(state, 'history')).rejects.toThrow('history failed');
+
+    expect(state).toEqual({ events: [], histories: [], lifecycleVersion: 6, status: 'evaluation' });
+  });
+});

--- a/packages/domain-claims/src/claims/transition-events.test.ts
+++ b/packages/domain-claims/src/claims/transition-events.test.ts
@@ -11,6 +11,57 @@ type ClaimState = {
   lifecycleVersion: number;
   status: ClaimStatus;
 };
+type FailOn = 'history' | 'event';
+
+class FakeSelect {
+  constructor(private readonly state: ClaimState) {}
+  from(): this {
+    return this;
+  }
+  where(): this {
+    return this;
+  }
+  async limit(): Promise<Row[]> {
+    return [{ ...this.state, id: 'claim-1' }];
+  }
+}
+
+class FakeUpdate {
+  private values: Row = {};
+  constructor(private readonly staged: ClaimState) {}
+  set(values: Row): this {
+    this.values = values;
+    return this;
+  }
+  where(): this {
+    return this;
+  }
+  async returning(): Promise<Row[]> {
+    if (typeof this.values.status === 'string')
+      this.staged.status = this.values.status as ClaimStatus;
+    if ('lifecycleVersion' in this.values) this.staged.lifecycleVersion += 1;
+    return [{ id: 'claim-1', lifecycleVersion: this.staged.lifecycleVersion }];
+  }
+}
+
+class FakeInsert {
+  constructor(
+    private readonly staged: ClaimState,
+    private readonly table: unknown,
+    private readonly failOn?: FailOn
+  ) {}
+  values(values: Row) {
+    if (this.table === claimStageHistory) {
+      if (this.failOn === 'history') throw new Error('history failed');
+      this.staged.histories.push(values);
+    }
+    if (this.table === domainEvents) {
+      if (this.failOn === 'event') throw new Error('event failed');
+      this.staged.events.push(values);
+    }
+    return { returning: async () => [{ id: values.id }] };
+  }
+}
 
 function makeParams() {
   return {
@@ -23,36 +74,12 @@ function makeParams() {
   };
 }
 
-function makeTx(state: ClaimState, failOn?: 'history' | 'event') {
+function makeTx(state: ClaimState, failOn?: FailOn) {
   const staged = { ...state, events: [...state.events], histories: [...state.histories] };
   const tx = {
-    select: () => ({
-      from: () => ({ where: () => ({ limit: async () => [{ ...state, id: 'claim-1' }] }) }),
-    }),
-    update: () => ({
-      set: (values: Row) => ({
-        where: () => ({
-          returning: async () => {
-            if (typeof values.status === 'string') staged.status = values.status as ClaimStatus;
-            if ('lifecycleVersion' in values) staged.lifecycleVersion += 1;
-            return [{ id: 'claim-1', lifecycleVersion: staged.lifecycleVersion }];
-          },
-        }),
-      }),
-    }),
-    insert: (table: unknown) => ({
-      values: (values: Row) => {
-        if (table === claimStageHistory) {
-          if (failOn === 'history') throw new Error('history failed');
-          staged.histories.push(values);
-        }
-        if (table === domainEvents) {
-          if (failOn === 'event') throw new Error('event failed');
-          staged.events.push(values);
-        }
-        return { returning: async () => [{ id: values.id }] };
-      },
-    }),
+    select: () => new FakeSelect(state),
+    update: () => new FakeUpdate(staged),
+    insert: (table: unknown) => new FakeInsert(staged, table, failOn),
   };
   return { commit: () => Object.assign(state, staged), tx: tx as unknown as TransitionTx };
 }

--- a/packages/domain-claims/src/claims/transition.test.ts
+++ b/packages/domain-claims/src/claims/transition.test.ts
@@ -27,6 +27,7 @@ function makeTx(options: {
   updated?: UpdatedRows | (() => UpdatedRows);
 }) {
   const calls: {
+    eventValues?: unknown;
     historyValues?: unknown;
     updateValues?: Record<string, unknown>;
     whereConditions: unknown[];
@@ -58,14 +59,14 @@ function makeTx(options: {
     }),
     insert: (table: unknown) => ({
       values: (values: Record<string, unknown>) => {
-        if (table !== domainEvents) calls.historyValues = values;
+        if (table === domainEvents) calls.eventValues = values;
+        else calls.historyValues = values;
         return { returning: async () => [{ id: values.id }] };
       },
     }),
   };
   return { calls, tx: tx as unknown as TransitionTx };
 }
-
 describe('transitionClaimStatusInTransaction', () => {
   it('updates status with a lifecycle-version compare-and-set and appends history', async () => {
     const { calls, tx } = makeTx({
@@ -102,7 +103,6 @@ describe('transitionClaimStatusInTransaction', () => {
       })
     );
   });
-
   it('throws a typed conflict when the lifecycle version is stale', async () => {
     const { tx } = makeTx({
       current: { id: 'claim-1', lifecycleVersion: 6, status: 'evaluation' },
@@ -112,7 +112,6 @@ describe('transitionClaimStatusInTransaction', () => {
     const transition = transitionClaimStatusInTransaction(tx, makeParams());
     await expect(transition).rejects.toThrow(ClaimTransitionConflictError);
   });
-
   it('lets exactly one same-version transition win', async () => {
     let claimed = false;
     const { tx } = makeTx({
@@ -179,5 +178,6 @@ describe('transitionClaimStatusInTransaction', () => {
         toStatus: 'evaluation',
       })
     );
+    expect(calls.eventValues).toBeUndefined();
   });
 });

--- a/packages/domain-claims/src/claims/transition.test.ts
+++ b/packages/domain-claims/src/claims/transition.test.ts
@@ -1,4 +1,5 @@
 import { inspect } from 'node:util';
+import { domainEvents } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import { describe, expect, it } from 'vitest';
 
@@ -11,7 +12,6 @@ import {
 
 type UpdatedRows = Array<{ id: string; lifecycleVersion: number }>;
 type Params = TransitionClaimStatusParams;
-
 function makeParams(overrides: Partial<Params> = {}): Params {
   return {
     actor: { id: 'staff-1', role: 'staff' },
@@ -22,7 +22,6 @@ function makeParams(overrides: Partial<Params> = {}): Params {
     ...overrides,
   };
 }
-
 function makeTx(options: {
   current?: { id: string; lifecycleVersion: number; status: ClaimStatus | null };
   updated?: UpdatedRows | (() => UpdatedRows);
@@ -57,9 +56,10 @@ function makeTx(options: {
         };
       },
     }),
-    insert: () => ({
-      values: async (values: unknown) => {
-        calls.historyValues = values;
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>) => {
+        if (table !== domainEvents) calls.historyValues = values;
+        return { returning: async () => [{ id: values.id }] };
       },
     }),
   };

--- a/packages/domain-claims/src/claims/transition.ts
+++ b/packages/domain-claims/src/claims/transition.ts
@@ -1,4 +1,4 @@
-import { and, claimStageHistory, claims, db, eq, sql } from '@interdomestik/database';
+import { and, appendEvent, claimStageHistory, claims, db, eq, sql } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import type { SQLWrapper } from 'drizzle-orm';
@@ -23,6 +23,7 @@ export class ClaimTransitionConflictError extends Error {
 export type TransitionClaimStatusParams = {
   actor: ClaimTransitionActor;
   claimId: string;
+  correlationId?: string;
   isPublic?: boolean;
   note?: string | null;
   paymentAuthorizationState?: PaymentAuthorizationState | null;
@@ -43,6 +44,7 @@ export async function transitionClaimStatusInTransaction(
   const {
     actor,
     claimId,
+    correlationId,
     isPublic = true,
     note,
     paymentAuthorizationState,
@@ -116,6 +118,21 @@ export async function transitionClaimStatusInTransaction(
     note: note ?? null,
     isPublic,
     createdAt: now,
+  });
+
+  await appendEvent(tx, {
+    actor: { id: actor.id, role: actor.role?.trim() || 'unknown' },
+    aggregateVersion: lifecycleVersion,
+    correlationId: correlationId ?? crypto.randomUUID(),
+    createdAt: now,
+    entity: { id: claimId, type: 'claim' },
+    eventName: 'claim.status_changed',
+    eventVersion: 1,
+    payload: {
+      fromStatus: current.status,
+      toStatus,
+    },
+    tenantId,
   });
 
   return { success: true, fromStatus: current.status, lifecycleVersion, status: toStatus };

--- a/packages/domain-claims/src/claims/transition.ts
+++ b/packages/domain-claims/src/claims/transition.ts
@@ -120,20 +120,22 @@ export async function transitionClaimStatusInTransaction(
     createdAt: now,
   });
 
-  await appendEvent(tx, {
-    actor: { id: actor.id, role: actor.role?.trim() || 'unknown' },
-    aggregateVersion: lifecycleVersion,
-    correlationId: correlationId ?? crypto.randomUUID(),
-    createdAt: now,
-    entity: { id: claimId, type: 'claim' },
-    eventName: 'claim.status_changed',
-    eventVersion: 1,
-    payload: {
-      fromStatus: current.status,
-      toStatus,
-    },
-    tenantId,
-  });
+  if (current.status !== toStatus) {
+    await appendEvent(tx, {
+      actor: { id: actor.id, role: actor.role?.trim() || 'unknown' },
+      aggregateVersion: lifecycleVersion,
+      correlationId: correlationId ?? crypto.randomUUID(),
+      createdAt: now,
+      entity: { id: claimId, type: 'claim' },
+      eventName: 'claim.status_changed',
+      eventVersion: 1,
+      payload: {
+        fromStatus: current.status,
+        toStatus,
+      },
+      tenantId,
+    });
+  }
 
   return { success: true, fromStatus: current.status, lifecycleVersion, status: toStatus };
 }

--- a/packages/domain-claims/src/staff-claims/update-status.test.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.test.ts
@@ -211,6 +211,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@interdomestik/database', () => ({
   and: mocks.and,
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   claimEscalationAgreements: mocks.claimEscalationAgreements,
   claimStageHistory: mocks.claimStageHistory,
   claims: mocks.claims,
@@ -220,7 +221,6 @@ vi.mock('@interdomestik/database', () => ({
   sql: mocks.sql,
   subscriptions: mocks.subscriptions,
 }));
-
 vi.mock('@interdomestik/database/tenant-security', () => ({
   withTenant: mocks.withTenant,
 }));

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 32855187,
-  "maxTrackedFiles": 3891,
+  "maxTrackedBytes": 32859838,
+  "maxTrackedFiles": 3892,
   "maxLargestFileBytes": 2339000,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 16023712,
-    "source/scripts": 6420000,
-    "tests/e2e": 4238013,
+    "source/scripts": 6420418,
+    "tests/e2e": 4242198,
     "docs/text": 4513495,
     "config/data/messages": 1572864,
     "other": 1048576

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 32860610,
-  "maxTrackedFiles": 3892,
+  "maxTrackedBytes": 32861307,
+  "maxTrackedFiles": 3893,
   "maxLargestFileBytes": 2339000,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
-    "large support/generated-ish": 16023712,
+    "large support/generated-ish": 16024409,
     "source/scripts": 6420487,
     "tests/e2e": 4242901,
     "docs/text": 4513495,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 32859838,
+  "maxTrackedBytes": 32860423,
   "maxTrackedFiles": 3892,
   "maxLargestFileBytes": 2339000,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 16023712,
     "source/scripts": 6420418,
-    "tests/e2e": 4242198,
+    "tests/e2e": 4242783,
     "docs/text": 4513495,
     "config/data/messages": 1572864,
     "other": 1048576

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 32860423,
+  "maxTrackedBytes": 32860610,
   "maxTrackedFiles": 3892,
   "maxLargestFileBytes": 2339000,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 16023712,
-    "source/scripts": 6420418,
-    "tests/e2e": 4242783,
+    "source/scripts": 6420487,
+    "tests/e2e": 4242901,
     "docs/text": 4513495,
     "config/data/messages": 1572864,
     "other": 1048576


### PR DESCRIPTION
## Summary
- append claim.status_changed domain events inside the existing claim status transition transaction
- keep event payload conservative/non-PII with tenant, actor id/role, claim aggregate id, correlation id, and post-update lifecycle version
- add atomicity tests for successful append, event append rollback, and history failure no-partial-commit paths
- update existing database mocks and repo size budget for the new focused test

## Verification
- git diff --cached --check
- pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/transition.test.ts src/claims/transition-events.test.ts src/claims/transition-rejection.test.ts
- node scripts/check-claim-status-writers.mjs
- node --test scripts/ci/claim-status-writer-guard.test.mjs scripts/ci/claim-status-writer-guard-raw-sql.test.mjs
- pnpm --filter @interdomestik/domain-claims type-check
- pnpm --filter @interdomestik/web test:unit --run src/actions/claims.test.ts src/actions/agent-claims.test.ts
- pnpm --filter @interdomestik/domain-claims test:unit --run src/staff-claims/update-status.test.ts
- pnpm security:guard
- pnpm pr:verify
- pnpm e2e:gate

## Review
- Sonnet architecture/scope review completed; conditional aggregateVersion/tx/actor checks passed by inspection.

## Notes
- apps/web/src/proxy.ts untouched.
- Existing unstaged .codex/config.toml local change was not included.