### PR TITLE
fix: remove legacy storage policies

### DIFF
--- a/scripts/ci/storage-tenant-prefix-migration.test.mjs
+++ b/scripts/ci/storage-tenant-prefix-migration.test.mjs
@@ -10,6 +10,11 @@ const migrationPath = path.join(
   'supabase/migrations/00009_storage_tenant_prefix_backstop.sql'
 );
 const sql = fs.readFileSync(migrationPath, 'utf8');
+const cleanupMigrationPath = path.join(
+  repoRoot,
+  'supabase/migrations/20260607055009_storage_legacy_policy_cleanup.sql'
+);
+const cleanupSql = fs.readFileSync(cleanupMigrationPath, 'utf8');
 
 test('SEC06 migration has a legacy-object preflight', () => {
   assert.match(sql, /SEC06 storage preflight failed/);
@@ -43,4 +48,12 @@ test('SEC06 migration replaces legacy policies with tenant-prefix folder policie
   );
   assert.match(sql, /\(storage\.foldername\(name\)\)\[4\] = 'claims'/);
   assert.match(sql, /\(storage\.foldername\(name\)\)\[4\] = 'policies'/);
+});
+
+test('SEC06 cleanup migration removes legacy live storage policy names', () => {
+  assert.match(cleanupSql, /DROP POLICY IF EXISTS "Members can read own evidence objects"/);
+  assert.match(cleanupSql, /DROP POLICY IF EXISTS "Members can read own policy objects"/);
+  assert.match(cleanupSql, /DROP POLICY IF EXISTS "Members can read own voice note objects"/);
+  assert.match(cleanupSql, /DROP POLICY IF EXISTS "Members can insert own voice note objects"/);
+  assert.match(cleanupSql, /DROP POLICY IF EXISTS "Members can delete own voice note objects"/);
 });

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34528625,
-  "maxTrackedFiles": 3993,
+  "maxTrackedBytes": 34530098,
+  "maxTrackedFiles": 3994,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17205317,
     "source/scripts": 6485202,
-    "tests/e2e": 4316387,
+    "tests/e2e": 4317128,
     "docs/text": 4858066,
-    "config/data/messages": 1535188,
+    "config/data/messages": 1535264,
     "other": 1048576
   }
 }

--- a/supabase/migrations/20260607055009_storage_legacy_policy_cleanup.sql
+++ b/supabase/migrations/20260607055009_storage_legacy_policy_cleanup.sql
@@ -1,0 +1,9 @@
+-- ENT storage hardening: remove legacy user-prefix storage policies left behind by
+-- 00009 because the live project used read and voice note object policy names
+-- that differed from the legacy names covered by the original migration.
+
+DROP POLICY IF EXISTS "Members can read own evidence objects" ON storage.objects;
+DROP POLICY IF EXISTS "Members can read own policy objects" ON storage.objects;
+DROP POLICY IF EXISTS "Members can read own voice note objects" ON storage.objects;
+DROP POLICY IF EXISTS "Members can insert own voice note objects" ON storage.objects;
+DROP POLICY IF EXISTS "Members can delete own voice note objects" ON storage.objects;


### PR DESCRIPTION
## Summary
- Add a Supabase migration that drops legacy storage policies left behind after the tenant-prefix storage backstop was applied remotely.
- Extend the SEC06 storage migration contract test to pin the live legacy policy names observed in Supabase.
- Update the repo-size budget to the exact measured tracked inventory.

## Evidence
- Remote Supabase migration 00009 applied successfully with legacy storage object counts at 0.
- Post-apply read-only policy inspection showed tenant-prefix policies plus leftover legacy read/voice-note policies.
- Supabase dry-run now shows only 20260607055009_storage_legacy_policy_cleanup.sql pending.

## Verification
- node --test scripts/ci/storage-tenant-prefix-migration.test.mjs
- pnpm test:ci:contracts
- pnpm repo:size:check
- pnpm security:guard
- git diff --check origin/main...HEAD
- interdomestik_qa scope audit: no proxy/README/AGENTS changes

## Scope
No runtime UI, proxy, canonical route, auth, tenancy routing, billing, README, or AGENTS changes.