### PR TITLE
feat: add recovery law routing

### DIFF
--- a/packages/database/drizzle/0082_claim_recovery_law.sql
+++ b/packages/database/drizzle/0082_claim_recovery_law.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "claim" ADD COLUMN "recovery_law" text;--> statement-breakpoint
+ALTER TABLE "claim" ADD COLUMN "recovery_legal_tenant_id" text;--> statement-breakpoint
+ALTER TABLE "claim" ADD CONSTRAINT "claim_recovery_legal_tenant_id_tenants_id_fk" FOREIGN KEY ("recovery_legal_tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "claim" ADD CONSTRAINT "claim_recovery_law_check" CHECK ("claim"."recovery_law" is null or "claim"."recovery_law" ~ '^[A-Z]{2}$');

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1781296139304,
       "tag": "0081_user_residence_country",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1781306185466,
+      "tag": "0082_claim_recovery_law",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/claims.ts
+++ b/packages/database/src/schema/claims.ts
@@ -24,13 +24,13 @@ export const claims = pgTable(
     tenantId: text('tenant_id')
       .notNull()
       .references(() => tenants.id),
-    claimNumber: text('claim_number'), // Human readable ID, unique per tenant (idx_claims_tenant_number).
+    claimNumber: text('claim_number'),
     userId: text('userId')
       .notNull()
       .references(() => user.id),
-    agentId: text('agent_id').references(() => user.id), // Sales agent from membership
-    branchId: text('branch_id').references(() => branches.id), // Branch scoping from membership
-    staffId: text('staffId').references(() => user.id), // Assigned staff handler
+    agentId: text('agent_id').references(() => user.id),
+    branchId: text('branch_id').references(() => branches.id),
+    staffId: text('staffId').references(() => user.id),
     assignedAt: timestamp('assignedAt'),
     assignedById: text('assignedById').references(() => user.id),
     title: text('title').notNull(),
@@ -42,16 +42,17 @@ export const claims = pgTable(
     ).$type<ClaimRecoveryLifecycleState | null>(),
     incidentCountryCode: text('incident_country_code'),
     incidentJurisdiction: text('incident_jurisdiction'),
+    recoveryLaw: text('recovery_law'),
+    recoveryLegalTenantId: text('recovery_legal_tenant_id').references(() => tenants.id),
     lifecycleVersion: integer('lifecycle_version').notNull().default(0),
-    origin: text('origin').default('portal').notNull(), // 'portal' | 'agent' | 'admin' | 'api'
-    originRefId: text('origin_ref_id'), // agentId or staffId
-    category: text('category').notNull(), // e.g. 'retail', 'services'
+    origin: text('origin').default('portal').notNull(),
+    originRefId: text('origin_ref_id'),
+    category: text('category').notNull(),
     companyName: text('companyName').notNull(),
     claimAmount: decimal('amount', { precision: 10, scale: 2 }),
     currency: text('currency').default('EUR'),
     createdAt: timestamp('createdAt').defaultNow(),
     updatedAt: timestamp('updatedAt').$onUpdate(() => new Date()),
-    // Tracks when status was last changed (for accurate daysInStage calculation)
     statusUpdatedAt: timestamp('statusUpdatedAt'),
   },
   table => [
@@ -85,6 +86,10 @@ export const claims = pgTable(
     check(
       'claim_incident_jurisdiction_check',
       sql`${table.incidentJurisdiction} is null or ${table.incidentJurisdiction} ~ '^country:[A-Z]{2}$'`
+    ),
+    check(
+      'claim_recovery_law_check',
+      sql`${table.recoveryLaw} is null or ${table.recoveryLaw} ~ '^[A-Z]{2}$'`
     ),
   ]
 );

--- a/packages/database/test/claim-recovery-law.test.ts
+++ b/packages/database/test/claim-recovery-law.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { claims } from '../src/schema';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const migrationPath = path.join(repoRoot, 'packages/database/drizzle/0082_claim_recovery_law.sql');
+
+test('claim schema exports nullable recovery law routing columns', () => {
+  assert.equal(claims.recoveryLaw.name, 'recovery_law');
+  assert.equal(claims.recoveryLegalTenantId.name, 'recovery_legal_tenant_id');
+  assert.equal(claims.recoveryLaw.notNull, false);
+  assert.equal(claims.recoveryLegalTenantId.notNull, false);
+});
+
+test('recovery law columns are positioned after incident jurisdiction', () => {
+  const keys = Object.keys(claims);
+  const incidentJurisdictionIdx = keys.indexOf('incidentJurisdiction');
+  const recoveryLawIdx = keys.indexOf('recoveryLaw');
+  const recoveryTenantIdx = keys.indexOf('recoveryLegalTenantId');
+  assert.ok(incidentJurisdictionIdx >= 0, 'incidentJurisdiction must exist');
+  assert.ok(recoveryLawIdx > incidentJurisdictionIdx, 'recoveryLaw must follow incident data');
+  assert.ok(
+    recoveryTenantIdx > incidentJurisdictionIdx,
+    'recovery tenant must follow incident data'
+  );
+});
+
+test('claim recovery law migration is additive and compatibility-safe', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  assert.match(sql, /ALTER TABLE "claim" ADD COLUMN "recovery_law" text;/u);
+  assert.match(sql, /ALTER TABLE "claim" ADD COLUMN "recovery_legal_tenant_id" text;/u);
+  assert.match(
+    sql,
+    /FOREIGN KEY \("recovery_legal_tenant_id"\) REFERENCES "public"\."tenants"\("id"\)/u
+  );
+  assert.match(sql, /"recovery_law" is null or "claim"\."recovery_law" ~ '\^\[A-Z\]\{2\}\$'/u);
+  assert.doesNotMatch(sql, /"recovery_law" text NOT NULL/u);
+  assert.doesNotMatch(sql, /"recovery_legal_tenant_id" text NOT NULL/u);
+  assert.doesNotMatch(sql, /UPDATE "claim"/u);
+});

