### PR TITLE
feat: add governing_law and terms_version to tenants table (ARCH-M1-10 / T-111)

### DIFF
--- a/packages/database/drizzle/0076_tenant_governing_law_terms_version.sql
+++ b/packages/database/drizzle/0076_tenant_governing_law_terms_version.sql
@@ -1,4 +1,4 @@
 ALTER TABLE "tenants" ADD COLUMN "governing_law" text;--> statement-breakpoint
 ALTER TABLE "tenants" ADD COLUMN "terms_version" text;--> statement-breakpoint
-UPDATE "tenants" SET "governing_law" = "country_code" WHERE "governing_law" IS NULL;--> statement-breakpoint
+UPDATE "tenants" SET "governing_law" = UPPER("country_code") WHERE "governing_law" IS NULL;--> statement-breakpoint
 ALTER TABLE "tenants" ADD CONSTRAINT "tenants_governing_law_check" CHECK ("tenants"."governing_law" IS NULL OR "tenants"."governing_law" ~ '^[A-Z]{2}$');

--- a/packages/database/drizzle/0076_tenant_governing_law_terms_version.sql
+++ b/packages/database/drizzle/0076_tenant_governing_law_terms_version.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "tenants" ADD COLUMN "governing_law" text;--> statement-breakpoint
+ALTER TABLE "tenants" ADD COLUMN "terms_version" text;--> statement-breakpoint
+UPDATE "tenants" SET "governing_law" = "country_code" WHERE "governing_law" IS NULL;--> statement-breakpoint
+ALTER TABLE "tenants" ADD CONSTRAINT "tenants_governing_law_check" CHECK ("tenants"."governing_law" IS NULL OR "tenants"."governing_law" ~ '^[A-Z]{2}$');

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1780868100000,
       "tag": "0075_optimize_tenant_rls_initplan",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1780905600000,
