### PR TITLE
fix: harden sentinel runner node path

### DIFF
--- a/scripts/ci/sentinel-agent-contract.test.mjs
+++ b/scripts/ci/sentinel-agent-contract.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SENTINEL_AGENT = path.join(REPO_ROOT, 'scripts/multi-agent/sentinel-agent.sh');
+
+test('sentinel agent preserves caller Node PATH for nested commands', () => {
+  const source = fs.readFileSync(SENTINEL_AGENT, 'utf8');
+
+  assert.match(source, /PATH_WITH_NODE="\$PATH"/);
+  assert.match(source, /env PATH="\$PATH_WITH_NODE" bash -c "cd '\$ROOT_DIR' && \$command"/);
+  assert.doesNotMatch(source, /run_redacted "\$log_file" bash -lc/);
+  assert.match(source, /ACTIVE_NODE_VERSION=/);
+  assert.ok(
+    source.includes('echo "- node: \\`${ACTIVE_NODE_VERSION} (${ACTIVE_NODE_BIN:-unknown})\\`"')
+  );
+});

--- a/scripts/multi-agent/sentinel-agent.sh
+++ b/scripts/multi-agent/sentinel-agent.sh
@@ -7,6 +7,11 @@ source "$ROOT_DIR/scripts/multi-agent/pr-hardening-common.sh"
 RUN_ROOT=""
 ROLE="sentinel"
 FIRST_FAILING_COMMAND="none"
+PATH_WITH_NODE="$PATH"
+
+if [[ -n "${NVM_BIN:-}" && -d "${NVM_BIN:-}" ]]; then
+  PATH_WITH_NODE="${NVM_BIN}:$PATH_WITH_NODE"
+fi
 
 usage() {
   cat <<'USAGE'
@@ -45,7 +50,7 @@ run_cmd() {
   local command="$1"
   local log_file="$2"
   set +e
-  run_redacted "$log_file" bash -lc "cd '$ROOT_DIR' && $command"
+  run_redacted "$log_file" env PATH="$PATH_WITH_NODE" bash -c "cd '$ROOT_DIR' && $command"
   local status=$?
   set -e
   if [[ "$status" -ne 0 && "$FIRST_FAILING_COMMAND" == "none" ]]; then
@@ -57,7 +62,7 @@ run_cmd() {
 run_cmd 'pnpm security:guard' "$EVIDENCE_DIR/security-guard.log" || true
 
 set +e
-run_redacted "$EVIDENCE_DIR/sensitive-path-scan.txt" bash -lc \
+run_redacted "$EVIDENCE_DIR/sensitive-path-scan.txt" env PATH="$PATH_WITH_NODE" bash -c \
   "cd '$ROOT_DIR' && git diff --name-only '$BASE_COMMIT'...HEAD | rg -n 'apps/web/src/proxy.ts|apps/web/src/.*(auth|tenant|proxy)|packages/.*/(auth|tenant)' || true"
 SCAN_STATUS=$?
 set -e
@@ -89,10 +94,14 @@ if [[ "$FIRST_FAILING_COMMAND" != "none" || "$SECRET_HITS" -gt 0 ]]; then
   STATUS="FAIL"
 fi
 
+ACTIVE_NODE_BIN="$(PATH="$PATH_WITH_NODE" command -v node || true)"
+ACTIVE_NODE_VERSION="$(PATH="$PATH_WITH_NODE" node -v 2>/dev/null || printf 'unknown')"
+
 {
   echo "# Sentinel Summary"
   echo
   echo "- status: \`$STATUS\`"
+  echo "- node: \`${ACTIVE_NODE_VERSION} (${ACTIVE_NODE_BIN:-unknown})\`"
   echo "- first_failing_command: \`$FIRST_FAILING_COMMAND\`"
   echo "- secret_hits: \`$SECRET_HITS\`"
   if [[ "$SECRET_HITS" -gt 0 ]]; then

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34442174,
-  "maxTrackedFiles": 3975,
+  "maxTrackedBytes": 34443446,
+  "maxTrackedFiles": 3976,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17204870,
-    "source/scripts": 6465725,
-    "tests/e2e": 4301123,
+    "source/scripts": 6466135,
+    "tests/e2e": 4301985,
     "docs/text": 4807193,
     "config/data/messages": 1535030,
     "other": 1048576


### PR DESCRIPTION
## Summary

- Preserve the caller Node/PATH environment when Sentinel runs nested commands.
- Prefer `NVM_BIN` when present so the repo-required Node 24 toolchain is retained inside Sentinel checks.
- Add a CI contract test covering the runner executor contract and summary diagnostics.
- Update repo-size budget to the exact measured delta for the new test and script change.

## Why

Sentinel was already installed in this repo, but a direct runner invocation could fail because `bash -lc` selected `/usr/local/bin/node` (`v22.14.0`) instead of the repo Node 24 toolchain. This made `pnpm security:guard` fail before Sentinel could provide useful evidence.

## Scope

Changed only:

- `scripts/multi-agent/sentinel-agent.sh`
- `scripts/ci/sentinel-agent-contract.test.mjs`
- `scripts/repo-size-budget.json`

No runtime, proxy, auth, tenancy, routing, schema, UI, README, AGENTS, or architecture-plan changes.

## Verification

- `git diff --check`
- `pnpm exec prettier --check scripts/ci/sentinel-agent-contract.test.mjs scripts/repo-size-budget.json`
- `bash -n scripts/multi-agent/sentinel-agent.sh`
- `node --test scripts/ci/sentinel-agent-contract.test.mjs`
- `pnpm repo:size:check`
- `pnpm test:ci:contracts` (`188 passed`)
- `pnpm security:guard`
- Repo MCP scope audit: pass for allowed paths only
- Direct Sentinel run: `SENTINEL_STATUS: PASS`
  - Node: `v24.15.0 (/Users/arbenlila/.nvm/versions/node/v24.15.0/bin/node)`
  - `first_failing_command: none`
  - `secret_hits: 0`
- Sonnet architecture/scope review: `PASS`, no must-fix findings

## Rollback

Revert this commit to restore the prior Sentinel executor behavior and budget values.
