### PR TITLE
feat: add claim status audit projection consumer

### DIFF
--- a/packages/database/src/domain-event-audit-projection.ts
+++ b/packages/database/src/domain-event-audit-projection.ts
@@ -1,0 +1,116 @@
+import { CLAIM_STATUSES, type ClaimStatus } from './constants';
+import { relayDomainEvents } from './domain-event-relay';
+import type {
+  DomainEventRelayConsumer,
+  DomainEventRelayEvent,
+  RelayDomainEventsParams,
+  RelayDomainEventsResult,
+} from './domain-event-relay-types';
+import type { DomainEventTx } from './domain-events';
+import { auditLog } from './schema/notes';
+
+export const CLAIM_STATUS_AUDIT_PROJECTION_CONSUMER_NAME = 'audit_projection';
+
+type AuditProjectionRelayTx = DomainEventTx & {
+  execute<T>(query: unknown): Promise<T[]>;
+};
+
+type ClaimStatusChangedPayload = {
+  fromStatus: ClaimStatus;
+  toStatus: ClaimStatus;
+};
+
+export type ProjectClaimStatusChangedAuditResult = {
+  auditLogId: string;
+  status: 'projected' | 'already_projected';
+};
+
+const CLAIM_STATUS_SET = new Set<string>(CLAIM_STATUSES);
+
+function assertNonBlank(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`audit projection requires ${field}`);
+  return normalized;
+}
+
+function assertClaimStatus(value: unknown, field: string): asserts value is ClaimStatus {
+  if (typeof value !== 'string' || !CLAIM_STATUS_SET.has(value)) {
+    throw new Error(`audit projection requires payload.${field} to be a claim status`);
+  }
+}
+
+function claimStatusAuditLogId(eventId: string): string {
+  return `domain-event-audit:${assertNonBlank(eventId, 'event.id')}`;
+}
+
+function claimStatusChangedPayload(event: DomainEventRelayEvent): ClaimStatusChangedPayload {
+  if (event.eventName !== 'claim.status_changed' || event.eventVersion !== 1) {
+    throw new Error('audit projection only supports claim.status_changed@1');
+  }
+  if (event.entityType !== 'claim') {
+    throw new Error('audit projection requires claim entity events');
+  }
+  assertClaimStatus(event.payload.fromStatus, 'fromStatus');
+  assertClaimStatus(event.payload.toStatus, 'toStatus');
+  return {
+    fromStatus: event.payload.fromStatus,
+    toStatus: event.payload.toStatus,
+  };
+}
+
+export async function projectClaimStatusChangedAuditEvent(
+  tx: DomainEventTx,
+  event: DomainEventRelayEvent,
+  delivery: { idempotencyKey: string }
+): Promise<ProjectClaimStatusChangedAuditResult> {
+  const payload = claimStatusChangedPayload(event);
+  const auditLogId = claimStatusAuditLogId(event.id);
+  const [row] = await tx
+    .insert(auditLog)
+    .values({
+      id: auditLogId,
+      tenantId: assertNonBlank(event.tenantId, 'tenantId'),
+      actorId: assertNonBlank(event.actorId, 'actor.id'),
+      actorRole: assertNonBlank(event.actorRole, 'actor.role'),
+      action: event.eventName,
+      entityType: event.entityType,
+      entityId: assertNonBlank(event.entityId, 'entity.id'),
+      metadata: {
+        aggregateVersion: event.aggregateVersion,
+        correlationId: event.correlationId,
+        eventId: event.id,
+        eventCreatedAt: event.createdAt.toISOString(),
+        eventName: event.eventName,
+        eventVersion: event.eventVersion,
+        fromStatus: payload.fromStatus,
+        idempotencyKey: delivery.idempotencyKey,
+        projection: CLAIM_STATUS_AUDIT_PROJECTION_CONSUMER_NAME,
+        toStatus: payload.toStatus,
+      },
+    })
+    .onConflictDoNothing({ target: auditLog.id })
+    .returning({ id: auditLog.id });
+
+  return { auditLogId, status: row ? 'projected' : 'already_projected' };
+}
+
+export function claimStatusAuditProjectionConsumer(tx: DomainEventTx): DomainEventRelayConsumer {
+  return {
+    name: CLAIM_STATUS_AUDIT_PROJECTION_CONSUMER_NAME,
+    deliver: async (event, delivery) => {
+      await projectClaimStatusChangedAuditEvent(tx, event, delivery);
+    },
+  };
+}
+
+export async function relayClaimStatusAuditProjectionEvents(
+  tx: AuditProjectionRelayTx,
+  params: Omit<RelayDomainEventsParams, 'consumer'>
+): Promise<RelayDomainEventsResult> {
+  return relayDomainEvents(tx, {
+    ...params,
+    consumer: claimStatusAuditProjectionConsumer(tx),
+    eventName: 'claim.status_changed',
+    eventVersion: 1,
+  });
+}

