### PR TITLE
fix: align d07 alert resolve thresholds

### DIFF
--- a/docs/plans/ent-alert03-d07-resolve-threshold-drift-disposition-2026-06-06.md
+++ b/docs/plans/ent-alert03-d07-resolve-threshold-drift-disposition-2026-06-06.md
@@ -1,0 +1,71 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: platform
+last_reviewed: 2026-06-06
+superseded_by:
+---
+
+# ENT-ALERT03 D07 Resolve-Threshold Drift Disposition - 2026-06-06
+
+> Status: Input document. This records the disposition for the D07 resolve-threshold drift found by
+> `ENT-ALERT02`. It does not mutate Sentry, production telemetry, runtime code, incident policy, or
+> claim full enterprise readiness.
+
+## Decision
+
+The remote D07 resolve-threshold values are accepted as intentional operating policy. The repo-owned
+Sentry catalog now models each D07 alert as resolving at its warning threshold instead of `null`.
+
+Rationale:
+
+- The remote values are consistent across all three D07 rules.
+- Each remote resolve threshold equals that rule's warning threshold.
+- Accepting the current remote policy avoids a write-scoped Sentry mutation from this repo thread.
+- A warning-threshold resolve policy is conservative for burn-rate and latency recovery because it
+  requires the metric to return below the warning line before Sentry resolves the alert.
+
+## Repo Update
+
+- `scripts/sentry-alerts-lib.mjs` now builds D07 metric-alert payloads with
+  `resolveThreshold = alert.thresholds.warning` at the rule and trigger levels.
+- `scripts/sentry-alerts.test.mjs` keeps focused diff coverage aligned with warning-threshold
+  resolution for read-only remote checks.
+
+## Verification
+
+Read-only remote check after the catalog update:
+
+```bash
+node scripts/run-with-dotenv.mjs pnpm sentry:alerts:check --json
+```
+
+Expected result:
+
+- mode: `remote-check`
+- project: `interdmestik-nextjs`
+- environment: `production`
+- missing: `0`
+- changed: `0`
+- unchanged D07 rules:
+  - `18664` `[D07] SLO1 Paddle webhook processing burn rate`
+  - `18665` `[D07] SLO2 Document download burn rate`
+  - `18666` `[D07] SLO3 Core API latency p95 (/api/claims)`
+
+## Safety
+
+- Sentry mutations performed: no
+- Production traffic changed or degraded: no
+- Secrets or credentials exposed in this record: no
+- Raw PII, claim narratives, document contents, or payment data exposed: no
+
+## Remaining Alert-Routing Gap
+
+This closes the resolve-threshold drift blocker only. Passing alert-routing proof still requires a
+separate no-production-impact notification exercise proving that at least one intended owner receives
+and acknowledges a routed D07 notification.
+
+Next bounded follow-up:
+
+`ENT-ALERT04 D07 Notification Acknowledgement Exercise`

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -31,7 +31,7 @@ enterprise-ready.
 | Repo governance              | `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, architecture-finalization program/tracker, PR finalizer, required checks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Strong                                                                                                                                 |
 | Plugin/tool discipline       | `docs/plans/plugin-usage-playbook.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Strong                                                                                                                                 |
 | Incident procedure           | `docs/plans/2026-03-09-d06-incident-playbook-evidence.md`, `docs/INCIDENT_PLAYBOOK.md`, `docs/RUNBOOK.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Documented                                                                                                                             |
-| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `docs/plans/ent-alert01-alert-routing-evidence-contract-2026-06-06.md`, `docs/plans/ent-alert02-d07-alert-routing-exercise-record-2026-06-06.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                                                                                                                                                                                                                                                                                                                                                   | D07 routing inventory recorded; drift and notification exercise proof pending                                                          |
+| Sentry alert foundation      | `docs/plans/2026-03-09-d07-sentry-burn-rate-alerts-evidence.md`, `docs/plans/ent-alert01-alert-routing-evidence-contract-2026-06-06.md`, `docs/plans/ent-alert02-d07-alert-routing-exercise-record-2026-06-06.md`, `docs/plans/ent-alert03-d07-resolve-threshold-drift-disposition-2026-06-06.md`, `pnpm sentry:alerts:check`, `pnpm sentry:seer:sweep:pre`, `pnpm sentry:seer:sweep:post`                                                                                                                                                                                                                                                                                                   | D07 drift disposition recorded; notification acknowledgement proof pending                                                             |
 | Sensitive route ownership    | `docs/reviews/2026-04-25-sensitive-route-ownership-map.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Documented                                                                                                                             |
 | Production go-live checklist | `docs/plans/2026-04-27-p22-go01-production-go-live-readiness.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Governed checklist                                                                                                                     |
 | Pilot operations evidence    | `docs/pilot/**` launch, daily, rollback, incident, KPI, and closeout records                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Bounded pilot evidence                                                                                                                 |
