### PR TITLE
docs: add data lifecycle evidence contract

### DIFF
--- a/docs/plans/ent-dlv01-data-lifecycle-verification-evidence-contract-2026-06-06.md
+++ b/docs/plans/ent-dlv01-data-lifecycle-verification-evidence-contract-2026-06-06.md
@@ -1,0 +1,141 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: platform
+last_reviewed: 2026-06-06
+superseded_by:
+---
+
+# ENT-DLV01 Data Lifecycle Verification Evidence Contract - 2026-06-06
+
+> Status: Input document. This contract defines the evidence required to prove data lifecycle
+> residue checks for deleted or deactivated users. It does not run cleanup, change deletion
+> behavior, change retention policy, or claim full enterprise readiness.
+
+## Purpose
+
+Move the data-lifecycle enterprise-readiness lane from partial evidence to an operator-executable
+proof contract. A future record can use this template to show whether a deleted or deactivated user
+leaves tenant-scoped database rows or storage objects behind in an isolated, production-safe
+environment.
+
+## Current Repo Evidence
+
+Existing repo evidence identifies the gap but does not close it:
+
+- `docs/reviews/2026-04-25-production-professionalism-rereview.md` records data lifecycle
+  automation as partial and says periodic verification that deleted users leave no tenant-scoped
+  rows or storage objects is not yet a gate.
+- `docs/reviews/2026-04-25-sensitive-route-ownership-map.md` names upload, document, notification,
+  and privileged verification surfaces where user-bound data is created or read.
+- Existing repo gates prove delivery discipline and service-role storage centralization, but they do
+  not periodically exercise deletion or deactivation residue checks.
+- The enterprise readiness register still lists data lifecycle verification as an open maturity
+  lane.
+
+## Scope
+
+This contract covers non-production lifecycle proof for one fixture user and its tenant-scoped data
+footprint.
+
+In scope:
+
+- Fixture tenant id, fixture user id, and fixture user role.
+- Pre-lifecycle inventory of tenant-scoped database rows that reference the fixture user directly.
+- Pre-lifecycle inventory of storage prefixes or object keys owned by the fixture user.
+- The lifecycle action used for proof: delete, deactivation, anonymization, or provider-side user
+  removal.
+- Post-lifecycle residue checks for database rows and storage objects.
+- Allowed residual rows, if any, with retention/legal basis and owner sign-off.
+- Pass/fail decision and follow-up issue capture.
+
+Out of scope:
+
+- Production deletion, production cleanup, or production storage object removal.
+- New runtime deletion behavior, retention automation, schema changes, RLS changes, auth changes,
+  tenancy changes, routing changes, billing changes, product UI changes, proxy edits, README,
+  AGENTS, or broad architecture docs.
+- Raw PII, claim narratives, document contents, payment data, or storage object contents in evidence.
+
+## Evidence Template
+
+Copy this section into a dated verification record when a real non-production proof is executed.
+
+```md
+# Data Lifecycle Verification Record - YYYY-MM-DD
+
+## Identity
+
+- Verification id:
+- Environment:
+- Fixture tenant id:
+- Fixture user id:
+- Fixture user role:
+- Lifecycle action:
+- Executed by:
+- Decision owner:
+
+## Pre-Lifecycle Inventory
+
+| Surface | Query or provider command | Expected fixture rows or objects | Sensitive output stored? |
+| ------- | ------------------------- | -------------------------------- | ------------------------ |
+|         |                           |                                  | no                       |
+
+## Lifecycle Action
+
+- Action command or operator step:
+- Production data affected: no
+- Storage objects intentionally removed: yes/no
+- Database rows intentionally removed: yes/no
+- Provider user removed or deactivated: yes/no
+
+## Post-Lifecycle Residue Checks
+
+| Surface | Query or provider command | Residue count | Allowed residual basis | Owner |
+| ------- | ------------------------- | ------------- | ---------------------- | ----- |
+|         |                           |               |                        |       |
+
+## Safety
+
+- Production data was not changed: yes/no
+- Restore or rollback path identified: yes/no
+- Secrets or credentials exposed in this record: no
+- Raw PII, claim narratives, document contents, payment data, or object contents exposed: no
+
+## Result
+
+- Decision: pass/fail
+- Blocking findings:
+- Non-blocking findings:
+- Follow-up issue or PR:
+- Owner sign-off:
+```
+
+## Acceptance Criteria
+
+A data-lifecycle verification record satisfies this contract only when:
+
+- the proof runs against an isolated non-production environment or fixture tenant;
+- the fixture tenant id, user id, role, lifecycle action, executor, and decision owner are recorded;
+- pre-lifecycle inventory covers both database rows and storage prefixes or object keys that can
+  reference the fixture user;
+- post-lifecycle checks rerun the same inventory surfaces after the lifecycle action;
+- every remaining row or object has an explicit allowed residual basis, retention owner, and
+  follow-up decision;
+- the record stores counts, redacted paths, hashes, or command metadata rather than secrets, raw
+  PII, claim narratives, document contents, payment data, or object contents;
+- a named owner records pass/fail; and
+- every blocker has a follow-up issue, PR, or explicit risk owner.
+
+This contract does not by itself prove the full data lifecycle lane. It only defines the evidence
+required for the first safe verification record.
+
+## Recommended Next Proof
+
+The next repo-owned enterprise slice should create
+`ENT-DLV02 Data Lifecycle Surface Inventory And Probe Record` by enumerating the current user-bound
+database and storage surfaces from repo evidence, then either running a non-production fixture probe
+or recording the exact environment or provider-access blocker. That follow-up must not run
+production cleanup, change runtime deletion behavior, or edit auth, tenancy, routing, billing,
+product UI, proxy, README, AGENTS, schema, RLS, or broad architecture docs.