--- a/packages/database/src/domain-event-delivery-keys.ts
+++ b/packages/database/src/domain-event-delivery-keys.ts
@@ -1,0 +1,9 @@
+function assertNonBlank(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`domain event relay requires ${field}`);
+  return normalized;
+}
+
+export function domainEventDeliveryIdempotencyKey(eventId: string, consumerName: string): string {
+  return `domain-event:${assertNonBlank(consumerName, 'consumer.name')}:${assertNonBlank(eventId, 'event.id')}`;
+}

--- a/packages/database/src/domain-event-delivery-recording.ts
+++ b/packages/database/src/domain-event-delivery-recording.ts
@@ -1,0 +1,38 @@
+import type { DomainEventTx } from './domain-events';
+import { domainEventDeliveryIdempotencyKey } from './domain-event-delivery-keys';
+import { domainEventDeliveries } from './schema/domain-event-deliveries';
+
+function assertNonBlank(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`domain event relay requires ${field}`);
+  return normalized;
+}
+
+export async function recordDomainEventDelivery(
+  tx: DomainEventTx,
+  params: { consumerName: string; eventId: string; id?: string; tenantId: string }
+): Promise<{
+  id: string | null;
+  idempotencyKey: string;
+  status: 'delivered' | 'already_delivered';
+}> {
+  const consumerName = assertNonBlank(params.consumerName, 'consumer.name');
+  const deliveryId =
+    params.id === undefined ? crypto.randomUUID() : assertNonBlank(params.id, 'delivery.id');
+  const idempotencyKey = domainEventDeliveryIdempotencyKey(params.eventId, consumerName);
+  const [row] = await tx
+    .insert(domainEventDeliveries)
+    .values({
+      id: deliveryId,
+      tenantId: assertNonBlank(params.tenantId, 'tenantId'),
+      eventId: assertNonBlank(params.eventId, 'event.id'),
+      consumerName,
+      idempotencyKey,
+    })
+    .onConflictDoNothing({
+      target: [domainEventDeliveries.eventId, domainEventDeliveries.consumerName],
+    })
+    .returning({ id: domainEventDeliveries.id });
+
+  return { id: row?.id ?? null, idempotencyKey, status: row ? 'delivered' : 'already_delivered' };
+}