@@ -51,7 +51,7 @@ separate from the active architecture-finalization queue unless explicitly promo
 | Exercised incident readiness | Partial                                                                                                                                                                           | Quarterly drills for auth-secret rotation, Supabase failover, restore, and tenant-cookie recovery                                              |
 | Threat model                 | Evidence contract scoped; initial uploads, authenticated uploads, document access, share packs, AI review, Paddle webhooks, assisted registration, and admin verification modeled | Written per-surface model for registration, uploads, documents, share packs, AI review, billing, webhooks, and privileged verification details |
 | Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending                                                                                                | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                                                 |
-| Alert routing proof          | D07 inventory recorded; resolve-threshold drift blocks passing exercise proof; broader auth/RLS/protected-route coverage pending                                                  | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes                                            |
+| Alert routing proof          | D07 inventory and resolve-threshold disposition recorded; notification acknowledgement proof and broader auth/RLS/protected-route coverage pending                                | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes                                            |
 | Data lifecycle verification  | Partial                                                                                                                                                                           | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                                                               |
 | Performance regression gate  | Not yet scoped                                                                                                                                                                    | Representative route/storage performance budgets that can block releases                                                                       |
 
@@ -87,34 +87,32 @@ Rationale:
 While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest repo-owned
 enterprise-hardening slice is:
 
-`ENT-ALERT02 D07 Alert Routing Exercise Record`
+`ENT-ALERT03 D07 Resolve-Threshold Drift Disposition`
 
 Scope:
 
-- Record the first read-only D07 alert-routing exercise attempt against current Sentry state.
-- Prove all three D07 remote rule ids are present, owner-set, and action-backed with warning and
-  critical email team routes.
-- Record the blocking resolve-threshold drift and missing no-production-impact notification
-  acknowledgement proof.
+- Accept the current remote D07 resolve-threshold policy as intentional operating posture.
+- Align the repo-owned Sentry catalog and focused tests so read-only drift checks can return zero
+  changed rules without mutating Sentry.
+- Preserve the remaining no-production-impact notification acknowledgement gap.
 - Promote exactly one next bounded follow-up:
-  `ENT-ALERT03 D07 Resolve-Threshold Drift Disposition`.
+  `ENT-ALERT04 D07 Notification Acknowledgement Exercise`.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
 Rationale:
 
-- The `ENT-ALERT01` contract required a real attempt rather than assuming routing proof from rule
-  presence alone.
-- The read-only exercise found useful routing inventory, but the current Sentry rules are not green
-  against the checked-in catalog because remote resolve thresholds differ.
-- The next smallest alerting slice is to disposition that drift before attempting notification and
-  acknowledgement proof.
+- `ENT-ALERT02` proved useful D07 routing inventory but found resolve-threshold drift.
+- The remote resolve thresholds consistently equal the warning threshold, which is a conservative
+  accepted resolution policy.
+- The next smallest alerting slice is a no-production-impact routed notification acknowledgement
+  exercise.
 - The broader enterprise alerting lane remains open after this contract until dedicated auth, RLS or
   tenant-boundary, and protected-route failure-mode alert coverage is cataloged and exercised.
 
 Next enterprise maturity remains broader than this repo-owned slice. The highest-value remaining
 lanes are the blocked `ENT-OPS02` staging restore drill, the promoted
