### PR TITLE
feat: emit escalation agreement domain event

### DIFF
--- a/packages/database/src/domain-event-payload-helpers.ts
+++ b/packages/database/src/domain-event-payload-helpers.ts
@@ -1,0 +1,57 @@
+export function assertNoUnexpectedPayloadFields(
+  payload: Record<string, unknown>,
+  eventName: string,
+  allowedKeys: Set<string>
+): void {
+  for (const field of Object.keys(payload)) {
+    if (!allowedKeys.has(field)) {
+      throw new Error(`appendEvent payload field ${field} is not allowlisted for ${eventName}`);
+    }
+  }
+}
+
+export function assertRequiredPayloadField(
+  payload: Record<string, unknown>,
+  field: string
+): unknown {
+  if (!Object.hasOwn(payload, field)) {
+    throw new Error(`appendEvent requires payload.${field}`);
+  }
+  return payload[field];
+}
+
+export function assertBooleanPayloadField(
+  payload: Record<string, unknown>,
+  field: string
+): boolean {
+  const value = assertRequiredPayloadField(payload, field);
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`appendEvent requires payload.${field} to be a boolean`);
+  }
+  return value;
+}
+
+export function assertStringSetPayloadField(
+  payload: Record<string, unknown>,
+  field: string,
+  allowedValues: Set<string>,
+  description: string
+): string {
+  const value = assertRequiredPayloadField(payload, field);
+  if (typeof value !== 'string' || !allowedValues.has(value)) {
+    throw new Error(`appendEvent requires payload.${field} to be ${description}`);
+  }
+  return value;
+}
+
+export function assertIntegerPayloadField(
+  payload: Record<string, unknown>,
+  field: string,
+  minimum: number
+): number {
+  const value = assertRequiredPayloadField(payload, field);
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < minimum) {
+    throw new Error(`appendEvent requires payload.${field} to be an integer >= ${minimum}`);
+  }
+  return value;
+}

--- a/packages/database/src/domain-event-payloads.ts
+++ b/packages/database/src/domain-event-payloads.ts
@@ -1,4 +1,11 @@
 import { CLAIM_STATUSES, type ClaimStatus } from './constants';
+import {
+  assertBooleanPayloadField,
+  assertIntegerPayloadField,
+  assertNoUnexpectedPayloadFields,
+  assertRequiredPayloadField,
+  assertStringSetPayloadField,
+} from './domain-event-payload-helpers';
 import type { AppendEventParams } from './domain-events';
 
 const CASE_CREATED_KEYS = new Set(['hasDocuments', 'initialStatus']);
@@ -8,8 +15,18 @@ const RECOVERY_DECISION_RECORDED_KEYS = new Set([
   'declineReasonCode',
   'hasExplanation',
 ]);
+const RECOVERY_ESCALATION_AGREEMENT_RECORDED_KEYS = new Set([
+  'decisionNextStatus',
+  'feePercentage',
+  'hasDecisionReason',
+  'hasLegalActionCap',
+  'hasMinimumFee',
+  'paymentAuthorizationState',
+]);
 const CLAIM_STATUS_SET = new Set<string>(CLAIM_STATUSES);
 const RECOVERY_DECISION_TYPES = new Set(['accepted', 'declined']);