--- a/packages/database/src/domain-event-relay-types.ts
+++ b/packages/database/src/domain-event-relay-types.ts
@@ -22,6 +22,8 @@ export type RelayMode = 'undelivered' | 'replay';
 
 export type RelayDomainEventsParams = {
   consumer: DomainEventRelayConsumer;
+  eventName?: string;
+  eventVersion?: number;
   limit: number;
   mode?: RelayMode;
   replayFrom?: { createdAt: Date; eventId?: string };

--- a/packages/database/src/domain-event-relay.ts
+++ b/packages/database/src/domain-event-relay.ts
@@ -1,12 +1,13 @@
 import { sql } from 'drizzle-orm';
 
+import { domainEventDeliveryIdempotencyKey } from './domain-event-delivery-keys';
+import { recordDomainEventDelivery } from './domain-event-delivery-recording';
 import { type DomainEventTx } from './domain-events';
 import type {
   DomainEventRelayEvent,
   RelayDomainEventsParams,
   RelayDomainEventsResult,
 } from './domain-event-relay-types';
-import { domainEventDeliveries } from './schema/domain-event-deliveries';
 
 export type {
   DomainEventRelayConsumer,
@@ -15,6 +16,8 @@ export type {
   RelayDomainEventsResult,
   RelayMode,
 } from './domain-event-relay-types';
+export { recordDomainEventDelivery } from './domain-event-delivery-recording';
+export { domainEventDeliveryIdempotencyKey } from './domain-event-delivery-keys';
 
 type RelayTx = DomainEventTx & {
   execute<T>(query: unknown): Promise<T[]>;
@@ -33,10 +36,6 @@ function assertLimit(limit: number): number {
   return limit;
 }
 
-export function domainEventDeliveryIdempotencyKey(eventId: string, consumerName: string): string {
-  return `domain-event:${assertNonBlank(consumerName, 'consumer.name')}:${assertNonBlank(eventId, 'event.id')}`;
-}
-
 export async function selectDomainEventsForRelay(
   tx: RelayTx,
   params: Omit<RelayDomainEventsParams, 'consumer'> & { consumerName: string }
@@ -46,6 +45,19 @@ export async function selectDomainEventsForRelay(
   const limit = assertLimit(params.limit);
   const replayFrom = params.replayFrom;
   const mode = params.mode ?? 'undelivered';
+  const eventNameFilter =
+    params.eventName !== undefined
+      ? sql`and e."event_name" = ${assertNonBlank(params.eventName, 'eventName')}`
+      : sql``;
+  if (
+    params.eventVersion !== undefined &&
+    (!Number.isInteger(params.eventVersion) || params.eventVersion < 1)
+  ) {
+    throw new Error('domain event relay requires eventVersion >= 1');
+  }
+  const eventVersionFilter = params.eventVersion
+    ? sql`and e."event_version" = ${params.eventVersion}`
+    : sql``;
   const deliveryFilter =
     mode === 'replay'
       ? sql``
@@ -79,41 +91,14 @@ export async function selectDomainEventsForRelay(
     from "domain_events" e
     where 1 = 1
     and e."tenant_id" = ${tenantId}
+    ${eventNameFilter}
+    ${eventVersionFilter}
     ${deliveryFilter}
     ${offsetFilter}
     order by e."created_at" asc, e."id" asc
     limit ${limit}
     ${lockClause}
   `);
-}
-
-export async function recordDomainEventDelivery(
-  tx: DomainEventTx,
-  params: { consumerName: string; eventId: string; id?: string; tenantId: string }
-): Promise<{
-  id: string | null;
-  idempotencyKey: string;
-  status: 'delivered' | 'already_delivered';
-}> {
-  const consumerName = assertNonBlank(params.consumerName, 'consumer.name');
-  const deliveryId =
-    params.id === undefined ? crypto.randomUUID() : assertNonBlank(params.id, 'delivery.id');
-  const idempotencyKey = domainEventDeliveryIdempotencyKey(params.eventId, consumerName);
-  const [row] = await tx
-    .insert(domainEventDeliveries)
-    .values({
-      id: deliveryId,
-      tenantId: assertNonBlank(params.tenantId, 'tenantId'),
-      eventId: assertNonBlank(params.eventId, 'event.id'),
-      consumerName,
-      idempotencyKey,
-    })
-    .onConflictDoNothing({
-      target: [domainEventDeliveries.eventId, domainEventDeliveries.consumerName],
-    })
-    .returning({ id: domainEventDeliveries.id });
-
-  return { id: row?.id ?? null, idempotencyKey, status: row ? 'delivered' : 'already_delivered' };
 }
 
 export async function relayDomainEvents(

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -21,6 +21,13 @@ export {
   type RelayDomainEventsResult,
   type RelayMode,
 } from './domain-event-relay';
+export {
+  CLAIM_STATUS_AUDIT_PROJECTION_CONSUMER_NAME,
+  claimStatusAuditProjectionConsumer,
+  projectClaimStatusChangedAuditEvent,
+  relayClaimStatusAuditProjectionEvents,
+  type ProjectClaimStatusChangedAuditResult,
+} from './domain-event-audit-projection';
 export { withTenantContext, withTenantDb, type TenantTransaction } from './tenant';
 
 // Export Drizzle instance and schema

--- a/packages/database/test/domain-event-audit-projection.test.ts
+++ b/packages/database/test/domain-event-audit-projection.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  projectClaimStatusChangedAuditEvent,
+  relayClaimStatusAuditProjectionEvents,
+  type DomainEventRelayEvent,
+  type DomainEventTx,
+} from '../src';
+import { auditLog, domainEventDeliveries } from '../src/schema';
+
+const event = {
+  actorId: 'staff-1',
+  actorRole: 'staff',
+  aggregateVersion: 2,
+  correlationId: 'corr-1',
+  createdAt: new Date('2026-06-04T13:00:00.000Z'),
+  entityId: 'claim-1',
+  entityType: 'claim',
+  eventName: 'claim.status_changed',
+  eventVersion: 1,
+  id: 'event-1',
+  payload: { fromStatus: 'draft', toStatus: 'submitted' },
+  tenantId: 'tenant-1',
+} satisfies DomainEventRelayEvent;
+
+class FakeInsertStep {
+  constructor(
+    private readonly tx: FakeProjectionTx,
+    private readonly table: unknown
+  ) {}
+
+  values(row: Record<string, unknown>) {
+    if (this.tx.failAuditInsert && this.table === auditLog) {
+      throw new Error('audit sink unavailable');
+    }
+    if (this.table === auditLog) this.tx.auditRows.push(row);
+    if (this.table === domainEventDeliveries) this.tx.deliveryRows.push(row);
+    return {
+      onConflictDoNothing: () => ({
+        returning: () => (this.tx.conflict ? [] : [{ id: row.id }]),
+      }),
+    };
+  }
+}
+
+class FakeProjectionTx {
+  auditRows: Record<string, unknown>[] = [];
+  deliveryRows: Record<string, unknown>[] = [];
+
+  constructor(
+    private readonly rows: DomainEventRelayEvent[] = [],
+    readonly conflict = false,
+    readonly failAuditInsert = false
+  ) {}
+
+  execute<T>() {
+    return Promise.resolve(this.rows as T[]);
+  }
+
+  insert(table: unknown) {
+    return new FakeInsertStep(this, table);
+  }
+}
+
+describe('claim status audit projection consumer', () => {
+  it('projects claim.status_changed events into deterministic tenant audit rows', async () => {
+    const tx = new FakeProjectionTx();
+
+    const result = await projectClaimStatusChangedAuditEvent(
+      tx as unknown as DomainEventTx,
+      event,
+      {
+        idempotencyKey: 'domain-event:audit_projection:event-1',
+      }
+    );
+
+    assert.deepEqual(result, {
+      auditLogId: 'domain-event-audit:event-1',
+      status: 'projected',
+    });
+    assert.equal(tx.auditRows[0].id, 'domain-event-audit:event-1');
+    assert.equal(tx.auditRows[0].tenantId, 'tenant-1');
+    assert.equal(tx.auditRows[0].action, 'claim.status_changed');
+    assert.equal(Object.hasOwn(tx.auditRows[0], 'createdAt'), false);
+    assert.deepEqual(tx.auditRows[0].metadata, {
+      aggregateVersion: 2,
+      correlationId: 'corr-1',
+      eventId: 'event-1',
+      eventCreatedAt: '2026-06-04T13:00:00.000Z',
+      eventName: 'claim.status_changed',
+      eventVersion: 1,
+      fromStatus: 'draft',
+      idempotencyKey: 'domain-event:audit_projection:event-1',
+      projection: 'audit_projection',
+      toStatus: 'submitted',
+    });
+  });
+
+  it('treats repeated projection inserts as idempotent', async () => {
+    const tx = new FakeProjectionTx([], true);
+
+    const result = await projectClaimStatusChangedAuditEvent(
+      tx as unknown as DomainEventTx,
+      event,
+      {
+        idempotencyKey: 'domain-event:audit_projection:event-1',
+      }
+    );
+
+    assert.equal(result.status, 'already_projected');
+    assert.equal(tx.auditRows[0].id, 'domain-event-audit:event-1');
+  });
+
+  it('records delivery only after the audit projection succeeds', async () => {
+    const tx = new FakeProjectionTx([event], false, true);
+
+    await assert.rejects(
+      () => relayClaimStatusAuditProjectionEvents(tx as never, { limit: 10, tenantId: 'tenant-1' }),
+      /audit sink unavailable/
+    );
+    assert.equal(tx.deliveryRows.length, 0);
+  });
+
+  it('rejects unsupported event families before inserting an audit row', async () => {
+    const tx = new FakeProjectionTx();
+
+    await assert.rejects(
+      () =>
+        projectClaimStatusChangedAuditEvent(
+          tx as unknown as DomainEventTx,
+          { ...event, eventName: 'case.created' },
+          { idempotencyKey: 'domain-event:audit_projection:event-1' }
+        ),
+      /claim\.status_changed@1/
+    );
+    assert.equal(tx.auditRows.length, 0);
+  });
+});

--- a/packages/database/test/domain-event-relay-selection.test.ts
+++ b/packages/database/test/domain-event-relay-selection.test.ts
@@ -38,6 +38,38 @@ describe('domain event relay selection', () => {
     assert.match(query, /for update skip locked/);
   });
 
+  it('can narrow relay selection to one event family and version', async () => {
+    const tx = new FakeSelectTx();
+
+    await selectDomainEventsForRelay(tx as never, {
+      consumerName: 'audit_projection',
+      eventName: 'claim.status_changed',
+      eventVersion: 1,
+      limit: 10,
+      tenantId: 'tenant-1',
+    });
+
+    const query = sqlText(tx.query).toLowerCase();
+    assert.match(query, /event_name/);
+    assert.match(query, /event_version/);
+  });
+
+  it('rejects blank event names before building the query', async () => {
+    const tx = new FakeSelectTx();
+
+    await assert.rejects(
+      () =>
+        selectDomainEventsForRelay(tx as never, {
+          consumerName: 'audit_projection',
+          eventName: '   ',
+          limit: 10,
+          tenantId: 'tenant-1',
+        }),
+      /eventName/
+    );
+    assert.equal(tx.query, undefined);
+  });
+
   it('selects replay batches from an arbitrary offset without delivery filtering', async () => {
     const tx = new FakeSelectTx();
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 33297262,
-  "maxTrackedFiles": 3905,
+  "maxTrackedBytes": 33307961,
+  "maxTrackedFiles": 3909,
   "maxLargestFileBytes": 2343522,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 16422184,
-    "source/scripts": 6430541,
-    "tests/e2e": 4254693,
+    "source/scripts": 6436211,
+    "tests/e2e": 4259722,
     "docs/text": 4529730,
     "config/data/messages": 1531649,
     "other": 1048576


### PR DESCRIPTION
## Summary
- add a bounded `claim.status_changed` audit projection consumer that writes deterministic, idempotent audit rows from domain events
- keep relay selection bounded with optional event name/version filters and a fixed `audit_projection` consumer wrapper
- split relay delivery key/recording helpers so the touched relay files stay within the repository line budget

## Verification
- `pnpm --filter @interdomestik/database type-check`
- `pnpm --filter @interdomestik/database test:unit -- domain-event-audit-projection.test.ts domain-event-relay.test.ts domain-event-relay-selection.test.ts domain-events.test.ts domain-event-payload-allowlist.test.ts` (`55 passed`, `3 skipped`)
- `pnpm repo:size:check`
- `pnpm security:guard`
- `git diff --cached --check`
- `pnpm pr:verify` (`PR E2E Gate: 134 passed, 6 skipped`; smoke: `13 passed, 1 skipped`)
- `pnpm e2e:gate` (`134 passed`, `6 skipped`)
- repo MCP `scope_audit`
- Codex Security diff scan: no reportable findings (`/tmp/codex-security-scans/interdomestik-crystal-home/local_patch_20260604T140139Z`)

## Review Notes
- Sonnet direct review via `claude` was blocked by local session limit.
- Copilot CLI Sonnet fallback found and I fixed: unbounded wrapper event selection, and copying `domain_events.created_at` into `audit_log.created_at`.
- A final Docker local parity attempt, `pnpm ci:local:full`, progressed through repo audits, commitlint, gitleaks, lint, type-check, i18n, coverage, release-gate, migrations, RLS, and then the PR E2E web build was killed with exit `137` during the TypeScript phase. This appears resource-related; the host `pnpm pr:verify` and full `pnpm e2e:gate` already passed.

## Scope
- No changes to `apps/web/src/proxy.ts`, canonical routes, auth, tenancy, billing, product UI, README, AGENTS, broad architecture docs, schema, or Drizzle migrations.
- `.codex/config.toml` remains a local-only unrelated modification and is not part of this PR.