-`ENT-ALERT03 D07 Resolve-Threshold Drift Disposition`, data lifecycle verification, and performance
+`ENT-ALERT04 D07 Notification Acknowledgement Exercise`, data lifecycle verification, and performance
 regression gates.
 
 ## Non-Goals

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34296814,
-  "maxTrackedFiles": 3952,
+  "maxTrackedBytes": 34299209,
+  "maxTrackedFiles": 3954,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
-    "tests/e2e": 4291944,
-    "docs/text": 4683544,
+    "tests/e2e": 4291973,
+    "docs/text": 4685867,
     "config/data/messages": 1534798,
     "other": 1048576
   }

--- a/scripts/sentry-alerts-config.test.mjs
+++ b/scripts/sentry-alerts-config.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findMissingScopes, normalizeSentryBaseUrl } from './sentry-alerts-lib.mjs';
+
+test('findMissingScopes reports missing Sentry auth scopes for live apply', () => {
+  assert.deepEqual(findMissingScopes(['alerts:read', 'org:read'], ['alerts:read']), []);
+  assert.deepEqual(
+    findMissingScopes(['alerts:read', 'org:read'], ['alerts:read', 'alerts:write']),
+    ['alerts:write']
+  );
+});
+
+test('normalizeSentryBaseUrl trims trailing slashes without changing the origin', () => {
+  assert.equal(normalizeSentryBaseUrl(), 'https://sentry.io');
+  assert.equal(normalizeSentryBaseUrl(null), 'https://sentry.io');
+  assert.equal(normalizeSentryBaseUrl(''), 'https://sentry.io');
+  assert.equal(normalizeSentryBaseUrl('https://sentry.io////'), 'https://sentry.io');
+  assert.equal(
+    normalizeSentryBaseUrl('https://self-hosted.sentry.local/api/'),
+    'https://self-hosted.sentry.local/api'
+  );
+  assert.equal(normalizeSentryBaseUrl('https://sentry.io'), 'https://sentry.io');
+});

--- a/scripts/sentry-alerts-lib.mjs
+++ b/scripts/sentry-alerts-lib.mjs
@@ -139,7 +139,7 @@ export function buildMetricAlertPayload(alert, context) {
     queryType: alert.queryType,
     timeWindow: alert.timeWindow,
     thresholdType: alert.thresholdType,
-    resolveThreshold: null,
+    resolveThreshold: alert.thresholds.warning,
     environment: context.environment ?? null,
     projects: [context.project],
     ...(context.owner ? { owner: context.owner } : {}),
@@ -148,14 +148,14 @@ export function buildMetricAlertPayload(alert, context) {
         label: 'critical',
         thresholdType: alert.thresholdType,
         alertThreshold: alert.thresholds.critical,
-        resolveThreshold: null,
+        resolveThreshold: alert.thresholds.warning,
         actions: actionsByLabel.critical ?? [],
       },
       {
         label: 'warning',
         thresholdType: alert.thresholdType,
         alertThreshold: alert.thresholds.warning,
-        resolveThreshold: null,
+        resolveThreshold: alert.thresholds.warning,
         actions: actionsByLabel.warning ?? [],
       },
     ],
@@ -291,9 +291,13 @@ function validateAlertShape(alert, alertId, problems) {
     problems.push(`alert ${alertId} missing docsRefs`);
   }
 
