### PR TITLE
feat: emit case.created for submitted claims

### DIFF
--- a/packages/database/src/domain-events.ts
+++ b/packages/database/src/domain-events.ts
@@ -5,88 +5,88 @@ import { domainEvents } from './schema/domain-events';
 export type DomainEventTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 export type AppendEventParams = {
-  actor: {
-    id: string;
-    role: string;
-  };
+  actor: { id: string; role: string };
   aggregateVersion: number;
   correlationId: string;
   createdAt?: Date;
-  entity: {
-    id: string;
-    type: string;
-  };
+  entity: { id: string; type: string };
   eventName: string;
   eventVersion: number;
   id?: string;
   payload?: Record<string, unknown>;
   tenantId: string;
 };
+export type AppendEventResult = { id: string };
 
-export type AppendEventResult = {
-  id: string;
-};
-
-type PayloadValidator = (payload: Record<string, unknown>) => Record<string, unknown>;
-
-const CLAIM_STATUS_SET = new Set<string>(CLAIM_STATUSES);
+const CASE_CREATED_KEYS = new Set(['hasDocuments', 'initialStatus']);
 const CLAIM_STATUS_CHANGED_KEYS = new Set(['fromStatus', 'toStatus']);
-
+const CLAIM_STATUS_SET = new Set<string>(CLAIM_STATUSES);
 function assertNonEmpty(value: string, field: string): void {
   if (value.trim().length === 0) {
     throw new Error(`appendEvent requires ${field}`);
   }
 }
-
 function assertIntegerAtLeast(value: number, minimum: number, field: string): void {
   if (!Number.isInteger(value) || value < minimum) {
     throw new Error(`appendEvent requires ${field} >= ${minimum}`);
   }
 }
-
-function eventPayloadAllowlistKey(params: AppendEventParams): string {
-  return `${params.eventName}@${params.eventVersion}`;
-}
-
 function assertClaimStatus(value: unknown, field: string): asserts value is ClaimStatus {
   if (typeof value !== 'string' || !CLAIM_STATUS_SET.has(value)) {
     throw new Error(`appendEvent requires payload.${field} to be a claim status`);
   }
 }
-
 function assertNoUnexpectedPayloadFields(
   payload: Record<string, unknown>,
-  eventName: string
+  eventName: string,
+  allowedKeys: Set<string>
 ): void {
   for (const field of Object.keys(payload)) {
-    if (!CLAIM_STATUS_CHANGED_KEYS.has(field)) {
+    if (!allowedKeys.has(field)) {
       throw new Error(`appendEvent payload field ${field} is not allowlisted for ${eventName}`);
     }
   }
 }
-
-function assertClaimStatusChangedPayload(payload: Record<string, unknown>): void {
-  assertNoUnexpectedPayloadFields(payload, 'claim.status_changed');
+function assertRequiredPayloadField(payload: Record<string, unknown>, field: string): unknown {
+  if (!Object.hasOwn(payload, field)) {
+    throw new Error(`appendEvent requires payload.${field}`);
+  }
+  return payload[field];
+}
+function assertBooleanPayloadField(payload: Record<string, unknown>, field: string): boolean {
+  const value = assertRequiredPayloadField(payload, field);
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`appendEvent requires payload.${field} to be a boolean`);
+  }
+  return value;
+}
+function claimStatusChangedPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(payload, 'claim.status_changed', CLAIM_STATUS_CHANGED_KEYS);
   for (const field of CLAIM_STATUS_CHANGED_KEYS) {
-    if (!Object.hasOwn(payload, field)) {
-      throw new Error(`appendEvent requires payload.${field}`);
-    }
+    assertRequiredPayloadField(payload, field);
     assertClaimStatus(payload[field], field);
   }
-}
-
-function claimStatusChangedPayload(payload: Record<string, unknown>): Record<string, unknown> {
-  assertClaimStatusChangedPayload(payload);
   return { fromStatus: payload.fromStatus, toStatus: payload.toStatus };
 }
