### PR TITLE
feat: activate claim status audit projection

### DIFF
--- a/packages/domain-claims/src/admin-claims/update-status.test-support.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test-support.ts
@@ -43,6 +43,7 @@ vi.mock('@interdomestik/database', () => ({
     select: updateStatusMocks.dbSelect,
     update: updateStatusMocks.dbUpdate,
   },
+  relayClaimStatusAuditProjectionEvents: vi.fn(),
   claimEscalationAgreements: {
     claimId: 'claim_escalation_agreements.claim_id',
     paymentAuthorizationState: 'claim_escalation_agreements.payment_authorization_state',

--- a/packages/domain-claims/src/admin-claims/update-status.test.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test.ts
@@ -60,9 +60,10 @@ describe('admin updateClaimStatusCore', () => {
 
   it('routes admin status changes through the transition command', async () => {
     const logAuditEvent = vi.fn();
+    const projectClaimStatusAuditProjection = vi.fn();
     mockClaim('submitted');
 
-    await runStatusUpdate('resolved', { logAuditEvent });
+    await runStatusUpdate('resolved', { logAuditEvent, projectClaimStatusAuditProjection });
 
     expect(mocks.dbUpdate).not.toHaveBeenCalled();
     expect(mocks.transitionClaimStatus).toHaveBeenCalledWith({
@@ -71,15 +72,11 @@ describe('admin updateClaimStatusCore', () => {
       tenantId: 'tenant-1',
       toStatus: 'resolved',
     });
-    expect(logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        actorId: 'admin-1',
-        action: 'claim.status_changed',
-        entityId: 'claim-1',
-        headers: requestHeaders,
-        metadata: { oldStatus: 'verification', newStatus: 'resolved' },
-      })
-    );
+    expect(logAuditEvent).not.toHaveBeenCalled();
+    expect(projectClaimStatusAuditProjection).toHaveBeenCalledWith({
+      limit: 10,
+      tenantId: 'tenant-1',
+    });
   });
 
   it('surfaces transition command rejection without audit or notification side effects', async () => {

--- a/packages/domain-claims/src/admin-claims/update-status.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.ts
@@ -3,6 +3,7 @@ import { withTenant } from '@interdomestik/database/tenant-security';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 
 import type { ClaimsDeps, ClaimsSession } from '../claims/types';
+import { activateClaimStatusAuditProjection } from '../claims/audit-projection';
 import { transitionClaimStatus } from '../claims/transition';
 import { getPaymentAuthorizationState } from './payment-authorization';
 
@@ -36,7 +37,7 @@ export async function updateClaimStatusCore(
   },
   deps: ClaimsDeps = {}
 ) {
-  const { claimId, newStatus, session, requestHeaders } = params;
+  const { claimId, newStatus, session } = params;
 
   const role = session?.user?.role;
   const isAdminRole = role === 'admin' || role === 'tenant_admin' || role === 'super_admin';
@@ -101,20 +102,7 @@ export async function updateClaimStatusCore(
   const persistedOldStatus = result.fromStatus;
   const persistedNewStatus = result.status;
 
-  if (deps.logAuditEvent) {
-    await deps.logAuditEvent({
-      actorId: session.user.id,
-      actorRole: session.user.role,
-      action: 'claim.status_changed',
-      entityType: 'claim',
-      entityId: claimId,
-      metadata: {
-        oldStatus: persistedOldStatus,
-        newStatus: persistedNewStatus,
-      },
-      headers: requestHeaders,
-    });
-  }
+  await activateClaimStatusAuditProjection({ deps, tenantId });
 
   // Send notification to claim owner (fire-and-forget)
   if (

--- a/packages/domain-claims/src/agent-claims/update-status.test.ts
+++ b/packages/domain-claims/src/agent-claims/update-status.test.ts
@@ -33,6 +33,7 @@ vi.mock('@interdomestik/database', () => ({
     select: mocks.dbSelect,
     update: mocks.dbUpdate,
   },
+  relayClaimStatusAuditProjectionEvents: vi.fn(),
   eq: vi.fn((left, right) => ({ left, right })),
   user: { email: 'user.email', id: 'user.id' },
 }));
@@ -95,10 +96,14 @@ describe('agent updateClaimStatusCore', () => {
   it('routes agent status changes through the transition command', async () => {
     const logAuditEvent = vi.fn();
     const notifyStatusChanged = vi.fn().mockResolvedValue(undefined);
+    const projectClaimStatusAuditProjection = vi.fn();
     mockClaim('submitted');
     mocks.getPaymentAuthorizationState.mockResolvedValueOnce('authorized');
 
-    const result = await runStatusUpdate({ logAuditEvent, notifyStatusChanged }, 'negotiation');
+    const result = await runStatusUpdate(
+      { logAuditEvent, notifyStatusChanged, projectClaimStatusAuditProjection },
+      'negotiation'
+    );
 
     expect(result).toEqual({ success: true, error: undefined });
     expect(mocks.dbUpdate).not.toHaveBeenCalled();
@@ -109,16 +114,11 @@ describe('agent updateClaimStatusCore', () => {
       tenantId: 'tenant-1',
       toStatus: 'negotiation',
     });
-    expect(logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        actorId: 'staff-1',
-        action: 'claim.status_changed',
-        entityId: 'claim-1',
-        headers: requestHeaders,
-        metadata: { oldStatus: 'submitted', newStatus: 'negotiation' },
-        tenantId: 'tenant-1',
-      })
-    );
+    expect(logAuditEvent).not.toHaveBeenCalled();
+    expect(projectClaimStatusAuditProjection).toHaveBeenCalledWith({
+      limit: 10,
+      tenantId: 'tenant-1',
+    });
     await vi.waitFor(() =>
       expect(notifyStatusChanged).toHaveBeenCalledWith(
         'member-1',

--- a/packages/domain-claims/src/agent-claims/update-status.ts
+++ b/packages/domain-claims/src/agent-claims/update-status.ts
@@ -3,6 +3,7 @@ import { withTenant } from '@interdomestik/database/tenant-security';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 
 import type { ActionResult, ClaimsDeps, ClaimsSession } from '../claims/types';
+import { activateClaimStatusAuditProjection } from '../claims/audit-projection';
 import { transitionClaimStatus } from '../claims/transition';
 import { claimStatusSchema } from '../validators/claims';
 import { getPaymentAuthorizationState } from '../admin-claims/payment-authorization';
@@ -36,7 +37,7 @@ export async function updateClaimStatusCore(
   },
   deps: ClaimsDeps = {}
 ): Promise<ActionResult> {
-  const { claimId, newStatus, session, requestHeaders } = params;
+  const { claimId, newStatus, session } = params;
 
   if (!session || !isStaffOrAdmin(session.user.role)) {
     return { success: false, error: 'Unauthorized', data: undefined };
@@ -98,21 +99,7 @@ export async function updateClaimStatusCore(
   const oldStatus = transitionResult.fromStatus;
   const persistedStatus = transitionResult.status;
 
-  if (deps.logAuditEvent) {
-    await deps.logAuditEvent({
-      actorId: session.user.id,
-      actorRole: session.user.role,
-      tenantId,
-      action: 'claim.status_changed',
-      entityType: 'claim',
-      entityId: claimId,
-      metadata: {
-        oldStatus,
-        newStatus: persistedStatus,
-      },
-      headers: requestHeaders,
-    });
-  }
+  await activateClaimStatusAuditProjection({ deps, tenantId });
 
   // Send notification to claim owner (fire-and-forget)
   if (

--- a/packages/domain-claims/src/claims/audit-projection.test.ts
+++ b/packages/domain-claims/src/claims/audit-projection.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  relayClaimStatusAuditProjectionEvents: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    transaction: mocks.transaction,
+  },
+  relayClaimStatusAuditProjectionEvents: mocks.relayClaimStatusAuditProjectionEvents,
+}));
+
+import {
+  activateClaimStatusAuditProjection,
+  projectClaimStatusAuditProjection,
+} from './audit-projection';
+
+describe('claim status audit projection activation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.transaction.mockImplementation(async callback => callback('tx'));
+    mocks.relayClaimStatusAuditProjectionEvents.mockResolvedValue({
+      consumerInvocations: 1,
+      deliveryRecordsAlreadyExisted: 0,
+      deliveryRecordsCreated: 1,
+      selected: 1,
+    });
+  });
+
+  it('runs the claim status audit projection through a relay transaction', async () => {
+    await expect(
+      projectClaimStatusAuditProjection({ tenantId: 'tenant-1' })
+    ).resolves.toMatchObject({
+      deliveryRecordsCreated: 1,
+      selected: 1,
+    });
+
+    expect(mocks.transaction).toHaveBeenCalledTimes(1);
+    expect(mocks.relayClaimStatusAuditProjectionEvents).toHaveBeenCalledWith('tx', {
+      limit: 10,
+      tenantId: 'tenant-1',
+    });
+  });
+
+  it('uses an injected projection runner for status writers', async () => {
+    const projectClaimStatusAuditProjection = vi.fn().mockResolvedValue(undefined);
+
+    await activateClaimStatusAuditProjection({
+      deps: { projectClaimStatusAuditProjection },
+      tenantId: 'tenant-1',
+    });
+
+    expect(projectClaimStatusAuditProjection).toHaveBeenCalledWith({
+      limit: 10,
+      tenantId: 'tenant-1',
+    });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+  });
+
+  it('reports projection failures without hiding retryability behind delivery records', async () => {
+    const error = new Error('audit sink unavailable');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      activateClaimStatusAuditProjection({
+        deps: { projectClaimStatusAuditProjection: vi.fn().mockRejectedValue(error) },
+        tenantId: 'tenant-1',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith('Failed to project claim status audit event:', error);
+    consoleError.mockRestore();
+  });
+});

--- a/packages/domain-claims/src/claims/audit-projection.ts
+++ b/packages/domain-claims/src/claims/audit-projection.ts
@@ -1,0 +1,39 @@
+import { db, relayClaimStatusAuditProjectionEvents } from '@interdomestik/database';
+
+import type { ClaimsDeps } from './types';
+
+export const CLAIM_STATUS_AUDIT_PROJECTION_LIMIT = 10;
+
+export type ClaimStatusAuditProjectionParams = {
+  limit?: number;
+  tenantId: string;
+};
+
+export async function projectClaimStatusAuditProjection(params: ClaimStatusAuditProjectionParams) {
+  const limit = params.limit ?? CLAIM_STATUS_AUDIT_PROJECTION_LIMIT;
+
+  // db-access-guard: tenant-scoped -- reason: tenantId scopes relay selection and delivery recording.
+  return db.transaction(tx =>
+    relayClaimStatusAuditProjectionEvents(tx as never, {
+      limit,
+      tenantId: params.tenantId,
+    })
+  );
+}
+
+export async function activateClaimStatusAuditProjection(params: {
+  deps: ClaimsDeps;
+  tenantId: string;
+}): Promise<void> {
+  const project =
+    params.deps.projectClaimStatusAuditProjection ?? projectClaimStatusAuditProjection;
+
+  try {
+    await project({
+      limit: CLAIM_STATUS_AUDIT_PROJECTION_LIMIT,
+      tenantId: params.tenantId,
+    });
+  } catch (error) {
+    console.error('Failed to project claim status audit event:', error);
+  }
+}

--- a/packages/domain-claims/src/claims/status.test.ts
+++ b/packages/domain-claims/src/claims/status.test.ts
@@ -15,6 +15,7 @@ vi.mock('@interdomestik/database', () => ({
       user: { findFirst: mocks.userFindFirst },
     },
   },
+  relayClaimStatusAuditProjectionEvents: vi.fn(),
   claims: { id: 'claims.id', tenantId: 'claims.tenant_id' },
   user: { id: 'user.id', tenantId: 'user.tenant_id' },
   eq: vi.fn((left, right) => ({ left, right })),
@@ -55,19 +56,20 @@ function mockClaim(status: string) {
 }
 
 function runStatusUpdate(deps = {}, newStatus = 'submitted') {
-  return updateClaimStatusCore(
-    { session: staffSession, requestHeaders, claimId: 'claim-1', newStatus },
-    deps
-  );
+  const params = { session: staffSession, requestHeaders, claimId: 'claim-1', newStatus };
+  return updateClaimStatusCore(params, deps);
 }
 
 function sideEffectDeps() {
   return {
     logAuditEvent: vi.fn(),
     notifyStatusChanged: vi.fn(),
+    projectClaimStatusAuditProjection: vi.fn(),
     revalidatePath: vi.fn(),
   };
 }
+
+const projectionCall = { limit: 10, tenantId: 'tenant-1' };
 
 describe('updateClaimStatusCore', () => {
   beforeEach(() => {
@@ -117,9 +119,8 @@ describe('updateClaimStatusCore', () => {
       paymentAuthorizationState: 'authorized',
       toStatus: 'negotiation',
     });
-    expect(deps.logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ metadata: { oldStatus: 'draft', newStatus: 'negotiation' } })
-    );
+    expect(deps.logAuditEvent).not.toHaveBeenCalled();
+    expect(deps.projectClaimStatusAuditProjection).toHaveBeenCalledWith(projectionCall);
     expect(deps.notifyStatusChanged).toHaveBeenCalledWith(
       'member-1',
       'member@example.com',

--- a/packages/domain-claims/src/claims/status.ts
+++ b/packages/domain-claims/src/claims/status.ts
@@ -8,6 +8,7 @@ import type { TransitionClaimStatusResult } from './transition';
 
 import { getPaymentAuthorizationState } from '../admin-claims/payment-authorization';
 import { claimStatusSchema } from '../validators/claims';
+import { activateClaimStatusAuditProjection } from './audit-projection';
 import { transitionClaimStatus } from './transition';
 
 function isStaffOrAdmin(role: string | null | undefined): boolean {
@@ -64,7 +65,7 @@ export async function updateClaimStatusCore(
   },
   deps: ClaimsDeps = {}
 ): Promise<ActionResult> {
-  const { session, requestHeaders, claimId, newStatus } = params;
+  const { session, claimId, newStatus } = params;
 
   if (!session || !isStaffOrAdmin(session.user.role ?? null)) {
     return { success: false, error: 'Unauthorized', data: undefined };
@@ -105,16 +106,7 @@ export async function updateClaimStatusCore(
     const oldStatus = transitionResult.fromStatus;
     const persistedStatus = transitionResult.status;
 
-    await deps.logAuditEvent?.({
-      action: 'claim.status_changed',
-      actorId: session.user.id,
-      actorRole: session.user.role,
-      entityId: claimId,
-      entityType: 'claim',
-      headers: requestHeaders,
-      metadata: { oldStatus, newStatus: persistedStatus },
-      tenantId,
-    });
+    await activateClaimStatusAuditProjection({ deps, tenantId });
 
     if (claim.userId && oldStatus !== persistedStatus && deps.notifyStatusChanged) {
       const member = await db.query.user.findFirst({

--- a/packages/domain-claims/src/claims/transition-events.test.ts
+++ b/packages/domain-claims/src/claims/transition-events.test.ts
@@ -12,6 +12,12 @@ type ClaimState = {
   status: ClaimStatus;
 };
 type FailOn = 'history' | 'event';
+const initialState = (): ClaimState => ({
+  events: [],
+  histories: [],
+  lifecycleVersion: 6,
+  status: 'evaluation',
+});
 
 class FakeSelect {
   constructor(private readonly state: ClaimState) {}
@@ -68,6 +74,8 @@ function makeParams() {
     actor: { id: 'staff-1', role: 'staff' },
     claimId: 'claim-1',
     correlationId: 'corr-1',
+    isPublic: false,
+    note: 'member-visible status note',
     paymentAuthorizationState: 'authorized' as const,
     tenantId: 'tenant-1',
     toStatus: 'negotiation' as const,
@@ -93,18 +101,19 @@ async function runTransaction(state: ClaimState, failOn?: 'history' | 'event') {
 
 describe('transitionClaimStatusInTransaction event atomicity', () => {
   it('commits status, history, and exactly one event for a successful transition', async () => {
-    const state: ClaimState = {
-      events: [],
-      histories: [],
-      lifecycleVersion: 6,
-      status: 'evaluation',
-    };
+    const state = initialState();
 
     await expect(runTransaction(state)).resolves.toMatchObject({ success: true });
 
     expect(state.status).toBe('negotiation');
     expect(state.lifecycleVersion).toBe(7);
     expect(state.histories).toHaveLength(1);
+    expect(state.histories[0]).toEqual(
+      expect.objectContaining({
+        isPublic: false,
+        note: 'member-visible status note',
+      })
+    );
     expect(state.events).toHaveLength(1);
     expect(state.events[0]).toEqual(
       expect.objectContaining({
@@ -119,15 +128,12 @@ describe('transitionClaimStatusInTransaction event atomicity', () => {
         tenantId: 'tenant-1',
       })
     );
+    expect(state.events[0].payload).not.toHaveProperty('isPublic');
+    expect(state.events[0].payload).not.toHaveProperty('note');
   });
 
   it('rolls back status and history when event append fails', async () => {
-    const state: ClaimState = {
-      events: [],
-      histories: [],
-      lifecycleVersion: 6,
-      status: 'evaluation',
-    };
+    const state = initialState();
 
     await expect(runTransaction(state, 'event')).rejects.toThrow('event failed');
 
@@ -135,12 +141,7 @@ describe('transitionClaimStatusInTransaction event atomicity', () => {
   });
 
   it('does not commit status or event when history insert fails', async () => {
-    const state: ClaimState = {
-      events: [],
-      histories: [],
-      lifecycleVersion: 6,
-      status: 'evaluation',
-    };
+    const state = initialState();
 
     await expect(runTransaction(state, 'history')).rejects.toThrow('history failed');
 

--- a/packages/domain-claims/src/claims/types.ts
+++ b/packages/domain-claims/src/claims/types.ts
@@ -29,6 +29,10 @@ export type ClaimsAuditEvent = {
 };
 
 export type ClaimsDeps = {
+  projectClaimStatusAuditProjection?: (args: {
+    limit?: number;
+    tenantId: string;
+  }) => Promise<unknown> | unknown;
   validateSubmittedClaimFile?: (args: {
     actorId: string;
     file: EvidenceFile;

--- a/packages/domain-claims/src/staff-claims/update-status.test.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.test.ts
@@ -110,6 +110,7 @@ const mocks = vi.hoisted(() => {
       transaction,
     },
     logAuditEvent: vi.fn(),
+    projectClaimStatusAuditProjection: vi.fn(),
     and: vi.fn((...conditions) => ({ op: 'and', conditions })),
     claims: {
       id: 'claims.id',
@@ -218,6 +219,7 @@ vi.mock('@interdomestik/database', () => ({
   db: mocks.db,
   eq: mocks.eq,
   serviceUsage: mocks.serviceUsage,
+  relayClaimStatusAuditProjectionEvents: vi.fn(),
   sql: mocks.sql,
   subscriptions: mocks.subscriptions,
 }));
@@ -313,7 +315,7 @@ async function runNegotiationUpdate(
       session: createSession({ userId: 'staff-1', branchId: 'branch-1' }),
       ...overrides,
     },
-    deps
+    deps ?? { projectClaimStatusAuditProjection: mocks.projectClaimStatusAuditProjection }
   );
 }
 
@@ -350,6 +352,7 @@ describe('staff updateClaimStatusCore', () => {
     ]);
     mocks.txInsertReturning.mockResolvedValue([{ id: 'usage-claim-1' }]);
     mocks.txUpdateReturning.mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 2 }]);
+    mocks.projectClaimStatusAuditProjection.mockResolvedValue(undefined);
   });
 
   it.each([
@@ -561,10 +564,17 @@ describe('staff updateClaimStatusCore', () => {
         newStatus: 'verification',
         session: createSession({ userId: 'staff-1', branchId: 'branch-1' }),
       },
-      { notifyStatusChanged }
+      {
+        notifyStatusChanged,
+        projectClaimStatusAuditProjection: mocks.projectClaimStatusAuditProjection,
+      }
     );
 
     expect(result).toEqual({ success: true, error: undefined });
+    expect(mocks.projectClaimStatusAuditProjection).toHaveBeenCalledWith({
+      limit: 10,
+      tenantId: 'tenant-1',
+    });
     await vi.waitFor(() =>
       expect(notifyStatusChanged).toHaveBeenCalledWith(
         'member-1',
@@ -710,18 +720,19 @@ describe('staff updateClaimStatusCore', () => {
       {
         allowanceOverrideReason: 'Family upgrade is pending but recovery must start now',
       },
-      { logAuditEvent: mocks.logAuditEvent }
+      {
+        logAuditEvent: mocks.logAuditEvent,
+        projectClaimStatusAuditProjection: mocks.projectClaimStatusAuditProjection,
+      }
     );
 
     expect(result).toEqual({ success: true, error: undefined });
     expect(mocks.txInsert).toHaveBeenCalledWith(mocks.serviceUsage);
-    expect(mocks.logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metadata: expect.objectContaining({
-          allowanceOverrideReason: 'Family upgrade is pending but recovery must start now',
-        }),
-      })
-    );
+    expect(mocks.logAuditEvent).not.toHaveBeenCalled();
+    expect(mocks.projectClaimStatusAuditProjection).toHaveBeenCalledWith({
+      limit: 10,
+      tenantId: 'tenant-1',
+    });
   });
 
   it('treats a conflicting recovery usage insert as an already consumed matter', async () => {
@@ -762,7 +773,7 @@ describe('staff updateClaimStatusCore', () => {
     expect(mocks.txInsert).not.toHaveBeenCalled();
   });
 
-  it('records an audit event when staff decline a recovery matter', async () => {
+  it('activates audit projection when staff decline a recovery matter', async () => {
     const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
 
     mocks.db.select.mockReturnValueOnce(mocks.claimSelectChain);
@@ -782,29 +793,17 @@ describe('staff updateClaimStatusCore', () => {
         requestHeaders,
         session: createSession({ userId: 'staff-1', branchId: 'branch-1' }),
       },
-      { logAuditEvent: mocks.logAuditEvent }
+      {
+        logAuditEvent: mocks.logAuditEvent,
+        projectClaimStatusAuditProjection: mocks.projectClaimStatusAuditProjection,
+      }
     );
 
     expect(result).toEqual({ success: true, error: undefined });
-    expect(mocks.logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: 'claim.status_changed',
-        actorId: 'staff-1',
-        actorRole: 'staff',
-        entityId: 'claim-1',
-        entityType: 'claim',
-        headers: requestHeaders,
-        tenantId: 'tenant-1',
-        metadata: expect.objectContaining({
-          decisionNextStatus: 'rejected',
-          declineReasonCode: 'no_monetary_recovery_path',
-          decisionReason: 'Declined after review',
-          decisionType: 'declined',
-          oldStatus: 'negotiation',
-          newStatus: 'rejected',
-          note: 'This matter does not currently show a clear monetary recovery path for staff-led recovery.',
-        }),
-      })
-    );
+    expect(mocks.logAuditEvent).not.toHaveBeenCalled();
+    expect(mocks.projectClaimStatusAuditProjection).toHaveBeenCalledWith({
+      limit: 10,
+      tenantId: 'tenant-1',
+    });
   });
 });

--- a/packages/domain-claims/src/staff-claims/update-status.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.ts
@@ -17,6 +17,7 @@ import {
 } from './accepted-recovery-prerequisites';
 import { resolveCommercialHandlingScopeGate } from './commercial-handling-scope';
 import { claimStatusSchema } from '../validators/claims';
+import { activateClaimStatusAuditProjection } from '../claims/audit-projection';
 import {
   getMatterAllowanceContextForSubscription,
   getMatterAllowanceSubscriptionContextForUser,
@@ -300,53 +301,6 @@ async function assignClaimToActingStaffIfUnassigned(params: {
     .where(params.staffScopeWhere);
 }
 
-async function logClaimStatusAudit(params: {
-  auditMetadata?: Record<string, boolean | string | undefined>;
-  claimId: string;
-  currentStatus: ClaimStatus | null;
-  deps: ClaimsDeps;
-  isPublicChange: boolean;
-  note?: string;
-  requestHeaders?: Headers;
-  session: ClaimsSession;
-  status: ClaimStatus;
-  tenantId: string;
-}) {
-  const {
-    auditMetadata,
-    claimId,
-    currentStatus,
-    deps,
-    isPublicChange,
-    note,
-    requestHeaders,
-    session,
-    status,
-    tenantId,
-  } = params;
-
-  if (!deps.logAuditEvent) {
-    return;
-  }
-
-  await deps.logAuditEvent({
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    tenantId,
-    action: 'claim.status_changed',
-    entityType: 'claim',
-    entityId: claimId,
-    metadata: {
-      oldStatus: currentStatus,
-      newStatus: status,
-      note: note || undefined,
-      isPublic: isPublicChange,
-      ...auditMetadata,
-    },
-    headers: requestHeaders,
-  });
-}
-
 function scheduleStatusChangeNotification(params: {
   claimId: string;
   claimTitle: string;
@@ -458,7 +412,10 @@ async function finalizeClaimStatusChange(params: {
 
   const sideEffectParams = { ...rest, currentStatus: transitionResult.fromStatus };
 
-  await logClaimStatusAudit(sideEffectParams);
+  await activateClaimStatusAuditProjection({
+    deps: sideEffectParams.deps,
+    tenantId: sideEffectParams.tenantId,
+  });
 
   if (sideEffectParams.isPublicChange) {
     scheduleStatusChangeNotification({

--- a/scripts/check-claim-status-writers.mjs
+++ b/scripts/check-claim-status-writers.mjs
@@ -27,7 +27,6 @@ const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']
 
 export const CLAIM_STATUS_TRANSITION_WRITERS = new Set([
   'packages/domain-claims/src/claims/transition.ts',
-  'packages/domain-claims/src/staff-claims/update-status.ts',
 ]);
 
 export const CLAIM_STATUS_INITIALIZATION_WRITERS = new Set([

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 33318018,
-  "maxTrackedFiles": 3910,
+  "maxTrackedBytes": 33320692,
+  "maxTrackedFiles": 3912,
   "maxLargestFileBytes": 2343776,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 16422438,
     "source/scripts": 6436211,
-    "tests/e2e": 4259722,
+    "tests/e2e": 4262672,
     "docs/text": 4539533,
     "config/data/messages": 1531649,
     "other": 1048576


### PR DESCRIPTION
## Summary
- activate the bounded `claim.status_changed@1` audit projection runner from claims status paths
- retire duplicate best-effort `claim.status_changed` audit writes from aggregate status transitions
- keep domain-event payload sanitized while proving history retains note/public metadata
- update the claim-status writer guard and exact repo-size budget for the measured staged delta

## Verification
- MCP `scope_audit`: pass
- `git diff --check`
- `pnpm plan:status`
- `pnpm plan:audit`
- `pnpm track:audit`
- `pnpm docs:verify`
- `pnpm repo:size:check`
- `pnpm security:guard`
- `pnpm --filter @interdomestik/domain-claims type-check`
- `pnpm test:unit:domains`
- `pnpm pr:verify` (`e2e:gate:pr`: 134 passed, 6 skipped; smoke: 13 passed, 1 skipped)
- `pnpm e2e:gate` (134 passed, 6 skipped)

## Review Notes
- Sonnet 4.6 architecture/scope review completed once and flagged audit metadata scope plus relay retry semantics. The implementation keeps the promoted sanitized event contract, adds explicit proof that history retains note/public fields while the event payload remains `fromStatus`/`toStatus`, and relies on existing relay behavior/tests where consumer delivery completes before delivery records are written in the same transaction.
- A second Sonnet rerun was attempted via Claude CLI and Copilot fallback; both routes hung without output and were terminated after waiting.

## Scope
No proxy, canonical route, auth, tenancy, billing, product UI, README, AGENTS, or broad architecture-doc changes.