### PR TITLE
feat: emit membership agent binding event

### DIFF
--- a/packages/database/src/domain-event-membership-payloads.ts
+++ b/packages/database/src/domain-event-membership-payloads.ts
@@ -1,0 +1,33 @@
+import {
+  assertNoUnexpectedPayloadFields,
+  assertStringSetPayloadField,
+} from './domain-event-payload-helpers';
+
+const MEMBERSHIP_AGENT_CLIENT_BOUND_KEYS = new Set(['bindingStatus', 'ownershipSource']);
+const MEMBERSHIP_AGENT_CLIENT_BINDING_STATUSES = new Set(['active']);
+const MEMBERSHIP_OWNERSHIP_SOURCES = new Set(['user.agentId', 'checkout.customData.agentId']);
+
+export function membershipAgentClientBoundPayload(
+  payload: Record<string, unknown>
+): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(
+    payload,
+    'membership.agent_client_bound',
+    MEMBERSHIP_AGENT_CLIENT_BOUND_KEYS
+  );
+
+  return {
+    bindingStatus: assertStringSetPayloadField(
+      payload,
+      'bindingStatus',
+      MEMBERSHIP_AGENT_CLIENT_BINDING_STATUSES,
+      'an agent-client binding status'
+    ),
+    ownershipSource: assertStringSetPayloadField(
+      payload,
+      'ownershipSource',
+      MEMBERSHIP_OWNERSHIP_SOURCES,
+      'a membership ownership source'
+    ),
+  };
+}

--- a/packages/database/src/domain-event-payloads.ts
+++ b/packages/database/src/domain-event-payloads.ts
@@ -9,6 +9,7 @@ import {
   recoveryEscalationAgreementRecordedPayload,
   recoverySuccessFeeCollectedPayload,
 } from './domain-event-recovery-payloads';
+import { membershipAgentClientBoundPayload } from './domain-event-membership-payloads';
 import type { AppendEventParams } from './domain-events';
 
 const CASE_CREATED_KEYS = new Set(['hasDocuments', 'initialStatus']);
@@ -49,6 +50,7 @@ const PAYLOAD_VALIDATORS: Record<
   'recovery.decision_recorded@1': recoveryDecisionRecordedPayload,
   'recovery.escalation_agreement_recorded@1': recoveryEscalationAgreementRecordedPayload,
   'recovery.success_fee_collected@1': recoverySuccessFeeCollectedPayload,
