### PR TITLE
docs: add document download threat model

### DIFF
--- a/docs/plans/ent-tm04-document-signed-urls-and-downloads-threat-model-2026-06-06.md
+++ b/docs/plans/ent-tm04-document-signed-urls-and-downloads-threat-model-2026-06-06.md
@@ -1,0 +1,120 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: documents
+last_reviewed: 2026-06-06
+superseded_by:
+---
+
+# ENT-TM04 Document Signed URLs And Downloads Threat Model - 2026-06-06
+
+> Status: Input document. This record applies the `ENT-TM01` contract to document signed
+> URLs and direct document downloads only. It does not change runtime behavior or claim full
+> enterprise threat-model completion.
+
+## Identity
+
+- Surface: document signed URLs and direct document downloads.
+- Owner: document custody and claim access.
+- Reviewers: PR reviewers, Copilot, SonarCloud, and CI/security gates.
+- Entry points: `apps/web/src/app/api/documents/[id]/route.ts`,
+  `apps/web/src/app/api/documents/[id]/download/route.ts`,
+  `apps/web/src/app/api/documents/_core.ts`,
+  `apps/web/src/app/api/documents/storage-service.server.ts`.
+- Proof files: `apps/web/src/app/api/documents/[id]/route.test.ts`,
+  `apps/web/src/app/api/documents/[id]/download/route.test.ts`,
+  `apps/web/src/app/api/documents/_core.test.ts`.
+- Source inventory: `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`.
+- Last reviewed: 2026-06-06.
+
+## Data And Assets
+
+- Protected data: document ids, document names, MIME types, file sizes, buckets, tenant-scoped
+  storage paths, claim/member/policy entity links, signed download URLs, and streamed document
+  bytes.
+- Durable records: polymorphic `documents` rows, legacy `claim_documents` rows, related `claims`
+  and `policies` rows used for access resolution, and document access audit events.
+- Storage objects: PII-classified claim and policy documents under tenant-leading storage prefixes.
+- External systems: Supabase Storage service-role signed URL and download operations, browser
+  clients holding signed URLs, and Sentry SLO tagging for direct download paths.
+- Audit or provenance records: allowed `document.signed_url_issued`, `document.view`, and
+  `document.download` events plus forbidden-access audit events.
+- Explicit non-data: this record does not include file contents, signed URL values, raw PII, claim
+  narratives, payment data, production secrets, or storage provider credentials.
+
+## Actors And Trust Boundaries
+
+- Trusted actors: authenticated member owners, document uploaders where allowed, assigned agents,
+  branch-scoped staff and branch managers, and full-tenant claims roles.
+- Untrusted actors: unauthenticated callers, wrong-tenant sessions, cross-member callers,
+  unassigned agents, staff or branch managers outside claim scope, forged document ids, and leaked
+  signed URL holders.
+- External systems: browser clients, Next.js route handlers, Supabase Storage, audit logging, and
+  Sentry telemetry.
+- Trust boundaries: browser to document route, route to shared access core, access core to database,
+  service-role server to storage, signed URL bearer to storage, and streamed response to browser.
+- Tenant isolation boundary: `ensureTenantId(session)`, tenant-scoped document and legacy document
+  reads, tenant-scoped claim/policy checks, bucket-family resolution, and
+  `assertTenantStoragePath` before signed URL creation or storage download.
+
+## Existing Controls
+
+- Authentication and authorization controls: routes require session; access core authorizes
+  polymorphic member/profile, claim, and policy documents plus legacy claim documents by current
+  role, ownership, uploader, branch, assignment, and full-tenant role rules.
+- Tenant-scoping controls: document lookups include tenant id, claim and policy reads include tenant
+  id, and storage service calls pass tenant id with the resolved `claims` or `policies` storage
+  family.
+- Input validation and rate limits: both routes enforce a production-sensitive 60/minute rate limit;
+  signed URL responses use a fixed five-minute TTL; download disposition is allowlisted to
+  `inline` or `attachment`; filenames are sanitized for content-disposition headers.
+- Storage or persistence controls: storage helpers assert bucket and `pii/tenants/<tenant>/<family>`
+  prefixes before service-role signed URL or download calls; signed URL JSON responses set
+  `Cache-Control: private, no-store, max-age=0` and `Referrer-Policy: no-referrer`; direct downloads
+  set `Cache-Control: private, no-store` and `Referrer-Policy: no-referrer`.
+- Audit, telemetry, or evidence controls: allowed signed URL, view, download, and forbidden access
+  attempts are audited; direct downloads set the `d07.document.download` SLO tag; focused tests
+  prove unauthenticated, missing, forbidden, signed URL, stream, inline, and audit behavior.
+- Current proof files: route, download route, access core, storage helper, signed URL exposure, and
+  ownership map files listed in this record.
+
+## STRIDE Threat Table
+
+| Category               | Threat                                                        | Existing control                                                                 | Residual risk                                                  | Follow-up or owner                  |
+| ---------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------- |
+| Spoofing               | Wrong actor requests a document URL or stream.                | Session requirement, tenant-bound reads, ownership/role/branch/assignment rules. | Stolen sessions remain outside this surface record.            | Auth/incident drills lane.          |
+| Tampering              | Caller manipulates document id, disposition, bucket, or path. | Server-side lookup resolves bucket/path; disposition allowlist; storage asserts. | Legacy rows depend on stored bucket/path integrity.            | Documents owner; audit/event lane.  |
+| Repudiation            | Actor denies viewing, downloading, or requesting a URL.       | Allowed and forbidden access audit events include actor, entity, action, path.   | Audit retention and alerting cadence are not proven here.      | Alert-routing/data-lifecycle lanes. |
+| Information disclosure | Signed URL, path, headers, or streamed bytes leak documents.  | Short TTL, no-store/no-referrer, access before issuance/download, path asserts.  | Signed URLs are bearer capabilities until expiry.              | Documents owner; TTL accepted.      |
+| Denial of service      | Caller repeatedly signs or streams large documents.           | Per-route rate limits and storage-provider error handling.                       | Bandwidth, object-size, and storage egress budgets need proof. | Performance/alert-routing lanes.    |
+| Elevation of privilege | Agent/staff/branch manager reads another claim document.      | Claim access helper enforces assignment, branch, or full-tenant role boundaries. | Full-tenant roles retain broad document access by policy.      | Platform/documents owner accepted.  |
+
+## Verification
+
+- Required local proof for this record: `git diff --check`, `pnpm docs:verify`,
+  `pnpm plan:status`, `pnpm plan:audit`, `pnpm track:audit`, `pnpm repo:size:check`,
+  `pnpm security:guard`.
+- Runtime proof cited by this model exists in the route, download route, and access-core tests
+  listed in the identity section; this docs slice does not rerun or change those tests.
+- Reviewer disposition must focus on whether the model is bounded to document signed URLs and
+  downloads, accurately distinguishes signed URL issuance from server-streamed downloads, and
+  avoids claiming runtime enforcement beyond existing evidence.
+- Explicitly skipped proof: heavy local E2E is not required because this slice is docs/register only.
+
+## Result
+
+- Decision: pass for the document signed URLs and downloads threat-model record.
+- Blocking gaps: none for this documentation slice.
+- Non-blocking gaps: audit retention cadence, bandwidth/egress limits, storage-provider abuse
+  alerting, and account-compromise drills remain outside this surface record.
+- Accepted residual risks: signed download URLs remain bearer capabilities for a five-minute TTL,
+  and full-tenant roles retain broad access by current policy.
+- Follow-up slice: `ENT-TM05 Share Packs Threat Model`.
+- Owner sign-off: platform/documents review through PR checks and review threads.
+
+## Relationship To Enterprise Readiness
+
+This record completes the first document-access custody surface required by `ENT-TM01`. The broader
+threat-model lane still requires per-surface records for share packs, Paddle webhooks, AI review,
+registration, admin verification, and other promoted sensitive surfaces.

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -26,34 +26,34 @@ enterprise-ready.
 
 ## Evidence Already Present
 
