### PR TITLE
ci: verify deploy image digest boundary

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -1,0 +1,120 @@
+name: Trigger digest-verified deploy
+description: Trigger an environment deploy webhook and require immutable image digest confirmation.
+
+inputs:
+  environment:
+    required: true
+  webhook-url:
+    required: true
+  webhook-token:
+    required: true
+  registry:
+    required: true
+  image-name:
+    required: true
+  image-tag:
+    required: true
+  image-digest:
+    required: true
+  sha:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Trigger deploy webhook
+      shell: bash
+      env:
+        DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+        DEPLOY_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        DEPLOY_WEBHOOK_TOKEN: ${{ inputs.webhook-token }}
+        IMAGE_REGISTRY: ${{ inputs.registry }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
+        IMAGE_DIGEST: ${{ inputs.image-digest }}
+        COMMIT_SHA: ${{ inputs.sha }}
+      run: |
+        set -euo pipefail
+
+        missing=()
+        [[ -n "${DEPLOY_ENVIRONMENT:-}" ]] || missing+=("environment")
+        [[ -n "${DEPLOY_WEBHOOK_URL:-}" ]] || missing+=("webhook-url")
+        [[ -n "${DEPLOY_WEBHOOK_TOKEN:-}" ]] || missing+=("webhook-token")
+        [[ -n "${IMAGE_REGISTRY:-}" ]] || missing+=("registry")
+        [[ -n "${IMAGE_NAME:-}" ]] || missing+=("image-name")
+        [[ -n "${IMAGE_TAG:-}" ]] || missing+=("image-tag")
+        [[ -n "${IMAGE_DIGEST:-}" ]] || missing+=("image-digest")
+        [[ -n "${COMMIT_SHA:-}" ]] || missing+=("sha")
+
+        if (( ${#missing[@]} > 0 )); then
+          echo "::error::Missing ${DEPLOY_ENVIRONMENT:-unknown} deploy prerequisite(s): ${missing[*]}."
+          exit 1
+        fi
+
+        image_ref="${IMAGE_REGISTRY}/${IMAGE_NAME}"
+        payload_file="$(mktemp)"
+        response_file="$(mktemp)"
+        trap 'rm -f "${payload_file}" "${response_file}"' EXIT
+
+        printf '{"environment":"%s","image":"%s","image_tag":"%s","image_digest":"%s","sha":"%s"}' \
+          "${DEPLOY_ENVIRONMENT}" \
+          "${image_ref}" \
+          "${IMAGE_TAG}" \
+          "${IMAGE_DIGEST}" \
+          "${COMMIT_SHA}" > "${payload_file}"
+
+        curl_exit=0
+        http_status="$(
+          curl --silent --show-error --output "${response_file}" --write-out '%{http_code}' \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-delay 5 \
+            -H 'content-type: application/json' \
+            -H "authorization: Bearer ${DEPLOY_WEBHOOK_TOKEN}" \
+            --data-binary @"${payload_file}" \
+            "${DEPLOY_WEBHOOK_URL}"
+        )" || curl_exit=$?
+
+        if (( curl_exit != 0 )); then
+          echo "::error::Failed to trigger ${DEPLOY_ENVIRONMENT} deploy webhook."
+          if [[ -s "${response_file}" ]]; then
+            cat "${response_file}"
+          fi
+          exit "${curl_exit}"
+        fi
+
+        if [[ ! "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
+          echo "::error::${DEPLOY_ENVIRONMENT} deploy webhook returned HTTP ${http_status}."
+          cat "${response_file}"
+          exit 1
+        fi
+
+        DEPLOY_WEBHOOK_RESPONSE_FILE="${response_file}" node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const expected = process.env.IMAGE_DIGEST;
+          const environment = process.env.DEPLOY_ENVIRONMENT || 'unknown';
+          const responseFile = process.env.DEPLOY_WEBHOOK_RESPONSE_FILE;
+          if (!expected || !responseFile) {
+            throw new Error('IMAGE_DIGEST and DEPLOY_WEBHOOK_RESPONSE_FILE are required');
+          }
+
+          const raw = fs.readFileSync(responseFile, 'utf8').trim();
+          if (!raw) {
+            throw new Error(`${environment} deploy webhook must confirm image_digest in JSON`);
+          }
+
+          let response;
+          try {
+            response = JSON.parse(raw);
+          } catch (error) {
+            throw new Error(`${environment} deploy webhook must confirm image_digest in JSON`, {
+              cause: error,
+            });
+          }
+          const actual = response?.image_digest;
+          if (actual !== expected) {
+            throw new Error(`${environment} deploy digest mismatch: expected ${expected}, got ${actual || 'missing'}`);
+          }
+
+          console.log(`${environment} deploy webhook confirmed image digest: ${actual}`);
+        NODE

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -74,57 +74,22 @@ jobs:
       url: https://staging.interdomestik.com
     env:
       BASE_URL: https://staging.interdomestik.com
-      DEPLOY_WEBHOOK_URL: ${{ secrets.INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL }}
-      DEPLOY_WEBHOOK_TOKEN: ${{ secrets.INTERDOMESTIK_STAGING_DEPLOY_TOKEN }}
       EXPECTED_COMMIT_SHA: ${{ github.sha }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+
       - name: Trigger Staging Deploy
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          missing=()
-          [[ -n "${DEPLOY_WEBHOOK_URL:-}" ]] || missing+=("INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL")
-          [[ -n "${DEPLOY_WEBHOOK_TOKEN:-}" ]] || missing+=("INTERDOMESTIK_STAGING_DEPLOY_TOKEN")
-
-          if (( ${#missing[@]} > 0 )); then
-            echo "::error::Missing staging deploy secret(s): ${missing[*]}."
-            exit 1
-          fi
-
-          payload_file="$(mktemp)"
-          response_file="$(mktemp)"
-          trap 'rm -f "${payload_file}" "${response_file}"' EXIT
-
-          printf '{"environment":"%s","image":"%s","image_tag":"%s","sha":"%s"}' \
-            "staging" \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" \
-            "${{ needs.build-staging.outputs.image_tag }}" \
-            "${{ github.sha }}" > "${payload_file}"
-
-          curl_exit=0
-          http_status="$(
-            curl --silent --show-error --output "${response_file}" --write-out '%{http_code}' \
-              --retry 3 --retry-delay 5 \
-              -H 'content-type: application/json' \
-              -H "authorization: Bearer ${DEPLOY_WEBHOOK_TOKEN}" \
-              --data-binary @"${payload_file}" \
-              "${DEPLOY_WEBHOOK_URL}"
-          )" || curl_exit=$?
-
-          if (( curl_exit != 0 )); then
-            echo "::error::Failed to trigger staging deploy webhook."
-            if [[ -s "${response_file}" ]]; then
-              cat "${response_file}"
-            fi
-            exit "${curl_exit}"
-          fi
-
-          if [[ ! "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
-            echo "::error::Staging deploy webhook returned HTTP ${http_status}."
-            cat "${response_file}"
-            exit 1
-          fi
+        uses: ./.github/actions/trigger-digest-verified-deploy
+        with:
+          environment: staging
+          webhook-url: ${{ secrets.INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL }}
+          webhook-token: ${{ secrets.INTERDOMESTIK_STAGING_DEPLOY_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          image-tag: ${{ needs.build-staging.outputs.image_tag }}
+          image-digest: ${{ needs.build-staging.outputs.image_digest }}
+          sha: ${{ github.sha }}
 
       - name: Wait for Staging Health
         shell: bash
@@ -194,7 +159,7 @@ jobs:
       RELEASE_GATE_ADMIN_MK_EMAIL: ${{ secrets.RELEASE_GATE_ADMIN_MK_EMAIL }}
       RELEASE_GATE_ADMIN_MK_PASSWORD: ${{ secrets.RELEASE_GATE_ADMIN_MK_PASSWORD }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
 
       - uses: ./.github/actions/setup
         with:
@@ -236,7 +201,7 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -281,58 +246,21 @@ jobs:
     environment:
       name: production
       url: https://app.interdomestik.com
-    env:
-      BASE_URL: https://app.interdomestik.com
-      DEPLOY_WEBHOOK_URL: ${{ secrets.INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL }}
-      DEPLOY_WEBHOOK_TOKEN: ${{ secrets.INTERDOMESTIK_PRODUCTION_DEPLOY_TOKEN }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+
       - name: Trigger Production Deploy
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          missing=()
-          [[ -n "${DEPLOY_WEBHOOK_URL:-}" ]] || missing+=("INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL")
-          [[ -n "${DEPLOY_WEBHOOK_TOKEN:-}" ]] || missing+=("INTERDOMESTIK_PRODUCTION_DEPLOY_TOKEN")
-
-          if (( ${#missing[@]} > 0 )); then
-            echo "::error::Missing production deploy secret(s): ${missing[*]}."
-            exit 1
-          fi
-
-          payload_file="$(mktemp)"
-          response_file="$(mktemp)"
-          trap 'rm -f "${payload_file}" "${response_file}"' EXIT
-
-          printf '{"environment":"%s","image":"%s","image_tag":"%s","sha":"%s"}' \
-            "production" \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" \
-            "${{ needs.build-production.outputs.image_tag }}" \
-            "${{ github.sha }}" > "${payload_file}"
-
-          curl_exit=0
-          http_status="$(
-            curl --silent --show-error --output "${response_file}" --write-out '%{http_code}' \
-              --retry 3 --retry-delay 5 \
-              -H 'content-type: application/json' \
-              -H "authorization: Bearer ${DEPLOY_WEBHOOK_TOKEN}" \
-              --data-binary @"${payload_file}" \
-              "${DEPLOY_WEBHOOK_URL}"
-          )" || curl_exit=$?
-
-          if (( curl_exit != 0 )); then
-            echo "::error::Failed to trigger production deploy webhook."
-            if [[ -s "${response_file}" ]]; then
-              cat "${response_file}"
-            fi
-            exit "${curl_exit}"
-          fi
-
-          if [[ ! "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
-            echo "::error::Production deploy webhook returned HTTP ${http_status}."
-            cat "${response_file}"
-            exit 1
-          fi
+        uses: ./.github/actions/trigger-digest-verified-deploy
+        with:
+          environment: production
+          webhook-url: ${{ secrets.INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL }}
+          webhook-token: ${{ secrets.INTERDOMESTIK_PRODUCTION_DEPLOY_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          image-tag: ${{ needs.build-production.outputs.image_tag }}
+          image-digest: ${{ needs.build-production.outputs.image_digest }}
+          sha: ${{ github.sha }}
 
   verify-production:
     needs: deploy-production
@@ -360,7 +288,7 @@ jobs:
       SENTRY_ENVIRONMENT: production
       SENTRY_SEVERITY_THRESHOLD: error
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
 
       - uses: ./.github/actions/setup
         with:

--- a/docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md
+++ b/docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md
@@ -1,0 +1,64 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: platform
+last_reviewed: 2026-06-05
+superseded_by:
+---
+
+# ENT-SCA03 Deploy Digest Verification Boundary
+
+> Status: Input document. This record documents the repo-owned deploy-boundary proof added after
+> `ENT-SCA02`. It does not claim full enterprise readiness or replace the active program/tracker
+> authority.
+
+## Scope
+
+This slice implements the next repo-owned supply-chain proof from
+`docs/plans/enterprise-readiness-register.md`.
+
+Changed surfaces:
+
+- `.github/workflows/cd.yml`
+- `.github/actions/trigger-digest-verified-deploy/action.yml`
+- `scripts/ci/cd-deploy-digest-boundary.test.mjs`
+- `scripts/ci/workflow-contracts.test.mjs`
+- `docs/plans/enterprise-readiness-register.md`
+
+Out of scope:
+
+- Runtime code, schema, auth, tenancy, routing, billing, product UI, proxy, README, AGENTS, and
+  broad architecture docs.
+- Production operations, credential changes, registry administration, or provider-side deploy
+  webhook implementation.
+- Simulated digest equality or mutable tag-only deployment proof.
+
+## Implemented Proof
+
+The staging and production CD deploy jobs now:
+
+- carry the immutable image digest from the corresponding build job as `EXPECTED_IMAGE_DIGEST`;
+- include `image_digest` in the environment-scoped deploy webhook payload;
+- fail closed when the build job does not produce an image digest;
+- require the deploy webhook to return a JSON body with `image_digest`; and
+- compare the webhook-confirmed digest to the attested build digest before deploy sign-off.
+
+The contract tests fail if either deploy job drops digest propagation, stops sending
+`image_digest`, or stops comparing the webhook-confirmed digest with the build output digest.
+
+## Current Enterprise Gap
+
+This slice closes the repo-owned CD/deploy boundary for immutable digest handoff, but provider-side
+runtime proof still depends on the external deploy webhook or platform reporting the real running
+image digest. If the webhook cannot yet return the digest it deployed, the CD workflow now records
+that as a hard failure instead of treating tag or commit equality as sufficient.
+
+## Result
+
+- Decision: deploy-boundary digest confirmation configured.
+- Residual risk: external deploy webhook/platform support must return the deployed digest in real
+  CD runs; otherwise production sign-off fails closed.
+- Follow-up lane: first real CD run should attach the webhook-confirmed digest evidence to the
+  release record; broader enterprise work still includes restore drills, threat modeling, alert
+  routing, data lifecycle verification, and performance gates.

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -26,33 +26,33 @@ enterprise-ready.
 
 ## Evidence Already Present
 
-| Lane                         | Current evidence                                                                                                                                         | Status                    |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| Repo governance              | `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, architecture-finalization program/tracker, PR finalizer, required checks               | Strong                    |
-| Plugin/tool discipline       | `docs/plans/plugin-usage-playbook.md`                                                                                                                    | Strong                    |
-| Incident procedure           | `docs/plans/2026-03-09-d06-incident-playbook-evidence.md`, `docs/INCIDENT_PLAYBOOK.md`, `docs/RUNBOOK.md`                                                | Documented                |
-| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post` | Partial operational proof |
-| Sensitive route ownership    | `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`                                                                                               | Documented                |
-| Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                         | Governed checklist        |
-| Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                             | Bounded pilot evidence    |
-| Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                        | Strong for repo delivery  |
-| Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                | Blocker recorded          |
-| Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`             | CI proof configured       |
+| Lane                         | Current evidence                                                                                                                                                                                                       | Status                           |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| Repo governance              | `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, architecture-finalization program/tracker, PR finalizer, required checks                                                                             | Strong                           |
+| Plugin/tool discipline       | `docs/plans/plugin-usage-playbook.md`                                                                                                                                                                                  | Strong                           |
+| Incident procedure           | `docs/plans/2026-03-09-d06-incident-playbook-evidence.md`, `docs/INCIDENT_PLAYBOOK.md`, `docs/RUNBOOK.md`                                                                                                              | Documented                       |
+| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                               | Partial operational proof        |
+| Sensitive route ownership    | `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`                                                                                                                                                             | Documented                       |
+| Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                                                                                       | Governed checklist               |
+| Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                                                                                           | Bounded pilot evidence           |
+| Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                                                                                      | Strong for repo delivery         |
+| Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                                                                              | Blocker recorded                 |
+| Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`; `docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md` | Deploy-boundary proof configured |
 
 ## Open Enterprise Maturity Lanes
 
 These lanes come from `docs/reviews/2026-04-25-production-professionalism-rereview.md` and remain
 separate from the active architecture-finalization queue unless explicitly promoted.
 
-| Lane                         | Current gap                                        | Enterprise requirement                                                                                        |
-| ---------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Backup/restore drill cadence | First attempt blocked by restore-access gap        | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
-| Exercised incident readiness | Partial                                            | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
-| Threat model                 | Not yet scoped                                     | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
-| Supply-chain attestation     | CI proof configured; deployed digest proof pending | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
-| Alert routing proof          | Partial                                            | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
-| Data lifecycle verification  | Partial                                            | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
-| Performance regression gate  | Not yet scoped                                     | Representative route/storage performance budgets that can block releases                                      |
+| Lane                         | Current gap                                                                        | Enterprise requirement                                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Backup/restore drill cadence | First attempt blocked by restore-access gap                                        | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
+| Exercised incident readiness | Partial                                                                            | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
+| Threat model                 | Not yet scoped                                                                     | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
+| Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
+| Alert routing proof          | Partial                                                                            | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
+| Data lifecycle verification  | Partial                                                                            | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
+| Performance regression gate  | Not yet scoped                                                                     | Representative route/storage performance budgets that can block releases                                      |
 
 ## Next Bounded Operational Slice
 
@@ -81,21 +81,19 @@ Rationale:
 - The evidence contract is now defined; the missing proof is an executed staging drill record.
 - A drill record can be pursued without disturbing active `ARCH-M1` work.
 
-## Next Repo-Owned Enterprise-Hardening Slice
+## Latest Repo-Owned Enterprise-Hardening Slice
 
 While `ENT-OPS02` remains blocked on provider or CLI restore access, the next smallest repo-owned
-enterprise-hardening slice is:
+enterprise-hardening slice was:
 
 `ENT-SCA03 Deploy Digest Verification Boundary`
 
 Scope:
 
 - Build on `ENT-SCA02` by adding a deploy-boundary contract for immutable image digest proof.
-- Ensure the deployment webhook accepts the digest used for deployment, or the deploy platform
-  exposes the running OCI image digest through a safe non-secret status channel.
-- Compare the deployed digest with the attested digest before production sign-off.
-- Record the exact provider, webhook, or runtime capability blocker instead of simulating digest
-  equality.
+- Send the attested image digest to the environment-scoped deploy webhook.
+- Require the deploy webhook to confirm the same digest in a non-secret JSON response.
+- Fail closed when the provider, webhook, or runtime boundary cannot confirm digest equality.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
@@ -103,10 +101,14 @@ Rationale:
 
 - `ENT-SCA02` adds repo-owned SBOM/provenance generation, digest capture, signed provenance, and
   pre-deploy attestation verification.
-- The remaining supply-chain gap is not another repo-local assertion; it is proving that the
-  running deployment equals the attested digest.
-- This should be handled as the next smallest bounded supply-chain slice when the deploy boundary
-  can be changed or inspected.
+- The remaining supply-chain gap after `ENT-SCA02` was proving that deployment promotion carries
+  the attested immutable digest instead of relying on mutable tags or commit equality alone.
+- `ENT-SCA03` configures the repo-owned deploy boundary to fail closed until the deploy webhook
+  confirms the digest it accepted or deployed.
+
+Next enterprise maturity remains broader than this repo-owned slice. The highest-value remaining
+lanes are the blocked `ENT-OPS02` staging restore drill, formal threat modeling, alert-routing
+exercise proof, data lifecycle verification, and performance regression gates.
 
 ## Non-Goals
 

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const cdWorkflow = yaml.load(
+  fs.readFileSync(path.join(rootDir, '.github/workflows/cd.yml'), 'utf8')
+);
+const deployAction = yaml.load(
+  fs.readFileSync(
+    path.join(rootDir, '.github/actions/trigger-digest-verified-deploy/action.yml'),
+    'utf8'
+  )
+);
+
+function findStep(steps, name) {
+  return steps.find(step => step?.name === name);
+}
+
+function findStepIndex(steps, name) {
+  return steps.findIndex(step => step?.name === name);
+}
+
+function assertBuildDigestOutput(jobName) {
+  const job = cdWorkflow.jobs[jobName];
+  assert.ok(job, `${jobName} must exist`);
+  assert.equal(job.outputs.image_digest, '${{ steps.build.outputs.digest }}');
+}
+
+function assertDeployDigestBoundary({ jobName, buildJobName, stepName, environmentName }) {
+  const job = cdWorkflow.jobs[jobName];
+  assert.ok(job, `${jobName} must exist`);
+
+  const step = findStep(job.steps, stepName);
+  assert.ok(step, `${jobName} must trigger deployment`);
+  assert.ok(findStepIndex(job.steps, 'Checkout repository') < findStepIndex(job.steps, stepName));
+  assert.equal(step.uses, './.github/actions/trigger-digest-verified-deploy');
+  assert.equal(step.with.environment, environmentName);
+  assert.equal(step.with['image-tag'], `\${{ needs.${buildJobName}.outputs.image_tag }}`);
+  assert.equal(step.with['image-digest'], `\${{ needs.${buildJobName}.outputs.image_digest }}`);
+  assert.equal(step.with.sha, '${{ github.sha }}');
+}
+
+function assertDeployActionDigestVerification() {
+  const step = findStep(deployAction.runs.steps, 'Trigger deploy webhook');
+  assert.ok(step, 'deploy action must trigger the webhook');
+  assert.equal(step.env.IMAGE_DIGEST, '${{ inputs.image-digest }}');
+  assert.match(step.run, /"image_digest":"%s"/u);
+  assert.match(step.run, /missing\+=\("webhook-url"\)/u);
+  assert.match(step.run, /missing\+=\("image-digest"\)/u);
+  assert.match(step.run, /--connect-timeout 10 --max-time 120/u);
+  assert.match(step.run, /\$\{IMAGE_DIGEST\}/u);
+  assert.match(step.run, /DEPLOY_WEBHOOK_RESPONSE_FILE/u);
+  assert.match(step.run, /try \{\s+response = JSON\.parse\(raw\);/u);
+  assert.match(step.run, /deploy webhook must confirm image_digest in JSON/u);
+  assert.match(step.run, /response\?\.image_digest/u);
+  assert.match(step.run, /deploy digest mismatch/u);
+  assert.match(step.run, /deploy webhook confirmed image digest/u);
+  return step.run;
+}
+
+function extractDigestVerifierScript(runScript) {
+  const match = runScript.match(/node --input-type=module <<'NODE'\n([\s\S]+?)\nNODE/u);
+  assert.ok(match, 'deploy action must keep digest verifier in a node heredoc');
+  return match[1].replace(/^ {2}/gmu, '');
+}
+
+function runDigestVerifier(script, responseBody) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-digest-'));
+  const responseFile = path.join(tempDir, 'response.json');
+  fs.writeFileSync(responseFile, responseBody);
+  try {
+    return spawnSync(process.execPath, ['--input-type=module'], {
+      input: script,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DEPLOY_ENVIRONMENT: 'staging',
+        DEPLOY_WEBHOOK_RESPONSE_FILE: responseFile,
+        IMAGE_DIGEST: 'sha256:expected',
+      },
+    });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function assertDigestVerifierRejects(script, responseBody, expectedMessage) {
+  const result = runDigestVerifier(script, responseBody);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr.toString(), expectedMessage);
+}
+
+test('CD deploy boundary requires immutable image digest confirmation', () => {
+  assertBuildDigestOutput('build-staging');
+  assertBuildDigestOutput('build-production');
+  assertDeployDigestBoundary({
+    jobName: 'deploy-staging',
+    buildJobName: 'build-staging',
+    stepName: 'Trigger Staging Deploy',
+    environmentName: 'staging',
+  });
+  assertDeployDigestBoundary({
+    jobName: 'deploy-production',
+    buildJobName: 'build-production',
+    stepName: 'Trigger Production Deploy',
+    environmentName: 'production',
+  });
+  const verifierScript = extractDigestVerifierScript(assertDeployActionDigestVerification());
+  const success = runDigestVerifier(verifierScript, '{"image_digest":"sha256:expected"}');
+  assert.equal(success.status, 0);
+  assert.match(success.stdout, /confirmed image digest/u);
+  assertDigestVerifierRejects(
+    verifierScript,
+    '{"image_digest":"sha256:other"}',
+    /deploy digest mismatch/u
+  );
+  assertDigestVerifierRejects(verifierScript, '{"status":"ok"}', /got missing/u);
+  assertDigestVerifierRejects(verifierScript, 'not json', /must confirm image_digest in JSON/u);
+});

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -522,6 +522,7 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.ok(buildStagingJob);
   assert.equal(buildStagingJob.environment.name, 'staging');
   assert.equal(buildStagingJob.outputs.image_tag, '${{ steps.meta.outputs.version }}');
+  assert.equal(buildStagingJob.outputs.image_digest, '${{ steps.build.outputs.digest }}');
   const buildStagingStep = findStep(
     buildStagingJob.steps,
     'Build, attest, and verify Docker image'
@@ -536,6 +537,7 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.deepEqual(normalizeNeeds(buildProductionJob.needs), ['e2e-staging']);
   assert.equal(buildProductionJob.environment.name, 'production');
   assert.equal(buildProductionJob.outputs.image_tag, '${{ steps.meta.outputs.version }}');
+  assert.equal(buildProductionJob.outputs.image_digest, '${{ steps.build.outputs.digest }}');
   const buildProductionStep = findStep(
     buildProductionJob.steps,
     'Build, attest, and verify Docker image'
@@ -547,23 +549,20 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(buildProductionStep.with['app-url'], 'https://app.interdomestik.com');
 
   assert.deepEqual(normalizeNeeds(deployStagingJob.needs), ['build-staging']);
-  assert.equal(
-    deployStagingJob.env.DEPLOY_WEBHOOK_URL,
-    '${{ secrets.INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL }}'
-  );
-  assert.equal(
-    deployStagingJob.env.DEPLOY_WEBHOOK_TOKEN,
-    '${{ secrets.INTERDOMESTIK_STAGING_DEPLOY_TOKEN }}'
-  );
   assert.equal(deployStagingJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');
   const triggerStagingDeployStep = findStep(deployStagingJob.steps, 'Trigger Staging Deploy');
   assert.ok(triggerStagingDeployStep);
-  assert.match(triggerStagingDeployStep.run, /INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL/);
-  assert.match(triggerStagingDeployStep.run, /INTERDOMESTIK_STAGING_DEPLOY_TOKEN/);
-  assert.match(triggerStagingDeployStep.run, /authorization: Bearer/);
-  assert.match(triggerStagingDeployStep.run, /curl --silent --show-error/);
-  assert.match(triggerStagingDeployStep.run, /http_status/);
-  assert.match(triggerStagingDeployStep.run, /needs\.build-staging\.outputs\.image_tag/);
+  assert.equal(triggerStagingDeployStep.uses, './.github/actions/trigger-digest-verified-deploy');
+  assert.equal(triggerStagingDeployStep.with.environment, 'staging');
+  assert.match(triggerStagingDeployStep.with['webhook-url'], /INTERDOMESTIK_STAGING_DEPLOY/);
+  assert.equal(
+    triggerStagingDeployStep.with['image-tag'],
+    '${{ needs.build-staging.outputs.image_tag }}'
+  );
+  assert.equal(
+    triggerStagingDeployStep.with['image-digest'],
+    '${{ needs.build-staging.outputs.image_digest }}'
+  );
   const stagingHealthIndex = findStepIndex(deployStagingJob.steps, 'Wait for Staging Health');
   const stagingProvenanceIndex = findStepIndex(
     deployStagingJob.steps,
@@ -598,25 +597,25 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(stagingArtifactsStep.with['if-no-files-found'], 'error');
 
   assert.deepEqual(normalizeNeeds(deployProductionJob.needs), ['build-production']);
-  assert.equal(
-    deployProductionJob.env.DEPLOY_WEBHOOK_URL,
-    '${{ secrets.INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL }}'
-  );
-  assert.equal(
-    deployProductionJob.env.DEPLOY_WEBHOOK_TOKEN,
-    '${{ secrets.INTERDOMESTIK_PRODUCTION_DEPLOY_TOKEN }}'
-  );
   const triggerProductionDeployStep = findStep(
     deployProductionJob.steps,
     'Trigger Production Deploy'
   );
   assert.ok(triggerProductionDeployStep);
-  assert.match(triggerProductionDeployStep.run, /INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL/);
-  assert.match(triggerProductionDeployStep.run, /INTERDOMESTIK_PRODUCTION_DEPLOY_TOKEN/);
-  assert.match(triggerProductionDeployStep.run, /authorization: Bearer/);
-  assert.match(triggerProductionDeployStep.run, /curl --silent --show-error/);
-  assert.match(triggerProductionDeployStep.run, /http_status/);
-  assert.match(triggerProductionDeployStep.run, /needs\.build-production\.outputs\.image_tag/);
+  assert.equal(
+    triggerProductionDeployStep.uses,
+    './.github/actions/trigger-digest-verified-deploy'
+  );
+  assert.equal(triggerProductionDeployStep.with.environment, 'production');
+  assert.match(triggerProductionDeployStep.with['webhook-url'], /INTERDOMESTIK_PRODUCTION_DEPLOY/);
+  assert.equal(
+    triggerProductionDeployStep.with['image-tag'],
+    '${{ needs.build-production.outputs.image_tag }}'
+  );
+  assert.equal(
+    triggerProductionDeployStep.with['image-digest'],
+    '${{ needs.build-production.outputs.image_digest }}'
+  );
 
   assert.deepEqual(normalizeNeeds(verifyProductionJob.needs), ['deploy-production']);
   assert.equal(verifyProductionJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34190805,
-  "maxTrackedFiles": 3938,
+  "maxTrackedBytes": 34201142,
+  "maxTrackedFiles": 3941,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
-    "tests/e2e": 4287238,
-    "docs/text": 4583911,
-    "config/data/messages": 1533128,
+    "tests/e2e": 4291944,
+    "docs/text": 4587872,
+    "config/data/messages": 1534798,
     "other": 1048576
   }
 }


### PR DESCRIPTION
## Summary

- Add a local deploy trigger action that sends the immutable build image digest to the deployment webhook and fails closed unless the webhook returns matching `image_digest` JSON.
- Wire staging and production CD deploy jobs to consume build-produced image digests instead of relying on tag-only deployment intent.
- Add focused workflow/action contract coverage plus enterprise readiness notes for the remaining real-provider evidence gap.

## Verification

- `pnpm test:ci:contracts` - 180 passed
- `git diff --check` - passed
- `pnpm repo:size:check` - passed
- `pnpm security:guard` - passed
- `pnpm pr:verify` - passed; PR gate `134 passed / 6 skipped`, smoke `13 passed / 1 skipped`
- Standalone `pnpm e2e:gate` - passed earlier in this slice; `134 passed / 6 skipped`
- `pnpm plan:status`, `pnpm plan:audit`, `pnpm track:audit`, `pnpm docs:verify` - passed earlier in this slice

## Review Disposition

- Sonnet direct architecture/scope route was attempted and blocked by a hung local CLI run; process was killed after no output.
- Copilot Sonnet fallback completed with no blockers.
- Addressed reviewer H1-H3:
  - fail closed on non-JSON deploy webhook responses,
  - added action-level fail-closed contract coverage for success, mismatch, missing digest, and non-JSON response bodies,
  - corrected checkout pin comments from `v5` to `v4`.
- Deferred optional reviewer suggestions:
  - tighter legacy workflow-contract webhook URL assertions, to avoid growing the large legacy test file further,
  - renaming `image_tag` to `image_tag_hint`; digest is now the verification anchor while tag remains useful deploy metadata.

## Residual Risk

- The next real CD run must return the deployed `image_digest` from the provider/webhook. If it does not, deployment will fail closed by design.