+  'membership.agent_client_bound@1': membershipAgentClientBoundPayload,
 };
 
 export function assertAllowlistedPayload(params: AppendEventParams): Record<string, unknown> {

--- a/packages/database/test/domain-event-membership-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-membership-payload-allowlist.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { appendEvent } from '../src/domain-events';
+import { makeEventTx } from './domain-event-test-utils';
+
+function makeMembershipAgentClientBoundEvent(
+  overrides: Partial<Parameters<typeof appendEvent>[1]> = {}
+) {
+  return {
+    actor: { id: 'paddle-webhook', role: 'system' },
+    aggregateVersion: 0,
+    correlationId: 'corr-1',
+    entity: { id: 'member-1', type: 'member' },
+    eventName: 'membership.agent_client_bound',
+    eventVersion: 1,
+    id: 'event-1',
+    payload: {
+      bindingStatus: 'active',
+      ownershipSource: 'checkout.customData.agentId',
+    },
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+describe('appendEvent membership payload allowlist', () => {
+  for (const [name, event, error] of [
+    [
+      'inline member identifiers',
+      makeMembershipAgentClientBoundEvent({
+        payload: {
+          bindingStatus: 'active',
+          memberEmail: 'member@example.invalid',
+          ownershipSource: 'checkout.customData.agentId',
+        },
+      }),
+      /memberEmail is not allowlisted/,
+    ],
+    [
+      'inline agent identifiers',
+      makeMembershipAgentClientBoundEvent({
+        payload: {
+          agentId: 'agent-1',
+          bindingStatus: 'active',
+          ownershipSource: 'checkout.customData.agentId',
+        },
+      }),
+      /agentId is not allowlisted/,
+    ],
+    [
+      'unsupported ownership source',
+      makeMembershipAgentClientBoundEvent({
+        payload: { bindingStatus: 'active', ownershipSource: 'paddle.customData' },
+      }),
+      /payload\.ownershipSource to be a membership ownership source/,
+    ],
+    [
+      'unsupported binding status',
+      makeMembershipAgentClientBoundEvent({
+        payload: {
+          bindingStatus: 'inactive',
+          ownershipSource: 'checkout.customData.agentId',
+        },
+      }),
+      /payload\.bindingStatus to be an agent-client binding status/,
+    ],
+  ] as const) {
+    it(`rejects ${name} before inserting`, async () => {
+      const { capture, tx } = makeEventTx();
+      await assert.rejects(() => appendEvent(tx, event), error);
+      assert.equal(capture.row, undefined);
+    });
+  }
+
+  it('allows sanitized membership binding payload fields', async () => {
+    const { capture, tx } = makeEventTx();
+    await appendEvent(tx, makeMembershipAgentClientBoundEvent());
+    assert.deepEqual(capture.row?.payload, {
+      bindingStatus: 'active',
+      ownershipSource: 'checkout.customData.agentId',
+    });
+  });
+});

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/test-support.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/test-support.ts
@@ -1,11 +1,8 @@
 import { expect, vi } from 'vitest';
-
 import { createQueuedFrom as createQueuedFromMock } from '../../../../../scripts/tests/queued-select-mock';
 
 export { createQueuedFromMock as createQueuedFrom };
-
 type MockFunction = ReturnType<typeof vi.fn>;
-
 interface PaddleHandlerMocks {
   db: {
     query: {
@@ -24,6 +21,7 @@ interface PaddleHandlerMocks {
   };
   selectResults: unknown[][];
   and: MockFunction;
+  appendEvent: MockFunction;
   asc: MockFunction;
   subscriptions: { id: string };
   user: { id: string };
@@ -42,7 +40,6 @@ interface PaddleHandlerMocks {
   insertedUserValues: MockFunction;
   updatedUserValues: MockFunction;
 }
-
 interface ProviderSubscriptionLookupArgs {
   where?: (
     subs: Record<string, string>,
@@ -60,6 +57,7 @@ interface PaddleDatabaseMockModule {
     agentId: string;
   };
   and: MockFunction;
+  appendEvent: MockFunction;
   asc: MockFunction;
   db: PaddleHandlerMocks['db'];
   eq: MockFunction;
@@ -100,6 +98,7 @@ export function createHoistedPaddleHandlerMocks(): PaddleHandlerMocks {
     },
     selectResults: [] as unknown[][],
     and: vi.fn((...conditions: unknown[]) => ({ op: 'and', conditions })),
+    appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
     asc: vi.fn((value: unknown) => ({ op: 'asc', value })),
     subscriptions: { id: 'id_col' },
     user: { id: 'user.id' },
@@ -130,6 +129,7 @@ export function createPaddleDatabaseMockModule(
       agentId: 'agent_clients.agent_id',
     },
     and: hoisted.and,
+    appendEvent: hoisted.appendEvent,
     asc: hoisted.asc,
     db: hoisted.db,
     eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras-events.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras-events.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMemberReferralRewardCore } from '../../../../../domain-referrals/src';
+import { createCommissionCore } from '../../../commissions/create';
+import { handleNewSubscriptionExtras } from './extras';
+
+const databaseMocks = vi.hoisted(() => ({
+  appendEvent: vi.fn(),
+  findAgentSettings: vi.fn(),
+  findReferral: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  agentClients: {
+    agentId: 'agentClients.agentId',
+    memberId: 'agentClients.memberId',
+    tenantId: 'agentClients.tenantId',
+  },
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  appendEvent: databaseMocks.appendEvent,
+  db: {
+    query: {
+      agentSettings: { findFirst: databaseMocks.findAgentSettings },
+      referrals: { findFirst: databaseMocks.findReferral },
+    },
+    transaction: databaseMocks.transaction,
+  },
+  eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
+}));
+
+vi.mock('nanoid', () => ({ nanoid: vi.fn(() => 'agent-client-id') }));
+vi.mock('../../../../../domain-referrals/src', () => ({ createMemberReferralRewardCore: vi.fn() }));
+vi.mock('../../../commissions/create', () => ({ createCommissionCore: vi.fn() }));
+vi.mock('../../../commissions/create-renewal', () => ({ createRenewalCommissionCore: vi.fn() }));
+
+describe('handleNewSubscriptionExtras membership events', () => {
+  const deps = { logAuditEvent: vi.fn(), sendThankYouLetter: vi.fn() };
+  const tx = { insert: vi.fn(), update: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    databaseMocks.appendEvent.mockResolvedValue({ id: 'event-1' });
+    vi.mocked(createCommissionCore).mockResolvedValue({
+      success: true,
+      data: { id: 'commission-1' },
+    });
+    vi.mocked(createMemberReferralRewardCore).mockResolvedValue({
+      success: true,
+      data: { kind: 'no-op', created: false, reason: 'no_referral' },
+    });
+    databaseMocks.findAgentSettings.mockResolvedValue(null);
+    databaseMocks.findReferral.mockResolvedValue(null);
+    databaseMocks.transaction.mockImplementation(async callback => callback(tx));
+    tx.update.mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    });
+    tx.insert.mockReturnValue({
+      values: vi.fn(() => ({ onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) })),
+    });
+  });
+
+  it('emits sanitized membership binding event in the agent-client binding transaction', async () => {
+    await handleNewSubscriptionExtras({
+      customData: { agentId: 'agent_1' },
+      deps,
+      priceId: 'price_1',
+      sub: {
+        id: 'sub_123',
+        currentBillingPeriod: { endsAt: '2026-01-01T00:00:00Z' },
+        items: [{ price: { unitPrice: { amount: '2000', currencyCode: 'EUR' } } }],
+      },
+      tenantId: 'tenant_1',
+      userId: 'user_1',
+      userRecord: { email: 'member@example.invalid', memberNumber: 'M-1', name: 'Member' },
+    });
+
+    expect(databaseMocks.appendEvent).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        actor: { id: 'paddle-webhook', role: 'system' },
+        correlationId: 'membership:user_1:agent-client-bound',
+        entity: { id: 'user_1', type: 'member' },
+        eventName: 'membership.agent_client_bound',
+        eventVersion: 1,
+        payload: {
+          bindingStatus: 'active',
+          ownershipSource: 'checkout.customData.agentId',
+        },
+        tenantId: 'tenant_1',
+      })
+    );
+  });
+});

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.test.ts
@@ -9,7 +9,6 @@ import {
   redactEmail,
 } from './extras';
 
