### PR TITLE
feat: add incident country backfill tooling

### DIFF
--- a/packages/domain-claims/src/claims/incident-country-backfill.test.ts
+++ b/packages/domain-claims/src/claims/incident-country-backfill.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildIncidentCountryBackfillPlan,
+  type IncidentCountryBackfillRow,
+} from './incident-country-backfill';
+
+const diasporaNote =
+  'Started from Diaspora / Green Card quickstart. Country: IT. Incident location: abroad.';
+
+function row(overrides: Partial<IncidentCountryBackfillRow> = {}): IncidentCountryBackfillRow {
+  return {
+    id: 'claim-1',
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+describe('buildIncidentCountryBackfillPlan', () => {
+  it('prefers claim-pack JSON country over diaspora notes for missing rows', () => {
+    const plan = buildIncidentCountryBackfillPlan([
+      row({
+        claimPackJson: { answers: { incidentCountry: ' de ' } },
+        diasporaPublicNotes: [diasporaNote],
+      }),
+    ]);
+
+    expect(plan.updates).toEqual([
+      {
+        claimId: 'claim-1',
+        incidentCountryCode: 'DE',
+        incidentJurisdiction: 'country:DE',
+        source: 'claim_pack_json',
+        tenantId: 'tenant-1',
+      },
+    ]);
+    expect(plan.updatesBySource).toEqual({ claim_pack_json: 1, diaspora_origin_note: 0 });
+  });
+
+  it('uses a later valid claim-pack country code when an earlier value is invalid', () => {
+    const plan = buildIncidentCountryBackfillPlan([
+      row({
+        claimPackJson: { answers: { incidentCountry: 'Germany', incidentCountryCode: 'DE' } },
+      }),
+    ]);
+
+    expect(plan.updates).toEqual([
+      expect.objectContaining({
+        claimId: 'claim-1',
+        incidentCountryCode: 'DE',
+        source: 'claim_pack_json',
+      }),
+    ]);
+    expect(plan.skippedInvalidSource).toBe(0);
+  });
+
+  it('uses diaspora origin notes when no claim-pack JSON source exists', () => {
+    const plan = buildIncidentCountryBackfillPlan([
+      row({ id: 'claim-2', diasporaPublicNotes: [diasporaNote] }),
+    ]);
+
+    expect(plan.updates).toEqual([
+      expect.objectContaining({
+        claimId: 'claim-2',
+        incidentCountryCode: 'IT',
+        incidentJurisdiction: 'country:IT',
+        source: 'diaspora_origin_note',
+      }),
+    ]);
+  });
+
+  it('does not plan updates for rows that already have live incident-country values', () => {
+    const plan = buildIncidentCountryBackfillPlan([
+      row({
+        claimPackJson: { answers: { incidentCountry: 'DE' } },
+        incidentCountryCode: 'CH',
+        incidentJurisdiction: 'country:CH',
+      }),
+    ]);
+
+    expect(plan.alreadyPopulated).toBe(1);
+    expect(plan.updates).toEqual([]);
+  });
+
+  it('reports invalid source values separately from missing durable sources', () => {
+    const plan = buildIncidentCountryBackfillPlan([
+      row({ claimPackJson: { answers: { incidentCountry: 'Germany' } } }),
+      row({ id: 'claim-2', diasporaPublicNotes: ['Member added a receipt.'] }),
+    ]);
+
+    expect(plan.skippedInvalidSource).toBe(1);
+    expect(plan.skippedNoDurableSource).toBe(1);
+    expect(plan.updates).toEqual([]);
+  });
+});

--- a/packages/domain-claims/src/claims/incident-country-backfill.ts
+++ b/packages/domain-claims/src/claims/incident-country-backfill.ts
@@ -1,0 +1,136 @@
+import { parseDiasporaOriginFromPublicNote } from './diaspora-origin';
+import { resolveClaimIncidentCountry, type ClaimIncidentCountry } from './incident-country';
+
+export type IncidentCountryBackfillSource = 'claim_pack_json' | 'diaspora_origin_note';
+
+export type IncidentCountryBackfillRow = {
+  claimPackJson?: unknown;
+  diasporaPublicNotes?: Array<string | null | undefined>;
+  id: string;
+  incidentCountryCode?: string | null;
+  incidentJurisdiction?: string | null;
+  tenantId: string;
+};
+
+export type IncidentCountryBackfillUpdate = ClaimIncidentCountry & {
+  claimId: string;
+  source: IncidentCountryBackfillSource;
+  tenantId: string;
+};
+
+export type IncidentCountryBackfillPlan = {
+  alreadyPopulated: number;
+  rowsExamined: number;
+  skippedInvalidSource: number;
+  skippedNoDurableSource: number;
+  updates: IncidentCountryBackfillUpdate[];
+  updatesBySource: Record<IncidentCountryBackfillSource, number>;
+};
+
+const CLAIM_PACK_COUNTRY_PATHS = [
+  ['answers', 'incidentCountry'],
+  ['answers', 'incidentCountryCode'],
+  ['input', 'answers', 'incidentCountry'],
+  ['input', 'answers', 'incidentCountryCode'],
+  ['claimPackInput', 'answers', 'incidentCountry'],
+  ['claimPackInput', 'answers', 'incidentCountryCode'],
+  ['data', 'answers', 'incidentCountry'],
+  ['data', 'input', 'answers', 'incidentCountry'],
+] as const;
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readStringPath(value: unknown, path: readonly string[]): string | null {
+  let cursor: unknown = value;
+  for (const segment of path) {
+    const record = readRecord(cursor);
+    if (!record) return null;
+    cursor = record[segment];
+  }
+
+  return typeof cursor === 'string' ? cursor : null;
+}
+
+function resolveCandidate(
+  source: IncidentCountryBackfillSource,
+  countryCode: string | null
+): {
+  country: ClaimIncidentCountry;
+  invalid: boolean;
+  source: IncidentCountryBackfillSource;
+} | null {
+  if (!countryCode) return null;
+  const country = resolveClaimIncidentCountry({ incidentCountryCode: countryCode });
+  return country.incidentCountryCode
+    ? { country, invalid: false, source }
+    : { country, invalid: true, source };
+}
+
+function readClaimPackCandidate(row: IncidentCountryBackfillRow) {
+  let firstInvalid: ReturnType<typeof resolveCandidate> = null;
+  for (const path of CLAIM_PACK_COUNTRY_PATHS) {
+    const candidate = resolveCandidate('claim_pack_json', readStringPath(row.claimPackJson, path));
+    if (!candidate) continue;
+    if (!candidate.invalid) return candidate;
+    firstInvalid ??= candidate;
+  }
+
+  return firstInvalid;
+}
+
+function readDiasporaCandidate(row: IncidentCountryBackfillRow) {
+  for (const note of row.diasporaPublicNotes ?? []) {
+    const origin = parseDiasporaOriginFromPublicNote(note);
+    const candidate = resolveCandidate('diaspora_origin_note', origin?.country ?? null);
+    if (candidate) return candidate;
+  }
+
+  return null;
+}
+
+export function buildIncidentCountryBackfillPlan(
+  rows: IncidentCountryBackfillRow[]
+): IncidentCountryBackfillPlan {
+  const plan: IncidentCountryBackfillPlan = {
+    alreadyPopulated: 0,
+    rowsExamined: rows.length,
+    skippedInvalidSource: 0,
+    skippedNoDurableSource: 0,
+    updates: [],
+    updatesBySource: { claim_pack_json: 0, diaspora_origin_note: 0 },
+  };
+
+  for (const row of rows) {
+    if (row.incidentCountryCode) {
+      plan.alreadyPopulated++;
+      continue;
+    }
+
+    const candidates = [readClaimPackCandidate(row), readDiasporaCandidate(row)];
+    const selected = candidates.find(candidate => candidate && !candidate.invalid);
+
+    if (!selected) {
+      if (candidates.some(candidate => candidate?.invalid)) {
+        plan.skippedInvalidSource++;
+      } else {
+        plan.skippedNoDurableSource++;
+      }
+      continue;
+    }
+
+    plan.updates.push({
+      claimId: row.id,
+      incidentCountryCode: selected.country.incidentCountryCode,
+      incidentJurisdiction: selected.country.incidentJurisdiction,
+      source: selected.source,
+      tenantId: row.tenantId,
+    });
+    plan.updatesBySource[selected.source]++;
+  }
+
+  return plan;
+}

--- a/packages/domain-claims/src/index.ts
+++ b/packages/domain-claims/src/index.ts
@@ -8,6 +8,7 @@ export * from './claims/constants';
 export * from './claims/ai-workflows';
 export * from './claims/diaspora-origin';
 export * from './claims/diaspora-origin-filter';
+export * from './claims/incident-country-backfill';
 export type { ClaimStatus } from './staff-claims/types';
 export * from './validators/claims';
 

--- a/scripts/backfill-incident-country.ts
+++ b/scripts/backfill-incident-country.ts
@@ -1,0 +1,148 @@
+import 'dotenv/config';
+import {
+  and,
+  asc,
+  claimStageHistory,
+  claims,
+  db,
+  eq,
+  inArray,
+  isNull,
+  sql,
+} from '@interdomestik/database';
+import {
+  buildIncidentCountryBackfillPlan,
+  type IncidentCountryBackfillRow,
+} from '@interdomestik/domain-claims';
+import { parseArgs } from 'node:util';
+import {
+  formatIncidentCountryBackfillReport,
+  parseBackfillLimit,
+  type Coverage,
+  type ScriptOptions,
+} from './incident-country-backfill-report';
+
+async function getCoverage(tenantId: string | undefined): Promise<Coverage> {
+  // db-access-guard: system-exempt -- reason: dry-run operator coverage may report cross-tenant aggregate counts without row details
+  const [row] = await db
+    .select({
+      populated: sql<number>`count(${claims.incidentCountryCode})::int`,
+      total: sql<number>`count(*)::int`,
+    })
+    .from(claims)
+    .where(tenantId ? eq(claims.tenantId, tenantId) : undefined);
+
+  return { populated: Number(row?.populated ?? 0), total: Number(row?.total ?? 0) };
+}
+
+async function listMissingClaims(tenantId: string | undefined, limit: number | undefined) {
+  // db-access-guard: system-exempt -- reason: dry-run operator discovery may enumerate missing rows across tenants before scoped apply
+  const query = db
+    .select({
+      id: claims.id,
+      incidentCountryCode: claims.incidentCountryCode,
+      tenantId: claims.tenantId,
+    })
+    .from(claims)
+    .where(
+      tenantId
+        ? and(eq(claims.tenantId, tenantId), isNull(claims.incidentCountryCode))
+        : isNull(claims.incidentCountryCode)
+    )
+    .orderBy(asc(claims.tenantId), asc(claims.createdAt), asc(claims.id));
+  return limit ? query.limit(limit) : query;
+}
+
+async function listDiasporaNotes(
+  claimRows: IncidentCountryBackfillRow[],
+  tenantId: string | undefined
+) {
+  const claimIds = claimRows.map(row => row.id);
+  if (claimIds.length === 0) return new Map<string, Array<string | null>>();
+
+  // db-access-guard: system-exempt -- reason: dry-run operator discovery reads public notes for selected claim ids only
+  const rows = await db
+    .select({ claimId: claimStageHistory.claimId, note: claimStageHistory.note })
+    .from(claimStageHistory)
+    .where(
+      and(
+        tenantId ? eq(claimStageHistory.tenantId, tenantId) : undefined,
+        eq(claimStageHistory.isPublic, true),
+        inArray(claimStageHistory.claimId, claimIds)
+      )
+    )
+    .orderBy(asc(claimStageHistory.claimId), asc(claimStageHistory.createdAt));
+
+  const notesByClaimId = new Map<string, Array<string | null>>();
+  rows.forEach(row => {
+    const notes = notesByClaimId.get(row.claimId) ?? [];
+    notes.push(row.note);
+    notesByClaimId.set(row.claimId, notes);
+  });
+  return notesByClaimId;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const parsedArgs = args[0] === '--' ? args.slice(1) : args;
+  const { values } = parseArgs({
+    args: parsedArgs,
+    options: {
+      apply: { type: 'boolean' },
+      limit: { type: 'string' },
+      tenant: { type: 'string' },
+    },
+  }) as { values: ScriptOptions };
+  const tenantId = values.tenant;
+  const limit = parseBackfillLimit(values.limit);
+  if (values.apply && !tenantId && !limit) {
+    throw new Error('--apply requires --tenant or --limit to avoid an unbounded write run');
+  }
+  const before = await getCoverage(tenantId);
+  const missingRows = await listMissingClaims(tenantId, limit);
+  const notesByClaimId = await listDiasporaNotes(missingRows, tenantId);
+  const plan = buildIncidentCountryBackfillPlan(
+    missingRows.map(row => ({ ...row, diasporaPublicNotes: notesByClaimId.get(row.id) ?? [] }))
+  );
+
+  let updated = 0;
+  if (values.apply) {
+    for (const update of plan.updates) {
+      // db-access-guard: tenant-scoped -- reason: update includes tenant_id and still-null guard to preserve live incident-country values
+      const rows = await db
+        .update(claims)
+        .set({
+          incidentCountryCode: update.incidentCountryCode,
+          incidentJurisdiction: update.incidentJurisdiction,
+        })
+        .where(
+          and(
+            eq(claims.id, update.claimId),
+            eq(claims.tenantId, update.tenantId),
+            isNull(claims.incidentCountryCode)
+          )
+        )
+        .returning({ id: claims.id });
+      updated += rows.length;
+    }
+  }
+
+  const after = values.apply ? await getCoverage(tenantId) : before;
+  console.log(
+    formatIncidentCountryBackfillReport({
+      after,
+      before,
+      limit,
+      missingScanned: missingRows.length,
+      plan,
+      tenantId,
+      updated,
+      writeMode: values.apply,
+    })
+  );
+}
+
+void main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/incident-country-backfill-report.ts
+++ b/scripts/incident-country-backfill-report.ts
@@ -1,0 +1,66 @@
+import type { IncidentCountryBackfillPlan } from '@interdomestik/domain-claims';
+
+export type Coverage = { populated: number; total: number };
+export type ScriptOptions = { apply?: boolean; limit?: string; tenant?: string };
+
+export function parseBackfillLimit(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  if (!/^[1-9]\d*$/u.test(value)) {
+    throw new Error('--limit must be a positive integer');
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error('--limit must be a positive integer');
+  }
+  return parsed;
+}
+
+function withPercent(coverage: Coverage) {
+  const percent =
+    coverage.total === 0 ? '0.00' : ((coverage.populated / coverage.total) * 100).toFixed(2);
+  return { ...coverage, percent };
+}
+
+export function formatIncidentCountryBackfillReport(args: {
+  after: Coverage;
+  before: Coverage;
+  limit: number | undefined;
+  missingScanned: number;
+  plan: IncidentCountryBackfillPlan;
+  tenantId: string | undefined;
+  updated: number;
+  writeMode: boolean | undefined;
+}): string {
+  const projected = {
+    ...args.before,
+    populated: args.before.populated + args.plan.updates.length,
+  };
+
+  return JSON.stringify(
+    {
+      mode: args.writeMode ? 'apply' : 'dry-run',
+      scope: { limit: args.limit ?? null, tenantId: args.tenantId ?? null },
+      durableSources: {
+        claimPackJson: 'unavailable:no persisted claim-pack JSON source is attached to claims',
+        diasporaOriginNotes: 'available:claim_stage_history.note',
+      },
+      coverage: {
+        before: withPercent(args.before),
+        after: withPercent(args.after),
+        projectedAfterDryRun: withPercent(projected),
+      },
+      rows: {
+        missingScanned: args.missingScanned,
+        planned: args.plan.updates.length,
+        updated: args.updated,
+      },
+      skipped: {
+        invalidSource: args.plan.skippedInvalidSource,
+        noDurableSource: args.plan.skippedNoDurableSource,
+      },
+      updatesBySource: args.plan.updatesBySource,
+    },
+    null,
+    2
+  );
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34137791,
-  "maxTrackedFiles": 3926,
+  "maxTrackedBytes": 34151368,
+  "maxTrackedFiles": 3930,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
-    "source/scripts": 6442568,
-    "tests/e2e": 4279490,
+    "source/scripts": 6453611,
+    "tests/e2e": 4282185,
     "docs/text": 4550982,
     "config/data/messages": 1531649,
     "other": 1048576


### PR DESCRIPTION
## Summary
- add a pure incident-country backfill planner for missing claim incident country codes
- add dry-run-first operator tooling and a JSON coverage report for T-102
- export the planner from domain-claims and cover durable-source precedence/regression cases

## Slice
ARCH-M1-09 / T-102: Incident Country Backfill And Coverage Reporting. Scope stayed inside domain-claims and operator scripts; no proxy, route, auth, tenancy, schema, product UI, docs, README, or AGENTS changes. `.codex/config.toml` remains local-only and is excluded from the PR.

## Verification
- pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/incident-country-backfill.test.ts
- pnpm --filter @interdomestik/domain-claims type-check
- pnpm --filter @interdomestik/domain-claims test:unit
- node scripts/run-with-default-db-url.mjs pnpm exec tsx scripts/backfill-incident-country.ts -- --limit 1
- pnpm check:db-access
- pnpm check:architecture-boundaries
- pnpm repo:size:check
- pnpm security:guard via interdomestik_qa security guard
- git diff --check
- git diff --cached --check
- pnpm plan:status
- pnpm plan:audit
- pnpm track:audit
- pnpm docs:verify
- pnpm pr:verify (post-Sonnet hardening; included PR E2E gate and smoke)
- pnpm e2e:gate (standalone before Sonnet hardening: 134 passed, 6 skipped)
- interdomestik_qa scope audit passed for the allowed ARCH-M1-09 paths

## Model Review Disposition
- Sonnet: ran via `claude -p --model claude-sonnet-4-6 --tools "" --no-session-persistence`; no blockers. One hardening suggestion was applied and covered by a regression test.
- Gemini: not applicable; this is backend/domain/operator tooling with no product UI, UX, copy, mobile-density, or accessibility surface.
- Codex Security diff-scan: blocked because tool discovery did not expose the Codex Security scan tool in this runtime; fallback repo security guard passed.
- Copilot/Sonar/reviewer comments: pending PR monitoring.

## Rollback / Risk
The backfill script is dry-run by default and writes only with `--apply`. Updates are guarded by claim id, tenant id, and `incidentCountryCode IS NULL`; row counts use returned updated rows. Reverting this PR removes the planner/export/scripts without schema or runtime workflow migration.