### PR TITLE
docs: add authenticated evidence upload threat model

### DIFF
--- a/docs/plans/ent-tm03-authenticated-claim-evidence-uploads-threat-model-2026-06-06.md
+++ b/docs/plans/ent-tm03-authenticated-claim-evidence-uploads-threat-model-2026-06-06.md
@@ -1,0 +1,123 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: claims
+last_reviewed: 2026-06-06
+superseded_by:
+---
+
+# ENT-TM03 Authenticated Claim Evidence Uploads Threat Model - 2026-06-06
+
+> Status: Input document. This record applies the `ENT-TM01` contract to authenticated
+> claim evidence uploads only. It does not change runtime behavior or claim full enterprise
+> threat-model completion.
+
+## Identity
+
+- Surface: Authenticated claim evidence uploads.
+- Owner: Claims operations and evidence custody.
+- Reviewers: PR reviewers, Copilot, SonarCloud, and CI/security gates.
+- Entry points: `apps/web/src/app/api/claims/evidence-upload/route.ts`,
+  `apps/web/src/app/api/claims/evidence-upload/_core.ts`,
+  `apps/web/src/features/claims/upload/server/shared-upload.ts`,
+  `apps/web/src/features/member/claims/actions.ts`,
+  `apps/web/src/features/admin/claims/actions/evidence-upload.ts`.
+- Proof files: `apps/web/src/app/api/claims/evidence-upload/route.test.ts`,
+  `apps/web/src/features/member/claims/actions.test.ts`,
+  `apps/web/src/features/admin/claims/actions/evidence-upload.test.ts`,
+  `apps/web/src/features/claims/upload/server/access.test.ts`.
+- Source inventory: `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`.
+- Last reviewed: 2026-06-06.
+
+## Data And Assets
+
+- Protected data: claim-bound evidence metadata, legal/evidence category, MIME type, storage
+  content type, file size, storage path, file id, tenant id, actor id, claim id, and signed upload
+  URL or direct multipart upload response.
+- Durable records: `claim_documents` rows and queued claim-document AI workflow records created
+  after claim access, upload-intent, path, and stored-object validation.
+- Storage objects: PII-classified claim evidence objects under tenant/claim scoped assigned paths.
+- External systems: Supabase Storage service-role upload/list/signed-URL operations and Sentry
+  warning telemetry for metadata-confirmation failure after direct storage upload.
+- Audit or provenance records: uploaded actor, tenant, claim, bucket, path, category, document id,
+  and AI workflow queue metadata cited by focused action and route tests.
+- Explicit non-data: this record does not include file contents, claim narratives, raw PII,
+  payment data, production secrets, or signed URL values.
+
+## Actors And Trust Boundaries
+
+- Trusted actors: authenticated member owners; full-tenant admin roles; branch managers scoped to
+  their branch; staff scoped to branch or assignment according to current access helpers.
+- Untrusted actors: unauthenticated callers, missing-tenant sessions, wrong-tenant users, members
+  uploading to claims they do not own, staff or branch managers outside claim scope, forged clients,
+  oversized-file clients, and clients attempting metadata/path substitution.
+- External systems: browser clients, Next.js route/server actions, Supabase Storage, Sentry, and
+  asynchronous AI workflow dispatch.
+- Trust boundaries: browser to route/server action, server to storage service role, signed URL
+  holder to storage object, direct multipart upload to metadata confirmation, and persisted
+  document metadata to AI workflow queue.
+- Tenant isolation boundary: `ensureTenantId(session)`, host-to-tenant check for admin upload
+  actions, tenant-scoped claim lookup, tenant-leading assigned storage path assertion, and
+  tenant-bound upload-intent verification.
+
+## Existing Controls
+
+- Authentication and authorization controls: route and server actions require session; member
+  uploads require owned-claim lookup; admin actions require upload role plus host tenant match;
+  staff and branch-manager access is constrained by branch and assignment.
+- Tenant-scoping controls: claim lookups include tenant id, storage helpers receive tenant id, and
+  assigned storage paths must match `pii/tenants/<tenant>/claims/<claim>/<fileId>.<ext>`.
+- Input validation and rate limits: direct route parses multipart form, requires valid locale,
+  category, claim id, and file; shared upload helpers reject non-positive or over-50 MiB files and
+  unsafe file names before storage writes or signed URL creation.
+- Storage or persistence controls: generated file ids, HMAC upload-intent tokens, safe storage path
+  assertions, bucket mismatch checks, stored-object size/content-type verification, transactional
+  `claim_documents` insert, and post-persistence AI queueing.
+- Audit, telemetry, or evidence controls: focused tests prove claim access denial before storage,
+  forged metadata rejection before persistence, object metadata mismatch rejection, orphan-upload
+  Sentry telemetry, and AI queue failure tolerance after metadata persistence.
+- Current proof files: route, member action, admin action, access-helper, and ownership map files
+  listed in the identity section.
+
+## STRIDE Threat Table
+
+| Category               | Threat                                                          | Existing control                                                                | Residual risk                                                    | Follow-up or owner                      |
+| ---------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------- |
+| Spoofing               | Wrong actor obtains upload credentials or confirms metadata.    | Session check, role/host checks, member ownership, branch/assignment access.    | Session theft remains outside this surface record.               | Auth/incident drills lane.              |
+| Tampering              | Client swaps file id, path, bucket, size, MIME, or category.    | HMAC intent token, bucket checks, assigned path assertion, stored-object check. | Storage provider metadata remains an external trust dependency.  | Claims owner; provider config proof.    |
+| Repudiation            | Actor denies direct upload or signed-upload confirmation.       | Actor id, tenant, claim, path, bucket, and document id are persisted or queued. | Dedicated immutable upload audit event is not modeled here.      | Future audit/event lane.                |
+| Information disclosure | Signed URL, storage path, or document metadata leaks evidence.  | Tenant-leading paths, redacted signed-URL errors, scoped claim access.          | Signed URLs remain bearer capabilities during their lifetime.    | Claims owner; short TTL retained.       |
+| Denial of service      | Caller uploads oversized files or floods storage/AI queues.     | 50 MiB limit, validation before persistence, bounded signed-URL retry behavior. | Provider bandwidth and queue-volume caps need operational proof. | Ops/alert-routing/performance lanes.    |
+| Elevation of privilege | Member/staff/branch manager attaches evidence to another claim. | Tenant-scoped ownership/access helpers and host tenant match for admin actions. | Full-tenant admin roles retain broad claim upload authority.     | Claims/platform owner accepted by role. |
+
+## Verification
+
+- Required local proof for this record: `git diff --check`, `pnpm docs:verify`,
+  `pnpm plan:status`, `pnpm plan:audit`, `pnpm track:audit`, `pnpm repo:size:check`,
+  `pnpm security:guard`.
+- Runtime proof cited by this model exists in focused upload, access, action, and route tests listed
+  in the identity section; this docs slice does not rerun or change those tests.
+- Reviewer disposition must focus on whether the model is bounded to authenticated evidence
+  uploads, accurately distinguishes direct and signed-upload flows, and avoids claiming runtime
+  enforcement beyond existing tests.
+- Explicitly skipped proof: heavy local E2E is not required because this slice is docs/register only.
+
+## Result
+
+- Decision: pass for the authenticated claim evidence upload threat-model record.
+- Blocking gaps: none for this documentation slice.
+- Non-blocking gaps: immutable upload audit-event modeling, provider-level bandwidth/object-abuse
+  caps, queue-volume operational proof, and exercised account-compromise response remain outside
+  this surface record.
+- Accepted residual risks: short-lived signed upload URLs remain bearer capabilities by design, and
+  full-tenant admin upload authority remains role-authorized by current access policy.
+- Follow-up slice: `ENT-TM04 Document Signed URLs And Downloads Threat Model`.
+- Owner sign-off: platform/claims review through PR checks and review threads.
+
+## Relationship To Enterprise Readiness
+
+This record completes the second upload-custody surface required by `ENT-TM01`. The broader
+threat-model lane still requires per-surface records for document signed URLs and downloads, share
+packs, Paddle webhooks, AI review, registration, admin verification, and other promoted sensitive
+surfaces.

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -3,7 +3,7 @@ plan_role: input
 status: active
 source_of_truth: false
 owner: platform