+const ESCALATION_DECISION_NEXT_STATUSES = new Set(['negotiation', 'court']);
+const PAYMENT_AUTHORIZATION_STATES = new Set(['pending', 'authorized', 'revoked']);
 const RECOVERY_DECLINE_REASON_CODES = new Set([
   'guidance_only_scope',
   'insufficient_evidence',
@@ -23,33 +40,6 @@ function assertClaimStatus(value: unknown, field: string): asserts value is Clai
   if (typeof value !== 'string' || !CLAIM_STATUS_SET.has(value)) {
     throw new Error(`appendEvent requires payload.${field} to be a claim status`);
   }
-}
-
-function assertNoUnexpectedPayloadFields(
-  payload: Record<string, unknown>,
-  eventName: string,
-  allowedKeys: Set<string>
-): void {
-  for (const field of Object.keys(payload)) {
-    if (!allowedKeys.has(field)) {
-      throw new Error(`appendEvent payload field ${field} is not allowlisted for ${eventName}`);
-    }
-  }
-}
-
-function assertRequiredPayloadField(payload: Record<string, unknown>, field: string): unknown {
-  if (!Object.hasOwn(payload, field)) {
-    throw new Error(`appendEvent requires payload.${field}`);
-  }
-  return payload[field];
-}
-
-function assertBooleanPayloadField(payload: Record<string, unknown>, field: string): boolean {
-  const value = assertRequiredPayloadField(payload, field);
-  if (typeof value !== 'boolean') {
-    throw new TypeError(`appendEvent requires payload.${field} to be a boolean`);
-  }
-  return value;
 }
 
 function claimStatusChangedPayload(payload: Record<string, unknown>): Record<string, unknown> {
@@ -79,23 +69,54 @@ function recoveryDecisionRecordedPayload(
     'recovery.decision_recorded',
     RECOVERY_DECISION_RECORDED_KEYS
   );
-  const decisionType = assertRequiredPayloadField(payload, 'decisionType');
-  if (typeof decisionType !== 'string' || !RECOVERY_DECISION_TYPES.has(decisionType)) {
-    throw new Error('appendEvent requires payload.decisionType to be a recovery decision type');
-  }
-
+  const decisionType = assertStringSetPayloadField(
+    payload,
+    'decisionType',
+    RECOVERY_DECISION_TYPES,
+    'a recovery decision type'
+  );
   const hasExplanation = assertBooleanPayloadField(payload, 'hasExplanation');
   if (decisionType === 'accepted') return { decisionType, hasExplanation };
 
-  const declineReasonCode = assertRequiredPayloadField(payload, 'declineReasonCode');
-  if (
-    typeof declineReasonCode !== 'string' ||
-    !RECOVERY_DECLINE_REASON_CODES.has(declineReasonCode)
-  ) {
-    throw new Error('appendEvent requires payload.declineReasonCode to be a recovery decline code');
-  }
-
+  const declineReasonCode = assertStringSetPayloadField(
+    payload,
+    'declineReasonCode',
+    RECOVERY_DECLINE_REASON_CODES,
+    'a recovery decline code'
+  );
   return { decisionType, declineReasonCode, hasExplanation };
+}
+
+function recoveryEscalationAgreementRecordedPayload(
+  payload: Record<string, unknown>
+): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(
+    payload,
+    'recovery.escalation_agreement_recorded',
+    RECOVERY_ESCALATION_AGREEMENT_RECORDED_KEYS
+  );
+  const decisionNextStatus = assertStringSetPayloadField(
+    payload,
+    'decisionNextStatus',
+    ESCALATION_DECISION_NEXT_STATUSES,
+    'an escalation status'
+  );
+  const paymentAuthorizationState = assertStringSetPayloadField(
+    payload,
+    'paymentAuthorizationState',
+    PAYMENT_AUTHORIZATION_STATES,
+    'a payment authorization state'
+  );
+  const feePercentage = assertIntegerPayloadField(payload, 'feePercentage', 1);
+
+  return {
+    decisionNextStatus,
+    feePercentage,
+    hasDecisionReason: assertBooleanPayloadField(payload, 'hasDecisionReason'),
+    hasLegalActionCap: assertBooleanPayloadField(payload, 'hasLegalActionCap'),
+    hasMinimumFee: assertBooleanPayloadField(payload, 'hasMinimumFee'),
+    paymentAuthorizationState,
+  };
 }
 
 const PAYLOAD_VALIDATORS: Record<
@@ -105,6 +126,7 @@ const PAYLOAD_VALIDATORS: Record<
   'case.created@1': caseCreatedPayload,
   'claim.status_changed@1': claimStatusChangedPayload,
   'recovery.decision_recorded@1': recoveryDecisionRecordedPayload,
