### PR TITLE
docs: add initial upload threat model

### DIFF
--- a/docs/plans/ent-tm02-initial-claim-uploads-threat-model-2026-06-05.md
+++ b/docs/plans/ent-tm02-initial-claim-uploads-threat-model-2026-06-05.md
@@ -1,0 +1,105 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: claims
+last_reviewed: 2026-06-05
+superseded_by:
+---
+
+# ENT-TM02 Initial Claim Uploads Threat Model - 2026-06-05
+
+> Status: Input document. This record applies the `ENT-TM01` contract to the initial
+> claim-wizard upload surface only. It does not change runtime behavior or claim full enterprise
+> threat-model completion.
+
+## Identity
+
+- Surface: Initial claim-wizard uploads.
+- Owner: Claims intake and upload safety.
+- Reviewers: PR reviewers, Copilot, SonarCloud, and CI/security gates.
+- Entry points: `apps/web/src/app/api/uploads/route.ts`,
+  `apps/web/src/app/api/uploads/_core.ts`,
+  `apps/web/src/features/claims/upload/server/initial-claim-upload.ts`.
+- Proof files: `apps/web/src/app/api/uploads/route.test.ts`,
+  `apps/web/src/features/claims/upload/server/initial-claim-upload.test.ts`,
+  `apps/web/src/actions/claims/submit.test.ts`,
+  `packages/domain-claims/src/claims/submit.test.ts`.
+- Source inventory: `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`.
+- Last reviewed: 2026-06-05.
+
+## Data And Assets
+
+- Protected data: uploaded evidence file metadata, MIME type, file size, storage path, upload id,
+  tenant id, actor id, optional claim id, and signed upload URL response.
+- Durable records: initial claim submission records and evidence metadata created only after
+  server-issued upload-intent and stored-object validation pass.
+- Storage objects: PII-classified evidence objects under tenant/actor scoped storage paths.
+- External systems: Supabase Storage service-role signed upload URL creation.
+- Audit or provenance records: actor, tenant, storage path, and upload-intent metadata cited by
+  submission validation tests; dedicated upload audit-event modeling remains a residual gap.
+- Explicit non-data: this record does not include file contents, claim narratives, raw PII, or
+  production secrets.
+
+## Actors And Trust Boundaries
+
+- Trusted actors: authenticated sessions with a valid tenant context; claim-bound uploads are
+  further limited to the member owner or assigned agent.
+- Untrusted actors: unauthenticated callers, sessions without tenant context, wrong-tenant users,
+  unassigned agents for claim-bound uploads, forged clients, oversized-file clients, and clients
+  attempting metadata/path substitution.
+- External boundary: browser to Next.js route, Next.js server to Supabase Storage, upload URL holder
+  to storage object, claim submission to stored-object confirmation.
+- Tenant boundary: `ensureTenantId(session)`, tenant-scoped optional claim lookup, tenant-leading
+  storage path assertion, and tenant-bound upload-intent verification.
+
+## Existing Controls
+
+- Authentication and authorization controls: route rate-limits before session work, returns `401`
+  for missing sessions, and authorizes optional claim uploads by member owner or assigned agent.
+- Tenant-scoping controls: `ensureTenantId(session)`, tenant-scoped claim lookup, and tenant-leading
+  storage path assertion.
+- Input validation and rate limits: schema requires non-empty file name/type and positive size;
+  allowed types are JPEG, PNG, PDF, and plain text; files over 10 MiB return `413`.
+- Storage or persistence controls: server-generated paths, `assertEvidenceStoragePath`, signed
+  upload URL creation, HMAC upload-intent token, and stored-object validation before metadata
+  acceptance.
+- Audit, telemetry, or evidence controls: focused route, initial-upload, action, and domain tests
+  prove the current control boundaries.
+
+## STRIDE Threat Table
+
+| Category               | Threat                                                      | Existing control                                                       | Residual risk                                      | Follow-up or owner                   |
+| ---------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------ |
+| Spoofing               | Unauthenticated or wrong actor requests upload credentials. | Rate limit, session check, tenant resolution, optional claim access.   | Session theft remains an account-security concern. | Auth/incident drills lane.           |
+| Tampering              | Client swaps path, file id, MIME type, size, or tenant.     | Server path generation, HMAC intent token, stored-object validation.   | Storage provider metadata trust remains external.  | Claims owner; provider config proof. |
+| Repudiation            | Actor denies requesting or submitting upload metadata.      | Actor id and tenant are bound into path/intent and claim submission.   | Dedicated upload audit event is not modeled here.  | Future audit/event lane.             |
+| Information disclosure | Signed URL or path leaks tenant evidence location.          | Tenant path assertion, bounded response headers, no raw file logging.  | URL holder can upload during token lifetime.       | Claims owner; short TTL retained.    |
+| Denial of service      | Caller floods signing endpoint or uploads oversized files.  | Rate limit, 10 MiB limit, MIME allowlist before URL creation.          | Storage-level bandwidth abuse needs provider caps. | Ops/alert-routing lane.              |
+| Elevation of privilege | Unassigned agent or wrong-tenant user attaches evidence.    | Tenant-scoped claim lookup, owner/assigned-agent authorization, token. | Initial unassigned flow depends on session tenant. | Claims owner; auth boundary tests.   |
+
+## Verification
+
+- Required local proof for this record: `git diff --check`, `pnpm docs:verify`,
+  `pnpm plan:status`, `pnpm plan:audit`, `pnpm track:audit`, `pnpm repo:size:check`,
+  `pnpm security:guard`.
+- Runtime proof cited by this model exists in focused upload and claim-submission tests listed in
+  the identity section; this docs slice does not rerun or change those tests.
+- Reviewer disposition must focus on whether the model is bounded to initial uploads, cites current
+  evidence, and avoids claiming runtime enforcement beyond existing tests.
+
+## Result
+
+- Decision: pass for the initial claim-wizard upload threat-model record.
+- Blocking gaps: none for this documentation slice.
+- Non-blocking gaps: upload audit-event modeling, provider-level storage abuse caps, and exercised
+  account-compromise response remain outside this surface record.
+- Accepted residual risks: short-lived signed upload URLs remain bearer capabilities by design.
+- Follow-up slice: `ENT-TM03 Authenticated Claim Evidence Uploads Threat Model`.
+- Owner sign-off: platform/claims review through PR checks and review threads.
+
+## Relationship To Enterprise Readiness
+
+This record completes the first surface model required by `ENT-TM01`. The broader threat-model lane
+still requires per-surface records for authenticated evidence uploads, documents, share packs,
+Paddle webhooks, AI review, registration, and other promoted sensitive surfaces.

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -38,6 +38,7 @@ enterprise-ready.
 | Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                                                                                      | Strong for repo delivery         |
 | Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                                                                              | Blocker recorded                 |
 | Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`; `docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md` | Deploy-boundary proof configured |
+| Threat-model evidence        | `docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md`; `docs/plans/ent-tm02-initial-claim-uploads-threat-model-2026-06-05.md`                                                                             | First surface modeled            |
 
 ## Open Enterprise Maturity Lanes
 
@@ -48,7 +49,7 @@ separate from the active architecture-finalization queue unless explicitly promo
 | ---------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Backup/restore drill cadence | First attempt blocked by restore-access gap                                        | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
 | Exercised incident readiness | Partial                                                                            | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
-| Threat model                 | Evidence contract scoped; first surface model pending                              | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
+| Threat model                 | Evidence contract scoped; initial claim-upload surface modeled                     | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
 | Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
 | Alert routing proof          | Partial                                                                            | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
 | Data lifecycle verification  | Partial                                                                            | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
@@ -86,33 +87,31 @@ Rationale:
 While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest repo-owned
 enterprise-hardening slice is:
 
-`ENT-TM01 Threat Model Evidence Contract`
+`ENT-TM02 Initial Claim Uploads Threat Model`
 
 Scope:
 
-- Scope the enterprise threat-model lane without claiming completion.
-- Define the required per-surface record, STRIDE coverage, evidence rules, and sensitive-data
-  exclusions.
-- Use `docs/reviews/2026-04-25-sensitive-route-ownership-map.md` as the surface inventory input.
-- Promote exactly one first bounded follow-up: `ENT-TM02 Initial Claim Uploads Threat Model`.
+- Apply the `ENT-TM01` contract to the initial claim-wizard upload surface only.
+- Model protected metadata, actors, trust boundaries, existing controls, STRIDE threats, residual
+  risks, and verification evidence.
+- Promote exactly one next bounded follow-up:
+  `ENT-TM03 Authenticated Claim Evidence Uploads Threat Model`.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
 Rationale:
 
-- The production professionalism re-review named formal per-surface threat modeling as an open
-  enterprise gap.
-- The sensitive route ownership map already identifies owners, entrypoints, boundary contracts,
-  expected failures, and current proof, making the threat-model contract the next repo-owned
-  hardening step while the restore drill remains externally blocked.
+- The threat-model evidence contract is already defined by `ENT-TM01`.
 - Initial claim uploads are the smallest high-value first model because they cross browser,
-  storage, tenant, file-content, and evidence-custody boundaries without requiring a runtime
-  change.
+  storage, tenant, file-content, and evidence-custody boundaries while staying bounded to existing
+  proof files.
+- Authenticated claim evidence uploads are the next adjacent custody surface and should be modeled
+  separately before documents, share packs, Paddle webhooks, AI review, and registration.
 
 Next enterprise maturity remains broader than this repo-owned slice. The highest-value remaining
-lanes are the blocked `ENT-OPS02` staging restore drill, `ENT-TM02 Initial Claim Uploads Threat
-Model`, alert-routing exercise proof, data lifecycle verification, and performance regression
-gates.
+lanes are the blocked `ENT-OPS02` staging restore drill,
+`ENT-TM03 Authenticated Claim Evidence Uploads Threat Model`, alert-routing exercise proof, data
+lifecycle verification, and performance regression gates.
 
 ## Non-Goals
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34206877,
-  "maxTrackedFiles": 3942,
+  "maxTrackedBytes": 34214059,
+  "maxTrackedFiles": 3943,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
     "tests/e2e": 4291944,
-    "docs/text": 4593607,
+    "docs/text": 4600789,
     "config/data/messages": 1534798,
     "other": 1048576
   }


### PR DESCRIPTION
## Summary
- Add `ENT-TM02 Initial Claim Uploads Threat Model` for the initial claim-wizard upload surface.
- Update the enterprise-readiness register to record the first modeled threat-model surface and promote exactly one next follow-up: `ENT-TM03 Authenticated Claim Evidence Uploads Threat Model`.
- Update the repo-size budget to the exact measured tracked-file and docs/text totals after adding the record.

## Classification
- `documentation/external-tracker-only`, Tier 0.
- No runtime code, schema, auth, tenancy, routing, billing, product UI, or proxy changes.
- `apps/web/src/proxy.ts`, `README.md`, and `AGENTS.md` are untouched.

## Verification
- MCP scope audit: pass before commit for `docs/plans/` and `scripts/repo-size-budget.json` only; forbidden paths unchanged.
- MCP `security_guard`: pass.
- `git diff --check HEAD~1 HEAD`: pass.
- `pnpm plan:status`: pass.
- `pnpm plan:audit`: pass.
- `pnpm track:audit`: pass.
- `pnpm docs:verify`: pass.
- `pnpm repo:size:check`: pass.
- `pnpm security:guard`: pass.

## Reviewer Disposition
- Sonnet architecture/scope review route attempted through Claude CLI; blocked by no-output CLI hang and killed after waiting.
- Gemini review route completed. It reported no must-fix architecture or scope issues. Optional strict-compliance suggestions were addressed by adding reviewer/date identity fields, a dated H1, labeled existing-control categories, and audit/provenance data coverage.
- Copilot, SonarCloud, CI, and `pr-finalizer` pending on this PR.

## Residual Risk
- This completes only the first per-surface threat-model record under `ENT-TM01`; it does not claim full enterprise threat-model completion.
- Broader threat-model lane remains open for authenticated evidence uploads, documents, share packs, Paddle webhooks, AI review, registration, and other promoted sensitive surfaces.