### PR TITLE
feat: emit recovery decision domain event

### DIFF
--- a/packages/database/src/domain-event-payloads.ts
+++ b/packages/database/src/domain-event-payloads.ts
@@ -1,0 +1,120 @@
+import { CLAIM_STATUSES, type ClaimStatus } from './constants';
+import type { AppendEventParams } from './domain-events';
+
+const CASE_CREATED_KEYS = new Set(['hasDocuments', 'initialStatus']);
+const CLAIM_STATUS_CHANGED_KEYS = new Set(['fromStatus', 'toStatus']);
+const RECOVERY_DECISION_RECORDED_KEYS = new Set([
+  'decisionType',
+  'declineReasonCode',
+  'hasExplanation',
+]);
+const CLAIM_STATUS_SET = new Set<string>(CLAIM_STATUSES);
+const RECOVERY_DECISION_TYPES = new Set(['accepted', 'declined']);
+const RECOVERY_DECLINE_REASON_CODES = new Set([
+  'guidance_only_scope',
+  'insufficient_evidence',
+  'no_monetary_recovery_path',
+  'counterparty_unidentified',
+  'time_limit_risk',
+  'conflict_or_integrity_concern',
+]);
+
+function assertClaimStatus(value: unknown, field: string): asserts value is ClaimStatus {
+  if (typeof value !== 'string' || !CLAIM_STATUS_SET.has(value)) {
+    throw new Error(`appendEvent requires payload.${field} to be a claim status`);
+  }
+}
+
+function assertNoUnexpectedPayloadFields(
+  payload: Record<string, unknown>,
+  eventName: string,
+  allowedKeys: Set<string>
+): void {
+  for (const field of Object.keys(payload)) {
+    if (!allowedKeys.has(field)) {
+      throw new Error(`appendEvent payload field ${field} is not allowlisted for ${eventName}`);
+    }
+  }
+}
+
+function assertRequiredPayloadField(payload: Record<string, unknown>, field: string): unknown {
+  if (!Object.hasOwn(payload, field)) {
+    throw new Error(`appendEvent requires payload.${field}`);
+  }
+  return payload[field];
+}
+
+function assertBooleanPayloadField(payload: Record<string, unknown>, field: string): boolean {
+  const value = assertRequiredPayloadField(payload, field);
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`appendEvent requires payload.${field} to be a boolean`);
+  }
+  return value;
+}
+
+function claimStatusChangedPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(payload, 'claim.status_changed', CLAIM_STATUS_CHANGED_KEYS);
+  for (const field of CLAIM_STATUS_CHANGED_KEYS) {
+    assertRequiredPayloadField(payload, field);
+    assertClaimStatus(payload[field], field);
+  }
+  return { fromStatus: payload.fromStatus, toStatus: payload.toStatus };
+}
+
+function caseCreatedPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(payload, 'case.created', CASE_CREATED_KEYS);
+  const initialStatus = assertRequiredPayloadField(payload, 'initialStatus');
+  assertClaimStatus(initialStatus, 'initialStatus');
+  return {
+    hasDocuments: assertBooleanPayloadField(payload, 'hasDocuments'),
+    initialStatus,
+  };
+}
+
+function recoveryDecisionRecordedPayload(
+  payload: Record<string, unknown>
+): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(
+    payload,
+    'recovery.decision_recorded',
+    RECOVERY_DECISION_RECORDED_KEYS
+  );
+  const decisionType = assertRequiredPayloadField(payload, 'decisionType');
+  if (typeof decisionType !== 'string' || !RECOVERY_DECISION_TYPES.has(decisionType)) {
+    throw new Error('appendEvent requires payload.decisionType to be a recovery decision type');
+  }
+
+  const hasExplanation = assertBooleanPayloadField(payload, 'hasExplanation');
+  if (decisionType === 'accepted') return { decisionType, hasExplanation };
+
+  const declineReasonCode = assertRequiredPayloadField(payload, 'declineReasonCode');
+  if (
+    typeof declineReasonCode !== 'string' ||
+    !RECOVERY_DECLINE_REASON_CODES.has(declineReasonCode)
+  ) {
+    throw new Error('appendEvent requires payload.declineReasonCode to be a recovery decline code');
+  }
+
+  return { decisionType, declineReasonCode, hasExplanation };
+}
+
+const PAYLOAD_VALIDATORS: Record<
+  string,
+  (payload: Record<string, unknown>) => Record<string, unknown>
+> = {
+  'case.created@1': caseCreatedPayload,
+  'claim.status_changed@1': claimStatusChangedPayload,
+  'recovery.decision_recorded@1': recoveryDecisionRecordedPayload,
+};
+
+export function assertAllowlistedPayload(params: AppendEventParams): Record<string, unknown> {
+  const payload = params.payload ?? {};
+  const allowlistKey = `${params.eventName}@${params.eventVersion}`;
+  const validator = PAYLOAD_VALIDATORS[allowlistKey];
+
+  if (!validator) {
+    throw new Error(`appendEvent payload allowlist missing for ${allowlistKey}`);
+  }
+
+  return validator(payload);
+}

