### PR TITLE
docs: record restore drill access blocker

### DIFF
--- a/docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md
+++ b/docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md
@@ -1,0 +1,106 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: platform
+last_reviewed: 2026-06-05
+superseded_by:
+---
+
+# ENT-OPS02 First Staging Restore Drill Record - 2026-06-05
+
+> Status: Blocked evidence record. This records a real restore-drill attempt and the
+> access/tooling blocker encountered. It does not claim restore success, authorize production
+> restore operations, or replace the active program/tracker authority.
+
+## Identity
+
+- Drill id: ENT-OPS02-2026-06-05
+- Environment restored from: not established
+- Restore target environment: not created
+- Backup or recovery point id: not obtained
+- Backup or recovery point timestamp: not obtained
+- Requested by: Interdomestik owner
+- Executed by: Codex operator in repository thread
+- Decision owner: platform owner
+
+## Timing
+
+- Drill start time: 2026-06-05 14:08 Europe/Berlin
+- Restore start time: not started
+- Restore completed time: not completed
+- Validation completed time: not completed
+- Measured RTO: not measured
+- Measured RPO: not measured
+- Target RTO: not established in repo evidence
+- Target RPO: not established in repo evidence
+
+## Safety
+
+- Production data was not overwritten: yes
+- Restore target isolated from live traffic: not created
+- Secrets or credentials exposed in this record: no
+- PII sampled in this record: no
+
+## Preflight Evidence
+
+- Repository branch: `codex/ent-ops02-restore-drill-blocker-record`
+- Repository base commit: `87031dea7755ffe887edd41fff0efd9fcb1a35db`
+- Local environment credential presence check: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`,
+  `SUPABASE_DB_PASSWORD`, `DATABASE_URL`, `STAGING_DATABASE_URL`,
+  `SUPABASE_STAGING_PROJECT_REF`, and `NEXT_PUBLIC_SUPABASE_URL` were not present in the shell
+  environment.
+- Supabase connector project discovery: the Interdomestik project was visible and reported active.
+- Supabase connector migration listing: reachable.
+- Supabase connector security and performance advisors: reachable.
+- Supabase connector branch listing: blocked with provider permission validation error,
+  `Project reference is missing when validating permissions`.
+- Available Supabase connector tools did not expose a backup recovery-point listing or restore
+  operation.
+
+## Validation
+
+- Database reachable: not validated against a restored target
+- Required migrations present: not validated against a restored target
+- Tenant count check: not run
+- Critical table row-count sanity check: not run
+- RLS or tenant-boundary sanity check: not run
+- Application smoke target: not created
+- Application smoke result: not run
+
+## Commands And Tools
+
+- `mcp__codex_apps__supabase._list_projects`: Interdomestik project visible and active.
+- `mcp__codex_apps__supabase._list_migrations`: connector reachable for migration metadata.
+- `mcp__codex_apps__supabase._get_advisors`: connector reachable for security/performance
+  advisor metadata.
+- `mcp__codex_apps__supabase._list_branches`: blocked by provider permission validation error.
+- Local shell credential-presence check: staging/database credentials missing; no secret values
+  printed.
+
+## Result
+
+- Decision: fail/blocked
+- Blocking findings:
+  - No backup or recovery-point identifier could be obtained through the available connector tools.
+  - No isolated restore target could be created from a staging-safe backup through the available
+    connector tools.
+  - Local shell credentials needed for direct database or provider CLI restore work were absent.
+  - Supabase branch listing failed with a permission-validation error.
+- Non-blocking findings:
+  - Supabase connector project discovery, migration metadata, and advisors were reachable.
+  - Security advisors reported existing function-search-path warnings; this drill did not modify
+    database functions.
+  - Performance advisors reported existing index findings; this drill did not modify schema or
+    indexes.
+- Follow-up issue or PR: grant a named operator provider-console or CLI access capable of listing
+  staging-safe backup recovery points and creating an isolated restore target, then rerun this
+  record against `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`.
+- Owner sign-off: blocked pending platform owner/provider access
+
+## Acceptance Disposition
+
+This record does not satisfy the restore-drill acceptance criteria because no recovery point was
+identified, no isolated target was restored, and no RTO/RPO or tenant-boundary validation could be
+measured. It satisfies the `ENT-OPS01` instruction to record missing provider access or connector
+credentials as blockers instead of simulating restore success.

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -36,26 +36,27 @@ enterprise-ready.
 | Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                         | Governed checklist        |
 | Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                             | Bounded pilot evidence    |
 | Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                        | Strong for repo delivery  |
-| Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`                                                                                         | Contract defined          |
+| Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                | Blocker recorded          |
 
 ## Open Enterprise Maturity Lanes
 
 These lanes come from `docs/reviews/2026-04-25-production-professionalism-rereview.md` and remain
 separate from the active architecture-finalization queue unless explicitly promoted.
 