+      "tag": "0076_tenant_governing_law_terms_version",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/tenants.ts
+++ b/packages/database/src/schema/tenants.ts
@@ -1,25 +1,35 @@
-import { boolean, jsonb, pgTable, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { boolean, check, jsonb, pgTable, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
 
-export const tenants = pgTable('tenants', {
-  id: text('id').primaryKey(),
-  name: text('name').notNull(),
-  legalName: text('legal_name').notNull(),
-  code: text('code').unique(), // Short tenant code (e.g. KS01) - Nullable for migration, will be unique later
-  countryCode: text('country_code').notNull(),
-  governingLaw: text('governing_law'),
-  termsVersion: text('terms_version'),
-  currency: text('currency').default('EUR').notNull(),
-  taxId: text('tax_id'),
-  address: jsonb('address').$type<Record<string, unknown>>(),
-  contact: jsonb('contact').$type<Record<string, unknown>>(),
-  branding: jsonb('branding').$type<Record<string, unknown>>(),
-  isActive: boolean('is_active').default(true).notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at')
-    .defaultNow()
-    .$onUpdate(() => new Date())
-    .notNull(),
-});
+export const tenants = pgTable(
+  'tenants',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    legalName: text('legal_name').notNull(),
+    code: text('code').unique(), // Short tenant code (e.g. KS01) - Nullable for migration, will be unique later
+    countryCode: text('country_code').notNull(),
+    governingLaw: text('governing_law'),
+    termsVersion: text('terms_version'),
+    currency: text('currency').default('EUR').notNull(),
+    taxId: text('tax_id'),
+    address: jsonb('address').$type<Record<string, unknown>>(),
+    contact: jsonb('contact').$type<Record<string, unknown>>(),
+    branding: jsonb('branding').$type<Record<string, unknown>>(),
+    isActive: boolean('is_active').default(true).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at')
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  table => [
+    check(
+      'tenants_governing_law_check',
+      sql`${table.governingLaw} IS NULL OR ${table.governingLaw} ~ '^[A-Z]{2}$'`
+    ),
+  ]
+);
 
 export const tenantSettings = pgTable(
   'tenant_settings',

--- a/packages/database/src/schema/tenants.ts
+++ b/packages/database/src/schema/tenants.ts
@@ -6,6 +6,8 @@ export const tenants = pgTable('tenants', {
   legalName: text('legal_name').notNull(),
   code: text('code').unique(), // Short tenant code (e.g. KS01) - Nullable for migration, will be unique later
   countryCode: text('country_code').notNull(),
+  governingLaw: text('governing_law'),
+  termsVersion: text('terms_version'),
   currency: text('currency').default('EUR').notNull(),
   taxId: text('tax_id'),
   address: jsonb('address').$type<Record<string, unknown>>(),

--- a/packages/database/test/tenant-governing-law-terms-version.test.ts
+++ b/packages/database/test/tenant-governing-law-terms-version.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { tenants } from '../src/schema';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const migrationPath = path.join(
+  repoRoot,
+  'packages/database/drizzle/0076_tenant_governing_law_terms_version.sql'
+);
+
+test('tenant schema exports nullable governing_law and terms_version columns', () => {
+  assert.equal(tenants.governingLaw.name, 'governing_law');
+  assert.equal(tenants.termsVersion.name, 'terms_version');
+  assert.equal(tenants.governingLaw.notNull, false);
+  assert.equal(tenants.termsVersion.notNull, false);
+});
+
+test('governing_law and terms_version are positioned after country_code', () => {
+  const keys = Object.keys(tenants);
+  const countryCodeIdx = keys.indexOf('countryCode');
+  const governingLawIdx = keys.indexOf('governingLaw');
+  const termsVersionIdx = keys.indexOf('termsVersion');
+  assert.ok(countryCodeIdx >= 0, 'countryCode must exist');
+  assert.ok(governingLawIdx > countryCodeIdx, 'governingLaw must follow countryCode');
+  assert.ok(termsVersionIdx > countryCodeIdx, 'termsVersion must follow countryCode');
+});
+
+test('tenant governing_law migration is additive and backfills from country_code', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  assert.match(sql, /ALTER TABLE "tenants" ADD COLUMN "governing_law" text;/u);
+  assert.match(sql, /ALTER TABLE "tenants" ADD COLUMN "terms_version" text;/u);
+  assert.match(
+    sql,
+    /UPDATE "tenants" SET "governing_law" = "country_code" WHERE "governing_law" IS NULL;/u
+  );
+  assert.match(sql, /"governing_law" IS NULL OR "tenants"\."governing_law" ~ '\^\[A-Z\]\{2\}\$'/u);
+  assert.doesNotMatch(sql, /"governing_law" text NOT NULL/u);
+  assert.doesNotMatch(sql, /"terms_version" text NOT NULL/u);
+});

--- a/packages/database/test/tenant-governing-law-terms-version.test.ts
+++ b/packages/database/test/tenant-governing-law-terms-version.test.ts
@@ -36,7 +36,7 @@ test('tenant governing_law migration is additive and backfills from country_code
   assert.match(sql, /ALTER TABLE "tenants" ADD COLUMN "terms_version" text;/u);
   assert.match(
     sql,
-    /UPDATE "tenants" SET "governing_law" = "country_code" WHERE "governing_law" IS NULL;/u
+    /UPDATE "tenants" SET "governing_law" = UPPER\("country_code"\) WHERE "governing_law" IS NULL;/u
   );
   assert.match(sql, /"governing_law" IS NULL OR "tenants"\."governing_law" ~ '\^\[A-Z\]\{2\}\$'/u);
   assert.doesNotMatch(sql, /"governing_law" text NOT NULL/u);

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34886748,
+  "maxTrackedBytes": 34886992,
   "maxTrackedFiles": 4005,
   "maxLargestFileBytes": 2628612,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17493644,
-    "source/scripts": 6485297,
+    "large support/generated-ish": 17493651,
+    "source/scripts": 6485537,
     "tests/e2e": 4325311,
     "docs/text": 4918036,
     "config/data/messages": 1535339,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 34884152,
-  "maxTrackedFiles": 4003,
+  "maxTrackedBytes": 34886748,
+  "maxTrackedFiles": 4005,
   "maxLargestFileBytes": 2628612,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17493060,
-    "source/scripts": 6485219,
-    "tests/e2e": 4323377,
+    "large support/generated-ish": 17493644,
+    "source/scripts": 6485297,
+    "tests/e2e": 4325311,
     "docs/text": 4918036,
     "config/data/messages": 1535339,
     "other": 1048576


### PR DESCRIPTION
## Summary

- Adds `governing_law` (text, nullable) to `tenants` — ISO country-code of the jurisdiction governing the tenant's corporate entity and member contracts; backfilled from `country_code` for all existing rows; constrained to 2-letter uppercase codes
- Adds `terms_version` (text, nullable) to `tenants` — contract version string accepted by the tenant; left null for existing rows pending operator assignment
- Drizzle migration `0076` is additive and safe to apply live (no NOT NULL, no default, backfill in-migration)
- Focused schema and migration tests in `packages/database/test/tenant-governing-law-terms-version.test.ts`

## Architecture context

This is `ARCH-M1-10 / T-111` — the entity-of-record foundation slice. These columns are distinct from:
- `recovery_law` (case/incident-level, T-208) — derives from `incident_country_code` via Rome II
- `access_tenant_id` (isolation/RLS boundary, T-302)

The full entity-of-record model (ADR-10, T-107) and billing/disclosure binding (T-112, T-407/408) follow in later slices.

## Scope

Additive schema + migration + tests. No proxy.ts, no route changes, no auth/session/tenancy/billing/product UI.

## Test plan

- [ ] All required CI checks pass
- [ ] `tenants.governingLaw` and `tenants.termsVersion` are nullable text columns in the Drizzle schema
- [ ] Migration 0076 adds both columns and backfills `governing_law` from `country_code`
- [ ] `governing_law` check constraint enforces 2-letter uppercase ISO code pattern
- [ ] Three focused tests pass: schema export, column ordering, migration content

🤖 Generated with [Claude Code](https://claude.com/claude-code)