-| Lane                         | Current evidence                                                                                                                                                                                                                  | Status                           |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| Repo governance              | `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, architecture-finalization program/tracker, PR finalizer, required checks                                                                                        | Strong                           |
-| Plugin/tool discipline       | `docs/plans/plugin-usage-playbook.md`                                                                                                                                                                                             | Strong                           |
-| Incident procedure           | `docs/plans/2026-03-09-d06-incident-playbook-evidence.md`, `docs/INCIDENT_PLAYBOOK.md`, `docs/RUNBOOK.md`                                                                                                                         | Documented                       |
-| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                                          | Partial operational proof        |
-| Sensitive route ownership    | `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`                                                                                                                                                                        | Documented                       |
-| Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                                                                                                  | Governed checklist               |
-| Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                                                                                                      | Bounded pilot evidence           |
-| Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                                                                                                 | Strong for repo delivery         |
-| Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                                                                                         | Blocker recorded                 |
-| Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`; `docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md`            | Deploy-boundary proof configured |
-| Threat-model evidence        | `docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md`; `docs/plans/ent-tm02-initial-claim-uploads-threat-model-2026-06-05.md`; `docs/plans/ent-tm03-authenticated-claim-evidence-uploads-threat-model-2026-06-06.md` | Upload custody surfaces modeled  |
+| Lane                         | Current evidence                                                                                                                                                                                                                                                                                                       | Status                                              |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Repo governance              | `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, architecture-finalization program/tracker, PR finalizer, required checks                                                                                                                                                                             | Strong                                              |
+| Plugin/tool discipline       | `docs/plans/plugin-usage-playbook.md`                                                                                                                                                                                                                                                                                  | Strong                                              |
+| Incident procedure           | `docs/plans/2026-03-09-d06-incident-playbook-evidence.md`, `docs/INCIDENT_PLAYBOOK.md`, `docs/RUNBOOK.md`                                                                                                                                                                                                              | Documented                                          |
+| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                                                                                                                               | Partial operational proof                           |
+| Sensitive route ownership    | `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`                                                                                                                                                                                                                                                             | Documented                                          |
+| Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                                                                                                                                                                                       | Governed checklist                                  |
+| Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                                                                                                                                                                                           | Bounded pilot evidence                              |
+| Security gates               | CodeQL, SonarCloud, gitleaks, pnpm-audit, `pnpm security:guard`, DB/RLS/access audits in PR gates                                                                                                                                                                                                                      | Strong for repo delivery                            |
+| Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                                                                                                                                                                              | Blocker recorded                                    |
+| Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`; `docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md`                                                                                                 | Deploy-boundary proof configured                    |
+| Threat-model evidence        | `docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md`; `docs/plans/ent-tm02-initial-claim-uploads-threat-model-2026-06-05.md`; `docs/plans/ent-tm03-authenticated-claim-evidence-uploads-threat-model-2026-06-06.md`; `docs/plans/ent-tm04-document-signed-urls-and-downloads-threat-model-2026-06-06.md` | Upload and document-access custody surfaces modeled |
 
 ## Open Enterprise Maturity Lanes
 
 These lanes come from `docs/reviews/2026-04-25-production-professionalism-rereview.md` and remain
 separate from the active architecture-finalization queue unless explicitly promoted.
 