-| Lane                         | Current gap                          | Enterprise requirement                                                                                        |
-| ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| Backup/restore drill cadence | Contract defined; real drill pending | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
-| Exercised incident readiness | Partial                              | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
-| Threat model                 | Not yet scoped                       | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
-| Supply-chain attestation     | Not yet scoped                       | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
-| Alert routing proof          | Partial                              | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
-| Data lifecycle verification  | Partial                              | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
-| Performance regression gate  | Not yet scoped                       | Representative route/storage performance budgets that can block releases                                      |
+| Lane                         | Current gap                                 | Enterprise requirement                                                                                        |
+| ---------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Backup/restore drill cadence | First attempt blocked by restore-access gap | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
+| Exercised incident readiness | Partial                                     | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
+| Threat model                 | Not yet scoped                              | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
+| Supply-chain attestation     | Not yet scoped                              | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
+| Alert routing proof          | Partial                                     | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
+| Data lifecycle verification  | Partial                                     | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
+| Performance regression gate  | Not yet scoped                              | Representative route/storage performance budgets that can block releases                                      |
 
 ## Next Bounded Operational Slice
 
-The next concrete enterprise-hardening step is now one real operational drill:
+The next concrete enterprise-hardening step remains one real operational drill after the first
+attempt recorded the current restore-access blocker:
 
 `ENT-OPS02 First Staging Restore Drill Record`
 
@@ -66,6 +67,8 @@ Scope:
   pass/fail decision.
 - Record missing provider access or connector credentials as blockers instead of simulating
   success.
+- Resolve the 2026-06-05 blocker by granting a named operator backup/recovery-point listing and
+  isolated restore-target access before rerunning the drill.
 - Do not run a production restore in a repo thread.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34168220,
-  "maxTrackedFiles": 3933,
+  "maxTrackedBytes": 34173181,
+  "maxTrackedFiles": 3934,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
     "tests/e2e": 4282186,
-    "docs/text": 4569651,
+    "docs/text": 4574539,
     "config/data/messages": 1531649,
     "other": 1048576
   }


### PR DESCRIPTION
## Summary
- Add the dated ENT-OPS02 restore-drill evidence record for the 2026-06-05 attempt.
- Record the real blocker: current local env and exposed Supabase connector tools cannot identify a staging-safe recovery point or create an isolated restore target.
- Update the enterprise readiness register and exact repo-size budget to reflect the blocked restore-drill attempt.

## Scope
- Docs/tracker evidence only.
- No runtime code, schema, auth, tenancy, routing, billing, product UI, proxy, README, AGENTS, or production restore operation.
- The record intentionally does not claim RTO/RPO, recovery-point identity, tenant-boundary validation, or restore success.

## Verification
- Supabase connector preflight: project discovery, migrations, and advisors reachable; branch listing blocked with provider permission validation error; no backup/recovery-point restore tool exposed.
- Local env credential-presence check: staging/database/provider restore credentials absent; no secret values printed.
- git diff --cached --check
- pnpm exec prettier --check docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md docs/plans/enterprise-readiness-register.md scripts/repo-size-budget.json
- pnpm repo:size:check
- pnpm docs:verify
- pnpm plan:audit
- pnpm track:audit
- pnpm plan:status
- pnpm security:guard

## Follow-up
- A named operator needs provider-console or CLI access capable of listing staging-safe backup recovery points and creating an isolated restore target, then ENT-OPS02 should be rerun against the ENT-OPS01 contract.