### PR TITLE
fix(web): show membership card during grace period

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/membership/card/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/membership/card/_core.entry.tsx
@@ -1,11 +1,10 @@
-import { CommercialDisclaimerNotice } from '@/components/commercial/commercial-disclaimer-notice';
 import { getSessionSafe } from '@/components/shell/session';
 import { and, db, eq, subscriptions } from '@interdomestik/database';
-import { Badge, Button } from '@interdomestik/ui';
-import { ChevronLeft, Phone, QrCode, ShieldCheck, Wallet } from 'lucide-react';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
+
+import { MembershipCard } from './membership-card';
+import { toMemberCardSubscription } from './membership-card-subscription';
 
 export default async function MemberCardPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
@@ -27,8 +26,9 @@ export default async function MemberCardPage({ params }: { params: Promise<{ loc
       })
     : null;
 
-  if (subscription?.status !== 'active') {
-    // If not active, user shouldn't see the card
+  const cardSubscription = toMemberCardSubscription(subscription);
+
+  if (!cardSubscription) {
     redirect(`/${locale}/member/membership`);
   }
 
@@ -37,116 +37,14 @@ export default async function MemberCardPage({ params }: { params: Promise<{ loc
     `ID-${session.user.id.slice(0, 8).toUpperCase()}`;
 
   return (
-    <div className="min-h-[80vh] flex flex-col items-center justify-center p-4 py-8 animate-fade-in">
-      <div className="w-full max-w-sm flex flex-col gap-6">
-        <div className="flex items-center justify-between">
-          <Button variant="ghost" size="sm" asChild className="-ml-2">
-            <Link href={`/${locale}/member`}>
-              <ChevronLeft className="mr-2 h-4 w-4" />
-              {t('back_to_dashboard')}
-            </Link>
-          </Button>
-          <Badge className="bg-green-100 text-green-700 hover:bg-green-100 border-none">
-            {subscription.planId.toUpperCase()}
-          </Badge>
-        </div>
-
-        <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
-          <p className="text-muted-foreground text-sm px-4">{t('description')}</p>
-        </div>
-
-        {/* THE CARD */}
-        <div className="relative group cursor-pointer perspective-1000">
-          <div className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 rounded-[2rem] p-8 text-white shadow-2xl relative overflow-hidden aspect-[1.586/1] border border-white/10 ring-1 ring-white/20">
-            {/* Glossy overlay */}
-            <div className="absolute top-0 left-0 right-0 h-2/3 bg-gradient-to-b from-white/10 to-transparent skew-y-[-12deg] origin-top-left -translate-y-4" />
-
-            {/* Holographic sparkle effect (simulated) */}
-            <div className="absolute -inset-2 bg-gradient-to-tr from-transparent via-white/5 to-transparent opacity-30 group-hover:translate-x-full duration-1000 transition-transform" />
-
-            <div className="flex justify-between items-start relative z-10">
-              <div className="flex flex-col">
-                <span className="text-[10px] font-black tracking-[0.2em] opacity-60 uppercase mb-1">
-                  Interdomestik
-                </span>
-                <span className="text-xs font-bold tracking-widest opacity-90 uppercase">
-                  Service Club
-                </span>
-              </div>
-              <div className="bg-white/10 backdrop-blur-md p-2 rounded-2xl border border-white/20">
-                <ShieldCheck className="w-6 h-6 text-primary" />
-              </div>
-            </div>
-
-            <div className="mt-10 relative z-10">
-              <div className="text-[10px] font-bold opacity-40 uppercase tracking-widest mb-1.5">
-                {t('subtitle')}
-              </div>
-              <div className="text-2xl font-mono tracking-[0.15em] font-medium drop-shadow-md">
-                {memberNumber}
-              </div>
-            </div>
-
-            <div className="mt-auto flex justify-between items-end relative z-10">
-              <div className="flex flex-col gap-0.5">
-                <div className="text-[10px] font-bold opacity-40 uppercase tracking-widest">
-                  Member
-                </div>
-                <div className="text-xl font-bold tracking-tight">{session.user.name}</div>
-              </div>
-              <div className="bg-white p-2 rounded-xl shadow-inner border border-white/20 group-hover:scale-105 transition-transform">
-                <QrCode className="w-10 h-10 text-slate-900" />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <div className="bg-white p-4 rounded-2xl border shadow-sm flex flex-col gap-1">
-            <span className="text-[10px] font-bold text-muted-foreground uppercase">
-              {t('member_since')}
-            </span>
-            <span className="text-sm font-bold">
-              {new Date(session.user.createdAt).toLocaleDateString(locale)}
-            </span>
-          </div>
-          <div className="bg-white p-4 rounded-2xl border shadow-sm flex flex-col gap-1">
-            <span className="text-[10px] font-bold text-muted-foreground uppercase">
-              {t('valid_thru')}
-            </span>
-            <span className="text-sm font-bold">
-              {subscription.currentPeriodEnd
-                ? new Date(subscription.currentPeriodEnd).toLocaleDateString(locale)
-                : 'N/A'}
-            </span>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-3 pt-2">
-          <Button
-            size="lg"
-            className="h-14 rounded-2xl bg-slate-900 hover:bg-slate-800 shadow-xl shadow-slate-900/10"
-          >
-            <Wallet className="mr-3 h-5 w-5" />
-            Add to Wallet
-          </Button>
-          <Button variant="outline" size="lg" className="h-14 rounded-2xl border-2">
-            <Phone className="mr-3 h-5 w-5" />
-            {t('emergency_hotline')}
-          </Button>
-          <CommercialDisclaimerNotice
-            sectionTestId="member-card-hotline-disclaimer"
-            items={[
-              {
-                title: t('hotline_disclaimer.title'),
-                body: t('hotline_disclaimer.body'),
-              },
-            ]}
-          />
-        </div>
-      </div>
-    </div>
+    <MembershipCard
+      locale={locale}
+      memberName={session.user.name}
+      memberNumber={memberNumber}
+      memberSince={session.user.createdAt}
+      subscription={cardSubscription}
+      t={t}
+    />
   );
 }
 

--- a/apps/web/src/app/[locale]/(app)/member/membership/card/membership-card-subscription.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/card/membership-card-subscription.ts
@@ -1,0 +1,44 @@
+export interface MemberCardSubscription {
+  readonly status: 'active' | 'past_due';
+  readonly planId: string;
+  readonly currentPeriodEnd: Date | null;
+  readonly gracePeriodEndsAt: Date | null;
+}
+
+export type MemberCardSubscriptionInput =
+  | {
+      readonly status?: string | null;
+      readonly planId?: string | null;
+      readonly currentPeriodEnd?: Date | null;
+      readonly gracePeriodEndsAt?: Date | null;
+    }
+  | null
+  | undefined;
+
+export function toMemberCardSubscription(
+  subscription: MemberCardSubscriptionInput,
+  now = new Date()
+): MemberCardSubscription | null {
+  if (!subscription?.planId) return null;
+
+  if (subscription.status === 'active') {
+    return {
+      status: 'active',
+      planId: subscription.planId,
+      currentPeriodEnd: subscription.currentPeriodEnd ?? null,
+      gracePeriodEndsAt: subscription.gracePeriodEndsAt ?? null,
+    };
+  }
+
+  if (subscription.status !== 'past_due') return null;
+
+  const gracePeriodEndsAt = subscription.gracePeriodEndsAt ?? null;
+  if (!gracePeriodEndsAt || gracePeriodEndsAt.getTime() < now.getTime()) return null;
+
+  return {
+    status: 'past_due',
+    planId: subscription.planId,
+    currentPeriodEnd: subscription.currentPeriodEnd ?? null,
+    gracePeriodEndsAt,
+  };
+}

--- a/apps/web/src/app/[locale]/(app)/member/membership/card/membership-card.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/membership/card/membership-card.tsx
@@ -1,0 +1,136 @@
+import { CommercialDisclaimerNotice } from '@/components/commercial/commercial-disclaimer-notice';
+import { Button } from '@interdomestik/ui';
+import { ChevronLeft, Phone, QrCode, ShieldCheck, Wallet } from 'lucide-react';
+import Link from 'next/link';
+
+import type { MemberCardSubscription } from './membership-card-subscription';
+
+type TranslationFn = (key: string) => string;
+
+interface MembershipCardProps {
+  readonly locale: string;
+  readonly memberName: string | null | undefined;
+  readonly memberNumber: string;
+  readonly memberSince: Date | string;
+  readonly subscription: MemberCardSubscription;
+  readonly t: TranslationFn;
+}
+
+export function MembershipCard({
+  locale,
+  memberName,
+  memberNumber,
+  memberSince,
+  subscription,
+  t,
+}: MembershipCardProps) {
+  return (
+    <div
+      data-testid="member-membership-card-ready"
+      className="min-h-[80vh] flex flex-col items-center justify-center p-4 py-8 animate-fade-in"
+    >
+      <div className="w-full max-w-sm flex flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" size="sm" asChild className="-ml-2">
+            <Link href={`/${locale}/member`}>
+              <ChevronLeft className="mr-2 h-4 w-4" />
+              {t('back_to_dashboard')}
+            </Link>
+          </Button>
+          <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-semibold text-green-700">
+            {subscription.planId.toUpperCase()}
+          </span>
+        </div>
+
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+          <p className="text-muted-foreground text-sm px-4">{t('description')}</p>
+        </div>
+
+        <div className="relative group cursor-pointer perspective-1000">
+          <div className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 rounded-[2rem] p-8 text-white shadow-2xl relative overflow-hidden aspect-[1.586/1] border border-white/10 ring-1 ring-white/20">
+            <div className="absolute top-0 left-0 right-0 h-2/3 bg-gradient-to-b from-white/10 to-transparent skew-y-[-12deg] origin-top-left -translate-y-4" />
+            <div className="absolute -inset-2 bg-gradient-to-tr from-transparent via-white/5 to-transparent opacity-30 group-hover:translate-x-full duration-1000 transition-transform" />
+
+            <div className="flex justify-between items-start relative z-10">
+              <div className="flex flex-col">
+                <span className="text-[10px] font-black tracking-[0.2em] opacity-60 uppercase mb-1">
+                  Interdomestik
+                </span>
+                <span className="text-xs font-bold tracking-widest opacity-90 uppercase">
+                  Service Club
+                </span>
+              </div>
+              <div className="bg-white/10 backdrop-blur-md p-2 rounded-2xl border border-white/20">
+                <ShieldCheck className="w-6 h-6 text-primary" />
+              </div>
+            </div>
+
+            <div className="mt-10 relative z-10">
+              <div className="text-[10px] font-bold opacity-40 uppercase tracking-widest mb-1.5">
+                {t('subtitle')}
+              </div>
+              <div className="text-2xl font-mono tracking-[0.15em] font-medium drop-shadow-md">
+                {memberNumber}
+              </div>
+            </div>
+
+            <div className="mt-auto flex justify-between items-end relative z-10">
+              <div className="flex flex-col gap-0.5">
+                <div className="text-[10px] font-bold opacity-40 uppercase tracking-widest">
+                  Member
+                </div>
+                <div className="text-xl font-bold tracking-tight">{memberName}</div>
+              </div>
+              <div className="bg-white p-2 rounded-xl shadow-inner border border-white/20 group-hover:scale-105 transition-transform">
+                <QrCode className="w-10 h-10 text-slate-900" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <InfoTile
+            label={t('member_since')}
+            value={new Date(memberSince).toLocaleDateString(locale)}
+          />
+          <InfoTile
+            label={t('valid_thru')}
+            value={
+              subscription.currentPeriodEnd
+                ? new Date(subscription.currentPeriodEnd).toLocaleDateString(locale)
+                : 'N/A'
+            }
+          />
+        </div>
+
+        <div className="flex flex-col gap-3 pt-2">
+          <Button
+            size="lg"
+            className="h-14 rounded-2xl bg-slate-900 hover:bg-slate-800 shadow-xl shadow-slate-900/10"
+          >
+            <Wallet className="mr-3 h-5 w-5" />
+            Add to Wallet
+          </Button>
+          <Button variant="outline" size="lg" className="h-14 rounded-2xl border-2">
+            <Phone className="mr-3 h-5 w-5" />
+            {t('emergency_hotline')}
+          </Button>
+          <CommercialDisclaimerNotice
+            sectionTestId="member-card-hotline-disclaimer"
+            items={[{ title: t('hotline_disclaimer.title'), body: t('hotline_disclaimer.body') }]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function InfoTile({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <div className="bg-white p-4 rounded-2xl border shadow-sm flex flex-col gap-1">
+      <span className="text-[10px] font-bold text-muted-foreground uppercase">{label}</span>
+      <span className="text-sm font-bold">{value}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(app)/member/membership/card/page.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/membership/card/page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getNamespacedTranslation } from '@/test/coverage-matrix-test-utils';
 
 const hoisted = vi.hoisted(() => ({
@@ -18,6 +18,7 @@ const hoisted = vi.hoisted(() => ({
     status: 'active',
     planId: 'asistenca',
     currentPeriodEnd: new Date('2027-03-01T12:00:00.000Z'),
+    gracePeriodEndsAt: null as Date | null,
   })),
 }));
 
@@ -56,13 +57,31 @@ vi.mock('next/link', () => ({
 }));
 
 vi.mock('@interdomestik/ui', () => ({
-  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
   Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
 }));
 
 import MemberCardPage from './page';
 
 describe('MemberCardPage hotline disclaimer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSessionSafeMock.mockResolvedValue({
+      user: {
+        id: 'member-1',
+        name: 'Test Member',
+        tenantId: 'tenant-ks',
+        createdAt: new Date('2026-03-01T12:00:00.000Z'),
+        memberNumber: 'ID-MEMBER',
+      },
+    });
+    hoisted.findFirstMock.mockResolvedValue({
+      status: 'active',
+      planId: 'asistenca',
+      currentPeriodEnd: new Date('2027-03-01T12:00:00.000Z'),
+      gracePeriodEndsAt: null,
+    });
+  });
+
   it('renders routing-only hotline copy on the membership card surface', async () => {
     const tree = await MemberCardPage({
       params: Promise.resolve({ locale: 'en' }),
@@ -73,6 +92,44 @@ describe('MemberCardPage hotline disclaimer', () => {
     expect(hoisted.getSessionSafeMock).toHaveBeenCalledWith('MemberMembershipCardPage');
     expect(screen.getByText('membership.card.hotline_disclaimer.title')).toBeInTheDocument();
     expect(screen.getByText('membership.card.hotline_disclaimer.body')).toBeInTheDocument();
+  });
+
+  it('renders the card for a past_due subscription still inside its grace period', async () => {
+    hoisted.findFirstMock.mockResolvedValueOnce({
+      status: 'past_due',
+      planId: 'asistenca',
+      currentPeriodEnd: new Date('2027-03-01T12:00:00.000Z'),
+      gracePeriodEndsAt: new Date('2999-03-01T12:00:00.000Z'),
+    });
+
+    const tree = await MemberCardPage({
+      params: Promise.resolve({ locale: 'en' }),
+    });
+
+    render(tree);
+
+    expect(screen.getByTestId('member-membership-card-ready')).toBeInTheDocument();
+    expect(hoisted.redirectMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects when the subscription is not card-eligible', async () => {
+    hoisted.findFirstMock.mockResolvedValueOnce({
+      status: 'canceled',
+      planId: 'asistenca',
+      currentPeriodEnd: new Date('2027-03-01T12:00:00.000Z'),
+      gracePeriodEndsAt: null,
+    });
+    hoisted.redirectMock.mockImplementationOnce((url: string) => {
+      throw new Error(`redirect:${url}`);
+    });
+
+    await expect(
+      MemberCardPage({
+        params: Promise.resolve({ locale: 'sq' }),
+      })
+    ).rejects.toThrow('redirect:/sq/member/membership');
+
+    expect(hoisted.redirectMock).toHaveBeenCalledWith('/sq/member/membership');
   });
 
   it('redirects to the localized login page when the membership card is opened without a session', async () => {


### PR DESCRIPTION
## Summary
- Allow `/member/membership/card` to render for `past_due` subscriptions that are still inside `gracePeriodEndsAt`.
- Extract the membership-card rendering into a focused server component and isolate card eligibility in `toMemberCardSubscription()`.
- Add page-level regression coverage for active rendering, in-grace rendering, ineligible redirect, and unauthenticated redirect.

## Golden Loop evidence
- Reviewer waterfall dry-run: all routes available.
- First live review found blockers: untracked new files in the review packet and a stale server/client boundary concern.
- Remediation: staged all new files, confirmed `MembershipCard` is server-rendered, tightened `gracePeriodEndsAt` output type, then reduced file count after repo-size budget caught the extra helper test file.
- Final live reviewer waterfall: Fable returned contract-valid `READY`; no later reviewer calls were needed.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/(app)/member/membership/card/page.test.tsx'`
- `pnpm repo:size:check`
- `pnpm security:guard`
- `pnpm slice:verify`
- `pnpm pr:verify`
  - PR E2E lane: 134 passed, 6 skipped
  - Smoke E2E: 13 passed, 1 skipped
- Worktree-local `interdomestik_qa.scope_audit`: passed, changed files confined to `apps/web/src/app/[locale]/(app)/member/membership/card/`.

Per `docs/golden-loop/adapters/interdomestik.adapter.json`, standalone `pnpm e2e:gate` was not rerun because `pr:verify` covers the PR E2E lane and the adapter marks `e2e-gate` as `skipWhenCoveredBy: ["pr-verify"]`.

## Enterprise statements
- `ent-tm`: No new upload, signed URL, share-pack, AI, Paddle webhook, OTP, outbox relay, or payout surface is introduced. The change only adjusts membership-card eligibility for an existing subscription status/grace-period field.
- `ent-dlv`: No new persisted user-bound data, data movement, erasure path, export path, or retention behavior is introduced. Existing subscription fields are read only.
