### PR TITLE
docs: scope enterprise threat model contract

### DIFF
--- a/docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md
+++ b/docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md
@@ -1,0 +1,148 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: platform
+last_reviewed: 2026-06-05
+superseded_by:
+---
+
+# ENT-TM01 Threat Model Evidence Contract
+
+> Status: Input document. This contract scopes the enterprise threat-model evidence lane. It does
+> not claim that Interdomestik has completed a full per-surface threat model, and it does not
+> replace the active program or tracker authority.
+
+## Scope
+
+This contract covers sensitive application surfaces already identified by
+`docs/reviews/2026-04-25-sensitive-route-ownership-map.md` and the enterprise gap called out in
+`docs/reviews/2026-04-25-production-professionalism-rereview.md`.
+
+In scope:
+
+- Assisted registration; initial claim-wizard uploads; authenticated claim evidence uploads.
+- Document signed URLs and downloads; share packs; AI run read and review.
+- Paddle billing webhooks; admin verification details.
+- Notification and push settings only when a future slice changes delivery trust boundaries.
+
+Out of scope:
+
+- Runtime code, schema, auth, tenancy, routing, billing, product UI, proxy, README, AGENTS, or broad
+  architecture-document changes.
+- Production credential changes, data restores, provider configuration changes, or incident drills.
+- Raw PII, claim narratives, uploaded document contents, payment data, private keys, or production
+  secrets in any model record.
+- Replacing the route ownership map. A threat-model record may cite that map, but ownership and
+  entrypoint updates remain there.
+
+## Required Per-Surface Record
+
+Every future threat-model record must cover exactly one bounded surface unless the register
+explicitly promotes a grouped slice.
+
+Use this minimum structure:
+
+```md
+# ENT-TMxx <Surface> Threat Model - YYYY-MM-DD
+
+## Identity
+
+- Surface:
+- Owner:
+- Reviewers:
+- Related routes, jobs, or domain modules:
+- Related tests or gates:
+- Last reviewed:
+
+## Data And Assets
+
+- Protected data:
+- Durable records:
+- Storage objects or external systems:
+- Audit or provenance records:
+- Explicit non-data:
+
+## Actors And Trust Boundaries
+
+- Trusted actors:
+- Untrusted actors:
+- External systems:
+- Trust boundaries:
+- Tenant isolation boundary:
+
+## Existing Controls
+
+- Authentication and authorization controls:
+- Tenant-scoping controls:
+- Input validation and rate limits:
+- Storage or persistence controls:
+- Audit, telemetry, or evidence controls:
+- Current proof files:
+
+## STRIDE Threat Table
+
+| Category               | Threat | Existing control | Residual risk | Required follow-up or acceptance owner |
+| ---------------------- | ------ | ---------------- | ------------- | -------------------------------------- |
+| Spoofing               |        |                  |               |                                        |
+| Tampering              |        |                  |               |                                        |
+| Repudiation            |        |                  |               |                                        |
+| Information disclosure |        |                  |               |                                        |
+| Denial of service      |        |                  |               |                                        |
+| Elevation of privilege |        |                  |               |                                        |
+
+## Verification
+
+- Required local proof:
+- Required CI proof:
+- Required reviewer or security disposition:
+- Explicitly skipped proof and reason:
+
+## Result
+
+- Decision: pass/fail/deferred
+- Blocking gaps:
+- Non-blocking gaps:
+- Accepted residual risks:
+- Follow-up slice or issue:
+- Owner sign-off:
+```
+
+## Acceptance Criteria
+
+A per-surface threat-model record satisfies this contract only when:
+
+- it identifies the protected data, durable records, external systems, and tenant boundary for the
+  selected surface;
+- it includes at least one concrete threat and disposition for each STRIDE category, even when the
+  disposition is "not applicable" with rationale;
+- every residual high-impact tenant isolation, privilege, data exposure, or payment integrity risk
+  has a named follow-up slice, issue, or acceptance owner;
+- current controls are linked to repo evidence such as tests, gates, ownership maps, plans, or
+  implementation files without copying sensitive data;
+- it records verification that matches the touched surface and does not use docs-only checks to
+  claim runtime enforcement; and
+- it contains no secrets, credentials, raw PII, claim narratives, document contents, payment data,
+  or production-only operational details.
+
+## Recommended First Surface Slice
+
+The first bounded follow-up should be `ENT-TM02 Initial Claim Uploads Threat Model`.
+
+Scope:
+
+- Model initial claim-wizard uploads as one sensitive data-ingress surface.
+- Cover MIME and size validation, tenant and claim access checks, signed upload URL generation,
+  upload-intent creation, storage path safety, and post-upload metadata confirmation.
+- Cite existing proof from the ownership map and focused upload tests.
+- Record residual risks without changing runtime code.
+
+Rationale: uploads cross browser, storage, tenant, file-content, and evidence-custody boundaries,
+but the initial upload surface is smaller than the full document custody lane and already has clear
+route/core ownership plus test evidence.
+
+## Relationship To Enterprise Readiness
+
+This contract supports the open threat-model lane in
+`docs/plans/enterprise-readiness-register.md`. It changes the lane status from unscoped to scoped
+with a first per-surface model pending. It does not by itself prove full enterprise readiness.

--- a/docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md
+++ b/docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md
@@ -114,8 +114,8 @@ A per-surface threat-model record satisfies this contract only when:
 
 - it identifies the protected data, durable records, external systems, and tenant boundary for the
   selected surface;