-| Lane                         | Current gap                                                                        | Enterprise requirement                                                                                        |
-| ---------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Backup/restore drill cadence | First attempt blocked by restore-access gap                                        | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
-| Exercised incident readiness | Partial                                                                            | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
-| Threat model                 | Evidence contract scoped; initial and authenticated claim-upload surfaces modeled  | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
-| Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
-| Alert routing proof          | Partial                                                                            | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
-| Data lifecycle verification  | Partial                                                                            | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
-| Performance regression gate  | Not yet scoped                                                                     | Representative route/storage performance budgets that can block releases                                      |
+| Lane                         | Current gap                                                                                   | Enterprise requirement                                                                                        |
+| ---------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Backup/restore drill cadence | First attempt blocked by restore-access gap                                                   | Recurring staging restore drill with measured RTO/RPO and owner sign-off                                      |
+| Exercised incident readiness | Partial                                                                                       | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery             |
+| Threat model                 | Evidence contract scoped; initial uploads, authenticated uploads, and document access modeled | Written per-surface model for registration, uploads, documents, share packs, billing, AI review, and webhooks |
+| Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending            | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                |
+| Alert routing proof          | Partial                                                                                       | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes           |
+| Data lifecycle verification  | Partial                                                                                       | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                              |
+| Performance regression gate  | Not yet scoped                                                                                | Representative route/storage performance budgets that can block releases                                      |
 
 ## Next Bounded Operational Slice
 
@@ -87,33 +87,32 @@ Rationale:
 While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest repo-owned
 enterprise-hardening slice is:
 
-`ENT-TM03 Authenticated Claim Evidence Uploads Threat Model`
+`ENT-TM04 Document Signed URLs And Downloads Threat Model`
 
 Scope:
 
-- Apply the `ENT-TM01` contract to the authenticated claim evidence upload surface only.
-- Model member, staff, branch-manager, and admin upload actors; direct multipart and signed-upload
-  boundaries; claim access controls; storage/object validation; AI queueing; STRIDE threats;
-  residual risks; and verification evidence.
+- Apply the `ENT-TM01` contract to document signed URL issuance and direct document downloads only.
+- Model authenticated document actors, polymorphic and legacy document access, signed URL and
+  direct-download boundaries, tenant-scoped storage assertions, response headers, audit events,
+  STRIDE threats, residual risks, and verification evidence.
 - Promote exactly one next bounded follow-up:
-  `ENT-TM04 Document Signed URLs And Downloads Threat Model`.
+  `ENT-TM05 Share Packs Threat Model`.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
 Rationale:
 
 - The threat-model evidence contract is already defined by `ENT-TM01`, and `ENT-TM02` completed
-  the first upload-custody surface.
-- Authenticated claim evidence uploads are the adjacent custody surface because they add member,
-  staff, branch-manager, admin, direct-upload, signed-upload, object-validation, and AI queueing
-  boundaries while staying bounded to current route/action proof files.
-- Document signed URLs and downloads are the next adjacent custody surface and should be modeled
-  separately before share packs, Paddle webhooks, AI review, and registration.
+  the first upload-custody surface while `ENT-TM03` completed authenticated claim evidence uploads.
+- Document signed URLs and downloads are the adjacent custody surface because they expose
+  authorized document access through bearer signed URLs and server-streamed downloads while staying
+  bounded to current route/core proof files.
+- Share packs are the next adjacent custody surface and should be modeled separately before Paddle
+  webhooks, AI review, registration, and admin verification.
 
 Next enterprise maturity remains broader than this repo-owned slice. The highest-value remaining
-lanes are the blocked `ENT-OPS02` staging restore drill,
-`ENT-TM04 Document Signed URLs And Downloads Threat Model`, alert-routing exercise proof, data
-lifecycle verification, and performance regression gates.
+lanes are the blocked `ENT-OPS02` staging restore drill, `ENT-TM05 Share Packs Threat Model`,
+alert-routing exercise proof, data lifecycle verification, and performance regression gates.
 
 ## Non-Goals
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34223287,
-  "maxTrackedFiles": 3944,
+  "maxTrackedBytes": 34233343,
+  "maxTrackedFiles": 3945,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
     "tests/e2e": 4291944,
-    "docs/text": 4610017,
+    "docs/text": 4620073,
     "config/data/messages": 1534798,
     "other": 1048576
   }


### PR DESCRIPTION
## Summary
- Adds `ENT-TM04 Document Signed URLs And Downloads Threat Model` under the `ENT-TM01` evidence contract.
- Updates the enterprise readiness register so threat-model evidence includes ENT-TM01 through ENT-TM04 and records upload plus document-access custody surfaces as modeled.
- Promotes exactly one next bounded enterprise threat-model follow-up: `ENT-TM05 Share Packs Threat Model`.
- Updates the repo-size budget to the exact measured post-format totals.

## Classification And Scope
Classified as `documentation/external-tracker-only`, Tier 0.

Changed only:
- `docs/plans/ent-tm04-document-signed-urls-and-downloads-threat-model-2026-06-06.md`
- `docs/plans/enterprise-readiness-register.md`
- `scripts/repo-size-budget.json`

No runtime code, schema, proxy, canonical route, auth, tenancy, routing, billing, product UI, README, AGENTS, or broad architecture docs were changed.

## Verification
Local verification passed:
- `pnpm exec prettier --check docs/plans/ent-tm04-document-signed-urls-and-downloads-threat-model-2026-06-06.md docs/plans/enterprise-readiness-register.md scripts/repo-size-budget.json`
- `git diff --check && git diff --cached --check`
- `git diff --check HEAD~1 HEAD`
- `pnpm repo:size:check`
- `pnpm docs:verify`
- `pnpm plan:status`
- `pnpm plan:audit`
- `pnpm track:audit`
- Interdomestik QA MCP `scope_audit`
- Interdomestik QA MCP `security_guard`

Heavy local E2E intentionally skipped because this is docs/register/budget only and does not touch runtime, gates, or verification infrastructure.

## Reviewer And Security Disposition
- Sonnet architecture/scope route attempted with `claude -p --model claude-sonnet-4-6 --tools "" --no-session-persistence`; blocked by timeout with no usable output.
- Gemini route attempted with `gemini -p --model gemini-3.1-pro-preview --output-format text`; blocked by authentication prompt/timeout with no usable output.
- Copilot Sonnet fallback attempted with `copilot --model claude-sonnet-4.6`; blocked by timeout with no usable output.
- PR Copilot, SonarCloud, and CI checks are authoritative for PR readiness and will be monitored before merge.
- Interdomestik QA MCP `security_guard` passed.

## Residual Risk
This slice documents existing controls only. It does not prove runtime enforcement beyond the cited route/core tests and repo security gates. Accepted residual risks remain: signed URLs are bearer capabilities during their five-minute TTL, full-tenant document access remains role-authorized, and bandwidth/egress/alerting proof belongs to later operational lanes.

## Next Slice
If this PR merges cleanly, the next repo-owned enterprise threat-model slice is `ENT-TM05 Share Packs Threat Model`.
