### PR TITLE
chore: add repo size budget sync utility

### DIFF
--- a/scripts/ci/repo-size-budget-sync.test.mjs
+++ b/scripts/ci/repo-size-budget-sync.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '../..');
+const syncScript = path.join(repoRoot, 'scripts/repo-size-budget-sync.mjs');
+const auditScript = path.join(repoRoot, 'scripts/repo-size-audit.mjs');
+
+function runSync(args) {
+  return spawnSync(process.execPath, [syncScript, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+function trackedBytes() {
+  const result = spawnSync(
+    process.execPath,
+    [auditScript, '--json', '--no-disk', '--min-lines=0', '--top=1'],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout).tracked.total.bytes;
+}
+
+function createTempBudget(t, budget) {
+  const tempParent = path.join(repoRoot, 'tmp');
+  fs.mkdirSync(tempParent, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(tempParent, 'repo-size-sync-'));
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+
+  const budgetPath = path.join(tempRoot, 'repo-size-budget.json');
+  fs.writeFileSync(budgetPath, `${JSON.stringify(budget, null, 2)}\n`);
+  return budgetPath;
+}
+
+function createAuditedBudget(t, budget) {
+  const budgetPath = path.join(repoRoot, `.repo-size-sync-budget-${process.pid}.json`);
+  fs.writeFileSync(budgetPath, `${JSON.stringify(budget, null, 2)}\n`);
+  t.after(() => fs.rmSync(budgetPath, { force: true }));
+  return budgetPath;
+}
+
+function staleBudget() {
+  return {
+    version: 1,
+    maxTrackedBytes: 1,
+    maxTrackedFiles: 1,
+    maxLargestFileBytes: 1,
+    maxSourceOrTestLines: 1,
+    maxCategoryBytes: {
+      'large support/generated-ish': 1,
+      'source/scripts': 1,
+      'tests/e2e': 1,
+      'docs/text': 1,
+      'config/data/messages': 1,
+      other: 1,
+    },
+  };
+}
+
+test('repo size sync detects drift, updates the budget, then passes check mode', t => {
+  const budgetPath = createTempBudget(t, staleBudget());
+
+  const driftResult = runSync(['--tracked-only', '--check', `--budget=${budgetPath}`]);
+  assert.equal(driftResult.status, 1);
+  assert.match(driftResult.stdout, /Repo size budget drift/u);
+
+  const updateResult = runSync(['--tracked-only', `--budget=${budgetPath}`]);
+  assert.equal(updateResult.status, 0, updateResult.stderr);
+  assert.match(updateResult.stdout, /Repo size budget drift/u);
+
+  const updatedBudget = JSON.parse(fs.readFileSync(budgetPath, 'utf8'));
+  assert.equal(updatedBudget.maxTrackedBytes > 1, true);
+  assert.equal(updatedBudget.maxTrackedFiles > 1, true);
+  assert.equal(Object.keys(updatedBudget.maxCategoryBytes).length > 0, true);
+
+  const cleanResult = runSync(['--tracked-only', '--check', `--budget=${budgetPath}`]);
+  assert.equal(cleanResult.status, 0, cleanResult.stderr);
+  assert.match(cleanResult.stdout, /already synchronized/u);
+});
+
+test('repo size sync dry run reports drift without writing the budget', t => {
+  const originalBudget = staleBudget();
+  const budgetPath = createTempBudget(t, originalBudget);
+
+  const result = runSync(['--tracked-only', '--dry-run', `--budget=${budgetPath}`]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Repo size budget drift/u);
+  assert.deepEqual(JSON.parse(fs.readFileSync(budgetPath, 'utf8')), originalBudget);
+});
+
+test('repo size sync accounts for the budget file write when audited', t => {
+  const budgetPath = createAuditedBudget(t, staleBudget());
+
+  const updateResult = runSync([`--budget=${budgetPath}`]);
+  assert.equal(updateResult.status, 0, updateResult.stderr);
+
+  const cleanResult = runSync(['--check', `--budget=${budgetPath}`]);
+  assert.equal(cleanResult.status, 0, cleanResult.stderr);
+  assert.match(cleanResult.stdout, /already synchronized/u);
+});
+
+test('repo size sync includes non-ignored untracked files before staging', t => {
+  const untrackedPath = path.join(repoRoot, '.repo-size-sync-untracked.js');
+  const untrackedBytes = 321;
+  fs.writeFileSync(untrackedPath, 'x'.repeat(untrackedBytes));
+  t.after(() => fs.rmSync(untrackedPath, { force: true }));
+
+  const budgetPath = createTempBudget(t, staleBudget());
+  const result = runSync([`--budget=${budgetPath}`]);
+  assert.equal(result.status, 0, result.stderr);
+
+  const syncedBudget = JSON.parse(fs.readFileSync(budgetPath, 'utf8'));
+  assert.equal(syncedBudget.maxTrackedBytes >= trackedBytes() + untrackedBytes, true);
+});
+
+test('repo size sync rejects an empty budget path clearly', () => {
+  const result = runSync(['--budget=']);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--budget requires a non-empty value/u);
+});

--- a/scripts/repo-size-budget-sync-core.mjs
+++ b/scripts/repo-size-budget-sync-core.mjs
@@ -1,0 +1,92 @@
+import path from 'node:path';
+
+const SOURCE_EXTENSIONS = new Set(['.cjs', '.css', '.js', '.mjs', '.sh', '.ts', '.tsx']);
+const TEXT_DOC_EXTENSIONS = new Set(['.md', '.txt']);
+const CONFIG_DATA_EXTENSIONS = new Set(['.json', '.jsonl', '.toml', '.yaml', '.yml']);
+
+export function readNonEmptyValue(arg, prefix) {
+  const value = arg.slice(prefix.length).trim();
+  if (!value) throw new Error(`${prefix.slice(0, -1)} requires a non-empty value.`);
+  return value;
+}
+
+export function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function synchronizedBudget(report, previousBudget, budgetRelPath, previousText, included) {
+  if (!included) return exactBudgetFromReport(report, previousBudget);
+
+  let nextBudget = exactBudgetFromReport(report, previousBudget);
+  const previousBytes = Buffer.byteLength(previousText);
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const nextText = stableJson(nextBudget);
+    const adjustedReport = withBudgetFileBytes(
+      report,
+      budgetRelPath,
+      previousBytes,
+      Buffer.byteLength(nextText)
+    );
+    const adjustedBudget = exactBudgetFromReport(adjustedReport, previousBudget);
+    if (stableJson(adjustedBudget) === nextText) return adjustedBudget;
+    nextBudget = adjustedBudget;
+  }
+  throw new Error('Repo size budget sync did not converge.');
+}
+
+function exactBudgetFromReport(report, previousBudget) {
+  return {
+    version: 1,
+    maxTrackedBytes: report.tracked.total.bytes,
+    maxTrackedFiles: report.tracked.total.files,
+    maxCategoryBytes: Object.fromEntries(
+      report.tracked.categories.map(category => [category.name, category.bytes])
+    ),
+    ...preservedKnownLargeLimits(previousBudget, report),
+  };
+}
+
+function preservedKnownLargeLimits(previousBudget, report) {
+  const largestFile = report.tracked.largestFiles[0]?.bytes ?? 1;
+  const largestSource = report.tracked.sourceHotspots[0]?.lines ?? 1;
+  return {
+    maxLargestFileBytes: Math.max(largestFile, previousBudget.maxLargestFileBytes ?? 1),
+    maxSourceOrTestLines: Math.max(largestSource, previousBudget.maxSourceOrTestLines ?? 1),
+  };
+}
+
+function withBudgetFileBytes(report, relPath, fromBytes, toBytes) {
+  const delta = toBytes - fromBytes;
+  const categoryName = budgetCategory(relPath);
+  return {
+    ...report,
+    tracked: {
+      ...report.tracked,
+      total: { ...report.tracked.total, bytes: report.tracked.total.bytes + delta },
+      categories: report.tracked.categories.map(category =>
+        category.name === categoryName ? { ...category, bytes: category.bytes + delta } : category
+      ),
+    },
+  };
+}
+
+function budgetCategory(filePath) {
+  const extension = path.extname(filePath);
+  const base = path.basename(filePath);
+  if (
+    filePath.includes('/drizzle/') ||
+    filePath.includes('/snapshots/visual/') ||
+    filePath === 'pnpm-lock.yaml' ||
+    filePath.startsWith('apps/web/public/icon-') ||
+    filePath === 'docs/plans/current-tracker.md'
+  ) {
+    return 'large support/generated-ish';
+  }
+  if (/\.(test|spec)\.(js|mjs|ts|tsx)$/u.test(base) || filePath.includes('/e2e/')) {
+    return 'tests/e2e';
+  }
+  if (SOURCE_EXTENSIONS.has(extension)) return 'source/scripts';
+  if (TEXT_DOC_EXTENSIONS.has(extension)) return 'docs/text';
+  if (CONFIG_DATA_EXTENSIONS.has(extension)) return 'config/data/messages';
+  return 'other';
+}

--- a/scripts/repo-size-budget-sync.mjs
+++ b/scripts/repo-size-budget-sync.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  readNonEmptyValue,
+  stableJson,
+  synchronizedBudget,
+} from './repo-size-budget-sync-core.mjs';
+
+const DEFAULT_BUDGET_PATH = 'scripts/repo-size-budget.json';
+
+function parseArgs(argv) {
+  const options = {
+    budgetPath: DEFAULT_BUDGET_PATH,
+    check: false,
+    dryRun: false,
+    includeUntracked: true,
+  };
+  for (const arg of argv) {
+    if (arg === '--') {
+      continue;
+    } else if (arg === '--check') {
+      options.check = true;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--tracked-only') {
+      options.includeUntracked = false;
+    } else if (arg.startsWith('--budget=')) {
+      options.budgetPath = readNonEmptyValue(arg, '--budget=');
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(
+        'Usage: node scripts/repo-size-budget-sync.mjs [--check] [--dry-run] [--tracked-only] [--budget=<path>]'
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function repoRoot() {
+  return execFileSync('/usr/bin/git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+    env: { PATH: '/usr/bin:/bin:/usr/sbin:/sbin' },
+  }).trim();
+}
+
+function readAudit(root, options) {
+  const args = ['scripts/repo-size-audit.mjs', '--json', '--no-disk', '--min-lines=0', '--top=1'];
+  if (options.includeUntracked) args.push('--include-untracked');
+  const output = execFileSync(process.execPath, args, { cwd: root, encoding: 'utf8' });
+  return JSON.parse(output);
+}
+
+function resolveBudgetPath(root, inputPath) {
+  const absPath = path.resolve(root, inputPath);
+  const relPath = path.relative(root, absPath);
+  if (relPath === '' || relPath.startsWith('..') || path.isAbsolute(relPath)) {
+    throw new Error(`Budget path must stay inside repository: ${inputPath}`);
+  }
+  return absPath;
+}
+
+function isAuditedFile(root, relPath, options) {
+  const args = ['ls-files', '-z', '--cached'];
+  if (options.includeUntracked) args.push('--others', '--exclude-standard');
+  args.push('--', relPath);
+  return execFileSync('/usr/bin/git', args, {
+    cwd: root,
+    encoding: 'buffer',
+    env: { PATH: '/usr/bin:/bin:/usr/sbin:/sbin' },
+  }).length > 0;
+}
+
+function changedKeys(before, after) {
+  return Object.keys(after).filter(
+    key => JSON.stringify(before[key]) !== JSON.stringify(after[key])
+  );
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const root = repoRoot();
+  const budgetPath = resolveBudgetPath(root, options.budgetPath);
+  const budgetRelPath = path.relative(root, budgetPath);
+  const previousText = fs.readFileSync(budgetPath, 'utf8');
+  const previousBudget = JSON.parse(previousText);
+  const report = readAudit(root, options);
+  const nextBudget = synchronizedBudget(
+    report,
+    previousBudget,
+    budgetRelPath,
+    previousText,
+    isAuditedFile(root, budgetRelPath, options)
+  );
+  const changed = stableJson(previousBudget) !== stableJson(nextBudget);
+
+  if (!changed) {
+    console.log('Repo size budget is already synchronized.');
+    return;
+  }
+
+  console.log(`Repo size budget drift: ${changedKeys(previousBudget, nextBudget).join(', ')}`);
+  if (options.check) process.exit(1);
+  if (!options.dryRun) fs.writeFileSync(budgetPath, stableJson(nextBudget));
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35468569,
-  "maxTrackedFiles": 4125,
-  "maxLargestFileBytes": 2838000,
-  "maxSourceOrTestLines": 3000,
+  "maxTrackedBytes": 35480052,
+  "maxTrackedFiles": 4128,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689633,
-    "source/scripts": 6599068,
-    "tests/e2e": 4415213,
+    "source/scripts": 6605991,
     "docs/text": 5087043,
+    "tests/e2e": 4418549,
     "config/data/messages": 1549671,
     "other": 129165
-  }
+  },
+  "maxLargestFileBytes": 2838000,
+  "maxSourceOrTestLines": 3000
 }


### PR DESCRIPTION
## Summary
- Add `scripts/repo-size-budget-sync.mjs` to synchronize `scripts/repo-size-budget.json` from the current repo-size audit output.
- Add focused tests covering drift detection, dry-run behavior, and untracked file inclusion before staging.
- Sync the repo-size budget for the new utility and test files.

## Scope
- Tooling only; no runtime, product, routing, auth, tenant, or domain-event behavior changes.
- No `apps/web/src/proxy.ts`, README, AGENTS, architecture docs, or promotion docs touched.
- Not wired into existing CI/package scripts, to avoid growing legacy `package.json` and to keep this as an explicit helper.

## Verification
- `node --test scripts/ci/repo-size-budget-sync.test.mjs`
- `node --test scripts/ci/repo-size-audit.test.mjs`
- `pnpm repo:size:check`
- `pnpm check:modularity-guard`
- `pnpm security:guard`
- `git diff --check`
