### PR TITLE
ENT-DB04: Optimize tenant RLS initPlan policies

### DIFF
--- a/packages/database/drizzle/0075_optimize_tenant_rls_initplan.sql
+++ b/packages/database/drizzle/0075_optimize_tenant_rls_initplan.sql
@@ -1,0 +1,90 @@
+-- Wrap the tenant-context setting lookup so Postgres can treat it as an initPlan
+-- for the live repo-owned tenant-isolation policies flagged by Supabase.
+DO $$
+DECLARE
+  using_only_tables constant text[] := ARRAY[
+    'agent_clients',
+    'agent_commissions',
+    'audit_log',
+    'claim',
+    'claim_documents',
+    'claim_escalation_agreements',
+    'claim_messages',
+    'claim_stage_history',
+    'crm_activities',
+    'crm_deals',
+    'crm_leads',
+    'member_activities',
+    'member_notes',
+    'notifications',
+    'subscriptions'
+  ];
+  with_check_tables constant text[] := ARRAY[
+    'agent_settings',
+    'ai_runs',
+    'automation_logs',
+    'billing_invoices',
+    'billing_ledger_entries',
+    'branches',
+    'claim_counters',
+    'claim_threads',
+    'claim_tracking_tokens',
+    'commercial_action_idempotency',
+    'document_access_log',
+    'document_extractions',
+    'documents',
+    'email_campaign_logs',
+    'engagement_email_sends',
+    'lead_downloads',
+    'lead_payment_attempts',
+    'leads',
+    'member_leads',
+    'member_referral_rewards',
+    'member_referral_settings',
+    'membership_cards',
+    'membership_family_members',
+    'membership_plans',
+    'nps_survey_responses',
+    'nps_survey_tokens',
+    'partner_discount_usage',
+    'policies',
+    'push_subscriptions',
+    'referrals',
+    'service_requests',
+    'service_usage',
+    'share_packs',
+    'tenant_settings',
+    'user',
+    'user_notification_preferences',
+    'user_roles',
+    'webhook_events'
+  ];
+  target_table text;
+  target_policy text;
+  target_expr constant text :=
+    'tenant_id = (select current_setting(''app.current_tenant_id'', true))::text';
+BEGIN
+  FOREACH target_table IN ARRAY using_only_tables
+  LOOP
+    target_policy := format('tenant_isolation_%s', target_table);
+    EXECUTE format(
+      'ALTER POLICY %I ON public.%I USING (%s)',
+      target_policy,
+      target_table,
+      target_expr
+    );
+  END LOOP;
+
+  FOREACH target_table IN ARRAY with_check_tables
+  LOOP
+    target_policy := format('tenant_isolation_%s', target_table);
+    EXECUTE format(
+      'ALTER POLICY %I ON public.%I USING (%s) WITH CHECK (%s)',
+      target_policy,
+      target_table,
+      target_expr,
+      target_expr
+    );
+  END LOOP;
+END;
+$$;

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1780837200000,
       "tag": "0074_drop_duplicate_legacy_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1780868100000,