--- a/packages/database/src/domain-events.ts
+++ b/packages/database/src/domain-events.ts
@@ -1,5 +1,5 @@
-import { CLAIM_STATUSES, type ClaimStatus } from './constants';
 import { db } from './db';
+import { assertAllowlistedPayload } from './domain-event-payloads';
 import { domainEvents } from './schema/domain-events';
 
 export type DomainEventTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -18,9 +18,6 @@ export type AppendEventParams = {
 };
 export type AppendEventResult = { id: string };
 
-const CASE_CREATED_KEYS = new Set(['hasDocuments', 'initialStatus']);
-const CLAIM_STATUS_CHANGED_KEYS = new Set(['fromStatus', 'toStatus']);
-const CLAIM_STATUS_SET = new Set<string>(CLAIM_STATUSES);
 function assertNonEmpty(value: string, field: string): void {
   if (value.trim().length === 0) {
     throw new Error(`appendEvent requires ${field}`);
@@ -30,70 +27,6 @@ function assertIntegerAtLeast(value: number, minimum: number, field: string): vo
   if (!Number.isInteger(value) || value < minimum) {
     throw new Error(`appendEvent requires ${field} >= ${minimum}`);
   }
-}
-function assertClaimStatus(value: unknown, field: string): asserts value is ClaimStatus {
-  if (typeof value !== 'string' || !CLAIM_STATUS_SET.has(value)) {
-    throw new Error(`appendEvent requires payload.${field} to be a claim status`);
-  }
-}
-function assertNoUnexpectedPayloadFields(
-  payload: Record<string, unknown>,
-  eventName: string,
-  allowedKeys: Set<string>
-): void {
-  for (const field of Object.keys(payload)) {
-    if (!allowedKeys.has(field)) {
-      throw new Error(`appendEvent payload field ${field} is not allowlisted for ${eventName}`);
-    }
-  }
-}
-function assertRequiredPayloadField(payload: Record<string, unknown>, field: string): unknown {
-  if (!Object.hasOwn(payload, field)) {
-    throw new Error(`appendEvent requires payload.${field}`);
-  }
-  return payload[field];
-}
-function assertBooleanPayloadField(payload: Record<string, unknown>, field: string): boolean {
-  const value = assertRequiredPayloadField(payload, field);
-  if (typeof value !== 'boolean') {
-    throw new TypeError(`appendEvent requires payload.${field} to be a boolean`);
-  }
-  return value;
-}
-function claimStatusChangedPayload(payload: Record<string, unknown>): Record<string, unknown> {
-  assertNoUnexpectedPayloadFields(payload, 'claim.status_changed', CLAIM_STATUS_CHANGED_KEYS);
-  for (const field of CLAIM_STATUS_CHANGED_KEYS) {
-    assertRequiredPayloadField(payload, field);
-    assertClaimStatus(payload[field], field);
-  }
-  return { fromStatus: payload.fromStatus, toStatus: payload.toStatus };
-}
-function caseCreatedPayload(payload: Record<string, unknown>): Record<string, unknown> {
-  assertNoUnexpectedPayloadFields(payload, 'case.created', CASE_CREATED_KEYS);
-  const initialStatus = assertRequiredPayloadField(payload, 'initialStatus');
-  assertClaimStatus(initialStatus, 'initialStatus');
-  return {
-    hasDocuments: assertBooleanPayloadField(payload, 'hasDocuments'),
-    initialStatus,
-  };
-}
-const PAYLOAD_VALIDATORS: Record<
-  string,
-  (payload: Record<string, unknown>) => Record<string, unknown>
-> = {
-  'case.created@1': caseCreatedPayload,
-  'claim.status_changed@1': claimStatusChangedPayload,
-};
-function assertAllowlistedPayload(params: AppendEventParams): Record<string, unknown> {
-  const payload = params.payload ?? {};
-  const allowlistKey = `${params.eventName}@${params.eventVersion}`;
-  const validator = PAYLOAD_VALIDATORS[allowlistKey];
-
-  if (!validator) {
-    throw new Error(`appendEvent payload allowlist missing for ${allowlistKey}`);
-  }
-
-  return validator(payload);
 }
 export async function appendEvent(
   tx: DomainEventTx,

--- a/packages/database/test/domain-event-recovery-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-recovery-payload-allowlist.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { appendEvent, type DomainEventTx } from '../src/domain-events';
+
+class FakeInsertStep {
+  constructor(private readonly capture: { row?: Record<string, unknown> }) {}
+
+  values(row: Record<string, unknown>) {
+    this.capture.row = row;
+    return { returning: () => [{ id: row.id }] };
+  }
+}
+
+class FakeTx {
+  constructor(private readonly capture: { row?: Record<string, unknown> }) {}
+
+  insert() {
+    return new FakeInsertStep(this.capture);
+  }
+}
+
+function makeTx() {
+  const capture: { row?: Record<string, unknown> } = {};
+  return { capture, tx: new FakeTx(capture) as unknown as DomainEventTx };
+}
+
+function makeRecoveryDecisionEvent(overrides: Partial<Parameters<typeof appendEvent>[1]> = {}) {
+  return {
+    actor: { id: 'staff-1', role: 'staff' },
+    aggregateVersion: 0,
+    correlationId: 'corr-1',
+    entity: { id: 'claim-1', type: 'claim' },
+    eventName: 'recovery.decision_recorded',
+    eventVersion: 1,
+    id: 'event-1',
+    payload: {
+      decisionType: 'declined',
+      declineReasonCode: 'insufficient_evidence',
+      hasExplanation: true,
+    },
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+describe('appendEvent recovery decision payload allowlist', () => {
+  for (const [name, event, error] of [
+    [
+      'free-text recovery decision fields',
+      makeRecoveryDecisionEvent({
+        payload: {
+          decisionType: 'declined',
+          declineReasonCode: 'insufficient_evidence',
+          explanation: 'Free-text staff explanation',
+          hasExplanation: true,
+        },
+      }),
+      /explanation is not allowlisted/,
+    ],
+    [
+      'unsupported recovery decision values',
+      makeRecoveryDecisionEvent({ payload: { decisionType: 'maybe', hasExplanation: false } }),
+      /payload\.decisionType to be a recovery decision type/,
+    ],
+    [
+      'missing recovery decline reason',
+      makeRecoveryDecisionEvent({ payload: { decisionType: 'declined', hasExplanation: true } }),
+      /payload\.declineReasonCode/,
+    ],
+    [
+      'unsupported recovery decline reason',
+      makeRecoveryDecisionEvent({
+        payload: {
+          decisionType: 'declined',
+          declineReasonCode: 'customer_name',
+          hasExplanation: true,
+        },
+      }),
+      /payload\.declineReasonCode to be a recovery decline code/,
+    ],
+  ] as const) {
+    it(`rejects ${name} before inserting`, async () => {
+      const { capture, tx } = makeTx();
+      await assert.rejects(() => appendEvent(tx, event), error);
+      assert.equal(capture.row, undefined);
+    });
+  }
+
+  it('allows sanitized accepted recovery decision payload fields', async () => {
+    const { capture, tx } = makeTx();
+    await appendEvent(
+      tx,
+      makeRecoveryDecisionEvent({
+        payload: {
+          decisionType: 'accepted',
+          declineReasonCode: 'insufficient_evidence',
+          hasExplanation: false,
+        },
+      })
+    );
+    assert.deepEqual(capture.row?.payload, {
+      decisionType: 'accepted',
+      hasExplanation: false,
+    });
+  });
+
+  it('allows sanitized declined recovery decision payload fields', async () => {
+    const { capture, tx } = makeTx();
+    await appendEvent(tx, makeRecoveryDecisionEvent());
+    assert.deepEqual(capture.row?.payload, {
+      decisionType: 'declined',
+      declineReasonCode: 'insufficient_evidence',
+      hasExplanation: true,
+    });
+  });
+});

--- a/packages/domain-claims/src/staff-claims/recovery-decision-record.ts
+++ b/packages/domain-claims/src/staff-claims/recovery-decision-record.ts
@@ -1,0 +1,116 @@
+import {
+  appendEvent,
+  claimEscalationAgreements,
+  db,
+  eq,
+  type DomainEventTx,
+} from '@interdomestik/database';
+import { withTenant } from '@interdomestik/database/tenant-security';
+
+import type { ClaimsSession } from '../claims/types';
+import { buildRecoveryDecisionSnapshot } from './recovery-decision';
+import type { RecoveryDecisionSnapshot, SaveRecoveryDecisionInput } from './types';
+
+type DeclineReasonCode = Extract<
+  SaveRecoveryDecisionInput,
+  { decisionType: 'declined' }
+>['declineReasonCode'];
+type RecoveryDecisionTransaction = {
+  insert: typeof db.insert;
+  select: typeof db.select;
+  update: typeof db.update;
+};
+
+function recoveryDecisionPayload(params: {
+  decisionType: SaveRecoveryDecisionInput['decisionType'];
+  declineReasonCode?: DeclineReasonCode;
+  explanation: string | null;
+}) {
+  return {
+    decisionType: params.decisionType,
+    ...(params.decisionType === 'declined' && params.declineReasonCode !== undefined
+      ? { declineReasonCode: params.declineReasonCode }
+      : {}),
+    hasExplanation: Boolean(params.explanation),
+  };
+}
+
+export async function upsertRecoveryDecisionRecord(params: {
+  claimId: string;
+  decisionType: SaveRecoveryDecisionInput['decisionType'];
+  declineReasonCode?: DeclineReasonCode;
+  explanation?: string;
+  session: ClaimsSession;
+  tenantId: string;
+  tx: RecoveryDecisionTransaction;
+}): Promise<RecoveryDecisionSnapshot> {
+  const now = new Date();
+  const explanation = params.explanation?.trim() || null;
+
+  const [existingDecision] = await params.tx
+    .select({ id: claimEscalationAgreements.id })
+    .from(claimEscalationAgreements)
+    .where(
+      withTenant(
+        params.tenantId,
+        claimEscalationAgreements.tenantId,
+        eq(claimEscalationAgreements.claimId, params.claimId)
+      )
+    )
+    .limit(1);
+
+  const declineReasonCode: DeclineReasonCode | null =
+    params.decisionType === 'declined' ? (params.declineReasonCode ?? null) : null;
+  const values = {
+    acceptedAt: now,
+    acceptedById: params.session.user.id,
+    decisionReason: explanation,
+    decisionType: params.decisionType,
+    declineReasonCode,
+    updatedAt: now,
+  };
+
+  if (existingDecision) {
+    await params.tx
+      .update(claimEscalationAgreements)
+      .set(values)
+      .where(
+        withTenant(
+          params.tenantId,
+          claimEscalationAgreements.tenantId,
+          eq(claimEscalationAgreements.claimId, params.claimId)
+        )
+      );
+  } else {
+    await params.tx.insert(claimEscalationAgreements).values({
+      id: crypto.randomUUID(),
+      tenantId: params.tenantId,
+      claimId: params.claimId,
+      createdAt: now,
+      ...values,
+    });
+  }
+
+  await appendEvent(params.tx as DomainEventTx, {
+    actor: { id: params.session.user.id, role: params.session.user.role?.trim() || 'staff' },
+    aggregateVersion: 0,
+    correlationId: `claim:${params.claimId}:recovery-decision:${params.decisionType}`,
+    createdAt: now,
+    entity: { id: params.claimId, type: 'claim' },
+    eventName: 'recovery.decision_recorded',
+    eventVersion: 1,
+    payload: recoveryDecisionPayload({
+      decisionType: params.decisionType,
+      declineReasonCode: params.declineReasonCode,
+      explanation,
+    }),
+    tenantId: params.tenantId,
+  });
+
+  return buildRecoveryDecisionSnapshot({
+    decidedAt: now,
+    declineReasonCode,
+    decisionType: params.decisionType,
+    explanation,
+  });
+}

--- a/packages/domain-claims/src/staff-claims/recovery-decision-schema.ts
+++ b/packages/domain-claims/src/staff-claims/recovery-decision-schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+import { RECOVERY_DECLINE_REASON_CODES, RECOVERY_DECISION_TYPES } from './types';
+
+export const saveRecoveryDecisionSchema = z.discriminatedUnion('decisionType', [
+  z.object({
+    claimId: z.string().trim().min(1, 'Claim ID is required'),
+    decisionType: z.literal(RECOVERY_DECISION_TYPES[0]),
+    explanation: z.string().trim().optional(),
+  }),
+  z.object({
+    claimId: z.string().trim().min(1, 'Claim ID is required'),
+    decisionType: z.literal(RECOVERY_DECISION_TYPES[1]),
+    declineReasonCode: z.enum(RECOVERY_DECLINE_REASON_CODES),
+    explanation: z.string().trim().optional(),
+  }),
+]);

--- a/packages/domain-claims/src/staff-claims/save-recovery-decision-events.test.ts
+++ b/packages/domain-claims/src/staff-claims/save-recovery-decision-events.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ClaimsSession } from '../claims/types';
+import { saveRecoveryDecisionCore } from './save-recovery-decision';
+
+const mocks = vi.hoisted(() => {
+  const chain = () => ({ from: vi.fn(), where: vi.fn(), limit: vi.fn() });
+  const claimSelect = chain();
+  const decisionSelect = chain();
+  const txInsertValues = vi.fn();
+  const txInsert = vi.fn(() => ({ values: txInsertValues }));
+  const txSelect = vi.fn();
+  const txUpdateWhere = vi.fn();
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
+  const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
+  const transaction = vi.fn(async cb =>
+    cb({ insert: txInsert, select: txSelect, update: txUpdate })
+  );
+
+  return {
+    appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
+    and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+    claimEscalationAgreements: {
+      id: 'claim_escalation_agreements.id',
+      tenantId: 'claim_escalation_agreements.tenant_id',
+      claimId: 'claim_escalation_agreements.claim_id',
+    },
+    claims: { id: 'claims.id', tenantId: 'claims.tenant_id' },
+    db: { transaction },
+    eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
+    withTenant: vi.fn((_tenantId, _column, condition) => ({ scoped: true, condition })),
+    claimSelect,
+    decisionSelect,
+    txInsert,
+    txInsertValues,
+    txSelect,
+    txUpdate,
+    txUpdateSet,
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  and: mocks.and,
+  appendEvent: mocks.appendEvent,
+  claimEscalationAgreements: mocks.claimEscalationAgreements,
+  claims: mocks.claims,
+  db: mocks.db,
+  eq: mocks.eq,
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+function session(role = 'staff'): ClaimsSession {
+  return { user: { id: 'staff-1', role, tenantId: 'tenant-1', branchId: 'branch-1' } };
+}
+
+function primeScopeAndDecision(existingDecision: unknown[] = []) {
+  mocks.txSelect.mockReturnValueOnce(mocks.claimSelect).mockReturnValueOnce(mocks.decisionSelect);
+  mocks.claimSelect.from.mockReturnValue(mocks.claimSelect);
+  mocks.claimSelect.where.mockReturnValue(mocks.claimSelect);
+  mocks.claimSelect.limit.mockResolvedValue([{ id: 'claim-1' }]);
+  mocks.decisionSelect.from.mockReturnValue(mocks.decisionSelect);
+  mocks.decisionSelect.where.mockReturnValue(mocks.decisionSelect);
+  mocks.decisionSelect.limit.mockResolvedValue(existingDecision);
+}
+
+describe('saveRecoveryDecisionCore recovery decision events', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('emits sanitized accepted recovery decision events in the save transaction', async () => {
+    primeScopeAndDecision();
+
+    const result = await saveRecoveryDecisionCore({
+      claimId: 'claim-1',
+      decisionType: 'accepted',
+      explanation: 'Clear insurer path and viable monetary recovery.',
+      session: session(),
+    });
+
+    const row = mocks.txInsertValues.mock.calls[0]?.[0];
+    expect(result.success).toBe(true);
+    expect(mocks.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ insert: mocks.txInsert, select: mocks.txSelect }),
+      expect.objectContaining({
+        actor: { id: 'staff-1', role: 'staff' },
+        correlationId: 'claim:claim-1:recovery-decision:accepted',
+        createdAt: row.acceptedAt,
+        eventName: 'recovery.decision_recorded',
+        payload: { decisionType: 'accepted', hasExplanation: true },
+        tenantId: 'tenant-1',
+      })
+    );
+  });
+
+  it('emits sanitized declined recovery decision events in the save transaction', async () => {
+    primeScopeAndDecision([{ id: 'decision-1' }]);
+
+    const result = await saveRecoveryDecisionCore({
+      claimId: 'claim-1',
+      decisionType: 'declined',
+      declineReasonCode: 'insufficient_evidence',
+      explanation: ' Member needs better evidence. ',
+      session: session(),
+    });
+
+    const row = (mocks.txUpdateSet.mock.calls[0] as unknown[] | undefined)?.[0] as {
+      acceptedAt: Date;
+    };
+    expect(result.success).toBe(true);
+    expect(mocks.appendEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        correlationId: 'claim:claim-1:recovery-decision:declined',
+        createdAt: row.acceptedAt,
+        eventName: 'recovery.decision_recorded',
+        payload: {
+          decisionType: 'declined',
+          declineReasonCode: 'insufficient_evidence',
+          hasExplanation: true,
+        },
+      })
+    );
+  });
+
+  it('does not emit recovery decision events for denied callers or out-of-scope claims', async () => {
+    expect(
+      await saveRecoveryDecisionCore({
+        claimId: 'claim-1',
+        decisionType: 'accepted',
+        session: session('member'),
+      })
+    ).toEqual({ success: false, error: 'Unauthorized' });
+
+    mocks.txSelect.mockReturnValueOnce(mocks.claimSelect);
+    mocks.claimSelect.from.mockReturnValue(mocks.claimSelect);
+    mocks.claimSelect.where.mockReturnValue(mocks.claimSelect);
+    mocks.claimSelect.limit.mockResolvedValue([]);
+
+    expect(
+      await saveRecoveryDecisionCore({
+        claimId: 'claim-1',
+        decisionType: 'accepted',
+        session: session(),
+      })
+    ).toEqual({ success: false, error: 'Claim not found or access denied' });
+    expect(mocks.appendEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-claims/src/staff-claims/save-recovery-decision.test.ts
+++ b/packages/domain-claims/src/staff-claims/save-recovery-decision.test.ts
@@ -36,7 +36,7 @@ const mocks = vi.hoisted(() => {
       },
       transaction,
     },
-    logAuditEvent: vi.fn(),
+    appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
     claims: {
       id: 'claims.id',
       tenantId: 'claims.tenant_id',
@@ -64,12 +64,12 @@ const mocks = vi.hoisted(() => {
     txSelect,
     txUpdate,
     txUpdateSet,
-    txUpdateWhere,
   };
 });
 
 vi.mock('@interdomestik/database', () => ({
   and: mocks.and,
+  appendEvent: mocks.appendEvent,
   claimEscalationAgreements: mocks.claimEscalationAgreements,
   claims: mocks.claims,
   db: mocks.db,

--- a/packages/domain-claims/src/staff-claims/save-recovery-decision.ts
+++ b/packages/domain-claims/src/staff-claims/save-recovery-decision.ts
@@ -1,111 +1,15 @@
-import { claimEscalationAgreements, claims, db, eq } from '@interdomestik/database';
+import { claims, db } from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
-import { z } from 'zod';
 
 import type { ClaimsDeps, ClaimsSession } from '../claims/types';
+import { saveRecoveryDecisionSchema } from './recovery-decision-schema';
 import {
   buildScopedStaffClaimWhere,
   resolveScopedStaffClaimAccess,
   STAFF_SCOPE_ACCESS_DENIED_ERROR,
 } from './scope';
 import type { ActionResult, RecoveryDecisionSnapshot, SaveRecoveryDecisionInput } from './types';
-import { RECOVERY_DECLINE_REASON_CODES, RECOVERY_DECISION_TYPES } from './types';
-import { buildRecoveryDecisionSnapshot } from './recovery-decision';
-
-const saveRecoveryDecisionSchema = z.discriminatedUnion('decisionType', [
-  z.object({
-    claimId: z.string().trim().min(1, 'Claim ID is required'),
-    decisionType: z.literal(RECOVERY_DECISION_TYPES[0]),
-    explanation: z.string().trim().optional(),
-  }),
-  z.object({
-    claimId: z.string().trim().min(1, 'Claim ID is required'),
-    decisionType: z.literal(RECOVERY_DECISION_TYPES[1]),
-    declineReasonCode: z.enum(RECOVERY_DECLINE_REASON_CODES),
-    explanation: z.string().trim().optional(),
-  }),
-]);
-
-type RecoveryDecisionTransaction = {
-  insert: typeof db.insert;
-  select: typeof db.select;
-  update: typeof db.update;
-};
-
-export async function upsertRecoveryDecisionRecord(params: {
-  claimId: string;
-  decisionType: SaveRecoveryDecisionInput['decisionType'];
-  declineReasonCode?: Extract<
-    SaveRecoveryDecisionInput,
-    { decisionType: 'declined' }
-  >['declineReasonCode'];
-  explanation?: string;
-  session: ClaimsSession;
-  tenantId: string;
-  tx: RecoveryDecisionTransaction;
-}): Promise<RecoveryDecisionSnapshot> {
-  const now = new Date();
-  const explanation = params.explanation?.trim() || null;
-
-  const [existingDecision] = await params.tx
-    .select({
-      id: claimEscalationAgreements.id,
-      acceptedAt: claimEscalationAgreements.acceptedAt,
-    })
-    .from(claimEscalationAgreements)
-    .where(
-      withTenant(
-        params.tenantId,
-        claimEscalationAgreements.tenantId,
-        eq(claimEscalationAgreements.claimId, params.claimId)
-      )
-    )
-    .limit(1);
-
-  if (existingDecision) {
-    await params.tx
-      .update(claimEscalationAgreements)
-      .set({
-        acceptedAt: now,
-        acceptedById: params.session.user.id,
-        decisionType: params.decisionType,
-        declineReasonCode:
-          params.decisionType === 'declined' ? (params.declineReasonCode ?? null) : null,
-        decisionReason: explanation,
-        updatedAt: now,
-      })
-      .where(
-        withTenant(
-          params.tenantId,
-          claimEscalationAgreements.tenantId,
-          eq(claimEscalationAgreements.claimId, params.claimId)
-        )
-      );
-  } else {
-    // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
-    await params.tx.insert(claimEscalationAgreements).values({
-      id: crypto.randomUUID(),
-      tenantId: params.tenantId,
-      claimId: params.claimId,
-      decisionType: params.decisionType,
-      declineReasonCode:
-        params.decisionType === 'declined' ? (params.declineReasonCode ?? null) : null,
-      decisionReason: explanation,
-      acceptedById: params.session.user.id,
-      acceptedAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
-  }
-
-  return buildRecoveryDecisionSnapshot({
-    decidedAt: now,
-    declineReasonCode:
-      params.decisionType === 'declined' ? (params.declineReasonCode ?? null) : null,
-    decisionType: params.decisionType,
-    explanation,
-  });
-}
+import { upsertRecoveryDecisionRecord } from './recovery-decision-record';
 
 export async function saveRecoveryDecisionCore(
   params: SaveRecoveryDecisionInput & {

--- a/packages/domain-claims/src/staff-claims/update-status.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.ts
@@ -28,7 +28,7 @@ import {
   buildRecoveryDecisionSnapshot,
   getRecoveryDeclineMemberDescription,
 } from './recovery-decision';
-import { upsertRecoveryDecisionRecord } from './save-recovery-decision';
+import { upsertRecoveryDecisionRecord } from './recovery-decision-record';
 import {
   buildScopedStaffClaimWhere,
   resolveScopedStaffClaimAccess,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35445000,
-  "maxTrackedFiles": 4115,
+  "maxTrackedBytes": 35455394,
+  "maxTrackedFiles": 4120,
   "maxLargestFileBytes": 2838000,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17690000,
-    "source/scripts": 6593000,
-    "tests/e2e": 4401000,
-    "docs/text": 5088000,
-    "config/data/messages": 1555000,
-    "other": 1048576
+    "large support/generated-ish": 17689633,
+    "source/scripts": 6593327,
+    "tests/e2e": 4406555,
+    "docs/text": 5087043,
+    "config/data/messages": 1549671,
+    "other": 129165
   }
 }


### PR DESCRIPTION
## Summary
- emits sanitized `recovery.decision_recorded@1` events from the existing staff recovery decision transaction
- moves domain event payload validation into a focused allowlist module and adds recovery decision payload bounds
- keeps recovery event payloads free of explanation text, exposing only `decisionType`, `hasExplanation`, and bounded `declineReasonCode` for declined decisions

## Phase C scope
- no changes to `apps/web/src/proxy.ts`
- no route/auth/tenant/billing/schema/RLS/architecture-doc refactors
- does not promote T-204/T-209/T-408

## Verification
- `pnpm --filter @interdomestik/database exec tsx --test test/domain-events.test.ts test/domain-event-payload-allowlist.test.ts test/domain-event-recovery-payload-allowlist.test.ts`
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/staff-claims/save-recovery-decision.test.ts src/staff-claims/save-recovery-decision-events.test.ts src/staff-claims/update-status.test.ts`
- `pnpm --filter @interdomestik/database type-check && pnpm --filter @interdomestik/domain-claims type-check`
- `pnpm --filter @interdomestik/domain-claims test:unit`
- `pnpm --filter @interdomestik/database test:unit`
- `pnpm slice:verify`
- `pnpm pr:verify`
- `pnpm e2e:gate`
- `pnpm repo:size:check`
- `pnpm security:guard`
- `git diff --cached --check`

## Review notes
- Sonnet design review command stalled without output and was interrupted.
- Fable 5 escalation was unavailable/no access in this environment.
- `codex review --uncommitted` was blocked by CLI argument handling/hang, so review evidence is from local gates and this PR review path.