-  validateAlertField(problems, alertId, 'unsupported dataset', SUPPORTED_DATASETS.has(alert.dataset), {
-    value: alert.dataset,
-  });
+  validateAlertField(
+    problems,
+    alertId,
+    'unsupported dataset',
+    SUPPORTED_DATASETS.has(alert.dataset),
+    alert.dataset
+  );
   validateAlertField(
     problems,
     alertId,
@@ -312,12 +316,7 @@ function validateAlertShape(alert, alertId, problems) {
     'missing query',
     typeof alert.query === 'string' && alert.query.length > 0
   );
-  validateAlertField(
-    problems,
-    alertId,
-    'missing timeWindow',
-    typeof alert.timeWindow === 'number'
-  );
+  validateAlertField(problems, alertId, 'missing timeWindow', typeof alert.timeWindow === 'number');
   validateAlertField(
     problems,
     alertId,
@@ -333,13 +332,13 @@ function validateAlertShape(alert, alertId, problems) {
   }
 }
 
-function validateAlertField(problems, alertId, label, valid, options = {}) {
+function validateAlertField(problems, alertId, label, valid, value = undefined) {
   if (valid) {
     return;
   }
 
   if (label === 'unsupported dataset') {
-    problems.push(`alert ${alertId} has unsupported dataset: ${options.value}`);
+    problems.push(`alert ${alertId} has unsupported dataset: ${value}`);
     return;
   }
 

--- a/scripts/sentry-alerts.test.mjs
+++ b/scripts/sentry-alerts.test.mjs
@@ -5,18 +5,25 @@ import {
   buildMetricAlertPayload,
   diffMetricAlertRules,
   D07_SENTRY_ALERTS,
-  findMissingScopes,
   normalizeMetricAlertRule,
-  normalizeSentryBaseUrl,
   parseAlertActionsJson,
   validateAlertCatalog,
 } from './sentry-alerts-lib.mjs';
 
+const OPS_EMAIL_ACTION = {
+  type: 'email',
+  targetType: 'specific',
+  targetIdentifier: 'ops@interdomestik.dev',
+};
+
 test('D07 alert catalog defines the three committed SLO alert surfaces', () => {
-  assert.deepEqual(
-    D07_SENTRY_ALERTS.map(alert => alert.id),
-    ['d07-slo1-webhook-burn-rate', 'd07-slo2-document-download-burn-rate', 'd07-slo3-api-claims-latency']
-  );
+  const ids = D07_SENTRY_ALERTS.map(alert => alert.id);
+
+  assert.deepEqual(ids, [
+    'd07-slo1-webhook-burn-rate',
+    'd07-slo2-document-download-burn-rate',
+    'd07-slo3-api-claims-latency',
+  ]);
 
   assert.equal(validateAlertCatalog(D07_SENTRY_ALERTS).length, 0);
   assert.equal(
@@ -32,8 +39,8 @@ test('webhook burn-rate alert payload is built from the checked-in D07 definitio
       project: 'web',
       environment: 'production',
       actionsByLabel: {
-        critical: [{ type: 'email', targetType: 'specific', targetIdentifier: 'ops@interdomestik.dev' }],
-        warning: [{ type: 'email', targetType: 'specific', targetIdentifier: 'ops@interdomestik.dev' }],
+        critical: [OPS_EMAIL_ACTION],
+        warning: [OPS_EMAIL_ACTION],
       },
     }
   );
@@ -57,12 +64,12 @@ test('webhook burn-rate alert payload is built from the checked-in D07 definitio
       {
         label: 'critical',
         alertThreshold: 0.025,
-        actions: [{ type: 'email', targetType: 'specific', targetIdentifier: 'ops@interdomestik.dev' }],
+        actions: [OPS_EMAIL_ACTION],
       },
       {
         label: 'warning',
         alertThreshold: 0.01,
-        actions: [{ type: 'email', targetType: 'specific', targetIdentifier: 'ops@interdomestik.dev' }],
+        actions: [OPS_EMAIL_ACTION],
       },
     ]
   );
@@ -79,7 +86,7 @@ test('diffMetricAlertRules reports missing and drifted D07 rules by exact name',
       query: 'slo_alert:d07.webhook.processing',
       aggregate: 'failure_rate()',
       thresholdType: 0,
-      resolveThreshold: null,
+      resolveThreshold: 0.01,
       timeWindow: 30,
       environment: 'production',
       projects: ['web'],
@@ -98,16 +105,21 @@ test('diffMetricAlertRules reports missing and drifted D07 rules by exact name',
     },
   });
 
-  assert.deepEqual(diff.missing.map(item => item.id), [
-    'd07-slo2-document-download-burn-rate',
-    'd07-slo3-api-claims-latency',
-  ]);
-  assert.deepEqual(diff.changed.map(item => item.desired.id), ['d07-slo1-webhook-burn-rate']);
+  assert.deepEqual(
+    diff.missing.map(item => item.id),
+    ['d07-slo2-document-download-burn-rate', 'd07-slo3-api-claims-latency']
+  );
+  assert.deepEqual(
+    diff.changed.map(item => item.desired.id),
+    ['d07-slo1-webhook-burn-rate']
+  );
 });
 
 test('parseAlertActionsJson accepts arrays of action objects and rejects other shapes', () => {
   assert.deepEqual(
-    parseAlertActionsJson('[{"type":"email","targetType":"specific","targetIdentifier":"ops@interdomestik.dev"}]'),
+    parseAlertActionsJson(
+      '[{"type":"email","targetType":"specific","targetIdentifier":"ops@interdomestik.dev"}]'
+    ),
     [{ type: 'email', targetType: 'specific', targetIdentifier: 'ops@interdomestik.dev' }]
   );
 
@@ -131,7 +143,7 @@ test('diffMetricAlertRules can ignore owner and action drift for read-only check
       query: 'slo_alert:d07.webhook.processing',
       aggregate: 'failure_rate()',
       thresholdType: 0,
-      resolveThreshold: null,
+      resolveThreshold: 0.01,
       timeWindow: 60,
       environment: 'production',
       projects: ['web'],
@@ -141,14 +153,14 @@ test('diffMetricAlertRules can ignore owner and action drift for read-only check
           label: 'critical',
           thresholdType: 0,
           alertThreshold: 0.025,
-          resolveThreshold: null,
+          resolveThreshold: 0.01,
           actions: [{ type: 'email', targetType: 'team', targetIdentifier: '123' }],
         },
         {
           label: 'warning',
           thresholdType: 0,
           alertThreshold: 0.01,
-          resolveThreshold: null,
+          resolveThreshold: 0.01,
           actions: [{ type: 'email', targetType: 'team', targetIdentifier: '123' }],
         },
       ],
@@ -170,17 +182,9 @@ test('diffMetricAlertRules can ignore owner and action drift for read-only check
 
   assert.deepEqual(diff.missing, []);
   assert.deepEqual(diff.changed, []);
-  assert.deepEqual(diff.unchanged.map(item => item.id), ['d07-slo1-webhook-burn-rate']);
-});
-
-test('findMissingScopes reports missing Sentry auth scopes for live apply', () => {
   assert.deepEqual(
-    findMissingScopes(['alerts:read', 'org:read'], ['alerts:read']),
-    []
-  );
-  assert.deepEqual(
-    findMissingScopes(['alerts:read', 'org:read'], ['alerts:read', 'alerts:write']),
-    ['alerts:write']
+    diff.unchanged.map(item => item.id),
+    ['d07-slo1-webhook-burn-rate']
   );
 });
 
@@ -216,7 +220,10 @@ test('normalizeMetricAlertRule sorts projects, triggers, and actions determinist
   });
 
   assert.deepEqual(normalized.projects, ['api', 'web']);
-  assert.deepEqual(normalized.triggers.map(trigger => trigger.label), ['critical', 'warning']);
+  assert.deepEqual(
+    normalized.triggers.map(trigger => trigger.label),
+    ['critical', 'warning']
+  );
   assert.deepEqual(normalized.triggers[0].actions, [
     {
       type: 'email',
@@ -227,13 +234,4 @@ test('normalizeMetricAlertRule sorts projects, triggers, and actions determinist
       sentryAppId: null,
     },
   ]);
-});
-
-test('normalizeSentryBaseUrl trims trailing slashes without changing the origin', () => {
-  assert.equal(normalizeSentryBaseUrl(), 'https://sentry.io');
-  assert.equal(normalizeSentryBaseUrl(null), 'https://sentry.io');
-  assert.equal(normalizeSentryBaseUrl(''), 'https://sentry.io');
-  assert.equal(normalizeSentryBaseUrl('https://sentry.io////'), 'https://sentry.io');
-  assert.equal(normalizeSentryBaseUrl('https://self-hosted.sentry.local/api/'), 'https://self-hosted.sentry.local/api');
-  assert.equal(normalizeSentryBaseUrl('https://sentry.io'), 'https://sentry.io');
 });