+  'recovery.escalation_agreement_recorded@1': recoveryEscalationAgreementRecordedPayload,
 };
 
 export function assertAllowlistedPayload(params: AppendEventParams): Record<string, unknown> {

--- a/packages/database/test/domain-event-escalation-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-escalation-payload-allowlist.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { appendEvent } from '../src/domain-events';
+import { makeEventTx } from './domain-event-test-utils';
+
+function makeEscalationEvent(overrides: Partial<Parameters<typeof appendEvent>[1]> = {}) {
+  return {
+    actor: { id: 'staff-1', role: 'staff' },
+    aggregateVersion: 0,
+    correlationId: 'corr-1',
+    entity: { id: 'claim-1', type: 'claim' },
+    eventName: 'recovery.escalation_agreement_recorded',
+    eventVersion: 1,
+    id: 'event-1',
+    payload: {
+      decisionNextStatus: 'negotiation',
+      feePercentage: 15,
+      hasDecisionReason: true,
+      hasLegalActionCap: true,
+      hasMinimumFee: true,
+      paymentAuthorizationState: 'authorized',
+    },
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+describe('appendEvent escalation agreement payload allowlist', () => {
+  for (const [name, payload, error] of [
+    [
+      'decision reason text',
+      { decisionReason: 'Member accepted specific terms.' },
+      /decisionReason is not allowlisted/,
+    ],
+    ['minimum fee amount', { minimumFee: '25.00' }, /minimumFee is not allowlisted/],
+    ['terms version', { termsVersion: '2026-03-v1' }, /termsVersion is not allowlisted/],
+    ['member id', { memberId: 'member-1' }, /memberId is not allowlisted/],
+  ] as const) {
+    it(`rejects ${name} before inserting`, async () => {
+      const { capture, tx } = makeEventTx();
+
+      await assert.rejects(
+        () =>
+          appendEvent(
+            tx,
+            makeEscalationEvent({ payload: { ...makeEscalationEvent().payload, ...payload } })
+          ),
+        error
+      );
+      assert.equal(capture.row, undefined);
+    });
+  }
+
+  it('allows only sanitized escalation agreement fields', async () => {
+    const { capture, tx } = makeEventTx();
+
+    await appendEvent(tx, makeEscalationEvent());
+
+    assert.deepEqual(capture.row?.payload, {
+      decisionNextStatus: 'negotiation',
+      feePercentage: 15,
+      hasDecisionReason: true,
+      hasLegalActionCap: true,
+      hasMinimumFee: true,
+      paymentAuthorizationState: 'authorized',
+    });
+  });
+
+  it('rejects invalid escalation statuses and payment states', async () => {
+    const { tx } = makeEventTx();
+
+    await assert.rejects(
+      () =>
+        appendEvent(
+          tx,
+          makeEscalationEvent({
+            payload: { ...makeEscalationEvent().payload, decisionNextStatus: 'settlement' },
+          })
+        ),
+      /decisionNextStatus/
+    );
+    await assert.rejects(
+      () =>
+        appendEvent(
+          tx,
+          makeEscalationEvent({
+            payload: { ...makeEscalationEvent().payload, paymentAuthorizationState: 'paid' },
+          })
+        ),
+      /paymentAuthorizationState/
+    );
+  });
+});

--- a/packages/database/test/domain-event-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-payload-allowlist.test.ts
@@ -1,31 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { appendEvent, type DomainEventTx } from '../src/domain-events';
-
-type InsertedRow = Record<string, unknown>;
-
-class FakeInsertStep {
-  constructor(private readonly capture: { row?: InsertedRow }) {}
-
-  values(row: InsertedRow) {
-    this.capture.row = row;
-    return { returning: () => [{ id: row.id }] };
-  }
-}
-
-class FakeTx {
-  constructor(private readonly capture: { row?: InsertedRow }) {}
-
-  insert() {
-    return new FakeInsertStep(this.capture);
-  }
-}
-
-function makeTx() {
-  const capture: { row?: InsertedRow } = {};
-  return { capture, tx: new FakeTx(capture) as unknown as DomainEventTx };
-}
+import { appendEvent } from '../src/domain-events';
+import { makeEventTx } from './domain-event-test-utils';
 
 function makeEvent(overrides: Partial<Parameters<typeof appendEvent>[1]> = {}) {
   return {
@@ -94,7 +71,7 @@ describe('appendEvent payload allowlist', () => {
     ],
   ] as const) {
     it(`rejects ${name} before inserting`, async () => {
-      const { capture, tx } = makeTx();
+      const { capture, tx } = makeEventTx();
 
       await assert.rejects(() => appendEvent(tx, event), error);
       assert.equal(capture.row, undefined);
@@ -102,7 +79,7 @@ describe('appendEvent payload allowlist', () => {
   }
 
   it('inserts a sanitized plain payload instead of caller serialization hooks', async () => {
-    const { capture, tx } = makeTx();
+    const { capture, tx } = makeEventTx();
     const payloadWithSerializationHook = Object.assign(
       Object.create({
         toJSON: () => ({ fromStatus: 'evaluation', memberEmail: 'member@example.invalid' }),
@@ -119,7 +96,7 @@ describe('appendEvent payload allowlist', () => {
   });
 
   it('allows sanitized case.created payload fields', async () => {
-    const { capture, tx } = makeTx();
+    const { capture, tx } = makeEventTx();
 
     await appendEvent(tx, makeCaseCreatedEvent());
 

--- a/packages/database/test/domain-event-recovery-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-recovery-payload-allowlist.test.ts
@@ -1,29 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { appendEvent, type DomainEventTx } from '../src/domain-events';
-
-class FakeInsertStep {
-  constructor(private readonly capture: { row?: Record<string, unknown> }) {}
-
-  values(row: Record<string, unknown>) {
-    this.capture.row = row;
-    return { returning: () => [{ id: row.id }] };
-  }
-}
-
-class FakeTx {
-  constructor(private readonly capture: { row?: Record<string, unknown> }) {}
-
-  insert() {
-    return new FakeInsertStep(this.capture);
-  }
-}
-
-function makeTx() {
-  const capture: { row?: Record<string, unknown> } = {};
-  return { capture, tx: new FakeTx(capture) as unknown as DomainEventTx };
-}
+import { appendEvent } from '../src/domain-events';
+import { makeEventTx } from './domain-event-test-utils';
 
 function makeRecoveryDecisionEvent(overrides: Partial<Parameters<typeof appendEvent>[1]> = {}) {
   return {
@@ -81,14 +60,14 @@ describe('appendEvent recovery decision payload allowlist', () => {
     ],
   ] as const) {
     it(`rejects ${name} before inserting`, async () => {
-      const { capture, tx } = makeTx();
+      const { capture, tx } = makeEventTx();
       await assert.rejects(() => appendEvent(tx, event), error);
       assert.equal(capture.row, undefined);
     });
   }
 
   it('allows sanitized accepted recovery decision payload fields', async () => {
-    const { capture, tx } = makeTx();
+    const { capture, tx } = makeEventTx();
     await appendEvent(
       tx,
       makeRecoveryDecisionEvent({
@@ -106,7 +85,7 @@ describe('appendEvent recovery decision payload allowlist', () => {
   });
 
   it('allows sanitized declined recovery decision payload fields', async () => {
-    const { capture, tx } = makeTx();
+    const { capture, tx } = makeEventTx();
     await appendEvent(tx, makeRecoveryDecisionEvent());
     assert.deepEqual(capture.row?.payload, {
       decisionType: 'declined',

--- a/packages/database/test/domain-event-test-utils.ts
+++ b/packages/database/test/domain-event-test-utils.ts
@@ -1,0 +1,25 @@
+import type { DomainEventTx } from '../src/domain-events';
+
+type InsertedRow = Record<string, unknown>;
+
+class FakeInsertStep {
+  constructor(private readonly capture: { row?: InsertedRow }) {}
+
+  values(row: InsertedRow) {
+    this.capture.row = row;
+    return { returning: () => [{ id: row.id }] };
+  }
+}
+
+class FakeTx {
+  constructor(private readonly capture: { row?: InsertedRow }) {}
+
+  insert() {
+    return new FakeInsertStep(this.capture);
+  }
+}
+
+export function makeEventTx() {
+  const capture: { row?: InsertedRow } = {};
+  return { capture, tx: new FakeTx(capture) as unknown as DomainEventTx };
+}

--- a/packages/domain-claims/src/staff-claims/escalation-agreement-record.ts
+++ b/packages/domain-claims/src/staff-claims/escalation-agreement-record.ts
@@ -1,0 +1,86 @@
+import { appendEvent, type DomainEventTx } from '@interdomestik/database';
+
+import type { ClaimsSession } from '../claims/types';
+import type {
+  ClaimEscalationAgreementSnapshot,
+  EscalationDecisionNextStatus,
+  PaymentAuthorizationState,
+} from './types';
+
+type DateLike = Date | string | null | undefined;
+
+function normalizeDate(value: DateLike) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function buildEscalationAgreementPayload(params: {
+  decisionNextStatus: EscalationDecisionNextStatus;
+  decisionReason: string | null;
+  feePercentage: number;
+  legalActionCapPercentage: number;
+  minimumFee: string;
+  paymentAuthorizationState: PaymentAuthorizationState;
+}) {
+  return {
+    decisionNextStatus: params.decisionNextStatus,
+    feePercentage: params.feePercentage,
+    hasDecisionReason: Boolean(params.decisionReason),
+    hasLegalActionCap: params.legalActionCapPercentage > 0,
+    hasMinimumFee: params.minimumFee.trim().length > 0,
+    paymentAuthorizationState: params.paymentAuthorizationState,
+  };
+}
+
+export function buildEscalationAgreementSnapshot(params: {
+  acceptedAt: DateLike;
+  claimId: string;
+  decisionNextStatus: ClaimEscalationAgreementSnapshot['decisionNextStatus'];
+  decisionReason: string | null;
+  feePercentage: number;
+  legalActionCapPercentage: number;
+  minimumFee: string;
+  paymentAuthorizationState: ClaimEscalationAgreementSnapshot['paymentAuthorizationState'];
+  signedAt: DateLike;
+  termsVersion: string;
+}): ClaimEscalationAgreementSnapshot {
+  return {
+    acceptedAt: normalizeDate(params.acceptedAt),
+    claimId: params.claimId,
+    decisionNextStatus: params.decisionNextStatus,
+    decisionReason: params.decisionReason,
+    feePercentage: params.feePercentage,
+    legalActionCapPercentage: params.legalActionCapPercentage,
+    minimumFee: params.minimumFee,
+    paymentAuthorizationState: params.paymentAuthorizationState,
+    signedAt: normalizeDate(params.signedAt),
+    termsVersion: params.termsVersion,
+  };
+}
+
+export async function recordEscalationAgreementEvent(params: {
+  claimId: string;
+  decisionNextStatus: EscalationDecisionNextStatus;
+  decisionReason: string | null;
+  feePercentage: number;
+  legalActionCapPercentage: number;
+  minimumFee: string;
+  now: Date;
+  paymentAuthorizationState: PaymentAuthorizationState;
+  session: ClaimsSession;
+  tenantId: string;
+  tx: DomainEventTx;
+}) {
+  await appendEvent(params.tx, {
+    actor: { id: params.session.user.id, role: params.session.user.role?.trim() || 'staff' },
+    aggregateVersion: 0,
+    correlationId: `claim:${params.claimId}:recovery-escalation-agreement:${params.decisionNextStatus}`,
+    createdAt: params.now,
+    entity: { id: params.claimId, type: 'claim' },
+    eventName: 'recovery.escalation_agreement_recorded',
+    eventVersion: 1,
+    payload: buildEscalationAgreementPayload(params),
+    tenantId: params.tenantId,
+  });
+}

--- a/packages/domain-claims/src/staff-claims/save-escalation-agreement-events.test.ts
+++ b/packages/domain-claims/src/staff-claims/save-escalation-agreement-events.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { saveClaimEscalationAgreementCore } from './save-escalation-agreement';
+
+const mocks = vi.hoisted(() => {
+  const claimSelect = { from: vi.fn(), where: vi.fn(), limit: vi.fn() };
+  const agreementSelect = { from: vi.fn(), where: vi.fn(), limit: vi.fn() };
+  const txInsertValues = vi.fn();
+  const txInsert = vi.fn(() => ({ values: txInsertValues }));
+  const txUpdateWhere = vi.fn();
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
+  const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
+  const txSelect = vi.fn();
+  const transaction = vi.fn(async cb =>
+    cb({ insert: txInsert, select: txSelect, update: txUpdate })
+  );
+
+  return {
+    and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+    appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
+    claimEscalationAgreements: {
+      acceptedAt: 'agreement.accepted_at',
+      claimId: 'agreement.claim_id',
+      decisionNextStatus: 'agreement.decision_next_status',
+      decisionReason: 'agreement.decision_reason',
+      feePercentage: 'agreement.fee_percentage',
+      id: 'agreement.id',
+      legalActionCapPercentage: 'agreement.legal_action_cap_percentage',
+      minimumFee: 'agreement.minimum_fee',
+      paymentAuthorizationState: 'agreement.payment_authorization_state',
+      signedAt: 'agreement.signed_at',
+      tenantId: 'agreement.tenant_id',
+      termsVersion: 'agreement.terms_version',
+    },
+    claims: {
+      category: 'claims.category',
+      id: 'claims.id',
+      tenantId: 'claims.tenant_id',
+      userId: 'claims.user_id',
+    },
+    db: { transaction },
+    eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
+    withTenant: vi.fn((_tenantId, _column, condition) => ({ scoped: true, condition })),
+    agreementSelect,
+    claimSelect,
+    txInsert,
+    txInsertValues,
+    txSelect,
+    txUpdate,
+    txUpdateSet,
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  and: mocks.and,
+  appendEvent: mocks.appendEvent,
+  claimEscalationAgreements: mocks.claimEscalationAgreements,
+  claims: mocks.claims,
+  db: mocks.db,
+  eq: mocks.eq,
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+function session(role = 'staff') {
+  return { user: { id: 'staff-1', role, tenantId: 'tenant-1', branchId: 'branch-1' } };
+}
+
+function primeAgreement(existingAgreement: unknown[] = []) {
+  mocks.txSelect.mockReturnValueOnce(mocks.claimSelect).mockReturnValueOnce(mocks.agreementSelect);
+  mocks.claimSelect.from.mockReturnValue(mocks.claimSelect);
+  mocks.claimSelect.where.mockReturnValue(mocks.claimSelect);
+  mocks.claimSelect.limit.mockResolvedValue([
+    { category: 'vehicle', id: 'claim-1', userId: 'member-1' },
+  ]);
+  mocks.agreementSelect.from.mockReturnValue(mocks.agreementSelect);
+  mocks.agreementSelect.where.mockReturnValue(mocks.agreementSelect);
+  mocks.agreementSelect.limit.mockResolvedValue(existingAgreement);
+}
+
+function agreementParams(overrides = {}) {
+  return {
+    claimId: 'claim-1',
+    decisionNextStatus: 'negotiation' as const,
+    decisionReason: 'Member accepted commercial terms for negotiation.',
+    feePercentage: 15,
+    legalActionCapPercentage: 25,
+    minimumFee: 25,
+    paymentAuthorizationState: 'authorized' as const,
+    session: session(),
+    termsVersion: '2026-03-v1',
+    ...overrides,
+  };
+}
+
+describe('saveClaimEscalationAgreementCore escalation agreement events', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('emits a sanitized escalation agreement event in the insert transaction', async () => {
+    primeAgreement();
+
+    const result = await saveClaimEscalationAgreementCore(agreementParams());
+    const row = mocks.txInsertValues.mock.calls[0]?.[0];
+
+    expect(result.success).toBe(true);
+    expect(mocks.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ insert: mocks.txInsert, select: mocks.txSelect }),
+      expect.objectContaining({
+        actor: { id: 'staff-1', role: 'staff' },
+        correlationId: 'claim:claim-1:recovery-escalation-agreement:negotiation',
+        createdAt: row.acceptedAt,
+        eventName: 'recovery.escalation_agreement_recorded',
+        payload: {
+          decisionNextStatus: 'negotiation',
+          feePercentage: 15,
+          hasDecisionReason: true,
+          hasLegalActionCap: true,
+          hasMinimumFee: true,
+          paymentAuthorizationState: 'authorized',
+        },
+        tenantId: 'tenant-1',
+      })
+    );
+  });
+
+  it('emits the event in the update transaction and not on denied paths', async () => {
+    primeAgreement([{ id: 'agreement-1', signedAt: new Date('2026-03-11T09:00:00Z') }]);
+
+    expect(
+      await saveClaimEscalationAgreementCore(agreementParams({ decisionNextStatus: 'court' }))
+    ).toMatchObject({ success: true });
+    expect(mocks.appendEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        correlationId: 'claim:claim-1:recovery-escalation-agreement:court',
+      })
+    );
+
+    vi.clearAllMocks();
+    expect(
+      await saveClaimEscalationAgreementCore(agreementParams({ session: session('member') }))
+    ).toEqual({
+      success: false,
+      error: 'Unauthorized',
+    });
+    expect(mocks.appendEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-claims/src/staff-claims/save-escalation-agreement.test.ts
+++ b/packages/domain-claims/src/staff-claims/save-escalation-agreement.test.ts
@@ -35,9 +35,8 @@ const mocks = vi.hoisted(() => {
   );
 
   return {
-    db: {
-      transaction,
-    },
+    appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
+    db: { transaction },
     logAuditEvent: vi.fn(),
     claims: {
       id: 'claims.id',
@@ -81,6 +80,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@interdomestik/database', () => ({
   and: mocks.and,
+  appendEvent: mocks.appendEvent,
   claimEscalationAgreements: mocks.claimEscalationAgreements,
   claims: mocks.claims,
   db: mocks.db,

--- a/packages/domain-claims/src/staff-claims/save-escalation-agreement.ts
+++ b/packages/domain-claims/src/staff-claims/save-escalation-agreement.ts
@@ -1,19 +1,25 @@
-import { claimEscalationAgreements, claims, db, eq } from '@interdomestik/database';
+import {
+  claimEscalationAgreements,
+  claims,
+  db,
+  eq,
+  type DomainEventTx,
+} from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { z } from 'zod';
 
 import type { ClaimsDeps, ClaimsSession } from '../claims/types';
 import { buildCommercialHandlingScopeFailure } from './commercial-handling-scope';
 import {
+  buildEscalationAgreementSnapshot,
+  recordEscalationAgreementEvent,
+} from './escalation-agreement-record';
+import {
   buildScopedStaffClaimWhere,
   resolveScopedStaffClaimAccess,
   STAFF_SCOPE_ACCESS_DENIED_ERROR,
 } from './scope';
-import type {
-  ActionResult,
-  ClaimEscalationAgreementSnapshot,
-  SaveClaimEscalationAgreementInput,
-} from './types';
+import type { ActionResult, SaveClaimEscalationAgreementInput } from './types';
 import { ESCALATION_DECISION_NEXT_STATUSES, PAYMENT_AUTHORIZATION_STATES } from './types';
 
 const saveClaimEscalationAgreementSchema = z
@@ -32,47 +38,13 @@ const saveClaimEscalationAgreementSchema = z
     'Legal-action cap must be greater than or equal to the agreed fee percentage'
   );
 
-type DateLike = Date | string | null | undefined;
-
-function normalizeDate(value: DateLike) {
-  if (!value) return null;
-  const date = value instanceof Date ? value : new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date.toISOString();
-}
-
-function buildSnapshot(params: {
-  acceptedAt: DateLike;
-  claimId: string;
-  decisionNextStatus: ClaimEscalationAgreementSnapshot['decisionNextStatus'];
-  decisionReason: string | null;
-  feePercentage: number;
-  legalActionCapPercentage: number;
-  minimumFee: string;
-  paymentAuthorizationState: ClaimEscalationAgreementSnapshot['paymentAuthorizationState'];
-  signedAt: DateLike;
-  termsVersion: string;
-}): ClaimEscalationAgreementSnapshot {
-  return {
-    acceptedAt: normalizeDate(params.acceptedAt),
-    claimId: params.claimId,
-    decisionNextStatus: params.decisionNextStatus,
-    decisionReason: params.decisionReason,
-    feePercentage: params.feePercentage,
-    legalActionCapPercentage: params.legalActionCapPercentage,
-    minimumFee: params.minimumFee,
-    paymentAuthorizationState: params.paymentAuthorizationState,
-    signedAt: normalizeDate(params.signedAt),
-    termsVersion: params.termsVersion,
-  };
-}
-
 export async function saveClaimEscalationAgreementCore(
   params: SaveClaimEscalationAgreementInput & {
     requestHeaders?: Headers;
     session: ClaimsSession | null;
   },
   deps: ClaimsDeps = {}
-): Promise<ActionResult<ClaimEscalationAgreementSnapshot>> {
+): Promise<ActionResult<ReturnType<typeof buildEscalationAgreementSnapshot>>> {
   const { session } = params;
 
   if (session?.user?.role !== 'staff') {
@@ -174,21 +146,34 @@ export async function saveClaimEscalationAgreementCore(
             )
           );
 
-        return {
-          success: true,
-          data: buildSnapshot({
-            acceptedAt: now,
-            claimId: parsed.data.claimId,
-            decisionNextStatus: parsed.data.decisionNextStatus,
-            decisionReason,
-            feePercentage: parsed.data.feePercentage,
-            legalActionCapPercentage: parsed.data.legalActionCapPercentage,
-            minimumFee,
-            paymentAuthorizationState: parsed.data.paymentAuthorizationState,
-            signedAt,
-            termsVersion: parsed.data.termsVersion,
-          }),
-        };
+        const data = buildEscalationAgreementSnapshot({
+          acceptedAt: now,
+          claimId: parsed.data.claimId,
+          decisionNextStatus: parsed.data.decisionNextStatus,
+          decisionReason,
+          feePercentage: parsed.data.feePercentage,
+          legalActionCapPercentage: parsed.data.legalActionCapPercentage,
+          minimumFee,
+          paymentAuthorizationState: parsed.data.paymentAuthorizationState,
+          signedAt,
+          termsVersion: parsed.data.termsVersion,
+        });
+
+        await recordEscalationAgreementEvent({
+          claimId: parsed.data.claimId,
+          decisionNextStatus: parsed.data.decisionNextStatus,
+          decisionReason,
+          feePercentage: parsed.data.feePercentage,
+          legalActionCapPercentage: parsed.data.legalActionCapPercentage,
+          minimumFee,
+          now,
+          paymentAuthorizationState: parsed.data.paymentAuthorizationState,
+          session,
+          tenantId,
+          tx: tx as DomainEventTx,
+        });
+
+        return { success: true, data };
       }
 
       // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
@@ -211,21 +196,34 @@ export async function saveClaimEscalationAgreementCore(
         updatedAt: now,
       });
 
-      return {
-        success: true,
-        data: buildSnapshot({
-          acceptedAt: now,
-          claimId: parsed.data.claimId,
-          decisionNextStatus: parsed.data.decisionNextStatus,
-          decisionReason,
-          feePercentage: parsed.data.feePercentage,
-          legalActionCapPercentage: parsed.data.legalActionCapPercentage,
-          minimumFee,
-          paymentAuthorizationState: parsed.data.paymentAuthorizationState,
-          signedAt: now,
-          termsVersion: parsed.data.termsVersion,
-        }),
-      };
+      const data = buildEscalationAgreementSnapshot({
+        acceptedAt: now,
+        claimId: parsed.data.claimId,
+        decisionNextStatus: parsed.data.decisionNextStatus,
+        decisionReason,
+        feePercentage: parsed.data.feePercentage,
+        legalActionCapPercentage: parsed.data.legalActionCapPercentage,
+        minimumFee,
+        paymentAuthorizationState: parsed.data.paymentAuthorizationState,
+        signedAt: now,
+        termsVersion: parsed.data.termsVersion,
+      });
+
+      await recordEscalationAgreementEvent({
+        claimId: parsed.data.claimId,
+        decisionNextStatus: parsed.data.decisionNextStatus,
+        decisionReason,
+        feePercentage: parsed.data.feePercentage,
+        legalActionCapPercentage: parsed.data.legalActionCapPercentage,
+        minimumFee,
+        now,
+        paymentAuthorizationState: parsed.data.paymentAuthorizationState,
+        session,
+        tenantId,
+        tx: tx as DomainEventTx,
+      });
+
+      return { success: true, data };
     });
 
     if (result.success && result.data && deps.logAuditEvent) {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35455394,
-  "maxTrackedFiles": 4120,
+  "maxTrackedBytes": 35468569,
+  "maxTrackedFiles": 4125,
   "maxLargestFileBytes": 2838000,
   "maxSourceOrTestLines": 3000,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689633,
-    "source/scripts": 6593327,
-    "tests/e2e": 4406555,
+    "source/scripts": 6599068,
+    "tests/e2e": 4415213,
     "docs/text": 5087043,
     "config/data/messages": 1549671,
     "other": 129165


### PR DESCRIPTION
## Summary
- Emit `recovery.escalation_agreement_recorded@1` from the existing staff escalation agreement transaction seam.
- Add an allowlisted/sanitized payload snapshot and database payload validator for the new recovery event.
- Cover insert, update, denied caller, and payload allowlist behavior with focused domain/database tests.

## Phase C / Scope Guard
- No changes to `apps/web/src/proxy.ts`, canonical routes, clarity markers, README/AGENTS, or architecture-finalization docs.
- No promotion of T-204, T-209, or T-408.
- Event emission stays inside the existing transaction and uses the transaction handle, so append failure rolls back the agreement write.
- Payload excludes decision reason text, member/user identifiers, terms version, minimum fee amount, subscription/payment identifiers, and other non-allowlisted fields.

## Review Notes
- Senior engineer review performed from the staged diff; no blocker found.
- Sonnet review was explicitly waived by request after the Sonnet route timed out.
- Codex/MCP review path was not used further because `interdomestik_qa` was configured to the wrong repo root and the user requested shell-only review/verification.

## Verification
- `git diff --cached --check`
- `pnpm security:guard`
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/staff-claims/save-escalation-agreement-events.test.ts src/staff-claims/save-escalation-agreement.test.ts`
- `pnpm --filter @interdomestik/database test:unit --run test/domain-event-escalation-payload-allowlist.test.ts test/domain-event-payload-allowlist.test.ts test/domain-event-recovery-payload-allowlist.test.ts`
- `pnpm slice:verify`
- `pnpm pr:verify`
- `pnpm e2e:gate` (134 passed, 8 skipped)

## Local CI Note
- `pnpm ci:local:pr` reached the web production build, compiled successfully, then Docker killed the TypeScript/build process with exit 137. Host `pnpm pr:verify` and explicit `pnpm e2e:gate` passed afterward.