+      "tag": "0075_optimize_tenant_rls_initplan",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/test/rls-initplan-migration.test.ts
+++ b/packages/database/test/rls-initplan-migration.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const MIGRATION_PATH = fileURLToPath(
+  new URL('../drizzle/0075_optimize_tenant_rls_initplan.sql', import.meta.url)
+);
+const TARGET_EXPR = "tenant_id = (select current_setting(''app.current_tenant_id'', true))::text";
+
+const USING_ONLY_TABLES = [
+  'agent_clients',
+  'agent_commissions',
+  'audit_log',
+  'claim',
+  'claim_documents',
+  'claim_escalation_agreements',
+  'claim_messages',
+  'claim_stage_history',
+  'crm_activities',
+  'crm_deals',
+  'crm_leads',
+  'member_activities',
+  'member_notes',
+  'notifications',
+  'subscriptions',
+] as const;
+
+const WITH_CHECK_TABLES = [
+  'agent_settings',
+  'ai_runs',
+  'automation_logs',
+  'billing_invoices',
+  'billing_ledger_entries',
+  'branches',
+  'claim_counters',
+  'claim_threads',
+  'claim_tracking_tokens',
+  'commercial_action_idempotency',
+  'document_access_log',
+  'document_extractions',
+  'documents',
+  'email_campaign_logs',
+  'engagement_email_sends',
+  'lead_downloads',
+  'lead_payment_attempts',
+  'leads',
+  'member_leads',
+  'member_referral_rewards',
+  'member_referral_settings',
+  'membership_cards',
+  'membership_family_members',
+  'membership_plans',
+  'nps_survey_responses',
+  'nps_survey_tokens',
+  'partner_discount_usage',
+  'policies',
+  'push_subscriptions',
+  'referrals',
+  'service_requests',
+  'service_usage',
+  'share_packs',
+  'tenant_settings',
+  'user',
+  'user_notification_preferences',
+  'user_roles',
+  'webhook_events',
+] as const;
+
+function migrationSql(): string {
+  return readFileSync(MIGRATION_PATH, 'utf8');
+}
+
+function extractArray(sql: string, name: string): string[] {
+  const startMarker = `${name} constant text[] := ARRAY[`;
+  const start = sql.indexOf(startMarker);
+  assert.notEqual(start, -1, `Missing ${name} declaration`);
+  const bodyStart = start + startMarker.length;
+  const bodyEnd = sql.indexOf('];', bodyStart);
+  assert.notEqual(bodyEnd, -1, `Missing ${name} terminator`);
+  return [...sql.slice(bodyStart, bodyEnd).matchAll(/'([^']+)'/g)].map(([, value]) => value);
+}
+
+const comparePolicyTargets = (left: string, right: string): number => left.localeCompare(right);
+
+test('ENT-DB04 migration targets exactly the 53 scoped tenant-isolation policies', () => {
+  const sql = migrationSql();
+  const usingOnly = extractArray(sql, 'using_only_tables');
+  const withCheck = extractArray(sql, 'with_check_tables');
+  const allTargets = [...usingOnly, ...withCheck].sort(comparePolicyTargets);
+  const expectedTargets = [...USING_ONLY_TABLES, ...WITH_CHECK_TABLES].sort(comparePolicyTargets);
+
+  assert.deepEqual(usingOnly, USING_ONLY_TABLES);
+  assert.deepEqual(withCheck, WITH_CHECK_TABLES);
+  assert.equal(usingOnly.length, 15);
+  assert.equal(withCheck.length, 38);
+  assert.equal(new Set(allTargets).size, 53);
+  assert.deepEqual(allTargets, expectedTargets);
+});
+
+test('ENT-DB04 migration preserves policy shape and uses the initPlan expression', () => {
+  const sql = migrationSql();
+
+  assert.match(sql, /ALTER POLICY %I ON public\.%I USING \(%s\)'/);
+  assert.match(sql, /ALTER POLICY %I ON public\.%I USING \(%s\) WITH CHECK \(%s\)'/);
+  assert.match(sql, /target_policy := format\('tenant_isolation_%s', target_table\)/);
+  assert.match(sql, /target_expr constant text :=/);
+  assert.ok(sql.includes(TARGET_EXPR));
+  assert.doesNotMatch(sql, /tenant_id = current_setting\(''app\.current_tenant_id'', true\)::text/);
+});
+
+test('ENT-DB04 migration excludes outside tenant policy families', () => {
+  const sql = migrationSql();
+  const targets = new Set([
+    ...extractArray(sql, 'using_only_tables'),
+    ...extractArray(sql, 'with_check_tables'),
+  ]);
+
+  for (const forbidden of ['domain_events', 'domain_event_deliveries', 'storage', 'objects']) {
+    assert.equal(targets.has(forbidden), false, `Unexpected target ${forbidden}`);
+    assert.doesNotMatch(sql, new RegExp(`tenant_isolation_${forbidden}`));
+  }
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34545645,
-  "maxTrackedFiles": 3998,
+  "maxTrackedBytes": 34552538,
+  "maxTrackedFiles": 4000,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17205901,
+    "large support/generated-ish": 17208315,
     "source/scripts": 6485202,
-    "tests/e2e": 4319374,
+    "tests/e2e": 4323239,
     "docs/text": 4871322,
     "config/data/messages": 1535339,
     "other": 1048576

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34552538,
+  "maxTrackedBytes": 34552677,
   "maxTrackedFiles": 4000,
   "maxLargestFileBytes": 2343868,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17208315,
+    "large support/generated-ish": 17208818,
     "source/scripts": 6485202,
-    "tests/e2e": 4323239,
+    "tests/e2e": 4323377,
     "docs/text": 4871322,
     "config/data/messages": 1535339,
     "other": 1048576


### PR DESCRIPTION
## Summary

- Add `0075_optimize_tenant_rls_initplan` to rewrite exactly 53 live `public.tenant_isolation_*` policies to the Supabase auth RLS initPlan-safe tenant expression.
- Preserve the ENT-DB03 target split: 15 `USING`-only policies and 38 `USING` + `WITH CHECK` policies.
- Use identifier-safe `ALTER POLICY` formatting so quoted identifiers such as `public."user"` are handled correctly.
- Add focused migration parser tests for target scope, expression shape, shape preservation, and no outside-policy drift.

## Verification

- `pnpm --filter @interdomestik/database exec tsx --test test/rls-initplan-migration.test.ts`
- `pnpm db:migrations:check-journal`
- `pnpm db:rls:test:required`
- `node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/database migrate`
- Local `pg_policies` catalog check: 53 rewritten target policies, 15 `USING`-only, 38 `WITH CHECK`, no old `current_setting(...)` matches, `public."user"` policy present.
- `pnpm --filter @interdomestik/database test:unit`
- `pnpm docs:verify && pnpm plan:audit`
- `interdomestik_qa.scope_audit`
- `interdomestik_qa.security_guard`
- `pnpm repo:size:check`
- `pnpm exec prettier --check packages/database/test/rls-initplan-migration.test.ts scripts/repo-size-budget.json`
- `pnpm pr:verify`
- `pnpm e2e:gate` (134 passed, 6 skipped)

## Notes

- PR #992 post-merge sync was appended to Notion page `Interdomestik Program`.
- A sandboxed `pnpm e2e:gate` rerun failed on Google Fonts TLS/socket fetches; the required gate passed after rerunning with network escalation.
- Repo-wide `pnpm format:check` still reports pre-existing unrelated formatting drift; touched files passed Prettier.
