### PR TITLE
chore: add model review evidence receipts

### DIFF
--- a/scripts/ci/model-review-access.mjs
+++ b/scripts/ci/model-review-access.mjs
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+import {
+  assertKnownReviewers,
+  modelReviewRoutes,
+  parseReviewerList,
+} from './model-review-routes.mjs';
+
+const PROMPT =
+  'Interdomestik model-review access check. Reply OK only. No repository data included.';
+
+function argValue(args, name, fallback = '') {
+  const index = args.indexOf(name);
+  return index >= 0 && args[index + 1] ? args[index + 1] : fallback;
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15);
+}
+
+function commandAvailable(command) {
+  return spawnSync('/bin/sh', ['-lc', `command -v ${command}`], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function runProbe(route, probe) {
+  const available = commandAvailable(route.command);
+  if (available.status !== 0) {
+    return { status: 'blocked', reason: `${route.command} command unavailable` };
+  }
+  if (probe === 'command') {
+    return { status: 'available', reason: 'command available; auth/quota not probed' };
+  }
+  const result = spawnSync(route.command, route.args(PROMPT), {
+    encoding: 'utf8',
+    timeout: 45000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status === 0)
+    return { status: 'completed', reason: 'minimal access prompt completed' };
+  const output = `${result.stderr || ''}${result.stdout || ''}`.trim().slice(0, 240);
+  return { status: 'blocked', reason: output || `exit ${result.status ?? 'unknown'}` };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const required = parseReviewerList(argValue(args, '--required'), ['sonnet']);
+  const reviewers = [...new Set([...parseReviewerList(argValue(args, '--reviewers')), ...required])];
+  const probe = argValue(args, '--probe', 'call');
+  if (!['call', 'command'].includes(probe)) throw new Error('--probe must be call or command');
+  assertKnownReviewers(reviewers);
+
+  const runRoot =
+    argValue(args, '--run-root') || path.join('tmp', 'model-review-access', timestamp());
+  const reviewDir = path.join(runRoot, 'reviews');
+  fs.mkdirSync(reviewDir, { recursive: true });
+
+  const results = reviewers.map(reviewer => {
+    const route = modelReviewRoutes[reviewer];
+    return {
+      reviewer,
+      required: required.includes(reviewer),
+      label: route.label,
+      ...runProbe(route, probe),
+    };
+  });
+  const acceptableRequired = probe === 'command' ? ['available', 'completed'] : ['completed'];
+  const blockedRequired = results.filter(
+    result => result.required && !acceptableRequired.includes(result.status)
+  );
+  let status = 'pass';
+  if (blockedRequired.length > 0) {
+    status = 'blocked';
+  } else if (probe === 'command') {
+    status = 'available';
+  }
+  const receipt = {
+    status,
+    probe,
+    generatedAt: new Date().toISOString(),
+    reviewers,
+    required,
+    results,
+  };
+  const out = path.join(reviewDir, 'model-review-access.json');
+  fs.writeFileSync(out, `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log(`[model-review-access] receipt=${out}`);
+  if (blockedRequired.length > 0) process.exitCode = 1;
+}
+
+main();

--- a/scripts/ci/model-review-evidence.mjs
+++ b/scripts/ci/model-review-evidence.mjs
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { assertKnownReviewers, parseReviewerList } from './model-review-routes.mjs';
+
+function argValue(args, name, fallback = '') {
+  const index = args.indexOf(name);
+  return index >= 0 && args[index + 1] ? args[index + 1] : fallback;
+}
+
+function fail(message, details = {}) {
+  console.error(`model-review evidence failed: ${message}`);
+  if (Object.keys(details).length > 0) console.error(JSON.stringify(details, null, 2));
+  process.exit(1);
+}
+
+function readReceipt(runRoot) {
+  const file = path.join(runRoot, 'reviews', 'model-review-access.json');
+  if (!fs.existsSync(file)) fail('missing access receipt', { file });
+  return { file, receipt: JSON.parse(fs.readFileSync(file, 'utf8')) };
+}
+
+export function evaluateReceipt(receipt, options) {
+  const results = Array.isArray(receipt.results) ? receipt.results : [];
+  const resultByReviewer = new Map(results.map(result => [result.reviewer, result]));
+  const missingRequired = options.required.filter(reviewer => !resultByReviewer.has(reviewer));
+  const blockedRequired = options.required.filter(reviewer => {
+    const result = resultByReviewer.get(reviewer);
+    return result?.status === 'blocked';
+  });
+  const blockedOptional = options.optional.filter(reviewer => {
+    const result = resultByReviewer.get(reviewer);
+    return result?.status === 'blocked';
+  });
+  const commandOnlyRequired = options.requireCall
+    ? options.required.filter(reviewer => resultByReviewer.get(reviewer)?.status === 'available')
+    : [];
+  return { missingRequired, blockedRequired, blockedOptional, commandOnlyRequired };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const runRoot = argValue(args, '--run-root');
+  if (!runRoot) fail('missing --run-root');
+  const required = parseReviewerList(argValue(args, '--required'), ['sonnet']);
+  const optional = parseReviewerList(argValue(args, '--optional'), ['gemini', 'copilot']);
+  const requireCall = args.includes('--require-call');
+  assertKnownReviewers([...new Set([...required, ...optional])]);
+
+  const { file, receipt } = readReceipt(runRoot);
+  const result = evaluateReceipt(receipt, { required, optional, requireCall });
+  if (result.missingRequired.length > 0) fail('required reviewers missing', result);
+  if (result.blockedRequired.length > 0) fail('required reviewers blocked', result);
+  if (result.commandOnlyRequired.length > 0) fail('required reviewers need call proof', result);
+  console.log(
+    result.blockedOptional.length > 0
+      ? 'model-review evidence passed with blocked optional routes'
+      : 'model-review evidence passed'
+  );
+  console.log(`[model-review-evidence] receipt=${file}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/ci/model-review-evidence.test.mjs
+++ b/scripts/ci/model-review-evidence.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '../..');
+const accessScript = path.join(repoRoot, 'scripts/ci/model-review-access.mjs');
+const evidenceScript = path.join(repoRoot, 'scripts/ci/model-review-evidence.mjs');
+
+function addFakeClaude(binDir) {
+  fs.symlinkSync('/bin/echo', path.join(binDir, 'claude'));
+}
+
+function withReceipt(receipt, callback) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'model-review-evidence-'));
+  fs.mkdirSync(path.join(root, 'reviews'));
+  fs.writeFileSync(
+    path.join(root, 'reviews/model-review-access.json'),
+    `${JSON.stringify(receipt, null, 2)}\n`
+  );
+  try {
+    callback(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function runEvidence(root, args = []) {
+  return spawnSync(process.execPath, [evidenceScript, '--run-root', root, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+function runAccessWithFakeClaude(name, args) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `model-review-${name}-`));
+  const binDir = path.join(root, 'bin');
+  fs.mkdirSync(binDir);
+  addFakeClaude(binDir);
+  const result = spawnSync(process.execPath, [accessScript, '--run-root', root, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+  });
+  return { result, root };
+}
+
+function readAccessReceipt(root) {
+  return JSON.parse(fs.readFileSync(path.join(root, 'reviews/model-review-access.json'), 'utf8'));
+}
+
+test('model-review evidence passes when required route completed and optional route blocked', () => {
+  withReceipt(
+    {
+      results: [
+        { reviewer: 'sonnet', status: 'completed' },
+        { reviewer: 'gemini', status: 'blocked' },
+        { reviewer: 'copilot', status: 'completed' },
+      ],
+    },
+    root => {
+      const result = runEvidence(root, ['--required', 'sonnet', '--optional', 'gemini,copilot']);
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /blocked optional routes/u);
+    }
+  );
+});
+
+test('model-review evidence fails when a required route is blocked', () => {
+  withReceipt({ results: [{ reviewer: 'sonnet', status: 'blocked' }] }, root => {
+    const result = runEvidence(root, ['--required', 'sonnet']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /required reviewers blocked/u);
+  });
+});
+
+test('model-review evidence requires call proof when requested', () => {
+  withReceipt({ results: [{ reviewer: 'sonnet', status: 'available' }] }, root => {
+    const result = runEvidence(root, ['--required', 'sonnet', '--require-call']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /need call proof/u);
+  });
+});
+
+test('model-review access writes receipts for callable and command-only routes', () => {
+  const scenarios = [
+    {
+      name: 'access',
+      args: ['--reviewers', 'sonnet', '--required', 'sonnet'],
+      status: 'pass',
+      routeStatus: 'completed',
+    },
+    {
+      name: 'command',
+      args: ['--reviewers', 'sonnet', '--required', 'sonnet', '--probe', 'command'],
+      status: 'available',
+      routeStatus: 'available',
+    },
+    {
+      name: 'required-union',
+      args: ['--reviewers', 'copilot', '--required', 'sonnet', '--probe', 'command'],
+      status: 'available',
+      routeStatus: 'available',
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const { result, root } = runAccessWithFakeClaude(scenario.name, scenario.args);
+    try {
+      assert.equal(result.status, 0, result.stderr);
+      const receipt = readAccessReceipt(root);
+      assert.equal(receipt.status, scenario.status);
+      const sonnet = receipt.results.find(item => item.reviewer === 'sonnet');
+      assert.equal(sonnet.required, true);
+      assert.equal(sonnet.status, scenario.routeStatus);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});

--- a/scripts/ci/model-review-routes.mjs
+++ b/scripts/ci/model-review-routes.mjs
@@ -1,0 +1,52 @@
+export const defaultReviewers = ['sonnet', 'gemini', 'copilot'];
+
+export const modelReviewRoutes = {
+  sonnet: {
+    label: 'Claude Sonnet architecture/scope review',
+    command: 'claude',
+    args: prompt => [
+      '-p',
+      prompt,
+      '--model',
+      'claude-sonnet-4-6',
+      '--tools',
+      '',
+      '--no-session-persistence',
+    ],
+  },
+  gemini: {
+    label: 'Gemini product/design review',
+    command: 'gemini',
+    args: prompt => ['-p', prompt, '--model', 'gemini-3.1-pro-preview', '--output-format', 'text'],
+  },
+  copilot: {
+    label: 'Copilot Sonnet fallback review',
+    command: 'copilot',
+    args: prompt => [
+      '--model',
+      'claude-sonnet-4.6',
+      '-p',
+      prompt,
+      '--available-tools=',
+      '--disable-builtin-mcps',
+      '--no-custom-instructions',
+      '--no-color',
+      '--silent',
+    ],
+  },
+};
+
+export function parseReviewerList(value, fallback = defaultReviewers) {
+  const reviewers = String(value || '')
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+  return reviewers.length > 0 ? reviewers : fallback;
+}
+
+export function assertKnownReviewers(reviewers) {
+  const unknown = reviewers.filter(reviewer => !modelReviewRoutes[reviewer]);
+  if (unknown.length > 0) {
+    throw new Error(`unknown model reviewer route(s): ${unknown.join(', ')}`);
+  }
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34332670,
-  "maxTrackedFiles": 3958,
+  "maxTrackedBytes": 34344245,
+  "maxTrackedFiles": 3962,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
-    "source/scripts": 6453611,
-    "tests/e2e": 4291973,
+    "source/scripts": 6460532,
+    "tests/e2e": 4296182,
     "docs/text": 4719328,
-    "config/data/messages": 1534798,
+    "config/data/messages": 1535030,
     "other": 1048576
   }
 }


### PR DESCRIPTION
## Summary
- Add command/call receipt generation for Sonnet, Gemini, and Copilot model-review routes.
- Add evidence validation so required routes fail when blocked/missing, and `--require-call` distinguishes command availability from live call completion.
- Add focused tests for required/optional route evidence, command-only handling, receipt writer behavior, and required-reviewer unioning.

## Changed Areas
- `scripts/ci/model-review-routes.mjs`
- `scripts/ci/model-review-access.mjs`
- `scripts/ci/model-review-evidence.mjs`
- `scripts/ci/model-review-evidence.test.mjs`
- `scripts/repo-size-budget.json`

## Verification
Final commit: `0dad2340c4bd612abf7684b0edb9f80a89c524f6`.

- `node --test scripts/ci/model-review-evidence.test.mjs` passed: 4 tests.
- `pnpm check:modularity-guard` passed; every changed checked file is <=150 lines.
- `pnpm repo:size:check` passed.
- `git diff --check` passed.
- `pnpm verify-slice` final run root: `/Users/arbenlila/development/interdomestik-model-review-evidence/tmp/multi-agent/verify-slice/verify-slice-20260606T050938Z-06a784`.
- `pnpm verify-slice -- --run-root /Users/arbenlila/development/interdomestik-model-review-evidence/tmp/multi-agent/verify-slice/verify-slice-20260606T050938Z-06a784 --static` passed.
- Full local required-gates run root before the final review-thread-only fixes: `/Users/arbenlila/development/interdomestik-model-review-evidence/tmp/multi-agent/verify-slice/verify-slice-20260606T045245Z-2219e3`.
- `pnpm verify-slice -- --run-root /Users/arbenlila/development/interdomestik-model-review-evidence/tmp/multi-agent/verify-slice/verify-slice-20260606T045245Z-2219e3 --required-gates` passed: `pr:verify`, `security:guard`, and standalone `e2e-gate`.
- Local E2E evidence in that required-gates run: PR lane 134 passed / 6 skipped, smoke 13 passed / 1 skipped, standalone e2e-gate 134 passed / 6 skipped.

## Model Review Evidence
- Receipt path: `/Users/arbenlila/development/interdomestik-model-review-evidence/tmp/multi-agent/verify-slice/verify-slice-20260606T050938Z-06a784/reviews/model-review-access.json`.
- Probe mode: `command`.
- Sonnet route: `available`, required, auth/quota not probed.
- Gemini route: `available`, optional, auth/quota not probed.
- Copilot route: `available`, optional, auth/quota not probed, built-in MCPs disabled in call args.
- Live call proof can be enforced later with `model-review-evidence.mjs --require-call` after intentionally consuming reviewer quota.

## Reviewer / Security Disposition
- Pre-PR reviewer plan selected: `security_reviewer architect_reviewer qa_reviewer contracts_reviewer`.
- GitHub Advanced Security and Copilot review threads were addressed and resolved.
- Security guard passed in final static evidence and in the full local required-gates run.
- No secrets, production credentials, PII, or repo content were sent to external model routes by the command-only probe.

## Operational Notes
- Slice classification: AI-affected implementation, Tier 3, because it touches reviewer/model escalation evidence and shared verification behavior.
- Required reviewers are now always included in the probed route set, even if omitted from `--reviewers`.
- Primary dirty worktree was not modified; this branch was completed in isolated worktree `/Users/arbenlila/development/interdomestik-model-review-evidence`.