-
-const PAYLOAD_VALIDATORS: Record<string, PayloadValidator> = {
+function caseCreatedPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(payload, 'case.created', CASE_CREATED_KEYS);
+  const initialStatus = assertRequiredPayloadField(payload, 'initialStatus');
+  assertClaimStatus(initialStatus, 'initialStatus');
+  return {
+    hasDocuments: assertBooleanPayloadField(payload, 'hasDocuments'),
+    initialStatus,
+  };
+}
+const PAYLOAD_VALIDATORS: Record<
+  string,
+  (payload: Record<string, unknown>) => Record<string, unknown>
+> = {
+  'case.created@1': caseCreatedPayload,
   'claim.status_changed@1': claimStatusChangedPayload,
 };
-
 function assertAllowlistedPayload(params: AppendEventParams): Record<string, unknown> {
   const payload = params.payload ?? {};
-  const allowlistKey = eventPayloadAllowlistKey(params);
+  const allowlistKey = `${params.eventName}@${params.eventVersion}`;
   const validator = PAYLOAD_VALIDATORS[allowlistKey];
 
   if (!validator) {
@@ -95,7 +95,6 @@ function assertAllowlistedPayload(params: AppendEventParams): Record<string, unk
 
   return validator(payload);
 }
-
 export async function appendEvent(
   tx: DomainEventTx,
   params: AppendEventParams

--- a/packages/database/test/domain-event-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-payload-allowlist.test.ts
@@ -42,70 +42,64 @@ function makeEvent(overrides: Partial<Parameters<typeof appendEvent>[1]> = {}) {
   };
 }
 
+function makeCaseCreatedEvent(overrides: Partial<Parameters<typeof appendEvent>[1]> = {}) {
+  return makeEvent({
+    actor: { id: 'member-1', role: 'member' },
+    aggregateVersion: 1,
+    entity: { id: 'claim-1', type: 'case' },
+    eventName: 'case.created',
+    payload: {
+      hasDocuments: true,
+      initialStatus: 'submitted',
+    },
+    ...overrides,
+  });
+}
+
 describe('appendEvent payload allowlist', () => {
-  it('rejects extra claim.status_changed payload fields before inserting', async () => {
-    const { capture, tx } = makeTx();
+  for (const [name, event, error] of [
+    [
+      'extra claim.status_changed fields',
+      makeEvent({
+        payload: {
+          fromStatus: 'evaluation',
+          memberEmail: 'member@example.invalid',
+          toStatus: 'negotiation',
+        },
+      }),
+      /memberEmail is not allowlisted/,
+    ],
+    [
+      'unsupported event names',
+      makeEvent({ eventName: 'claim.note_added' }),
+      /claim\.note_added@1/,
+    ],
+    ['unsupported versions', makeEvent({ eventVersion: 2 }), /claim\.status_changed@2/],
+    ['missing required fields', makeEvent({ payload: { fromStatus: 'evaluation' } }), /toStatus/],
+    [
+      'non-status values',
+      makeEvent({ payload: { fromStatus: 'evaluation', toStatus: 'Ada Lovelace' } }),
+      /payload\.toStatus to be a claim status/,
+    ],
+    [
+      'extra case.created fields',
+      makeCaseCreatedEvent({
+        payload: {
+          companyName: 'Airline Co',
+          hasDocuments: true,
+          initialStatus: 'submitted',
+        },
+      }),
+      /companyName is not allowlisted/,
+    ],
+  ] as const) {
+    it(`rejects ${name} before inserting`, async () => {
+      const { capture, tx } = makeTx();
 
-    await assert.rejects(
-      () =>
-        appendEvent(
-          tx,
-          makeEvent({
-            payload: {
-              fromStatus: 'evaluation',
-              memberEmail: 'member@example.invalid',
-              toStatus: 'negotiation',
-            },
-          })
-        ),
-      /memberEmail is not allowlisted/
-    );
-    assert.equal(capture.row, undefined);
-  });
-
-  it('rejects unsupported event names before inserting', async () => {
-    const { capture, tx } = makeTx();
-
-    await assert.rejects(
-      () => appendEvent(tx, makeEvent({ eventName: 'claim.note_added' })),
-      /allowlist missing for claim\.note_added@1/
-    );
-    assert.equal(capture.row, undefined);
-  });
-
-  it('rejects unsupported event versions before inserting', async () => {
-    const { capture, tx } = makeTx();
-
-    await assert.rejects(
-      () => appendEvent(tx, makeEvent({ eventVersion: 2 })),
-      /allowlist missing for claim\.status_changed@2/
-    );
-    assert.equal(capture.row, undefined);
-  });
-
-  it('rejects missing required allowlisted fields before inserting', async () => {
-    const { capture, tx } = makeTx();
-
-    await assert.rejects(
-      () => appendEvent(tx, makeEvent({ payload: { fromStatus: 'evaluation' } })),
-      /requires payload\.toStatus/
-    );
-    assert.equal(capture.row, undefined);
-  });
-
-  it('rejects non-status values for allowed status fields before inserting', async () => {
-    const { capture, tx } = makeTx();
-
-    await assert.rejects(
-      () =>
-        appendEvent(
-          tx,
-          makeEvent({ payload: { fromStatus: 'evaluation', toStatus: 'Ada Lovelace' } })
-        ),
-      /payload\.toStatus to be a claim status/
-    );
-    assert.equal(capture.row, undefined);
-  });
+      await assert.rejects(() => appendEvent(tx, event), error);
+      assert.equal(capture.row, undefined);
+    });
+  }
 
   it('inserts a sanitized plain payload instead of caller serialization hooks', async () => {
     const { capture, tx } = makeTx();
@@ -122,5 +116,16 @@ describe('appendEvent payload allowlist', () => {
     await appendEvent(tx, makeEvent({ payload: payloadWithSerializationHook }));
 
     assert.deepEqual(capture.row?.payload, { fromStatus: 'evaluation', toStatus: 'negotiation' });
+  });
+
+  it('allows sanitized case.created payload fields', async () => {
+    const { capture, tx } = makeTx();
+
+    await appendEvent(tx, makeCaseCreatedEvent());
+
+    assert.deepEqual(capture.row?.payload, {
+      hasDocuments: true,
+      initialStatus: 'submitted',
+    });
   });
 });

--- a/packages/domain-claims/src/claims/incident-country-writers.test.ts
+++ b/packages/domain-claims/src/claims/incident-country-writers.test.ts
@@ -25,6 +25,7 @@ const h = vi.hoisted(() => {
   };
 });
 vi.mock('@interdomestik/database', () => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   agentClients: { agentId: 'agent_id', memberId: 'member_id', status: 'status', tenantId: 't' },
   claimDocuments: { __name: 'claim_documents' },
   claimStageHistory: { __name: 'claim_stage_history' },

--- a/packages/domain-claims/src/claims/lifecycle-initialization.test.ts
+++ b/packages/domain-claims/src/claims/lifecycle-initialization.test.ts
@@ -27,6 +27,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock('@interdomestik/database', () => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   agentClients: {
     agentId: 'agent_clients.agent_id',
     memberId: 'agent_clients.member_id',

--- a/packages/domain-claims/src/claims/submit.test.ts
+++ b/packages/domain-claims/src/claims/submit.test.ts
@@ -2,9 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => {
   const txInsertValues = vi.fn().mockResolvedValue(undefined);
-  const txInsert = vi.fn(() => ({
-    values: txInsertValues,
-  }));
+  const txInsert = vi.fn(() => ({ values: txInsertValues }));
   const transaction = vi.fn(async (callback: (tx: { insert: typeof txInsert }) => Promise<void>) =>
     callback({ insert: txInsert })
   );
@@ -46,6 +44,7 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock('@interdomestik/database', () => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   agentClients: {
     tenantId: 'agent_clients.tenant_id',
     memberId: 'agent_clients.member_id',
@@ -97,6 +96,7 @@ vi.mock('./ai-workflows', () => ({
   queueClaimDocumentAiWorkflows: hoisted.queueClaimDocumentAiWorkflows,
 }));
 
+import { appendEvent } from '@interdomestik/database';
 import { submitClaimCore } from './submit';
 import { MAX_CLAIM_EVIDENCE_FILES } from '../validators/claims';
 
@@ -120,8 +120,8 @@ function buildEvidenceFile(overrides: Partial<SubmitClaimFile> = {}): SubmitClai
 
 function buildClaimData(files: SubmitClaimFile[] = [buildEvidenceFile()]): SubmitClaimArgs['data'] {
   return {
-    title: 'Flight delay claim',
-    description: 'My flight was delayed overnight and I incurred hotel costs.',
+    title: 'Delay',
+    description: 'Delayed overnight costs.',
     category: 'travel',
     companyName: 'Airline Co',
     claimAmount: '650.00',
@@ -171,7 +171,7 @@ describe('submitClaimCore', () => {
     });
   });
 
-  it('queues claim AI workflows after persisting the submitted claim documents', async () => {
+  it('queues claim AI after documents persist', async () => {
     const dispatchClaimAiRun = vi.fn().mockResolvedValue(undefined);
     const validateSubmittedClaimFile = vi.fn().mockResolvedValue(undefined);
 
@@ -194,29 +194,26 @@ describe('submitClaimCore', () => {
       claimId: 'claim-1',
       claimNumber: 'CLM-T1-2026-000001',
     });
-    expect(hoisted.generateClaimNumber).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
-        claimId: 'claim-1',
-        tenantId: 'tenant-1',
-      })
-    );
     expect(hoisted.txInsert).toHaveBeenNthCalledWith(1, { __name: 'claim' });
     expect(hoisted.txInsert).toHaveBeenNthCalledWith(2, { __name: 'claim_stage_history' });
-    expect(hoisted.txInsertValues).toHaveBeenNthCalledWith(
-      2,
+    expect(hoisted.txInsert).toHaveBeenNthCalledWith(3, { __name: 'claim_documents' });
+    const stageHistoryRow = hoisted.txInsertValues.mock.calls[1]?.[0] as { createdAt?: Date };
+    const caseCreatedEvent = vi.mocked(appendEvent).mock.calls[0]?.[1];
+    expect(stageHistoryRow.createdAt).toBe(caseCreatedEvent?.createdAt);
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.any(Object),
       expect.objectContaining({
-        claimId: 'claim-1',
+        aggregateVersion: 1,
+        entity: { id: 'claim-1', type: 'case' },
+        eventName: 'case.created',
+        eventVersion: 1,
+        payload: {
+          hasDocuments: true,
+          initialStatus: 'submitted',
+        },
         tenantId: 'tenant-1',
-        fromStatus: null,
-        toStatus: 'submitted',
-        changedById: 'member-1',
-        changedByRole: 'member',
-        note: 'Started from Diaspora / Green Card quickstart. Country: IT. Incident location: abroad.',
-        isPublic: true,
       })
     );
-    expect(hoisted.txInsert).toHaveBeenNthCalledWith(3, { __name: 'claim_documents' });
     expect(hoisted.queueClaimDocumentAiWorkflows).toHaveBeenCalledWith(
       expect.objectContaining({
         claimId: 'claim-1',
@@ -244,7 +241,7 @@ describe('submitClaimCore', () => {
     });
   });
 
-  it('rejects submitted evidence without a server-issued upload intent before creating records', async () => {
+  it('rejects evidence without upload intent before writes', async () => {
     const validateSubmittedClaimFile = vi.fn().mockResolvedValue(undefined);
 
     await expect(
@@ -261,9 +258,10 @@ describe('submitClaimCore', () => {
 
     expect(validateSubmittedClaimFile).not.toHaveBeenCalled();
     expect(hoisted.txInsert).not.toHaveBeenCalled();
+    expect(appendEvent).not.toHaveBeenCalled();
   });
 
-  it('rejects submitted evidence when object validation fails before creating records', async () => {
+  it('rejects evidence when object validation fails before writes', async () => {
     const validateSubmittedClaimFile = vi
       .fn()
       .mockRejectedValue(new Error('Uploaded file was not found. Please retry upload.'));
@@ -278,7 +276,7 @@ describe('submitClaimCore', () => {
     expect(hoisted.txInsert).not.toHaveBeenCalled();
   });
 
-  it('fails as server misconfiguration when evidence validation is not wired', async () => {
+  it('fails when evidence validation is not wired', async () => {
     await expect(submitClaimCore(buildSubmitArgs())).rejects.toThrow(
       'Submitted claim file validation is not configured.'
     );
@@ -286,7 +284,7 @@ describe('submitClaimCore', () => {
     expect(hoisted.txInsert).not.toHaveBeenCalled();
   });
 
-  it('rejects too many evidence files before validating objects or creating records', async () => {
+  it('rejects too many evidence files before writes', async () => {
     const validateSubmittedClaimFile = vi.fn().mockResolvedValue(undefined);
     const files = Array.from({ length: MAX_CLAIM_EVIDENCE_FILES + 1 }, (_, index) => ({
       id: `upload-${index}`,
@@ -301,32 +299,9 @@ describe('submitClaimCore', () => {
     }));
 
     await expect(
-      submitClaimCore(
-        {
-          session: {
-            user: {
-              id: 'member-1',
-              role: 'member',
-              tenantId: 'tenant-1',
-              email: 'member@example.com',
-            },
-          },
-          requestHeaders: new Headers(),
-          data: {
-            title: 'Flight delay claim',
-            description: 'My flight was delayed overnight and I incurred hotel costs.',
-            category: 'travel',
-            companyName: 'Airline Co',
-            claimAmount: '650.00',
-            currency: 'EUR',
-            incidentDate: '2026-02-15',
-            files,
-          },
-        },
-        {
-          validateSubmittedClaimFile,
-        }
-      )
+      submitClaimCore(buildSubmitArgs({ files }), {
+        validateSubmittedClaimFile,
+      })
     ).rejects.toMatchObject({
       code: 'INVALID_PAYLOAD',
     });
@@ -335,34 +310,14 @@ describe('submitClaimCore', () => {
     expect(hoisted.txInsert).not.toHaveBeenCalled();
   });
 
-  it('derives branchId from the assigned agent when subscription branchId is missing', async () => {
+  it('derives branchId from assigned agent fallback', async () => {
     hoisted.getActiveSubscription.mockResolvedValue({
       branchId: null,
       agentId: 'agent-42',
     });
     hoisted.db.query.user.findFirst.mockResolvedValue({ branchId: 'ks-branch-a' });
 
-    await submitClaimCore({
-      session: {
-        user: {
-          id: 'member-1',
-          role: 'member',
-          tenantId: 'tenant-1',
-          email: 'member@example.com',
-        },
-      },
-      requestHeaders: new Headers(),
-      data: {
-        title: 'Flight delay claim',
-        description: 'My flight was delayed overnight and I incurred hotel costs.',
-        category: 'travel',
-        companyName: 'Airline Co',
-        claimAmount: '650.00',
-        currency: 'EUR',
-        incidentDate: '2026-02-15',
-        files: [],
-      },
-    });
+    await submitClaimCore(buildSubmitArgs({ files: [] }));
 
     expect(hoisted.db.query.user.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -378,28 +333,8 @@ describe('submitClaimCore', () => {
     );
   });
 
-  it('does not add a diaspora public note when no handoff context is provided', async () => {
-    await submitClaimCore({
-      session: {
-        user: {
-          id: 'member-1',
-          role: 'member',
-          tenantId: 'tenant-1',
-          email: 'member@example.com',
-        },
-      },
-      requestHeaders: new Headers(),
-      data: {
-        title: 'Flight delay claim',
-        description: 'My flight was delayed overnight and I incurred hotel costs.',
-        category: 'travel',
-        companyName: 'Airline Co',
-        claimAmount: '650.00',
-        currency: 'EUR',
-        incidentDate: '2026-02-15',
-        files: [],
-      },
-    });
+  it('omits diaspora note without handoff context', async () => {
+    await submitClaimCore(buildSubmitArgs({ files: [] }));
 
     expect(hoisted.txInsertValues).toHaveBeenNthCalledWith(
       2,
@@ -409,33 +344,10 @@ describe('submitClaimCore', () => {
     );
   });
 
-  it('records claim attribution metadata in the submission audit event', async () => {
-    await submitClaimCore(
-      {
-        session: {
-          user: {
-            id: 'member-1',
-            role: 'member',
-            tenantId: 'tenant-1',
-            email: 'member@example.com',
-          },
-        },
-        requestHeaders: new Headers(),
-        data: {
-          title: 'Flight delay claim',
-          description: 'My flight was delayed overnight and I incurred hotel costs.',
-          category: 'travel',
-          companyName: 'Airline Co',
-          claimAmount: '650.00',
-          currency: 'EUR',
-          incidentDate: '2026-02-15',
-          files: [],
-        },
-      },
-      {
-        logAuditEvent: hoisted.logAuditEvent,
-      }
-    );
+  it('records claim attribution audit metadata', async () => {
+    await submitClaimCore(buildSubmitArgs({ files: [] }), {
+      logAuditEvent: hoisted.logAuditEvent,
+    });
 
     expect(hoisted.logAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -450,7 +362,7 @@ describe('submitClaimCore', () => {
     );
   });
 
-  it('prefers active agent_clients ownership over stale subscription ownership for claim assignment', async () => {
+  it('prefers active agent_clients ownership for assignment', async () => {
     hoisted.getActiveSubscription.mockResolvedValue({
       branchId: null,
       agentId: 'agent-stale',
@@ -460,32 +372,9 @@ describe('submitClaimCore', () => {
     });
     hoisted.db.query.user.findFirst.mockResolvedValue({ branchId: 'branch-canonical' });
 
-    await submitClaimCore(
-      {
-        session: {
-          user: {
-            id: 'member-1',
-            role: 'member',
-            tenantId: 'tenant-1',
-            email: 'member@example.com',
-          },
-        },
-        requestHeaders: new Headers(),
-        data: {
-          title: 'Flight delay claim',
-          description: 'My flight was delayed overnight and I incurred hotel costs.',
-          category: 'travel',
-          companyName: 'Airline Co',
-          claimAmount: '650.00',
-          currency: 'EUR',
-          incidentDate: '2026-02-15',
-          files: [],
-        },
-      },
-      {
-        logAuditEvent: hoisted.logAuditEvent,
-      }
-    );
+    await submitClaimCore(buildSubmitArgs({ files: [] }), {
+      logAuditEvent: hoisted.logAuditEvent,
+    });
 
     expect(hoisted.txInsertValues).toHaveBeenNthCalledWith(
       1,

--- a/packages/domain-claims/src/claims/submit.ts
+++ b/packages/domain-claims/src/claims/submit.ts
@@ -1,11 +1,4 @@
-import {
-  agentClients,
-  claimDocuments,
-  claimStageHistory,
-  claims,
-  db,
-  tenantSettings,
-} from '@interdomestik/database';
+import { agentClients, claimDocuments, claims, db, tenantSettings } from '@interdomestik/database';
 import { generateClaimNumber } from '@interdomestik/database/claim-number';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { getActiveSubscription } from '@interdomestik/domain-membership-billing/subscription';
@@ -21,6 +14,7 @@ import {
   resolveSubmittedClaimIncidentCountry,
 } from './incident-country';
 import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
+import { recordSubmittedClaimLifecycle } from './transition-side-effects';
 import type { ClaimStartHandoffContext, ClaimsDeps, ClaimsSession } from './types';
 
 export class ClaimValidationError extends Error {
@@ -178,17 +172,14 @@ async function persistSubmittedClaim(args: {
       createdAt: args.createdAt,
     });
 
-    // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
-    await tx.insert(claimStageHistory).values({
-      id: crypto.randomUUID(),
-      tenantId: args.tenantId,
-      claimId: args.claimId,
-      fromStatus: null,
-      toStatus: 'submitted',
-      changedById: args.userId,
+    await recordSubmittedClaimLifecycle(tx, {
       changedByRole: args.changedByRole,
-      note: publicNote,
-      isPublic: true,
+      claimId: args.claimId,
+      createdAt: args.createdAt,
+      data: args.data,
+      publicNote,
+      tenantId: args.tenantId,
+      userId: args.userId,
     });
 
     if (!files?.length) {

--- a/packages/domain-claims/src/claims/transition-side-effects.ts
+++ b/packages/domain-claims/src/claims/transition-side-effects.ts
@@ -2,10 +2,10 @@ import { appendEvent, claimStageHistory, db } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { SQLWrapper } from 'drizzle-orm';
 import type { AuthorizedTransition, ClaimTransitionActor } from './transition-guard';
+import type { CreateClaimValues } from '../validators/claims';
 import type { PaymentAuthorizationState } from '../staff-claims/types';
 
 export type TransitionTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
-
 export type TransitionSideEffectsArgs = {
   actor: ClaimTransitionActor;
   claimId: string;
@@ -18,21 +18,27 @@ export type TransitionSideEffectsArgs = {
   tenantId: string;
   toStatus: ClaimStatus;
 };
-
+export type RecordSubmittedClaimLifecycleArgs = {
+  changedByRole: string;
+  claimId: string;
+  createdAt: Date;
+  data: Pick<CreateClaimValues, 'files'>;
+  publicNote: string | null;
+  tenantId: string;
+  userId: string;
+};
 export class ClaimTransitionConflictError extends Error {
   constructor(claimId: string) {
     super(`Claim ${claimId} changed before the status transition could be saved.`);
     this.name = 'ClaimTransitionConflictError';
   }
 }
-
 export class ClaimTransitionAuthorizationError extends Error {
   constructor(claimId: string) {
     super(`Claim ${claimId} status write attempted with a mismatched authorization proof.`);
     this.name = 'ClaimTransitionAuthorizationError';
   }
 }
-
 export type TransitionClaimStatusParams = {
   actor: ClaimTransitionActor;
   claimId: string;
@@ -45,11 +51,9 @@ export type TransitionClaimStatusParams = {
   tenantId: string;
   toStatus: ClaimStatus;
 };
-
 export type TransitionClaimStatusResult =
   | { success: true; fromStatus: ClaimStatus; lifecycleVersion: number; status: ClaimStatus }
   | { success: false; error: 'claim_not_found' | 'invalid_current_status' | 'transition_rejected' };
-
 export type PersistAuthorizedTransitionArgs = {
   actor: ClaimTransitionActor;
   authorization: AuthorizedTransition;
@@ -61,11 +65,41 @@ export type PersistAuthorizedTransitionArgs = {
   readWhere: SQLWrapper;
   tenantId: string;
 };
-
+export async function recordSubmittedClaimLifecycle(
+  tx: TransitionTx,
+  args: RecordSubmittedClaimLifecycleArgs
+): Promise<void> {
+  // db-access-guard: tenant-scoped -- reason: tenant proof is copied from the claim command boundary.
+  await tx.insert(claimStageHistory).values({
+    id: crypto.randomUUID(),
+    tenantId: args.tenantId,
+    claimId: args.claimId,
+    fromStatus: null,
+    toStatus: 'submitted',
+    changedById: args.userId,
+    changedByRole: args.changedByRole,
+    note: args.publicNote,
+    isPublic: true,
+    createdAt: args.createdAt,
+  });
+  await appendEvent(tx, {
+    actor: { id: args.userId, role: args.changedByRole.trim() || 'member' },
+    aggregateVersion: 1,
+    correlationId: crypto.randomUUID(),
+    createdAt: args.createdAt,
+    entity: { id: args.claimId, type: 'case' },
+    eventName: 'case.created',
+    eventVersion: 1,
+    payload: {
+      hasDocuments: Boolean(args.data.files?.length),
+      initialStatus: 'submitted',
+    },
+    tenantId: args.tenantId,
+  });
+}
 // T-002d Boy Scout split from transition.ts: stage-history + outbox side
 // effects for an authorized status transition. Must always run inside the
-// SAME Postgres transaction as the status write (constitution invariant #2);
-// this module performs no claims.status write itself.
+// SAME Postgres transaction as the status write; this module does not write claims.status.
 export async function recordTransitionSideEffects(
   tx: TransitionTx,
   args: TransitionSideEffectsArgs
@@ -96,7 +130,6 @@ export async function recordTransitionSideEffects(
     isPublic,
     createdAt: now,
   });
-
   if (fromStatus !== toStatus) {
     await appendEvent(tx, {
       actor: { id: actor.id, role: actor.role?.trim() || 'unknown' },


### PR DESCRIPTION
## Summary

Adds the next bounded T-105 continuation slice for event emission beyond `claim.status_changed`: submitted claims now emit a sanitized `case.created@1` domain event in the same transaction as initial case persistence.

## Scope

- Adds an allowlisted `case.created@1` payload contract to `appendEvent`.
- Emits `case.created@1` from the claim submission lifecycle path after initial stage history is recorded.
- Keeps payload intentionally narrow and free of user-controlled text: `hasDocuments`, `initialStatus`.
- Uses the same controlled timestamp for initial stage history and the emitted `case.created@1` event.
- Updates focused database and claim submission tests, including evidence-validation argument coverage.
- Does not touch `apps/web/src/proxy.ts`, canonical routes, auth, tenancy, billing, README, AGENTS, or architecture docs.

## Verification

Initial full local gates before review fixes:
- `pnpm slice:verify` passed.
- `pnpm pr:verify` passed.
- `pnpm e2e:gate` passed: 134 passed, 8 skipped.

Post-review focused verification on amended commit:
- `pnpm --filter @interdomestik/database exec tsx --test test/domain-events.test.ts test/domain-event-payload-allowlist.test.ts` passed.
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/submit.test.ts src/claims/lifecycle-initialization.test.ts src/claims/incident-country-writers.test.ts` passed.
- `pnpm --filter @interdomestik/database type-check && pnpm --filter @interdomestik/domain-claims type-check` passed.
- `pnpm repo:size:check` passed.
- `pnpm security:guard` passed.
- `git diff --check` passed.

## Review And Risk Notes

- Risk tier: Tier 3 due to outbox/domain-event semantics.
- Review comments addressed:
  - Stage history and event now share the same submission timestamp.
  - Evidence validation assertion again covers `actorId`, `tenantId`, file path, and upload-intent token.
  - `case.created@1` omits user-controlled strings instead of persisting category/currency text.
- The event write is inside the existing transaction and uses the caller-owned tenant proof.
- `T-204`, `T-209`, and `T-408` are not promoted by this slice.

## Rollback

Revert the commit to stop `case.created@1` emission. The allowlist and submission event write are isolated to this slice and do not introduce schema changes.