### PR DESCRIPTION
## Summary
- Accept the current remote D07 resolve-threshold posture as intentional: each D07 alert now resolves at its warning threshold in the repo-owned Sentry catalog payload.
- Record the ENT-ALERT03 drift disposition and keep full-enterprise readiness explicitly incomplete.
- Promote exactly one next bounded alerting follow-up: ENT-ALERT04 D07 Notification Acknowledgement Exercise.
- Update the repo-size budget with the exact measured tracked totals after adding the small disposition doc and split test file.

## Scope
- Changed only docs/plans, Sentry alert tooling/tests, and the measured repo-size budget.
- No runtime app code, proxy, canonical routes, auth, tenancy, schema, billing, product UI, README, AGENTS, or broad architecture docs changed.
- No Sentry mutations performed.

## Verification
- `node --test scripts/sentry-alerts.test.mjs scripts/sentry-alerts-config.test.mjs` — 8 passed.
- `node scripts/run-with-dotenv.mjs pnpm sentry:alerts:check --json` — remote-check, project `interdmestik-nextjs`, missing `[]`, changed `[]`, unchanged all three D07 rules (`18664`, `18665`, `18666`).
- `git diff --check` — passed.
- `pnpm docs:verify` — passed.
- `pnpm plan:status` — passed.
- `pnpm plan:audit` — passed.
- `pnpm track:audit` — passed.
- `pnpm repo:size:check` — passed after exact budget update.
- `pnpm test:ci:contracts` — 180 passed after exact budget update.
- `pnpm slice:verify` — passed, including static gates and web/domain unit suites before the budget amendment; post-amend touched only repo-size budget and reran size/contracts/security.
- MCP `interdomestik_qa.scope_audit` — passed; no forbidden Phase C paths changed.
- MCP `interdomestik_qa.security_guard` / `pnpm security:guard` — passed.

## Review Disposition
- Sonnet 4.6 staged-diff architecture/scope review: no must-fix findings. Low advisories deferred: future critical-only catalog assumption and broader per-SLO threshold fixture coverage.
- Gemini 3.1 Pro staged-diff architecture/scope review: no must-fix findings.
- Codex Security full artifact diff-scan: not run for this Tier 1 slice; repo/MCP security guard and CI contract security checks passed.

## Residual Risk
- This closes only the D07 resolve-threshold drift blocker. It does not prove notification receipt or acknowledgement.
- Broader enterprise alerting remains incomplete for auth, RLS/tenant-boundary, and protected-route failure-mode alert coverage.

## Rollback
- Revert this PR to restore the previous repo catalog expectation of null resolve thresholds and previous repo-size budget. No production state rollback is required because this PR performs no Sentry writes.