-// Mock dependencies
 vi.mock('@interdomestik/database', () => ({
   agentClients: {
     tenantId: 'agentClients.tenantId',
@@ -27,6 +26,7 @@ vi.mock('@interdomestik/database', () => ({
       },
     },
   },
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   and: vi.fn((...parts) => ({ op: 'and', parts })),
   eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
 }));

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/extras.ts
@@ -7,15 +7,12 @@ import { createRenewalCommissionCore } from '../../../commissions/create-renewal
 import { calculateCommission } from '../../../commissions/types';
 import { syncActiveAgentClientBinding } from '../../../ownership-attribution';
 import type { PaddleWebhookAuditDeps, PaddleWebhookDeps } from '../../types';
-
-type WebhookUserRecord = {
-  agentId?: string | null;
-  email?: string | null;
-  name?: string | null;
-  memberNumber?: string | null;
-};
-
-type NewMembershipOwnershipSource = 'user.agentId' | 'checkout.customData.agentId';
+import { recordMembershipAgentClientBoundEvent } from './membership-agent-client-bound-event';
+import {
+  resolveNewMembershipOwnership,
+  toOwnershipResolvedFrom,
+  type WebhookUserRecord,
+} from './new-membership-ownership';
 
 export const redactEmail = (email?: string | null) => {
   if (!email) return 'unknown';
@@ -24,37 +21,6 @@ export const redactEmail = (email?: string | null) => {
   const maskedLocal = local.length <= 2 ? `${local[0] ?? ''}*` : `${local[0]}***${local.slice(-1)}`;
   return `${maskedLocal}@${domain}`;
 };
-
-function normalizeAgentId(agentId: string | null | undefined): string | null {
-  if (typeof agentId !== 'string') return null;
-  const normalized = agentId.trim();
-  return normalized.length > 0 ? normalized : null;
-}
-
-function resolveNewMembershipOwnership(args: {
-  userRecord?: WebhookUserRecord | null;
-  customData?: { agentId?: string } | undefined;
-}) {
-  if (args.userRecord && 'agentId' in args.userRecord) {
-    const agentId = normalizeAgentId(args.userRecord.agentId);
-    return {
-      agentId,
-      resolvedFrom: agentId ? ('user.agentId' as const) : null,
-    };
-  }
-
-  const agentId = normalizeAgentId(args.customData?.agentId);
-  return {
-    agentId,
-    resolvedFrom: agentId ? ('checkout.customData.agentId' as const) : null,
-  };
-}
-
-function toOwnershipResolvedFrom(
-  source: NewMembershipOwnershipSource | null
-): NewMembershipOwnershipSource[] {
-  return source ? [source] : [];
-}
 
 async function processCommissions(args: {
   internalSubscriptionId?: string;
@@ -187,8 +153,10 @@ async function ensureAgentClientBinding(args: {
   customData: { agentId?: string } | undefined;
   userRecord?: WebhookUserRecord | null;
 }) {
-  const agentId = resolveNewMembershipOwnership(args).agentId;
-  if (!agentId) return;
+  const ownership = resolveNewMembershipOwnership(args);
+  const agentId = ownership.agentId;
+  const ownershipSource = ownership.resolvedFrom;
+  if (!agentId || !ownershipSource) return;
 
   const now = new Date();
   // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
@@ -198,6 +166,13 @@ async function ensureAgentClientBinding(args: {
       memberId: args.userId,
       agentId,
       now,
+    });
+    await recordMembershipAgentClientBoundEvent({
+      memberId: args.userId,
+      now,
+      ownershipSource,
+      tenantId: args.tenantId,
+      tx,
     });
   });
 }

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/membership-agent-client-bound-event.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/membership-agent-client-bound-event.ts
@@ -1,0 +1,26 @@
+import { appendEvent, type DomainEventTx } from '@interdomestik/database';
+
+import type { NewMembershipOwnershipSource } from './new-membership-ownership';
+
+export async function recordMembershipAgentClientBoundEvent(params: {
+  memberId: string;
+  now: Date;
+  ownershipSource: NewMembershipOwnershipSource;
+  tenantId: string;
+  tx: DomainEventTx;
+}) {
+  await appendEvent(params.tx, {
+    actor: { id: 'paddle-webhook', role: 'system' },
+    aggregateVersion: 0,
+    correlationId: `membership:${params.memberId}:agent-client-bound`,
+    createdAt: params.now,
+    entity: { id: params.memberId, type: 'member' },
+    eventName: 'membership.agent_client_bound',
+    eventVersion: 1,
+    payload: {
+      bindingStatus: 'active',
+      ownershipSource: params.ownershipSource,
+    },
+    tenantId: params.tenantId,
+  });
+}

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/new-membership-ownership.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/utils/new-membership-ownership.ts
@@ -1,0 +1,39 @@
+export type WebhookUserRecord = {
+  agentId?: string | null;
+  email?: string | null;
+  name?: string | null;
+  memberNumber?: string | null;
+};
+
+export type NewMembershipOwnershipSource = 'user.agentId' | 'checkout.customData.agentId';
+
+function normalizeAgentId(agentId: string | null | undefined): string | null {
+  if (typeof agentId !== 'string') return null;
+  const normalized = agentId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function resolveNewMembershipOwnership(args: {
+  userRecord?: WebhookUserRecord | null;
+  customData?: { agentId?: string };
+}) {
+  if (args.userRecord && 'agentId' in args.userRecord) {
+    const agentId = normalizeAgentId(args.userRecord.agentId);
+    return {
+      agentId,
+      resolvedFrom: agentId ? ('user.agentId' as const) : null,
+    };
+  }
+
+  const agentId = normalizeAgentId(args.customData?.agentId);
+  return {
+    agentId,
+    resolvedFrom: agentId ? ('checkout.customData.agentId' as const) : null,
+  };
+}
+
+export function toOwnershipResolvedFrom(
+  source: NewMembershipOwnershipSource | null
+): NewMembershipOwnershipSource[] {
+  return source ? [source] : [];
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35493030,
-  "maxTrackedFiles": 4133,
+  "maxTrackedBytes": 35501716,
+  "maxTrackedFiles": 4138,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689633,
-    "source/scripts": 6610466,
+    "source/scripts": 6613098,
     "docs/text": 5087043,
-    "tests/e2e": 4427052,
+    "tests/e2e": 4433106,
     "config/data/messages": 1549671,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Emit membership.agent_client_bound@1 from the existing Paddle new-membership agent binding transaction seam.
- Add a membership event payload allowlist so only sanitized bindingStatus and ownershipSource values are accepted.
- Extract ownership resolution and event recording helpers to keep the legacy webhook extras path smaller and focused.

## Design Gate
- Confirmed origin/main at d7d4ccd9d2ee8448998bf880d524cb31f9b9eeee.
- Confirmed recovery.success_fee_collected@1 is merged via #1041.
- Selected the smallest safe next T-105 seam: ensureAgentClientBinding in the membership billing Paddle webhook path, which already runs inside db.transaction and calls syncActiveAgentClientBinding.
- Rejected subscription-state upsert emission for this slice because that path is not an existing transactional event seam.
- Payload is allowlisted and sanitized: bindingStatus=active plus ownershipSource=user.agentId or checkout.customData.agentId. No PII, subscription id, raw agent id, or member email is included in payload.
- Did not touch apps/web/src/proxy.ts, canonical routes, clarity markers, README, AGENTS.md, or architecture docs.
- Did not promote T-204, T-209, or T-408.

## Verification
- pnpm --filter @interdomestik/database test:unit -- --test-reporter=spec test/domain-event-membership-payload-allowlist.test.ts
- pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/paddle-webhooks/handlers/utils/extras.test.ts src/paddle-webhooks/handlers/utils/extras-events.test.ts
- pnpm --filter @interdomestik/domain-membership-billing type-check
- pnpm --filter @interdomestik/database type-check
- pnpm --filter @interdomestik/domain-membership-billing test:unit
- pnpm check:modularity-guard
- git diff --check
- pnpm repo:size:check
- pnpm slice:verify
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate

## Review
- Required wrapped Codex reviewer route was attempted with run-reviewer-route.mjs but the wrapper did not return a disposition within the bounded wait and was interrupted.
- Direct Codex senior engineer review completed with no discrete correctness, security, or maintainability issues found in the changed and untracked files.
- No Sonnet/model-review or MCP review path was used for approval.

## Operational Notes
- The first local pnpm pr:verify attempt failed in v1-live-surface-revalidation because an unrelated dev server from another worktree was occupying port 3000. After killing that stale process, the focused pilot-host test passed and the full pnpm pr:verify rerun passed.
- Rollback is removing the event recorder call and membership payload validator registration; the binding sync behavior remains unchanged.
