### PR TITLE
feat: prove ida public tenant context

### DIFF
--- a/apps/web/e2e/gate/front-door-session-context.spec.ts
+++ b/apps/web/e2e/gate/front-door-session-context.spec.ts
@@ -26,6 +26,33 @@ function userForTenant(tenantId: FrontDoorTenant) {
 }
 
 test.describe('Front-door session context', () => {
+  test('renders ida.* public landing without a tenant cookie', async ({ browser }, testInfo) => {
+    const { origin, locale } = projectInfo(testInfo.project.use.baseURL?.toString());
+    if (!new URL(origin).hostname.startsWith('ida.')) {
+      test.skip(true, 'front-door public contract only runs in ida projects');
+      return;
+    }
+
+    const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    try {
+      const page = await context.newPage();
+      const docResponse = await gotoApp(page, new URL(`/${locale}`, origin).toString(), testInfo, {
+        marker: 'landing-page-ready',
+      });
+
+      expect(docResponse?.headers()['x-e2e-tenant']).toBe('none');
+      expect(docResponse?.headers()['x-e2e-tenant-context']).toBe('public');
+      await expect(page.getByTestId('tenant-chooser')).toHaveCount(0);
+
+      const tenantCookie = (await context.cookies(origin)).find(
+        cookie => cookie.name === 'tenantId'
+      );
+      expect(tenantCookie).toBeUndefined();
+    } finally {
+      await context.close();
+    }
+  });
+
   test('logs in on ida.* without country-host tenant identity', async ({ page }, testInfo) => {
     const { origin, locale } = projectInfo(testInfo.project.use.baseURL?.toString());
     const projectHeaders = testInfo.project.use.extraHTTPHeaders ?? {};

--- a/apps/web/src/app/api/auth/[...all]/_core.ts
+++ b/apps/web/src/app/api/auth/[...all]/_core.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 
+import { isKnownIdaFrontDoorHost, normalizeTenantHost } from '@/lib/tenant/tenant-front-door';
 import {
   coerceTenantId,
   resolveTenantIdFromSources,
@@ -11,11 +12,6 @@ import {
 export type AuthMethod = 'GET' | 'POST';
 
 const EMAIL_SIGN_IN_PATH_SUFFIXES = ['/api/auth/sign-in/email', '/api/auth/sign-in/email-otp'];
-const DEFAULT_FRONT_DOOR_HOSTS = new Set([
-  'ida.interdomestik.com',
-  'ida.localhost',
-  'ida.127.0.0.1.nip.io',
-]);
 
 function getAuthPathname(url: string): string | null {
   try {
@@ -121,59 +117,18 @@ function getDirectRequestHost(headers: Headers): string {
   return headers.get('host') ?? '';
 }
 
-function normalizeHost(host: string | null | undefined): string {
-  const raw = host?.split(',')[0]?.trim() ?? '';
-  const lower = raw.toLowerCase();
-  const localPlaintextPrefix = `${'http'}://`;
-  const securePrefix = `${'https'}://`;
-  let authority = lower;
-  if (authority.startsWith(localPlaintextPrefix)) {
-    authority = authority.slice(localPlaintextPrefix.length);
-  } else if (authority.startsWith(securePrefix)) {
-    authority = authority.slice(securePrefix.length);
-  }
-
-  const pathStart = authority.indexOf('/');
-  if (pathStart >= 0) {
-    authority = authority.slice(0, pathStart);
-  }
-
-  const portStart = authority.lastIndexOf(':');
-  if (
-    portStart >= 0 &&
-    authority
-      .slice(portStart + 1)
-      .split('')
-      .every(char => char >= '0' && char <= '9')
-  ) {
-    authority = authority.slice(0, portStart);
-  }
-
-  return authority.endsWith('.') ? authority.slice(0, -1) : authority;
-}
-
-function isKnownFrontDoorHost(host: string): boolean {
-  const normalized = normalizeHost(host);
-  const configuredIdaHost = normalizeHost(process.env.IDA_HOST);
-
-  return (
-    DEFAULT_FRONT_DOOR_HOSTS.has(normalized) ||
-    (configuredIdaHost.length > 0 && normalized === configuredIdaHost)
-  );
-}
-
 function hasKnownDirectFrontDoorHost(headers: Headers): boolean {
-  return isKnownFrontDoorHost(getDirectRequestHost(headers));
+  return isKnownIdaFrontDoorHost(getDirectRequestHost(headers));
 }
 
 function hasUnambiguousFrontDoorHost(headers: Headers): boolean {
-  const host = normalizeHost(getDirectRequestHost(headers));
-  if (!isKnownFrontDoorHost(host)) return false;
+  const host = normalizeTenantHost(getDirectRequestHost(headers));
+  if (!isKnownIdaFrontDoorHost(host)) return false;
 
   const forwardedHost = headers.get('x-forwarded-host');
   if (!forwardedHost) return true;
 
-  return normalizeHost(forwardedHost) === host;
+  return normalizeTenantHost(forwardedHost) === host;
 }
 
 function resolveFrontDoorTenantHint(headers: Headers): TenantId | null {

--- a/apps/web/src/lib/proxy-front-door.test.ts
+++ b/apps/web/src/lib/proxy-front-door.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { LOCALES } from '@/i18n/locales';
+
+const mockEmitAuthTelemetryEvent = vi.fn();
+
+vi.mock('@/i18n/routing', () => ({
+  routing: {
+    locales: LOCALES,
+  },
+}));
+
+vi.mock('@/lib/telemetry', () => ({
+  emitAuthTelemetryEvent: (...args: unknown[]) => mockEmitAuthTelemetryEvent(...args),
+}));
+
+import { proxy } from './proxy-logic';
+
+const ORIGINAL_IDA_HOST = process.env.IDA_HOST;
+const E2E_ENV_KEYS = ['INTERDOMESTIK_LOCAL_E2E', 'INTERDOMESTIK_E2E_DIAGNOSTICS', 'PLAYWRIGHT'];
+let originalE2eEnv: Record<string, string | undefined>;
+
+function restoreIdaHost(): void {
+  if (ORIGINAL_IDA_HOST === undefined) {
+    delete process.env.IDA_HOST;
+    return;
+  }
+
+  process.env.IDA_HOST = ORIGINAL_IDA_HOST;
+}
+
+function restoreE2eEnv(): void {
+  for (const key of E2E_ENV_KEYS) {
+    const value = originalE2eEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function makeRequest(pathname: string, cookieHeader?: string, host = 'ida.localhost:3000') {
+  const headers = new Headers({ host });
+  if (cookieHeader) headers.set('cookie', cookieHeader);
+  return new NextRequest(`http://${host}${pathname}`, { headers });
+}
+
+describe('proxy ida front-door context', () => {
+  beforeEach(() => {
+    originalE2eEnv = Object.fromEntries(E2E_ENV_KEYS.map(key => [key, process.env[key]]));
+    process.env.INTERDOMESTIK_LOCAL_E2E = '1';
+    process.env.INTERDOMESTIK_E2E_DIAGNOSTICS = '1';
+    process.env.PLAYWRIGHT = '1';
+    mockEmitAuthTelemetryEvent.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreE2eEnv();
+    restoreIdaHost();
+  });
+
+  it('resolves ida.localhost as public no-tenant context without setting a tenant cookie', async () => {
+    const response = await proxy(makeRequest('/sq'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-e2e-tenant')).toBe('none');
+    expect(response.headers.get('x-e2e-tenant-context')).toBe('public');
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('does not refresh stale tenant cookies on ida public requests', async () => {
+    const response = await proxy(
+      makeRequest('/sq/pricing', 'tenantId=tenant_mk', 'ida.127.0.0.1.nip.io:3000')
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-e2e-tenant')).toBe('none');
+    expect(response.headers.get('x-e2e-tenant-context')).toBe('public');
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('supports configured IDA_HOST as public no-tenant context', async () => {
+    process.env.IDA_HOST = 'https://front-door.localhost:3000';
+
+    const response = await proxy(makeRequest('/sq', undefined, 'front-door.localhost:3000'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-e2e-tenant')).toBe('none');
+    expect(response.headers.get('x-e2e-tenant-context')).toBe('public');
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/proxy-logic.ts
+++ b/apps/web/src/lib/proxy-logic.ts
@@ -2,8 +2,8 @@ import { routing } from '@/i18n/routing';
 import { isStaffAuthTolerantTenant } from '@/lib/feature-flags';
 import { isE2EDiagnosticsEnabled, isProductionDeployment } from '@/lib/runtime-environment';
 import { emitAuthTelemetryEvent } from '@/lib/telemetry';
+import { resolveTenantHostContext } from '@/lib/tenant/tenant-front-door';
 import { applyTenantCookie } from '@/lib/tenant/tenant-cookie';
-import { resolveTenantFromHost as resolveTenantFromCanonicalHost } from '@/lib/tenant/tenant-hosts';
 import { NextRequest, NextResponse } from 'next/server';
 import {
   buildReportOnlyCsp,
@@ -105,19 +105,6 @@ function applyResponseHardening(
   }
 
   return response;
-}
-
-function resolveTenantFromHost(
-  host: string
-): 'tenant_mk' | 'tenant_ks' | 'tenant_al' | 'pilot-mk' | null {
-  const canonicalTenant = resolveTenantFromCanonicalHost(host);
-  if (canonicalTenant) return canonicalTenant;
-
-  const raw = host.split(':')[0].toLowerCase();
-  if (raw.startsWith('pilot.')) return 'pilot-mk';
-  if (raw.includes('pilot.127.0.0.1.nip.io')) return 'pilot-mk';
-
-  return null;
 }
 
 function getSessionCookieValue(request: NextRequest): string | null {
@@ -434,7 +421,8 @@ function redirectToLogin(
 export async function proxy(request: NextRequest): Promise<NextResponse> {
   const { pathname } = request.nextUrl;
   const host = request.headers.get('host') ?? '';
-  const tenant = resolveTenantFromHost(host);
+  const tenantContext = resolveTenantHostContext(host);
+  const tenant = tenantContext.tenantId;
 
   // 1. Force nip.io in Dev (Optional, if env var set)
   // Logic simplified/removed to prevent loops - rely on manual access for now
@@ -492,6 +480,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 
   if (isE2EDiagnosticsEnabled()) {
     response.headers.set('x-e2e-tenant', tenant ?? 'none');
+    response.headers.set('x-e2e-tenant-context', tenantContext.kind);
     response.headers.set('x-e2e-host', host);
   }
 

--- a/apps/web/src/lib/tenant/tenant-front-door.test.ts
+++ b/apps/web/src/lib/tenant/tenant-front-door.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  isKnownIdaFrontDoorHost,
+  normalizeTenantHost,
+  resolveTenantHostContext,
+} from './tenant-front-door';
+
+describe('tenant-front-door', () => {
+  const mutableEnv = process.env as Record<string, string | undefined>;
+  const originalIdaHost = process.env.IDA_HOST;
+
+  afterEach(() => {
+    if (originalIdaHost === undefined) {
+      delete mutableEnv.IDA_HOST;
+    } else {
+      mutableEnv.IDA_HOST = originalIdaHost;
+    }
+  });
+
+  it('normalizes scheme, port, path, casing, and trailing dots', () => {
+    expect(normalizeTenantHost('HTTPS://IDA.LOCALHOST:3000/sq/login.')).toBe('ida.localhost');
+    expect(normalizeTenantHost('ida.127.0.0.1.nip.io:3000')).toBe('ida.127.0.0.1.nip.io');
+    expect(normalizeTenantHost('ida.localhost.')).toBe('ida.localhost');
+  });
+
+  it('recognizes built-in and configured ida front-door hosts', () => {
+    mutableEnv.IDA_HOST = 'https://front-door.localhost:3000';
+
+    expect(isKnownIdaFrontDoorHost('ida.localhost:3000')).toBe(true);
+    expect(isKnownIdaFrontDoorHost('front-door.localhost:3000')).toBe(true);
+    expect(isKnownIdaFrontDoorHost('ks.localhost:3000')).toBe(false);
+  });
+
+  it('resolves ida front-door hosts as public no-tenant context', () => {
+    expect(resolveTenantHostContext('ida.localhost:3000')).toEqual({
+      kind: 'public',
+      tenantId: null,
+      source: 'ida_front_door',
+    });
+  });
+
+  it('keeps country and pilot hosts as tenant contexts', () => {
+    expect(resolveTenantHostContext('ks.localhost:3000')).toEqual({
+      kind: 'tenant',
+      tenantId: 'tenant_ks',
+      source: 'host',
+    });
+    expect(resolveTenantHostContext('pilot.127.0.0.1.nip.io:3000')).toEqual({
+      kind: 'tenant',
+      tenantId: 'pilot-mk',
+      source: 'host',
+    });
+  });
+});

--- a/apps/web/src/lib/tenant/tenant-front-door.ts
+++ b/apps/web/src/lib/tenant/tenant-front-door.ts
@@ -1,0 +1,59 @@
+import { resolveTenantFromHost, type TenantId } from './tenant-hosts';
+
+const DEFAULT_IDA_FRONT_DOOR_HOSTS = new Set([
+  'ida.interdomestik.com',
+  'ida.localhost',
+  'ida.127.0.0.1.nip.io',
+]);
+
+export type TenantHostContext =
+  | { kind: 'tenant'; tenantId: TenantId; source: 'host' }
+  | { kind: 'public'; tenantId: null; source: 'ida_front_door' }
+  | { kind: 'unknown'; tenantId: null; source: 'unknown_host' };
+
+export function normalizeTenantHost(host: string | null | undefined): string {
+  const raw = host?.split(',')[0]?.trim() ?? '';
+  let authority = raw.toLowerCase();
+
+  if (authority.startsWith('http://')) {
+    authority = authority.slice('http://'.length);
+  } else if (authority.startsWith('https://')) {
+    authority = authority.slice('https://'.length);
+  }
+
+  const pathStart = authority.indexOf('/');
+  if (pathStart >= 0) {
+    authority = authority.slice(0, pathStart);
+  }
+
+  const portStart = authority.lastIndexOf(':');
+  const port = authority.slice(portStart + 1);
+  if (portStart >= 0 && port.length > 0 && [...port].every(char => char >= '0' && char <= '9')) {
+    authority = authority.slice(0, portStart);
+  }
+
+  return authority.endsWith('.') ? authority.slice(0, -1) : authority;
+}
+
+export function isKnownIdaFrontDoorHost(host: string | null | undefined): boolean {
+  const normalized = normalizeTenantHost(host);
+  const configuredIdaHost = normalizeTenantHost(process.env.IDA_HOST);
+
+  return (
+    DEFAULT_IDA_FRONT_DOOR_HOSTS.has(normalized) ||
+    (configuredIdaHost.length > 0 && normalized === configuredIdaHost)
+  );
+}
+
+export function resolveTenantHostContext(host: string): TenantHostContext {
+  const tenantId = resolveTenantFromHost(host);
+  if (tenantId) {
+    return { kind: 'tenant', tenantId, source: 'host' };
+  }
+
+  if (isKnownIdaFrontDoorHost(host)) {
+    return { kind: 'public', tenantId: null, source: 'ida_front_door' };
+  }
+
+  return { kind: 'unknown', tenantId: null, source: 'unknown_host' };
+}

--- a/scripts/ci/model-review-access.mjs
+++ b/scripts/ci/model-review-access.mjs
@@ -21,7 +21,7 @@ function timestamp() {
 }
 
 function commandAvailable(command) {
-  return spawnSync('/bin/sh', ['-lc', `command -v ${command}`], {
+  return spawnSync('/bin/sh', ['-c', `command -v ${command}`], {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35320000,
-  "maxTrackedFiles": 4071,
+  "maxTrackedBytes": 35325233,
+  "maxTrackedFiles": 4074,
   "maxLargestFileBytes": 2792614,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17651257,
-    "source/scripts": 6568000,
-    "tests/e2e": 4376000,
+    "source/scripts": 6566216,
+    "tests/e2e": 4380130,
     "docs/text": 5050952,
     "config/data/messages": 1555000,
     "other": 1048576


### PR DESCRIPTION
## Summary
- Add a shared tenant front-door resolver that treats known IDA front-door hosts as explicit public/no-tenant context while preserving country and pilot host resolution.
- Reuse the front-door host normalization in auth entry logic and proxy diagnostics.
- Add unit and E2E coverage proving ida public landing does not set tenant cookies, including stale-cookie and configured IDA_HOST cases.
- Fix CI model-review command lookup to preserve test-provided PATH inside the parity container.

## Verification
- pnpm --filter @interdomestik/web test:unit --run src/lib/tenant/tenant-front-door.test.ts src/lib/proxy-front-door.test.ts src/lib/proxy-logic.test.ts src/app/api/auth/[...all]/_core.test.ts
- pnpm --filter @interdomestik/web build:ci
- pnpm e2e:front-door
- pnpm slice:verify
- pnpm slice:e2e:pr
- pnpm security:guard
- pnpm e2e:gate
- pnpm pr:verify
- git diff --check
- interdomestik_qa.scope_audit: passed for the 8 intended files; forbidden files unchanged, including apps/web/src/proxy.ts
- repo-size audit passed after exact budget update

## Local parity note
- pnpm ci:local:pr reached the containerized production build, compiled successfully, then was killed with exit 137 during TypeScript. The same build and TypeScript phase passed locally in pnpm e2e:gate and pnpm pr:verify, so this is recorded as a local Docker memory ceiling rather than a code failure. pnpm ci:local:full was not rerun because it includes the same parity PR path plus the merge E2E gate and would re-enter the same local resource blocker.

## Review/Security
- security:guard passed.
- Earlier codex review for the slice changes was clean; a final rerun after the CI-helper tweak hung in the review runtime without findings and was terminated.
- Sonar and Copilot review will be checked after PR creation before merge.

## Risk / Rollback
- Risk is limited to tenant host classification, auth front-door host reuse, diagnostics headers, and test/CI helper behavior.
- Rollback is the single squash commit for this PR.
