### PR TITLE
ci: add supply chain attestation proof

### DIFF
--- a/.github/actions/build-attested-image/action.yml
+++ b/.github/actions/build-attested-image/action.yml
@@ -1,0 +1,102 @@
+name: Build Attested Image
+description: Build, push, attest, and verify an Interdomestik release image.
+
+inputs:
+  registry:
+    required: true
+  image-name:
+    required: true
+  tags:
+    required: true
+  labels:
+    required: true
+  deploy-env:
+    required: true
+  app-url:
+    required: true
+  supabase-url:
+    required: true
+  supabase-anon-key:
+    required: true
+  supabase-production-project-ref:
+    required: true
+
+outputs:
+  digest:
+    value: ${{ steps.build.outputs.digest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      with:
+        context: .
+        file: apps/web/Dockerfile
+        push: true
+        provenance: mode=max
+        sbom: true
+        tags: ${{ inputs.tags }}
+        labels: ${{ inputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: |
+          COMMIT_SHA=${{ github.sha }}
+          INTERDOMESTIK_DEPLOY_ENV=${{ inputs.deploy-env }}
+          NEXT_PUBLIC_SUPABASE_URL=${{ inputs.supabase-url }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ inputs.supabase-anon-key }}
+          SUPABASE_PRODUCTION_PROJECT_REF=${{ inputs.supabase-production-project-ref }}
+          NEXT_PUBLIC_APP_URL=${{ inputs.app-url }}
+
+    - name: Generate Image SBOM
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ steps.build.outputs.digest }}
+        format: spdx-json
+        output-file: image.sbom.spdx.json
+        upload-artifact: false
+        upload-release-assets: false
+
+    - name: Attest Image Build Provenance
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+      with:
+        subject-name: ${{ inputs.registry }}/${{ inputs.image-name }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true
+
+    - name: Attest Image SBOM
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+      with:
+        subject-name: ${{ inputs.registry }}/${{ inputs.image-name }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        sbom-path: image.sbom.spdx.json
+        push-to-registry: true
+
+    - name: Verify Signed Provenance And SBOM
+      env:
+        GH_TOKEN: ${{ github.token }}
+        IMAGE_REF: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ steps.build.outputs.digest }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        digest="${IMAGE_REF##*@}"
+        signer_workflow="${GITHUB_SERVER_URL#https://}/${GITHUB_REPOSITORY}/.github/workflows/cd.yml"
+        if [[ "${digest}" == "${IMAGE_REF}" || -z "${digest}" ]]; then
+          echo "::error::Missing image digest for attestation verification."
+          exit 1
+        fi
+
+        gh attestation verify "oci://${IMAGE_REF}" \
+          -R "${GITHUB_REPOSITORY}" \
+          --source-digest "${GITHUB_SHA}" \
+          --source-ref "${GITHUB_REF}" \
+          --signer-workflow "${signer_workflow}"
+
+        gh attestation verify "oci://${IMAGE_REF}" \
+          -R "${GITHUB_REPOSITORY}" \
+          --source-digest "${GITHUB_SHA}" \
+          --source-ref "${GITHUB_REF}" \
+          --signer-workflow "${signer_workflow}" \
+          --predicate-type https://spdx.dev/Document/v2.3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,8 +23,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     outputs:
       image_tag: ${{ steps.meta.outputs.version }}
+      image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -49,23 +52,19 @@ jobs:
           tags: |
             type=raw,value=staging-${{ github.sha }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      - name: Build, attest, and verify Docker image
+        id: build
+        uses: ./.github/actions/build-attested-image
         with:
-          context: .
-          file: apps/web/Dockerfile
-          push: true
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            COMMIT_SHA=${{ github.sha }}
-            INTERDOMESTIK_DEPLOY_ENV=staging
-            NEXT_PUBLIC_SUPABASE_URL=${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
-            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-            SUPABASE_PRODUCTION_PROJECT_REF=${{ vars.SUPABASE_PRODUCTION_PROJECT_REF || secrets.SUPABASE_PRODUCTION_PROJECT_REF }}
-            NEXT_PUBLIC_APP_URL=https://staging.interdomestik.com
+          deploy-env: staging
+          app-url: https://staging.interdomestik.com
+          supabase-url: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          supabase-anon-key: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          supabase-production-project-ref: ${{ vars.SUPABASE_PRODUCTION_PROJECT_REF || secrets.SUPABASE_PRODUCTION_PROJECT_REF }}
 
   deploy-staging:
     needs: build-staging
@@ -230,8 +229,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     outputs:
       image_tag: ${{ steps.meta.outputs.version }}
+      image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -259,23 +261,19 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      - name: Build, attest, and verify Docker image
+        id: build
+        uses: ./.github/actions/build-attested-image
         with:
-          context: .
-          file: apps/web/Dockerfile
-          push: true
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            COMMIT_SHA=${{ github.sha }}
-            INTERDOMESTIK_DEPLOY_ENV=production
-            NEXT_PUBLIC_SUPABASE_URL=${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
-            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-            SUPABASE_PRODUCTION_PROJECT_REF=${{ vars.SUPABASE_PRODUCTION_PROJECT_REF || secrets.SUPABASE_PRODUCTION_PROJECT_REF }}
-            NEXT_PUBLIC_APP_URL=https://app.interdomestik.com
+          deploy-env: production
+          app-url: https://app.interdomestik.com
+          supabase-url: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          supabase-anon-key: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          supabase-production-project-ref: ${{ vars.SUPABASE_PRODUCTION_PROJECT_REF || secrets.SUPABASE_PRODUCTION_PROJECT_REF }}
 
   deploy-production:
     needs: build-production

--- a/docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md
+++ b/docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md
@@ -1,0 +1,69 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: platform
+last_reviewed: 2026-06-05
+superseded_by:
+---
+
+# ENT-SCA02 Supply Chain Attestation CI Proof
+
+> Status: Input document. This record documents the repo-owned CD proof added for
+> supply-chain attestation. It does not claim full enterprise readiness or replace
+> the active program/tracker authority.
+
+## Scope
+
+This slice implements the next repo-owned proof from
+`docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`.
+
+Changed surfaces:
+
+- `.github/workflows/cd.yml`
+- `.github/actions/build-attested-image/action.yml`
+- `scripts/ci/cd-attestation-contract.test.mjs`
+- `scripts/ci/workflow-contracts.test.mjs`
+- `docs/plans/enterprise-readiness-register.md`
+
+Out of scope:
+
+- Runtime code, schema, auth, tenancy, routing, billing, product UI, proxy, README, AGENTS, and
+  broad architecture docs.
+- Production operations, credential changes, registry administration, or deploy-webhook changes.
+
+## Implemented Proof
+
+The staging and production CD build jobs now:
+
+- request GitHub OIDC and artifact-attestation permissions with `id-token: write` and
+  `attestations: write`;
+- build GHCR images with Docker Buildx `provenance: mode=max` and `sbom: true`;
+- generate an SPDX JSON image SBOM with Syft through pinned `anchore/sbom-action@v0.24.0`;
+- capture the immutable image digest through `steps.build.outputs.digest`;
+- publish the digest as a job output named `image_digest`;
+- create signed build-provenance and SBOM attestations with pinned `actions/attest@v4`;
+- push both attestations to the registry; and
+- run `gh attestation verify oci://... -R ...` for provenance and the SPDX SBOM predicate before
+  any deploy job can proceed, enforcing the current commit SHA, ref, and CD signer workflow.
+
+The new workflow contract test fails if either build job drops digest capture, SBOM/provenance
+generation, signed provenance or SBOM attestation, or attestation verification.
+
+## Current Enterprise Gap
+
+This slice improves artifact custody before deploy promotion, but it does not yet prove deployed
+digest equality. The current deploy webhook payload and `/api/health` contract prove the deployed
+commit SHA, not the running OCI image digest.
+
+The remaining blocker is therefore explicit:
+
+- Provider/deploy boundary must accept or expose the immutable image digest used for deployment.
+- The app or deploy platform must expose a safe non-secret runtime digest proof.
+- CD must compare that deployed digest to the attested digest before final production sign-off.
+
+## Result
+
+- Decision: repo-owned CI/CD attestation proof implemented.
+- Residual risk: deployed digest equality is still pending a deploy-boundary contract.
+- Follow-up slice: `ENT-SCA03 Deploy Digest Verification Boundary`.

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -37,22 +37,22 @@ enterprise-ready.
 | Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                             | Bounded pilot evidence    |
 | Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                        | Strong for repo delivery  |
 | Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                | Blocker recorded          |
-| Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`                                                                                     | Contract defined          |
+| Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`             | CI proof configured       |
 
 ## Open Enterprise Maturity Lanes
 
 These lanes come from `docs/reviews/2026-04-25-production-professionalism-rereview.md` and remain
 separate from the active architecture-finalization queue unless explicitly promoted.
 
-| Lane                         | Current gap                                    | Enterprise requirement                                                                                        |
-| ---------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Backup/restore drill cadence | First attempt blocked by restore-access gap    | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
-| Exercised incident readiness | Partial                                        | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
-| Threat model                 | Not yet scoped                                 | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
-| Supply-chain attestation     | Contract defined; implementation proof pending | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
-| Alert routing proof          | Partial                                        | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
-| Data lifecycle verification  | Partial                                        | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
-| Performance regression gate  | Not yet scoped                                 | Representative route/storage performance budgets that can block releases                                      |
+| Lane                         | Current gap                                        | Enterprise requirement                                                                                        |
+| ---------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Backup/restore drill cadence | First attempt blocked by restore-access gap        | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
+| Exercised incident readiness | Partial                                            | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
+| Threat model                 | Not yet scoped                                     | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
+| Supply-chain attestation     | CI proof configured; deployed digest proof pending | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
+| Alert routing proof          | Partial                                            | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
+| Data lifecycle verification  | Partial                                            | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
+| Performance regression gate  | Not yet scoped                                     | Representative route/storage performance budgets that can block releases                                      |
 
 ## Next Bounded Operational Slice
 
@@ -86,28 +86,27 @@ Rationale:
 While `ENT-OPS02` remains blocked on provider or CLI restore access, the next smallest repo-owned
 enterprise-hardening slice is:
 
-`ENT-SCA02 Supply Chain Attestation CI Proof`
+`ENT-SCA03 Deploy Digest Verification Boundary`
 
 Scope:
 
-- Build on `ENT-SCA01` by generating a real SBOM for the release image or a staging-equivalent
-  artifact.
-- Capture the immutable image digest and bind it to the GitHub workflow run, ref, and commit SHA.
-- Add signed provenance or artifact attestation from the trusted CI identity when registry and
-  runner permissions allow it.
-- Verify the SBOM, provenance, signature or attestation, and deployed digest before promotion, or
-  record the exact provider or permission blocker.
+- Build on `ENT-SCA02` by adding a deploy-boundary contract for immutable image digest proof.
+- Ensure the deployment webhook accepts the digest used for deployment, or the deploy platform
+  exposes the running OCI image digest through a safe non-secret status channel.
+- Compare the deployed digest with the attested digest before production sign-off.
+- Record the exact provider, webhook, or runtime capability blocker instead of simulating digest
+  equality.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
 Rationale:
 
-- The current CD lane already proves deployed commit SHA, but not artifact digest custody or signed
-  supply-chain provenance.
-- This lane is repo-owned and can make enterprise readiness more true while restore-drill access is
-  blocked.
-- The first slice is contract-only; the next slice should provide real CI/CD evidence or a recorded
-  external capability blocker.
+- `ENT-SCA02` adds repo-owned SBOM/provenance generation, digest capture, signed provenance, and
+  pre-deploy attestation verification.
+- The remaining supply-chain gap is not another repo-local assertion; it is proving that the
+  running deployment equals the attested digest.
+- This should be handled as the next smallest bounded supply-chain slice when the deploy boundary
+  can be changed or inspected.
 
 ## Non-Goals
 

--- a/scripts/ci/cd-attestation-contract.test.mjs
+++ b/scripts/ci/cd-attestation-contract.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const cdWorkflow = readYaml('.github/workflows/cd.yml');
+const attestedImageAction = readYaml('.github/actions/build-attested-image/action.yml');
+
+function readYaml(relativePath) {
+  return yaml.load(fs.readFileSync(path.join(rootDir, relativePath), 'utf8'));
+}
+
+function findStep(steps, name) {
+  return steps.find(step => step?.name === name);
+}
+
+function findStepIndex(steps, name) {
+  return steps.findIndex(step => step?.name === name);
+}
+
+function assertSupplyChainBuildJob(jobName, environmentName) {
+  const job = cdWorkflow.jobs[jobName];
+  assert.ok(job, `${jobName} must exist`);
+  assert.equal(job.environment.name, environmentName);
+  assert.equal(job.permissions.contents, 'read');
+  assert.equal(job.permissions.packages, 'write');
+  assert.equal(job.permissions['id-token'], 'write');
+  assert.equal(job.permissions.attestations, 'write');
+  assert.equal(job.outputs.image_tag, '${{ steps.meta.outputs.version }}');
+  assert.equal(job.outputs.image_digest, '${{ steps.build.outputs.digest }}');
+
+  const buildStep = findStep(job.steps, 'Build, attest, and verify Docker image');
+  assert.ok(buildStep, `${jobName} must use the attested image action`);
+  assert.equal(buildStep.id, 'build');
+  assert.equal(buildStep.uses, './.github/actions/build-attested-image');
+  assert.equal(buildStep.with['deploy-env'], environmentName);
+  assert.match(buildStep.with['supabase-url'], /\$\{\{\s*(vars|secrets)\.NEXT_PUBLIC_SUPABASE_URL/);
+  assert.match(
+    buildStep.with['supabase-anon-key'],
+    /\$\{\{\s*(vars|secrets)\.NEXT_PUBLIC_SUPABASE_ANON_KEY/
+  );
+  assert.match(
+    buildStep.with['supabase-production-project-ref'],
+    /\$\{\{\s*(vars|secrets)\.SUPABASE_PRODUCTION_PROJECT_REF/
+  );
+}
+
+function assertAttestedImageAction() {
+  assert.equal(attestedImageAction.outputs.digest.value, '${{ steps.build.outputs.digest }}');
+  const steps = attestedImageAction.runs.steps;
+  const buildStep = findStep(steps, 'Build and push Docker image');
+  assert.ok(buildStep, 'attested image action must build and push the image');
+  assert.match(buildStep.uses, /^docker\/build-push-action@[a-f0-9]{40}$/u);
+  assert.equal(buildStep.id, 'build');
+  assert.equal(buildStep.with.push, true);
+  assert.equal(buildStep.with.provenance, 'mode=max');
+  assert.equal(buildStep.with.sbom, true);
+  assert.match(buildStep.with.tags, /\$\{\{\s*inputs\.tags\s*\}\}/u);
+
+  const sbomStep = findStep(steps, 'Generate Image SBOM');
+  const attestStep = findStep(steps, 'Attest Image Build Provenance');
+  const attestSbomStep = findStep(steps, 'Attest Image SBOM');
+  const verifyStep = findStep(steps, 'Verify Signed Provenance And SBOM');
+  assert.ok(sbomStep, 'attested image action must generate an image SBOM');
+  assert.ok(attestStep, 'attested image action must create signed provenance');
+  assert.ok(attestSbomStep, 'attested image action must create a signed SBOM attestation');
+  assert.ok(verifyStep, 'attested image action must verify signed provenance and SBOM');
+  assert.match(sbomStep.uses, /^anchore\/sbom-action@[a-f0-9]{40}$/u);
+  assert.equal(sbomStep.with.format, 'spdx-json');
+  assert.equal(sbomStep.with['output-file'], 'image.sbom.spdx.json');
+  assert.equal(sbomStep.with['upload-artifact'], false);
+  assert.match(attestStep.uses, /^actions\/attest@[a-f0-9]{40}$/u);
+  assert.equal(attestStep.with['subject-name'], '${{ inputs.registry }}/${{ inputs.image-name }}');
+  assert.equal(attestStep.with['subject-digest'], '${{ steps.build.outputs.digest }}');
+  assert.equal(attestStep.with['push-to-registry'], true);
+  assert.match(attestSbomStep.uses, /^actions\/attest@[a-f0-9]{40}$/u);
+  assert.equal(attestSbomStep.with['sbom-path'], 'image.sbom.spdx.json');
+  assert.equal(attestSbomStep.with['push-to-registry'], true);
+  assert.equal(verifyStep.env.GH_TOKEN, '${{ github.token }}');
+  assert.match(verifyStep.env.IMAGE_REF, /steps\.build\.outputs\.digest/u);
+  assert.match(verifyStep.run, /gh attestation verify "oci:\/\/\$\{IMAGE_REF\}"/u);
+  assert.match(verifyStep.run, /-R "\$\{GITHUB_REPOSITORY\}"/u);
+  assert.match(verifyStep.run, /--source-digest "\$\{GITHUB_SHA\}"/u);
+  assert.match(verifyStep.run, /--source-ref "\$\{GITHUB_REF\}"/u);
+  assert.match(verifyStep.run, /--signer-workflow "\$\{signer_workflow\}"/u);
+  assert.match(verifyStep.run, /--predicate-type https:\/\/spdx\.dev\/Document\/v2\.3/u);
+  assert.ok(findStepIndex(steps, buildStep.name) < findStepIndex(steps, sbomStep.name));
+  assert.ok(findStepIndex(steps, sbomStep.name) < findStepIndex(steps, attestStep.name));
+  assert.ok(findStepIndex(steps, attestStep.name) < findStepIndex(steps, attestSbomStep.name));
+  assert.ok(findStepIndex(steps, attestSbomStep.name) < findStepIndex(steps, verifyStep.name));
+}
+
+test('CD release images emit SBOM, signed provenance, and verified immutable digests', () => {
+  assertSupplyChainBuildJob('build-staging', 'staging');
+  assertSupplyChainBuildJob('build-production', 'production');
+  assertAttestedImageAction();
+});

--- a/scripts/ci/cd-attestation-contract.test.mjs
+++ b/scripts/ci/cd-attestation-contract.test.mjs
@@ -60,6 +60,27 @@ function assertAttestedImageAction() {
   assert.equal(buildStep.with.provenance, 'mode=max');
   assert.equal(buildStep.with.sbom, true);
   assert.match(buildStep.with.tags, /\$\{\{\s*inputs\.tags\s*\}\}/u);
+  assert.match(buildStep.with['build-args'], /COMMIT_SHA=\$\{\{\s*github\.sha\s*\}\}/u);
+  assert.match(
+    buildStep.with['build-args'],
+    /INTERDOMESTIK_DEPLOY_ENV=\$\{\{\s*inputs\.deploy-env\s*\}\}/u
+  );
+  assert.match(
+    buildStep.with['build-args'],
+    /NEXT_PUBLIC_SUPABASE_URL=\$\{\{\s*inputs\.supabase-url\s*\}\}/u
+  );
+  assert.match(
+    buildStep.with['build-args'],
+    /NEXT_PUBLIC_SUPABASE_ANON_KEY=\$\{\{\s*inputs\.supabase-anon-key\s*\}\}/u
+  );
+  assert.match(
+    buildStep.with['build-args'],
+    /SUPABASE_PRODUCTION_PROJECT_REF=\$\{\{\s*inputs\.supabase-production-project-ref\s*\}\}/u
+  );
+  assert.match(
+    buildStep.with['build-args'],
+    /NEXT_PUBLIC_APP_URL=\$\{\{\s*inputs\.app-url\s*\}\}/u
+  );
 
   const sbomStep = findStep(steps, 'Generate Image SBOM');
   const attestStep = findStep(steps, 'Attest Image Build Provenance');

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -522,51 +522,29 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.ok(buildStagingJob);
   assert.equal(buildStagingJob.environment.name, 'staging');
   assert.equal(buildStagingJob.outputs.image_tag, '${{ steps.meta.outputs.version }}');
-  const buildStagingStep = findStep(buildStagingJob.steps, 'Build and push Docker image');
+  const buildStagingStep = findStep(
+    buildStagingJob.steps,
+    'Build, attest, and verify Docker image'
+  );
   assert.ok(buildStagingStep);
-  assert.match(buildStagingStep.with['build-args'], /COMMIT_SHA=\$\{\{\s*github\.sha\s*\}\}/);
-  assert.match(buildStagingStep.with['build-args'], /INTERDOMESTIK_DEPLOY_ENV=staging/);
-  assert.match(
-    buildStagingStep.with['build-args'],
-    /NEXT_PUBLIC_APP_URL=https:\/\/staging\.interdomestik\.com/
-  );
-  assert.match(
-    buildStagingStep.with['build-args'],
-    /NEXT_PUBLIC_SUPABASE_URL=\$\{\{\s*(vars|secrets)\.NEXT_PUBLIC_SUPABASE_URL/
-  );
-  assert.match(
-    buildStagingStep.with['build-args'],
-    /NEXT_PUBLIC_SUPABASE_ANON_KEY=\$\{\{\s*(vars|secrets)\.NEXT_PUBLIC_SUPABASE_ANON_KEY/
-  );
-  assert.match(
-    buildStagingStep.with['build-args'],
-    /SUPABASE_PRODUCTION_PROJECT_REF=\$\{\{\s*(vars|secrets)\.SUPABASE_PRODUCTION_PROJECT_REF/
-  );
+  assert.equal(buildStagingStep.id, 'build');
+  assert.equal(buildStagingStep.uses, './.github/actions/build-attested-image');
+  assert.equal(buildStagingStep.with['deploy-env'], 'staging');
+  assert.equal(buildStagingStep.with['app-url'], 'https://staging.interdomestik.com');
 
   assert.ok(buildProductionJob);
   assert.deepEqual(normalizeNeeds(buildProductionJob.needs), ['e2e-staging']);
   assert.equal(buildProductionJob.environment.name, 'production');
   assert.equal(buildProductionJob.outputs.image_tag, '${{ steps.meta.outputs.version }}');
-  const buildProductionStep = findStep(buildProductionJob.steps, 'Build and push Docker image');
+  const buildProductionStep = findStep(
+    buildProductionJob.steps,
+    'Build, attest, and verify Docker image'
+  );
   assert.ok(buildProductionStep);
-  assert.match(buildProductionStep.with['build-args'], /COMMIT_SHA=\$\{\{\s*github\.sha\s*\}\}/);
-  assert.match(buildProductionStep.with['build-args'], /INTERDOMESTIK_DEPLOY_ENV=production/);
-  assert.match(
-    buildProductionStep.with['build-args'],
-    /NEXT_PUBLIC_APP_URL=https:\/\/app\.interdomestik\.com/
-  );
-  assert.match(
-    buildProductionStep.with['build-args'],
-    /NEXT_PUBLIC_SUPABASE_URL=\$\{\{\s*(vars|secrets)\.NEXT_PUBLIC_SUPABASE_URL/
-  );
-  assert.match(
-    buildProductionStep.with['build-args'],
-    /NEXT_PUBLIC_SUPABASE_ANON_KEY=\$\{\{\s*(vars|secrets)\.NEXT_PUBLIC_SUPABASE_ANON_KEY/
-  );
-  assert.match(
-    buildProductionStep.with['build-args'],
-    /SUPABASE_PRODUCTION_PROJECT_REF=\$\{\{\s*(vars|secrets)\.SUPABASE_PRODUCTION_PROJECT_REF/
-  );
+  assert.equal(buildProductionStep.id, 'build');
+  assert.equal(buildProductionStep.uses, './.github/actions/build-attested-image');
+  assert.equal(buildProductionStep.with['deploy-env'], 'production');
+  assert.equal(buildProductionStep.with['app-url'], 'https://app.interdomestik.com');
 
   assert.deepEqual(normalizeNeeds(deployStagingJob.needs), ['build-staging']);
   assert.equal(

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34190072,
+  "maxTrackedBytes": 34190805,
   "maxTrackedFiles": 3938,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
-    "tests/e2e": 4286505,
+    "tests/e2e": 4287238,
     "docs/text": 4583911,
     "config/data/messages": 1533128,
     "other": 1048576

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34179709,
-  "maxTrackedFiles": 3935,
+  "maxTrackedBytes": 34190072,
+  "maxTrackedFiles": 3938,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
-    "tests/e2e": 4282186,
-    "docs/text": 4581067,
-    "config/data/messages": 1531649,
+    "tests/e2e": 4286505,
+    "docs/text": 4583911,
+    "config/data/messages": 1533128,
     "other": 1048576
   }
 }


### PR DESCRIPTION
## Summary
- Adds a local CD composite action that builds staging/production images with provenance/SBOM enabled, emits the image digest, creates signed provenance and SPDX SBOM attestations, pushes them to the registry, and verifies both before deploy.
- Updates CD workflow contracts and adds an attestation contract test for required permissions, digest outputs, pinned actions, attestation push, and source/ref/signer verification.
- Records ENT-SCA02 in the enterprise readiness register and promotes ENT-SCA03 for deployed digest equality proof.

## Scope
- CI/CD, workflow contracts, and planning docs only.
- No runtime app, proxy, auth, tenancy, routing, billing, product UI, database schema, or migration changes.

## Verification
- MCP scope audit: pass
- git diff --check: pass
- pnpm test:ci:contracts: pass
- pnpm plan:status: pass
- pnpm plan:audit: pass
- pnpm track:audit: pass
- pnpm docs:verify: pass
- pnpm repo:size:check: pass
- pnpm security:guard: pass
- pnpm pr:verify: pass
- pnpm e2e:gate: pass on rerun (134 passed, 6 skipped)

## Review Notes
- Sonnet architecture/scope review completed. Two findings were checked against current GitHub attestation docs and gh CLI help and treated as stale/false-positive; one hardening improvement was applied by enforcing source digest, source ref, and signer workflow during verification.
- Residual enterprise gap is intentionally captured as ENT-SCA03: proving the deployed runtime digest equals the attested image digest.

## Rollback
- Revert this PR to restore the previous CD build steps and readiness register state.