--- a/docs/plans/enterprise-readiness-register.md
+++ b/docs/plans/enterprise-readiness-register.md
@@ -39,6 +39,7 @@ enterprise-ready.
 | Restore drill contract       | `docs/plans/ent-ops01-backup-restore-drill-evidence-contract.md`; `docs/plans/ent-ops02-first-staging-restore-drill-record-2026-06-05.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Blocker recorded                                                                                                                       |
 | Supply-chain attestation     | `docs/plans/ent-sca01-supply-chain-attestation-evidence-contract.md`; `docs/plans/ent-sca02-supply-chain-attestation-ci-proof-2026-06-05.md`; `docs/plans/ent-sca03-deploy-digest-verification-boundary-2026-06-05.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Deploy-boundary proof configured                                                                                                       |
 | Threat-model evidence        | `docs/plans/ent-tm01-threat-model-evidence-contract-2026-06-05.md`; `docs/plans/ent-tm02-initial-claim-uploads-threat-model-2026-06-05.md`; `docs/plans/ent-tm03-authenticated-claim-evidence-uploads-threat-model-2026-06-06.md`; `docs/plans/ent-tm04-document-signed-urls-and-downloads-threat-model-2026-06-06.md`; `docs/plans/ent-tm05-share-packs-threat-model-2026-06-06.md`; `docs/plans/ent-tm06-ai-run-read-and-review-threat-model-2026-06-06.md`; `docs/plans/ent-tm07-paddle-billing-webhooks-threat-model-2026-06-06.md`; `docs/plans/ent-tm08-assisted-registration-threat-model-2026-06-06.md`; `docs/plans/ent-tm09-admin-verification-details-threat-model-2026-06-06.md` | Upload, document-access, share-pack, AI review, Paddle webhook, assisted-registration, and admin-verification details surfaces modeled |
