### PR TITLE
test: align ci contract script assertion

### DIFF
--- a/scripts/package-e2e-scripts.test.mjs
+++ b/scripts/package-e2e-scripts.test.mjs
@@ -72,7 +72,7 @@ test('web package exposes full and PR gate lanes separately', () => {
 });
 
 test('root package exposes the scripts/ci contract suite', () => {
-  assert.equal(packageJson.scripts['test:ci:contracts'], 'node --test scripts/ci/*.test.mjs');
+  assert.equal(packageJson.scripts['test:ci:contracts'], 'node --test scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs');
 });
 
 test('pilot readiness commands keep local verification and production proof distinct', () => {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34528573,
+  "maxTrackedBytes": 34528625,
   "maxTrackedFiles": 3993,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17205317,
     "source/scripts": 6485202,
-    "tests/e2e": 4316335,
+    "tests/e2e": 4316387,
     "docs/text": 4858066,
     "config/data/messages": 1535188,
     "other": 1048576


### PR DESCRIPTION
## Summary

- Align the package script contract test with the current `test:ci:contracts` command, which now includes `scripts/check-modularity-guard.test.mjs`.
- Update the repo-size budget to the exact measured tracked-byte delta from the test assertion change.

## Scope

- Scripts/test-contract only.
- No runtime, product UI, proxy, auth, tenancy, routing, billing, schema, or migration changes.
- Remote Supabase DDL was not applied in this slice.

## Verification

- `node --test scripts/package-e2e-scripts.test.mjs` -> 9 passed
- `pnpm test:ci:contracts` -> 188 passed
- `pnpm repo:size:check` -> passed
- `pnpm security:guard` -> passed
- `git diff --check` -> passed
- `interdomestik_qa.scope_audit` -> pass for `scripts/`, forbidden paths clean

## Review / Residual Risk

- Sonnet CLI review route was attempted for the bounded diff, but the CLI hung without output and was terminated. No secrets were sent; only the local diff was piped.
- `pnpm format:check` was attempted and still reports pre-existing formatting warnings in unrelated docs and `scripts/pilot-readiness-cadence.ts`; the touched files were not listed.
- Heavy local E2E was not run because this is a scripts/test-contract and repo-size budget fix with no runtime surface.
