### PR TITLE
docs: add alert routing evidence contract

### DIFF
--- a/docs/plans/ent-alert01-alert-routing-evidence-contract-2026-06-06.md
+++ b/docs/plans/ent-alert01-alert-routing-evidence-contract-2026-06-06.md
@@ -1,0 +1,147 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: platform
+last_reviewed: 2026-06-06
+superseded_by:
+---
+
+# ENT-ALERT01 Alert Routing Evidence Contract - 2026-06-06
+
+> Status: Input document. This contract defines the evidence required to prove alert routing for
+> the existing SLO alert surface. It does not change Sentry, production telemetry, runtime code,
+> incident policy, or claim full enterprise readiness.
+
+## Purpose
+
+Move the first alert-routing enterprise proof from partial evidence to a concrete,
+operator-executable contract. A future exercise record can prove that the existing D07 alerts are not
+only configured, but routed to a named owner and actionable without creating production impact.
+
+## Current Repo Evidence
+
+Existing alert evidence is useful but incomplete for enterprise readiness:
+
+- `docs/SLOS.md` defines the three committed SLO surfaces.
+- `docs/RUNBOOK.md` documents `pnpm sentry:alerts:check` and `pnpm sentry:alerts:apply`.
+- `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md` records that the three D07
+  Sentry alert rules were present and unchanged after provisioning.
+- `scripts/sentry-alerts-lib.mjs` defines the checked-in alert catalog for Paddle webhook burn
+  rate, document download burn rate, and `/api/claims` latency.
+- `scripts/sentry-alerts.mjs` supports catalog-only checks, remote drift checks, and remote apply
+  when Sentry token scopes and action targets are configured.
+- `scripts/sentry-alerts.test.mjs` proves catalog shape, payload construction, drift detection, and
+  action parsing.
+- Prior pilot records include remote D07 drift checks that found the rules unchanged.
+
+The repo does not yet prove:
+
+- named warning and critical routing targets from current Sentry state;
+- owner or escalation identity for each D07 alert action;
+- that an alert can be exercised without production traffic or customer impact;
+- that the exercise creates a visible notification the receiving owner can acknowledge, triage, and
+  record; or
+- dedicated auth, RLS, tenant-boundary, or protected-route failure-mode alert catalog coverage beyond
+  the current D07 surfaces.
+
+## Scope
+
+This contract covers the existing D07 SLO alert catalog and the evidence required to prove routing
+for Paddle webhook processing, document download availability, and `/api/claims` latency. It is the
+first alert-routing proof contract, not the full alerting-backed observability lane.
+
+In scope: remote drift check, warning and critical action inventory, named owner and escalation
+destination, no-production-impact exercise, notification receipt, acknowledgement, pass/fail
+decision, and follow-up capture.
+
+Out of scope: production incidents, traffic degradation, threshold changes, observability-vendor
+replacement, runtime code, schema, RLS, auth, tenancy, routing, billing, product UI, proxy, README,
+AGENTS, broad architecture docs, and secrets or sensitive customer data in evidence.
+
+## Evidence Template
+
+Copy this section into a dated exercise record when a real routing proof is performed.
+
+```md
+# Alert Routing Exercise Record - YYYY-MM-DD
+
+## Identity
+
+- Exercise id:
+- Environment:
+- Sentry org/project:
+- Alert catalog source:
+- Executed by:
+- Decision/escalation owner:
+
+## Alert Inventory
+
+| Alert                                        | Remote rule id | Query | Warning action | Critical action | Owner | Drift result |
+| -------------------------------------------- | -------------- | ----- | -------------- | --------------- | ----- | ------------ |
+| D07 SLO1 Paddle webhook processing burn rate |                |       |                |                 |       |              |
+| D07 SLO2 Document download burn rate         |                |       |                |                 |       |              |
+| D07 SLO3 Core API latency p95 (/api/claims)  |                |       |                |                 |       |              |
+
+## Exercise
+
+- Exercise method:
+- Production traffic affected: no
+- Test alert/notification id:
+- Trigger time:
+- First notification received time:
+- Acknowledged by:
+- Acknowledged time:
+- Triage destination:
+- Follow-up record:
+
+## Commands And Evidence
+
+- Drift check command:
+- Drift check result:
+- Routing-action inspection:
+- Exercise command/provider action:
+- Notification evidence location:
+
+## Safety
+
+- Secrets or credentials exposed in this record: no
+- Raw PII, claim narratives, document contents, or payment data exposed: no
+- Exercise used staging-safe, test-only, or provider-supported alert simulation: yes/no
+
+## Result
+
+- Decision: pass/fail
+- Blocking findings:
+- Non-blocking findings:
+- Follow-up issue or PR:
+- Owner sign-off:
+```
+
+## Acceptance Criteria
+
+An alert-routing exercise record satisfies this contract only when:
+
+- each checked-in D07 alert has a remote rule id and `pnpm sentry:alerts:check --json` reports no
+  missing or changed D07 rules;
+- warning and critical actions are inspected and recorded for each remote rule;
+- each action maps to a named owner, channel, or escalation destination;
+- the exercise uses a non-production-impact test path and records the exact method;
+- at least one routed notification is proven received and acknowledged by the intended owner;
+- the record captures trigger time, first received time, acknowledgement time, and triage
+  destination;
+- the evidence contains no secrets, credentials, raw PII, claim narratives, document contents, or
+  payment data;
+- a named decision owner records pass/fail; and
+- every blocker has a follow-up issue, PR, or explicit risk owner.
+
+This contract does not satisfy the broader enterprise alert lane by itself. Full alerting-backed
+observability still requires separate catalog and exercise proof for auth, RLS or tenant-boundary,
+and protected-route failure modes.
+
+## Recommended Next Proof
+
+The next unblocked enterprise slice should create `ENT-ALERT02 D07 Alert Routing Exercise Record` by
+executing this contract against the current Sentry project. If the available token can read rules but
+not inspect action details, trigger test notifications, or confirm recipient delivery, record the
+exact provider permission or destination blocker instead of claiming routing proof.

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -31,7 +31,7 @@ enterprise-ready.
 | Repo governance              | `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, architecture-finalization program/tracker, PR finalizer, required checks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Strong                                                                                                                                 |
 | Plugin/tool discipline       | `docs/plans/plugin-usage-playbook.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Strong                                                                                                                                 |
 | Incident procedure           | `docs/plans/2026-03-09-d06-incident-playbook-evidence.md`, `docs/INCIDENT_PLAYBOOK.md`, `docs/RUNBOOK.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Documented                                                                                                                             |
-| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Partial operational proof                                                                                                              |
+| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `docs/plans/ent-alert01-alert-routing-evidence-contract-2026-06-06.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                                                                                                                                                                                                                                                                                                                                                                                                                             | D07 contract-defined; exercise proof and broader auth/RLS/protected-route coverage pending                                             |
 | Sensitive route ownership    | `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Documented                                                                                                                             |
 | Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Governed checklist                                                                                                                     |
 | Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Bounded pilot evidence                                                                                                                 |
@@ -51,7 +51,7 @@ separate from the active architecture-finalization queue unless explicitly promo
 | Exercised incident readiness | Partial                                                                                                                                                                           | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery                                              |
 | Threat model                 | Evidence contract scoped; initial uploads, authenticated uploads, document access, share packs, AI review, Paddle webhooks, assisted registration, and admin verification modeled | Written per-surface model for registration, uploads, documents, share packs, AI review, billing, webhooks, and privileged verification details |
 | Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending                                                                                                | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                                                 |
-| Alert routing proof          | Partial                                                                                                                                                                           | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes                                            |
+| Alert routing proof          | D07 contract-defined; exercise proof and broader auth/RLS/protected-route coverage pending                                                                                        | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes                                            |
 | Data lifecycle verification  | Partial                                                                                                                                                                           | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                                                               |
 | Performance regression gate  | Not yet scoped                                                                                                                                                                    | Representative route/storage performance budgets that can block releases                                                                       |
 
@@ -87,36 +87,36 @@ Rationale:
 While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest repo-owned
 enterprise-hardening slice is:
 
-`ENT-TM09 Admin Verification Details Threat Model`
+`ENT-ALERT01 Alert Routing Evidence Contract`
 
 Scope:
 
-- Apply the `ENT-TM01` contract to the privileged admin verification details read route and query
-  only.
-- Model session authentication, tenant identity resolution, allowed verification roles, tenant and
-  branch query predicates, verification detail DTO data, document-link handoff to the document
-  custody route, timeline/audit provenance, STRIDE threats, residual risks, and verification
-  evidence.
+- Define the evidence required to prove that the existing D07 SLO alerts are present, owner-routed,
+  action-backed, and exercised without production impact.
+- Cover remote Sentry drift state, warning and critical action inventory, named owners or escalation
+  destinations, a no-production-impact exercise path, notification receipt, acknowledgement timing,
+  triage destination, pass/fail decision, and follow-up capture.
 - Promote exactly one next bounded follow-up:
-  `ENT-ALERT01 Alert Routing Evidence Contract`.
+  `ENT-ALERT02 D07 Alert Routing Exercise Record`.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
 Rationale:
 
-- The threat-model evidence contract is already defined by `ENT-TM01`; `ENT-TM02` through
-  `ENT-TM09` completed upload custody, document access, share-pack, AI review, Paddle webhook,
-  assisted-registration, and admin-verification-details surfaces.
-- Admin verification details are a distinct privileged read surface in the sensitive-route ownership
-  map because they expose payment verification case detail, lead PII, branch/agent context, document
-  links, and audit timeline metadata.
-- Alert-routing exercise proof is the next smallest repo-owned enterprise maturity lane after the
-  promoted threat-model surface because the restore drill remains blocked on provider or CLI restore
-  access and the register already records alert routing as partial.
+- The threat-model evidence lane now has a governed contract plus per-surface records through
+  `ENT-TM09`; the next smallest repo-owned enterprise lane is alert routing because Sentry D07
+  alert definitions already exist but routing and exercise proof remain partial.
+- A routing evidence contract can be completed entirely as repo-owned documentation without
+  production traffic, credential changes, Sentry mutation, runtime code, or architecture-tracker
+  disturbance.
+- The follow-up exercise record should use the existing `pnpm sentry:alerts:check` surface and
+  current Sentry project to prove owner routing or record the exact provider/destination blocker.
+- The broader enterprise alerting lane remains open after this contract until dedicated auth, RLS or
+  tenant-boundary, and protected-route failure-mode alert coverage is cataloged and exercised.
 
 Next enterprise maturity remains broader than this repo-owned slice. The highest-value remaining
 lanes are the blocked `ENT-OPS02` staging restore drill, the promoted
-`ENT-ALERT01 Alert Routing Evidence Contract`, data lifecycle verification, and performance
+`ENT-ALERT02 D07 Alert Routing Exercise Record`, data lifecycle verification, and performance
 regression gates.
 
 ## Non-Goals

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34286251,
-  "maxTrackedFiles": 3950,
+  "maxTrackedBytes": 34292586,
+  "maxTrackedFiles": 3951,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
     "tests/e2e": 4291944,
-    "docs/text": 4672981,
+    "docs/text": 4679316,
     "config/data/messages": 1534798,
     "other": 1048576
   }


### PR DESCRIPTION
## Summary
- Add `ENT-ALERT01 Alert Routing Evidence Contract` for the existing D07 SLO alert surface.
- Update the enterprise readiness register so alert routing is D07 contract-defined while exercise proof and broader auth/RLS/protected-route alert coverage remain pending.
- Update the repo-size budget to the exact staged tracked totals after the docs addition.

## Changed Areas
- `docs/plans/ent-alert01-alert-routing-evidence-contract-2026-06-06.md`
- `docs/plans/enterprise-readiness-register.md`
- `scripts/repo-size-budget.json`

## Verification
- `pnpm exec prettier --check docs/plans/ent-alert01-alert-routing-evidence-contract-2026-06-06.md docs/plans/enterprise-readiness-register.md scripts/repo-size-budget.json`
- `git diff --check` and `git diff --cached --check`
- `pnpm docs:verify`
- `pnpm plan:status`
- `pnpm plan:audit`
- `pnpm track:audit`
- `pnpm repo:size:check`
- `pnpm test:ci:contracts -- scripts/ci/repo-size-audit.test.mjs` (`180 passed`)
- Interdomestik QA MCP `scope_audit` passed for docs/register/budget-only paths.
- Interdomestik QA MCP `security_guard` passed.

## Reviewer And Security Disposition
- Sonnet architecture/scope review: no must-fix findings. It raised a non-blocking repo-size exactness question; the budget was remeasured after staging and corrected to the exact tracked totals.
- Gemini architecture/scope review: no must-fix findings.
- Codex Security diff-scan route: not exposed by tool search for this slice; repo security guard passed.
- Copilot/Sonar/CI: pending PR checks.

## Operational Notes
- This is a Tier 0 docs/register slice. It does not mutate Sentry, production telemetry, runtime code, schema, auth, tenancy, routing, billing, product UI, proxy, README, AGENTS, or broad architecture docs.
- The contract is deliberately D07-only and does not claim the broader enterprise alerting lane is complete. Auth, RLS or tenant-boundary, and protected-route alert coverage remain pending.

## Next Follow-Up
- `ENT-ALERT02 D07 Alert Routing Exercise Record`: execute the contract against the current Sentry project or record the exact provider/destination blocker.