-- it includes at least one concrete threat and disposition for each STRIDE category, even when the
-  disposition is "not applicable" with rationale;
+- it includes a threat disposition row for each STRIDE category; categories without an applicable
+  concrete threat must say "not applicable" with rationale;
 - every residual high-impact tenant isolation, privilege, data exposure, or payment integrity risk
   has a named follow-up slice, issue, or acceptance owner;
 - current controls are linked to repo evidence such as tests, gates, ownership maps, plans, or

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -83,7 +83,7 @@ Rationale:
 
 ## Latest Repo-Owned Enterprise-Hardening Slice
 
-While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest smallest repo-owned
+While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest repo-owned
 enterprise-hardening slice is:
 
 `ENT-TM01 Threat Model Evidence Contract`

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -48,7 +48,7 @@ separate from the active architecture-finalization queue unless explicitly promo
 | ---------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Backup/restore drill cadence | First attempt blocked by restore-access gap                                        | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
 | Exercised incident readiness | Partial                                                                            | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
-| Threat model                 | Not yet scoped                                                                     | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
+| Threat model                 | Evidence contract scoped; first surface model pending                              | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
 | Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
 | Alert routing proof          | Partial                                                                            | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
 | Data lifecycle verification  | Partial                                                                            | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
@@ -83,32 +83,36 @@ Rationale:
 
 ## Latest Repo-Owned Enterprise-Hardening Slice
 
-While `ENT-OPS02` remains blocked on provider or CLI restore access, the next smallest repo-owned
-enterprise-hardening slice was:
+While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest smallest repo-owned
+enterprise-hardening slice is:
 
-`ENT-SCA03 Deploy Digest Verification Boundary`
+`ENT-TM01 Threat Model Evidence Contract`
 
 Scope:
 
-- Build on `ENT-SCA02` by adding a deploy-boundary contract for immutable image digest proof.
-- Send the attested image digest to the environment-scoped deploy webhook.
-- Require the deploy webhook to confirm the same digest in a non-secret JSON response.
-- Fail closed when the provider, webhook, or runtime boundary cannot confirm digest equality.
+- Scope the enterprise threat-model lane without claiming completion.
+- Define the required per-surface record, STRIDE coverage, evidence rules, and sensitive-data
+  exclusions.
+- Use `docs/reviews/2026-04-25-sensitive-route-ownership-map.md` as the surface inventory input.
+- Promote exactly one first bounded follow-up: `ENT-TM02 Initial Claim Uploads Threat Model`.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
 Rationale:
 
-- `ENT-SCA02` adds repo-owned SBOM/provenance generation, digest capture, signed provenance, and
-  pre-deploy attestation verification.
-- The remaining supply-chain gap after `ENT-SCA02` was proving that deployment promotion carries
-  the attested immutable digest instead of relying on mutable tags or commit equality alone.
-- `ENT-SCA03` configures the repo-owned deploy boundary to fail closed until the deploy webhook
-  confirms the digest it accepted or deployed.
+- The production professionalism re-review named formal per-surface threat modeling as an open
+  enterprise gap.
+- The sensitive route ownership map already identifies owners, entrypoints, boundary contracts,
+  expected failures, and current proof, making the threat-model contract the next repo-owned
+  hardening step while the restore drill remains externally blocked.
+- Initial claim uploads are the smallest high-value first model because they cross browser,
+  storage, tenant, file-content, and evidence-custody boundaries without requiring a runtime
+  change.
 
 Next enterprise maturity remains broader than this repo-owned slice. The highest-value remaining
-lanes are the blocked `ENT-OPS02` staging restore drill, formal threat modeling, alert-routing
-exercise proof, data lifecycle verification, and performance regression gates.
+lanes are the blocked `ENT-OPS02` staging restore drill, `ENT-TM02 Initial Claim Uploads Threat
+Model`, alert-routing exercise proof, data lifecycle verification, and performance regression
+gates.
 
 ## Non-Goals
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34201142,
-  "maxTrackedFiles": 3941,
+  "maxTrackedBytes": 34206877,
+  "maxTrackedFiles": 3942,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
     "tests/e2e": 4291944,
-    "docs/text": 4587872,
+    "docs/text": 4593607,
     "config/data/messages": 1534798,
     "other": 1048576
   }


### PR DESCRIPTION
## Summary
- Add `ENT-TM01 Threat Model Evidence Contract` as a governed input document for the open enterprise threat-model lane.
- Update the enterprise readiness register from threat model not scoped to evidence-contract scoped with first surface model pending.
- Promote exactly one next bounded follow-up: `ENT-TM02 Initial Claim Uploads Threat Model`.
- Update repo-size budget to exact measured committed values.

## Scope Classification
- Classification: Tier 0 documentation/external-tracker-only.
- No runtime, schema, auth, tenancy, routing, billing, product UI, proxy, README, AGENTS, or broad architecture-document changes.
- `ENT-OPS02` remains blocked on provider/CLI restore access; this slice does not simulate restore success.

## Verification
- `git diff --check HEAD~1..HEAD`
- `pnpm docs:verify`
- `pnpm plan:status`
- `pnpm plan:audit`
- `pnpm track:audit`
- `pnpm repo:size:check`
- `pnpm security:guard`

## Reviewer / Security Disposition
- Sonnet architecture/scope review: blocked locally. `claude -p` transport succeeded for a trivial prompt, but every scoped review prompt hung with no output and was terminated; Copilot Sonnet and Gemini CLI review attempts also hung with no output. No reviewer approval is claimed from those blocked routes.
- Security guard: passed.
- Copilot/Sonar/CI: pending PR automation.

## Residual Risk
- This contract scopes the threat-model lane only; it does not complete a per-surface threat model or claim full enterprise readiness.
- The first actual model remains `ENT-TM02 Initial Claim Uploads Threat Model`.