-last_reviewed: 2026-06-05
+last_reviewed: 2026-06-06
 superseded_by:
 ---
 
@@ -26,19 +26,19 @@ enterprise-ready.
 
 ## Evidence Already Present
 
-| Lane                         | Current evidence                                                                                                                                                                                                       | Status                           |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| Repo governance              | `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, architecture-finalization program/tracker, PR finalizer, required checks                                                                             | Strong                           |
-| Plugin/tool discipline       | `docs/plans/plugin-usage-playbook.md`                                                                                                                                                                                  | Strong                           |
-| Incident procedure           | `docs/plans/2026-03-09-d06-incident-playbook-evidence.md`, `docs/INCIDENT_PLAYBOOK.md`, `docs/RUNBOOK.md`                                                                                                              | Documented                       |
-| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                               | Partial operational proof        |
-| Sensitive route ownership    | `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`                                                                                                                                                             | Documented                       |
-| Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                                                                                       | Governed checklist               |
-| Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                                                                                           | Bounded pilot evidence           |
-| Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                                                                                      | Strong for repo delivery         |
-| Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                                                                              | Blocker recorded                 |
-| Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`; `docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md` | Deploy-boundary proof configured |
-| Threat-model evidence        | `docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md`; `docs/plans/ent-tm02-initial-claim-uploads-threat-model-2026-06-05.md`                                                                             | First surface modeled            |
+| Lane                         | Current evidence                                                                                                                                                                                                                  | Status                           |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| Repo governance              | `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, architecture-finalization program/tracker, PR finalizer, required checks                                                                                        | Strong                           |
+| Plugin/tool discipline       | `docs/plans/plugin-usage-playbook.md`                                                                                                                                                                                             | Strong                           |
+| Incident procedure           | `docs/plans/2026-03-09-d06-incident-playbook-evidence.md`, `docs/INCIDENT_PLAYBOOK.md`, `docs/RUNBOOK.md`                                                                                                                         | Documented                       |
+| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                                          | Partial operational proof        |
+| Sensitive route ownership    | `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`                                                                                                                                                                        | Documented                       |
+| Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                                                                                                  | Governed checklist               |
+| Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                                                                                                      | Bounded pilot evidence           |
+| Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                                                                                                 | Strong for repo delivery         |
+| Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                                                                                         | Blocker recorded                 |
+| Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`; `docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md`            | Deploy-boundary proof configured |
+| Threat-model evidence        | `docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md`; `docs/plans/ent-tm02-initial-claim-uploads-threat-model-2026-06-05.md`; `docs/plans/ent-tm03-authenticated-claim-evidence-uploads-threat-model-2026-06-06.md` | Upload custody surfaces modeled  |
 
 ## Open Enterprise Maturity Lanes
 