+| Data lifecycle evidence      | `docs/plans/ent-dlv01-data-lifecycle-verification-evidence-contract-2026-06-06.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Evidence contract scoped; first non-production proof pending                                                                           |
 
 ## Open Enterprise Maturity Lanes
 
@@ -52,7 +53,7 @@ separate from the active architecture-finalization queue unless explicitly promo
 | Threat model                 | Evidence contract scoped; initial uploads, authenticated uploads, document access, share packs, AI review, Paddle webhooks, assisted registration, and admin verification modeled                       | Written per-surface model for registration, uploads, documents, share packs, AI review, billing, webhooks, and privileged verification details |
 | Supply-chain attestation     | Deploy-boundary digest confirmation configured; real provider run evidence pending                                                                                                                      | Release provenance, SBOM, artifact signing, and deployed-artifact verification                                                                 |
 | Alert routing proof          | D07 inventory, resolve-threshold disposition, drift-free notification exercise, and provider-proof attempt recorded; routed acknowledgement proof and broader auth/RLS/protected-route coverage pending | SLO alerts applied, routed, and exercised for auth, RLS, webhook, and protected-route failure modes                                            |
-| Data lifecycle verification  | Partial                                                                                                                                                                                                 | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                                                               |
+| Data lifecycle verification  | Evidence contract scoped; first non-production surface inventory and fixture proof pending                                                                                                              | Periodic proof that deleted users leave no tenant-scoped rows or storage objects                                                               |
 | Performance regression gate  | Not yet scoped                                                                                                                                                                                          | Representative route/storage performance budgets that can block releases                                                                       |
 
 ## Next Bounded Operational Slice
@@ -87,35 +88,34 @@ Rationale:
 While `ENT-OPS02` remains blocked on provider or CLI restore access, the latest repo-owned
 enterprise-hardening slice is:
 
-`ENT-ALERT05 D07 Provider-Supported Notification Proof`
+`ENT-DLV01 Data Lifecycle Verification Evidence Contract`
 
 Scope:
 
-- Re-run the D07 read-only drift check after the `ENT-ALERT04` blocked exercise.
-- Search available Sentry, Gmail, and Notion-connected operational evidence for a D07 routed
-  notification or acknowledgement.
-- Record that the routed acknowledgement proof still requires operator-provided evidence instead of
-  claiming a provider proof from configuration-only evidence.
+- Define the evidence required to prove deleted or deactivated users leave no tenant-scoped database
+  rows or storage objects in an isolated, production-safe environment.
+- Require pre-lifecycle and post-lifecycle database and storage inventory, allowed residual basis,
+  owner sign-off, and explicit blocker capture.
+- Keep production cleanup, runtime deletion changes, retention automation, schema changes, and
+  storage-object contents out of scope.
 - Promote exactly one next bounded follow-up:
-  `ENT-DLV01 Data Lifecycle Verification Evidence Contract`.
+  `ENT-DLV02 Data Lifecycle Surface Inventory And Probe Record`.
 - Do not change runtime code, schema, auth, tenancy, routing, billing, product UI, proxy,
   README, AGENTS, or broad architecture docs.
 
 Rationale:
 
-- `ENT-ALERT04` confirmed the clean D07 drift state but could not prove routed receipt or
-  acknowledgement.
-- `ENT-ALERT05` found no existing D07 issue, incident, Gmail, or Notion-connected acknowledgement
-  evidence and no callable safe provider notification trigger in this repo thread.
-- The D07 routed acknowledgement proof remains an operator-evidence gap with platform as risk
-  owner.
-- The next smallest repo-owned enterprise slice that can progress without external operator access
-  is a data lifecycle verification evidence contract.
+- `docs/reviews/2026-04-25-production-professionalism-rereview.md` records data lifecycle
+  automation as partial and says periodic verification for deleted-user database rows and storage
+  objects is not yet a gate.
+- `ENT-DLV01` scopes that proof without touching production data or changing lifecycle behavior.
+- The next smallest repo-owned enterprise slice is the first surface inventory and non-production
+  probe record, or an honest environment/provider-access blocker if the probe cannot safely run.
 
 Next enterprise maturity remains broader than this repo-owned slice. The highest-value remaining
 lanes are the blocked `ENT-OPS02` staging restore drill, the operator-blocked D07 notification
-acknowledgement proof, the promoted `ENT-DLV01 Data Lifecycle Verification Evidence Contract`, and performance
-regression gates.
+acknowledgement proof, the promoted
+`ENT-DLV02 Data Lifecycle Surface Inventory And Probe Record`, and performance regression gates.
 
 ## Non-Goals
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34310205,
-  "maxTrackedFiles": 3956,
+  "maxTrackedBytes": 34316929,
+  "maxTrackedFiles": 3957,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
     "source/scripts": 6453611,
     "tests/e2e": 4291973,
-    "docs/text": 4696863,
+    "docs/text": 4703587,
     "config/data/messages": 1534798,
     "other": 1048576
   }


### PR DESCRIPTION
## Summary
- add `ENT-DLV01 Data Lifecycle Verification Evidence Contract`
- scope the deleted/deactivated-user residue proof for isolated non-production database and storage checks
- update the enterprise readiness register so data lifecycle is evidence-contract scoped but first proof remains pending
- promote exactly one next repo-owned follow-up: `ENT-DLV02 Data Lifecycle Surface Inventory And Probe Record`
- update the repo-size budget to the exact measured committed-tree totals

## Verification
- `git diff --cached --check`
- `pnpm exec prettier --check docs/plans/ent-dlv01-data-lifecycle-verification-evidence-contract-2026-06-06.md docs/plans/enterprise-readiness-register.md scripts/repo-size-budget.json`
- `pnpm docs:verify`
- `pnpm plan:status`
- `pnpm plan:audit`
- `pnpm track:audit`
- `pnpm repo:size:check`
- `node --test scripts/ci/repo-size-audit.test.mjs`
- `pnpm security:guard`
- Interdomestik QA MCP `scope_audit`: pass
- Interdomestik QA MCP `security_guard`: pass

## Reviewer Disposition
- Sonnet architecture/scope review: ran; no must-fix findings
- Gemini advisory review: ran; no must-fix findings
- Copilot/Sonar/CI/pr-finalizer: pending PR
- Codex Security: local `pnpm security:guard` plus Interdomestik QA MCP `security_guard` passed

## Residual Risk
- This PR defines the data-lifecycle verification contract only. It does not prove deleted/deactivated-user cleanup, run production cleanup, change deletion behavior, change retention automation, or claim full enterprise readiness. The first proof remains pending in `ENT-DLV02`.