--- a/packages/domain-claims/src/claims/incident-country-backfill.test.ts
+++ b/packages/domain-claims/src/claims/incident-country-backfill.test.ts
@@ -36,7 +36,11 @@ describe('buildIncidentCountryBackfillPlan', () => {
         tenantId: 'tenant-1',
       },
     ]);
-    expect(plan.updatesBySource).toEqual({ claim_pack_json: 1, diaspora_origin_note: 0 });
+    expect(plan.updatesBySource).toEqual({
+      claim_pack_json: 1,
+      diaspora_origin_note: 0,
+      existing_incident_country: 0,
+    });
   });
 
   it('uses a later valid claim-pack country code when an earlier value is invalid', () => {
@@ -86,13 +90,45 @@ describe('buildIncidentCountryBackfillPlan', () => {
     ]);
   });
 
-  it('does not plan updates for rows that already have live incident-country values', () => {
+  it('plans recovery routing for supported rows that already have incident country', () => {
+    const plan = buildIncidentCountryBackfillPlan([
+      row({
+        incidentCountryCode: 'XK',
+        incidentJurisdiction: 'country:XK',
+        recoveryLaw: null,
+        recoveryLegalTenantId: null,
+      }),
+    ]);
+
+    expect(plan.updates).toEqual([
+      expect.objectContaining({
+        claimId: 'claim-1',
+        incidentCountryCode: 'XK',
+        recoveryLaw: 'XK',
+        recoveryLegalTenantId: 'tenant_ks',
+        source: 'existing_incident_country',
+      }),
+    ]);
+  });
+
+  it('does not plan updates for rows that already have full incident-country routing', () => {
     const plan = buildIncidentCountryBackfillPlan([
       row({
         claimPackJson: { answers: { incidentCountry: 'DE' } },
-        incidentCountryCode: 'CH',
-        incidentJurisdiction: 'country:CH',
+        incidentCountryCode: 'XK',
+        incidentJurisdiction: 'country:XK',
+        recoveryLaw: 'XK',
+        recoveryLegalTenantId: 'tenant_ks',
       }),
+    ]);
+
+    expect(plan.alreadyPopulated).toBe(1);
+    expect(plan.updates).toEqual([]);
+  });
+
+  it('does not invent recovery routing for unsupported existing incident countries', () => {
+    const plan = buildIncidentCountryBackfillPlan([
+      row({ incidentCountryCode: 'CH', incidentJurisdiction: 'country:CH' }),
     ]);
 
     expect(plan.alreadyPopulated).toBe(1);

--- a/packages/domain-claims/src/claims/incident-country-backfill.test.ts
+++ b/packages/domain-claims/src/claims/incident-country-backfill.test.ts
@@ -30,6 +30,8 @@ describe('buildIncidentCountryBackfillPlan', () => {
         claimId: 'claim-1',
         incidentCountryCode: 'DE',
         incidentJurisdiction: 'country:DE',
+        recoveryLaw: null,
+        recoveryLegalTenantId: null,
         source: 'claim_pack_json',
         tenantId: 'tenant-1',
       },
@@ -65,6 +67,21 @@ describe('buildIncidentCountryBackfillPlan', () => {
         incidentCountryCode: 'IT',
         incidentJurisdiction: 'country:IT',
         source: 'diaspora_origin_note',
+      }),
+    ]);
+  });
+
+  it('includes recovery law routing values for supported incident countries', () => {
+    const plan = buildIncidentCountryBackfillPlan([
+      row({ claimPackJson: { answers: { incidentCountryCode: 'MK' } } }),
+    ]);
+
+    expect(plan.updates).toEqual([
+      expect.objectContaining({
+        claimId: 'claim-1',
+        incidentCountryCode: 'MK',
+        recoveryLaw: 'MK',
+        recoveryLegalTenantId: 'tenant_mk',
       }),
     ]);
   });

--- a/packages/domain-claims/src/claims/incident-country-backfill.ts
+++ b/packages/domain-claims/src/claims/incident-country-backfill.ts
@@ -1,17 +1,19 @@
 import { parseDiasporaOriginFromPublicNote } from './diaspora-origin';
 import { resolveClaimIncidentCountry, type ClaimIncidentCountry } from './incident-country';
-
-export type IncidentCountryBackfillSource = 'claim_pack_json' | 'diaspora_origin_note';
-
+export type IncidentCountryBackfillSource =
+  | 'claim_pack_json'
+  | 'diaspora_origin_note'
+  | 'existing_incident_country';
 export type IncidentCountryBackfillRow = {
   claimPackJson?: unknown;
   diasporaPublicNotes?: Array<string | null | undefined>;
   id: string;
   incidentCountryCode?: string | null;
   incidentJurisdiction?: string | null;
+  recoveryLaw?: string | null;
+  recoveryLegalTenantId?: string | null;
   tenantId: string;
 };
-
 export type IncidentCountryBackfillUpdate = ClaimIncidentCountry & {
   claimId: string;
   source: IncidentCountryBackfillSource;
@@ -38,18 +40,17 @@ const CLAIM_PACK_COUNTRY_PATHS = [
   ['data', 'input', 'answers', 'incidentCountry'],
 ] as const;
 
-function readRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
+type IncidentCountryBackfillCandidate = {
+  country: ClaimIncidentCountry;
+  invalid: boolean;
+  source: IncidentCountryBackfillSource;
+};
 
 function readStringPath(value: unknown, path: readonly string[]): string | null {
   let cursor: unknown = value;
   for (const segment of path) {
-    const record = readRecord(cursor);
-    if (!record) return null;
-    cursor = record[segment];
+    if (cursor === null || typeof cursor !== 'object' || Array.isArray(cursor)) return null;
+    cursor = (cursor as Record<string, unknown>)[segment];
   }
 
   return typeof cursor === 'string' ? cursor : null;
@@ -58,11 +59,7 @@ function readStringPath(value: unknown, path: readonly string[]): string | null 
 function resolveCandidate(
   source: IncidentCountryBackfillSource,
   countryCode: string | null
-): {
-  country: ClaimIncidentCountry;
-  invalid: boolean;
-  source: IncidentCountryBackfillSource;
-} | null {
+): IncidentCountryBackfillCandidate | null {
   if (!countryCode) return null;
   const country = resolveClaimIncidentCountry({ incidentCountryCode: countryCode });
   return country.incidentCountryCode
@@ -92,6 +89,20 @@ function readDiasporaCandidate(row: IncidentCountryBackfillRow) {
   return null;
 }
 
+function appendUpdate(
+  plan: IncidentCountryBackfillPlan,
+  row: IncidentCountryBackfillRow,
+  selected: IncidentCountryBackfillCandidate
+) {
+  plan.updates.push({
+    claimId: row.id,
+    ...selected.country,
+    source: selected.source,
+    tenantId: row.tenantId,
+  });
+  plan.updatesBySource[selected.source]++;
+}
+
 export function buildIncidentCountryBackfillPlan(
   rows: IncidentCountryBackfillRow[]
 ): IncidentCountryBackfillPlan {
@@ -101,11 +112,21 @@ export function buildIncidentCountryBackfillPlan(
     skippedInvalidSource: 0,
     skippedNoDurableSource: 0,
     updates: [],
-    updatesBySource: { claim_pack_json: 0, diaspora_origin_note: 0 },
+    updatesBySource: { claim_pack_json: 0, diaspora_origin_note: 0, existing_incident_country: 0 },
   };
 
   for (const row of rows) {
     if (row.incidentCountryCode) {
+      const existing = resolveCandidate('existing_incident_country', row.incidentCountryCode);
+      if (
+        existing?.country.recoveryLaw &&
+        existing.country.recoveryLegalTenantId &&
+        (!row.recoveryLaw || !row.recoveryLegalTenantId)
+      ) {
+        appendUpdate(plan, row, existing);
+        continue;
+      }
+
       plan.alreadyPopulated++;
       continue;
     }
@@ -122,13 +143,7 @@ export function buildIncidentCountryBackfillPlan(
       continue;
     }
 
-    plan.updates.push({
-      claimId: row.id,
-      ...selected.country,
-      source: selected.source,
-      tenantId: row.tenantId,
-    });
-    plan.updatesBySource[selected.source]++;
+    appendUpdate(plan, row, selected);
   }
 
   return plan;

--- a/packages/domain-claims/src/claims/incident-country-backfill.ts
+++ b/packages/domain-claims/src/claims/incident-country-backfill.ts
@@ -124,8 +124,7 @@ export function buildIncidentCountryBackfillPlan(
 
     plan.updates.push({
       claimId: row.id,
-      incidentCountryCode: selected.country.incidentCountryCode,
-      incidentJurisdiction: selected.country.incidentJurisdiction,
+      ...selected.country,
       source: selected.source,
       tenantId: row.tenantId,
     });

--- a/packages/domain-claims/src/claims/incident-country.ts
+++ b/packages/domain-claims/src/claims/incident-country.ts
@@ -1,6 +1,10 @@
+import { recoveryLawClaimValues, resolveRecoveryLaw } from '@interdomestik/domain-recovery';
+
 import type { ClaimStartHandoffContext } from './types';
 
-export type ClaimIncidentCountry = {
+type ClaimRecoveryLawValues = ReturnType<typeof resolveClaimRecoveryLawValues>;
+
+export type ClaimIncidentCountry = ClaimRecoveryLawValues & {
   incidentCountryCode: string | null;
   incidentJurisdiction: string | null;
 };
@@ -43,12 +47,20 @@ function normalizeCountryJurisdiction(
   return `country:${countryCode}`;
 }
 
+function resolveClaimRecoveryLawValues(incidentCountryCode: string | null) {
+  return recoveryLawClaimValues(resolveRecoveryLaw({ incidentCountryCode }));
+}
+
 export function resolveClaimIncidentCountry(
   input: ClaimIncidentCountryInput
 ): ClaimIncidentCountry {
   const incidentCountryCode = normalizeCountryCode(input.incidentCountryCode);
   if (!incidentCountryCode) {
-    return { incidentCountryCode: null, incidentJurisdiction: null };
+    return {
+      incidentCountryCode: null,
+      incidentJurisdiction: null,
+      ...resolveClaimRecoveryLawValues(null),
+    };
   }
 
   return {
@@ -57,6 +69,7 @@ export function resolveClaimIncidentCountry(
       input.incidentJurisdiction,
       incidentCountryCode
     ),
+    ...resolveClaimRecoveryLawValues(incidentCountryCode),
   };
 }
 
@@ -78,7 +91,7 @@ export function resolveHandoffIncidentCountry(
   handoffContext: ClaimStartHandoffContext | null | undefined
 ): ClaimIncidentCountry {
   if (handoffContext?.source !== 'diaspora-green-card') {
-    return { incidentCountryCode: null, incidentJurisdiction: null };
+    return resolveClaimIncidentCountry({});
   }
 
   return resolveClaimIncidentCountry({ incidentCountryCode: handoffContext.country });

--- a/packages/domain-recovery/src/index.test.ts
+++ b/packages/domain-recovery/src/index.test.ts
@@ -1,9 +1,70 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { DOMAIN_RECOVERY_BOUNDARY, RECOVERY_LIFECYCLE_FIELD } from './index';
+import {
+  DEFAULT_RECOVERY_JURISDICTIONS,
+  DOMAIN_RECOVERY_BOUNDARY,
+  RECOVERY_LEGAL_TENANT_FIELD,
+  RECOVERY_LIFECYCLE_FIELD,
+  RECOVERY_LAW_FIELD,
+  recoveryLawClaimValues,
+  resolveRecoveryLaw,
+} from './index';
 
 test('domain-recovery exposes a bounded recovery lifecycle contract', () => {
   assert.equal(DOMAIN_RECOVERY_BOUNDARY, 'domain-recovery');
   assert.equal(RECOVERY_LIFECYCLE_FIELD, 'claims.recovery_lifecycle_state');
+  assert.equal(RECOVERY_LAW_FIELD, 'claims.recovery_law');
+  assert.equal(RECOVERY_LEGAL_TENANT_FIELD, 'claims.recovery_legal_tenant_id');
+});
+
+test('resolves recovery law from explicit incident country', () => {
+  const resolution = resolveRecoveryLaw({ incidentCountryCode: ' mk ' });
+
+  assert.equal(resolution.outcome, 'recovery_law_resolved');
+  assert.equal(resolution.incidentCountryCode, 'MK');
+  assert.equal(resolution.recoveryLaw, 'MK');
+  assert.equal(resolution.recoveryLegalTenantId, 'tenant_mk');
+  assert.equal(resolution.regulatedActivityNoteRequired, true);
+  assert.deepEqual(recoveryLawClaimValues(resolution), {
+    recoveryLaw: 'MK',
+    recoveryLegalTenantId: 'tenant_mk',
+  });
+});
+
+test('unsupported recovery country never falls back to membership or host context', () => {
+  const resolution = resolveRecoveryLaw({
+    incidentCountryCode: 'CH',
+    fallbackContext: {
+      accessTenantId: 'tenant_access',
+      bookingTenantId: 'tenant_booking',
+      hostTenantId: 'tenant_host',
+      membershipGoverningLaw: 'MK',
+      membershipLegalTenantId: 'tenant_mk',
+    },
+  });
+
+  assert.equal(resolution.outcome, 'no_network_or_unsupported_jurisdiction');
+  assert.equal(resolution.posture, 'guidance_only');
+  assert.equal(resolution.declineReason, 'no_network');
+  assert.equal(resolution.recoveryLaw, null);
+  assert.equal(resolution.recoveryLegalTenantId, null);
+});
+
+test('invalid country and invalid registry entries produce no-network routing', () => {
+  const resolution = resolveRecoveryLaw({
+    incidentCountryCode: 'Macedonia',
+    jurisdictions: [
+      {
+        incidentCountryCode: 'DE',
+        recoveryLaw: 'Germany',
+        recoveryLegalTenantId: '',
+        regulatedActivityNoteRequired: true,
+      },
+    ],
+  });
+
+  assert.equal(resolution.outcome, 'no_network_or_unsupported_jurisdiction');
+  assert.equal(resolution.incidentCountryCode, null);
+  assert.equal(DEFAULT_RECOVERY_JURISDICTIONS.length, 2);
 });

--- a/packages/domain-recovery/src/index.ts
+++ b/packages/domain-recovery/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './recovery-law';

--- a/packages/domain-recovery/src/recovery-law.ts
+++ b/packages/domain-recovery/src/recovery-law.ts
@@ -1,0 +1,129 @@
+export const RECOVERY_LAW_FIELD = 'claims.recovery_law' as const;
+export const RECOVERY_LEGAL_TENANT_FIELD = 'claims.recovery_legal_tenant_id' as const;
+
+export const RECOVERY_UNSUPPORTED_REASON = 'no_network_or_unsupported_jurisdiction' as const;
+export const RECOVERY_NO_NETWORK_DECLINE_REASON = 'no_network' as const;
+
+export type RecoveryJurisdictionConfig = {
+  incidentCountryCode: string;
+  recoveryLaw: string;
+  recoveryLegalTenantId: string;
+  regulatedActivityNoteRequired: true;
+};
+
+export type RecoveryFallbackContext = {
+  accessTenantId?: string | null;
+  bookingTenantId?: string | null;
+  hostTenantId?: string | null;
+  membershipGoverningLaw?: string | null;
+  membershipLegalTenantId?: string | null;
+};
+
+export type RecoveryLawResolution =
+  | {
+      outcome: 'recovery_law_resolved';
+      incidentCountryCode: string;
+      recoveryLaw: string;
+      recoveryLegalTenantId: string;
+      regulatedActivityNoteRequired: true;
+      posture: 'recovery_available';
+      reason: null;
+      declineReason: null;
+    }
+  | {
+      outcome: typeof RECOVERY_UNSUPPORTED_REASON;
+      incidentCountryCode: string | null;
+      recoveryLaw: null;
+      recoveryLegalTenantId: null;
+      regulatedActivityNoteRequired: true;
+      posture: 'guidance_only';
+      reason: typeof RECOVERY_UNSUPPORTED_REASON;
+      declineReason: typeof RECOVERY_NO_NETWORK_DECLINE_REASON;
+    };
+
+export type RecoveryLawClaimValues = Pick<
+  RecoveryLawResolution,
+  'recoveryLaw' | 'recoveryLegalTenantId'
+>;
+
+export const DEFAULT_RECOVERY_JURISDICTIONS = [
+  {
+    incidentCountryCode: 'XK',
+    recoveryLaw: 'XK',
+    recoveryLegalTenantId: 'tenant_ks',
+    regulatedActivityNoteRequired: true,
+  },
+  {
+    incidentCountryCode: 'MK',
+    recoveryLaw: 'MK',
+    recoveryLegalTenantId: 'tenant_mk',
+    regulatedActivityNoteRequired: true,
+  },
+] as const satisfies readonly RecoveryJurisdictionConfig[];
+
+const COUNTRY_CODE = /^[A-Z]{2}$/u;
+
+function normalizeCountryCode(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toUpperCase();
+  return normalized && COUNTRY_CODE.test(normalized) ? normalized : null;
+}
+
+function normalizeConfig(config: RecoveryJurisdictionConfig) {
+  const incidentCountryCode = normalizeCountryCode(config.incidentCountryCode);
+  const recoveryLaw = normalizeCountryCode(config.recoveryLaw);
+  const recoveryLegalTenantId = config.recoveryLegalTenantId.trim();
+
+  if (!incidentCountryCode || !recoveryLaw || !recoveryLegalTenantId) {
+    return null;
+  }
+
+  return {
+    incidentCountryCode,
+    recoveryLaw,
+    recoveryLegalTenantId,
+    regulatedActivityNoteRequired: config.regulatedActivityNoteRequired,
+  };
+}
+
+export function resolveRecoveryLaw(args: {
+  incidentCountryCode?: string | null;
+  jurisdictions?: readonly RecoveryJurisdictionConfig[];
+  fallbackContext?: RecoveryFallbackContext;
+}): RecoveryLawResolution {
+  const incidentCountryCode = normalizeCountryCode(args.incidentCountryCode);
+  const jurisdictions = args.jurisdictions ?? DEFAULT_RECOVERY_JURISDICTIONS;
+  const match = jurisdictions
+    .map(normalizeConfig)
+    .find(config => config?.incidentCountryCode === incidentCountryCode);
+
+  if (incidentCountryCode && match) {
+    return {
+      outcome: 'recovery_law_resolved',
+      incidentCountryCode,
+      recoveryLaw: match.recoveryLaw,
+      recoveryLegalTenantId: match.recoveryLegalTenantId,
+      regulatedActivityNoteRequired: true,
+      posture: 'recovery_available',
+      reason: null,
+      declineReason: null,
+    };
+  }
+
+  return {
+    outcome: RECOVERY_UNSUPPORTED_REASON,
+    incidentCountryCode,
+    recoveryLaw: null,
+    recoveryLegalTenantId: null,
+    regulatedActivityNoteRequired: true,
+    posture: 'guidance_only',
+    reason: RECOVERY_UNSUPPORTED_REASON,
+    declineReason: RECOVERY_NO_NETWORK_DECLINE_REASON,
+  };
+}
+
+export function recoveryLawClaimValues(resolution: RecoveryLawResolution): RecoveryLawClaimValues {
+  return {
+    recoveryLaw: resolution.recoveryLaw,
+    recoveryLegalTenantId: resolution.recoveryLegalTenantId,
+  };
+}

--- a/packages/domain-recovery/src/types.ts
+++ b/packages/domain-recovery/src/types.ts
@@ -9,4 +9,6 @@ export type RecoveryLifecycleSnapshot = {
   claimId: string;
   status: ClaimStatus;
   recoveryLifecycleState: RecoveryLifecycleState;
+  recoveryLaw: string | null;
+  recoveryLegalTenantId: string | null;
 };

--- a/scripts/backfill-incident-country.ts
+++ b/scripts/backfill-incident-country.ts
@@ -98,6 +98,8 @@ async function main() {
         .set({
           incidentCountryCode: update.incidentCountryCode,
           incidentJurisdiction: update.incidentJurisdiction,
+          recoveryLaw: update.recoveryLaw,
+          recoveryLegalTenantId: update.recoveryLegalTenantId,
         })
         .where(
           and(

--- a/scripts/backfill-incident-country.ts
+++ b/scripts/backfill-incident-country.ts
@@ -8,6 +8,7 @@ import {
   eq,
   inArray,
   isNull,
+  or,
   sql,
 } from '@interdomestik/database';
 import {
@@ -34,19 +35,23 @@ async function getCoverage(tenantId: string | undefined): Promise<Coverage> {
 }
 
 async function listMissingClaims(tenantId: string | undefined, limit: number | undefined) {
-  // db-access-guard: system-exempt -- reason: dry-run operator discovery may enumerate missing rows across tenants before scoped apply
+  // db-access-guard: system-exempt -- reason: dry-run operator discovery may enumerate missing routing rows across tenants before scoped apply
+  const missingRouting = or(
+    isNull(claims.incidentCountryCode),
+    isNull(claims.recoveryLaw),
+    isNull(claims.recoveryLegalTenantId)
+  );
   const query = db
     .select({
       id: claims.id,
       incidentCountryCode: claims.incidentCountryCode,
+      incidentJurisdiction: claims.incidentJurisdiction,
+      recoveryLaw: claims.recoveryLaw,
+      recoveryLegalTenantId: claims.recoveryLegalTenantId,
       tenantId: claims.tenantId,
     })
     .from(claims)
-    .where(
-      tenantId
-        ? and(eq(claims.tenantId, tenantId), isNull(claims.incidentCountryCode))
-        : isNull(claims.incidentCountryCode)
-    )
+    .where(tenantId ? and(eq(claims.tenantId, tenantId), missingRouting) : missingRouting)
     .orderBy(asc(claims.tenantId), asc(claims.createdAt), asc(claims.id));
   return limit ? query.limit(limit) : query;
 }
@@ -105,7 +110,11 @@ async function main() {
           and(
             eq(claims.id, update.claimId),
             eq(claims.tenantId, update.tenantId),
-            isNull(claims.incidentCountryCode)
+            or(
+              isNull(claims.incidentCountryCode),
+              isNull(claims.recoveryLaw),
+              isNull(claims.recoveryLegalTenantId)
+            )
           )
         )
         .returning({ id: claims.id });

--- a/scripts/ci/incident-country-backfill-contract.test.mjs
+++ b/scripts/ci/incident-country-backfill-contract.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const script = readFileSync('scripts/backfill-incident-country.ts', 'utf8');
+
+test('incident country backfill persists recovery-law routing fields', () => {
+  assert.match(script, /recoveryLaw: update\.recoveryLaw/u);
+  assert.match(script, /recoveryLegalTenantId: update\.recoveryLegalTenantId/u);
+  assert.match(script, /isNull\(claims\.incidentCountryCode\)/u);
+});

--- a/scripts/ci/incident-country-backfill-contract.test.mjs
+++ b/scripts/ci/incident-country-backfill-contract.test.mjs
@@ -1,11 +1,16 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
-const script = readFileSync('scripts/backfill-incident-country.ts', 'utf8');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const script = readFileSync(path.join(repoRoot, 'scripts/backfill-incident-country.ts'), 'utf8');
 
 test('incident country backfill persists recovery-law routing fields', () => {
   assert.match(script, /recoveryLaw: update\.recoveryLaw/u);
   assert.match(script, /recoveryLegalTenantId: update\.recoveryLegalTenantId/u);
   assert.match(script, /isNull\(claims\.incidentCountryCode\)/u);
+  assert.match(script, /isNull\(claims\.recoveryLaw\)/u);
+  assert.match(script, /isNull\(claims\.recoveryLegalTenantId\)/u);
 });

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35369788,
-  "maxTrackedFiles": 4101,
+  "maxTrackedBytes": 35379248,
+  "maxTrackedFiles": 4105,
   "maxLargestFileBytes": 2800588,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689065,
-    "source/scripts": 6580304,
-    "tests/e2e": 4388520,
+    "source/scripts": 6583069,
+    "tests/e2e": 4393640,
     "docs/text": 5070141,
     "config/data/messages": 1555000,
     "other": 1048576

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35379248,
+  "maxTrackedBytes": 35384000,
   "maxTrackedFiles": 4105,
   "maxLargestFileBytes": 2800588,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689065,
-    "source/scripts": 6583069,
-    "tests/e2e": 4393640,
+    "source/scripts": 6585000,
+    "tests/e2e": 4395000,
     "docs/text": 5070141,
     "config/data/messages": 1555000,
     "other": 1048576


### PR DESCRIPTION
## Summary

Implements T-208 recovery-law routing from explicit `incident_country_code`.

- adds nullable `claims.recovery_law` and `claims.recovery_legal_tenant_id`
- adds `domain-recovery` resolver for supported jurisdictions and typed unsupported/no-network outcomes
- wires claim incident-country resolution and backfill planning to derive recovery-law fields without falling back to membership law, booking tenant, host, or access tenant
- updates the incident-country backfill apply path to persist recovery-law routing fields
- adds focused database/domain/CI contract tests

## Scope / Risk

Classified as implementation, Tier 3, because it adds a database migration/schema fields and touches recovery-law domain routing. No changes to `apps/web/src/proxy.ts`, canonical routes, auth/session layering, or tenant isolation routing.

## Verification

Local focused checks passed:

- `TMPDIR=/private/tmp pnpm --filter @interdomestik/domain-recovery test:unit`
- `TMPDIR=/private/tmp pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/incident-country-backfill.test.ts src/claims/incident-country-writers.test.ts`
- `TMPDIR=/private/tmp pnpm --filter @interdomestik/database test:unit -- claim-recovery-law.test.ts`
- `node --test scripts/ci/incident-country-backfill-contract.test.mjs`
- `pnpm --filter @interdomestik/domain-recovery type-check && pnpm --filter @interdomestik/domain-claims type-check && pnpm --filter @interdomestik/database type-check`
- `pnpm check:architecture-boundaries`
- `pnpm check:db-access`
- `pnpm repo:size:check`
- `pnpm exec prettier --check ...` on changed TS/JSON files
- `git diff --check`

Notes:

- Database unit run reports three expected skips where `DATABASE_URL` is absent for RLS integration checks; suite exits 0.
- `codex review --uncommitted` custom prompt route was blocked by local CLI argument parsing; built-in uncommitted review then ran partial checks but hung without final disposition and was terminated. Manual follow-up found and fixed the backfill persistence gap before push.

## Rollback

Revert this PR to remove the new domain resolver wiring and additive migration reference. The migration itself is additive and nullable; existing claim rows remain compatible.

## Residual Risk

Full Phase C gates (`pnpm pr:verify`, `pnpm security:guard`, `pnpm e2e:gate`) were not run locally before PR creation; CI should be treated as authoritative before merge.