@@ -49,7 +49,7 @@ separate from the active architecture-finalization queue unless explicitly promo
 | ---------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Backup/restore drill cadence | First attempt blocked by restore-access gap                                        | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
 | Exercised incident readiness | Partial                                                                            | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
-| Threat model                 | Evidence contract scoped; initial claim-upload surface modeled                     | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
+| Threat model                 | Evidence contract scoped; initial and authenticated claim-upload surfaces modeled  | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
 | Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
 | Alert routing proof          | Partial                                                                            | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
 | Data lifecycle verification  | Partial                                                                            | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
@@ -87,30 +87,32 @@ Rationale:
 While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest repo-owned
 enterprise-hardening slice is:
 
-`ENT-TM02 Initial Claim Uploads Threat Model`
+`ENT-TM03 Authenticated Claim Evidence Uploads Threat Model`
 
 Scope:
 
-- Apply the `ENT-TM01` contract to the initial claim-wizard upload surface only.
-- Model protected metadata, actors, trust boundaries, existing controls, STRIDE threats, residual
-  risks, and verification evidence.
+- Apply the `ENT-TM01` contract to the authenticated claim evidence upload surface only.
+- Model member, staff, branch-manager, and admin upload actors; direct multipart and signed-upload
+  boundaries; claim access controls; storage/object validation; AI queueing; STRIDE threats;
+  residual risks; and verification evidence.
 - Promote exactly one next bounded follow-up:
-  `ENT-TM03 Authenticated Claim Evidence Uploads Threat Model`.
+  `ENT-TM04 Document Signed URLs And Downloads Threat Model`.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
 Rationale:
 
-- The threat-model evidence contract is already defined by `ENT-TM01`.
-- Initial claim uploads are the smallest high-value first model because they cross browser,
-  storage, tenant, file-content, and evidence-custody boundaries while staying bounded to existing
-  proof files.
-- Authenticated claim evidence uploads are the next adjacent custody surface and should be modeled
-  separately before documents, share packs, Paddle webhooks, AI review, and registration.
+- The threat-model evidence contract is already defined by `ENT-TM01`, and `ENT-TM02` completed
+  the first upload-custody surface.
+- Authenticated claim evidence uploads are the adjacent custody surface because they add member,
+  staff, branch-manager, admin, direct-upload, signed-upload, object-validation, and AI queueing
+  boundaries while staying bounded to current route/action proof files.
+- Document signed URLs and downloads are the next adjacent custody surface and should be modeled
+  separately before share packs, Paddle webhooks, AI review, and registration.
 
 Next enterprise maturity remains broader than this repo-owned slice. The highest-value remaining
 lanes are the blocked `ENT-OPS02` staging restore drill,
-`ENT-TM03 Authenticated Claim Evidence Uploads Threat Model`, alert-routing exercise proof, data
+`ENT-TM04 Document Signed URLs And Downloads Threat Model`, alert-routing exercise proof, data
 lifecycle verification, and performance regression gates.
 
 ## Non-Goals

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34214059,
-  "maxTrackedFiles": 3943,
+  "maxTrackedBytes": 34223287,
+  "maxTrackedFiles": 3944,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
     "tests/e2e": 4291944,
-    "docs/text": 4600789,
+    "docs/text": 4610017,
     "config/data/messages": 1534798,
     "other": 1048576
   }


### PR DESCRIPTION
## Summary
- Add `ENT-TM03 Authenticated Claim Evidence Uploads Threat Model` for the claim-bound authenticated evidence upload surface.
- Update the enterprise-readiness register to record both upload-custody threat-model surfaces and promote exactly one next follow-up: `ENT-TM04 Document Signed URLs And Downloads Threat Model`.
- Update the repo-size budget to the exact measured tracked-file and docs/text totals after adding the record.

## Classification
- `documentation/external-tracker-only`, Tier 0.
- No runtime code, schema, auth, tenancy, routing, billing, product UI, or proxy changes.
- `apps/web/src/proxy.ts`, `README.md`, and `AGENTS.md` are untouched.

## Verification
- MCP scope audit: pass for `docs/plans/` and `scripts/repo-size-budget.json` only; forbidden paths unchanged.
- MCP `security_guard`: pass.
- `git diff --check HEAD~1 HEAD`: pass.
- `pnpm plan:status`: pass.
- `pnpm plan:audit`: pass.
- `pnpm track:audit`: pass.
- `pnpm docs:verify`: pass.
- `pnpm repo:size:check`: pass.
- `pnpm security:guard`: pass via MCP.

## Reviewer Disposition
- Gemini review completed and reported no must-fix issues for scope, dependency ordering, STRIDE coverage, residual-risk ownership, or next-slice promotion.
- Sonnet exact route was attempted through Claude CLI and blocked by `The model's tool call could not be parsed`.
- Copilot Sonnet fallback was attempted and timed out with no output.
- Copilot, SonarCloud, CI, and `pr-finalizer` pending on this PR.

## Residual Risk
- This completes only the second upload-custody per-surface threat-model record under `ENT-TM01`; it does not claim full enterprise threat-model completion.
- Broader threat-model lane remains open for document signed URLs/downloads, share packs, Paddle webhooks, AI review, registration, admin verification, and other promoted sensitive surfaces.