### PR TITLE
feat: emit draft case created event

### DIFF
--- a/packages/database/test/domain-event-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-payload-allowlist.test.ts
@@ -105,4 +105,15 @@ describe('appendEvent payload allowlist', () => {
       initialStatus: 'submitted',
     });
   });
+
+  it('allows sanitized draft case.created payload fields', async () => {
+    const { capture, tx } = makeEventTx();
+
+    await appendEvent(
+      tx,
+      makeCaseCreatedEvent({ payload: { hasDocuments: false, initialStatus: 'draft' } })
+    );
+
+    assert.deepEqual(capture.row?.payload, { hasDocuments: false, initialStatus: 'draft' });
+  });
 });

--- a/packages/domain-claims/src/claims/case-created-event.ts
+++ b/packages/domain-claims/src/claims/case-created-event.ts
@@ -1,0 +1,29 @@
+import { appendEvent, type DomainEventTx } from '@interdomestik/database';
+import type { ClaimStatus } from '@interdomestik/database/constants';
+
+export async function recordCaseCreatedEvent(
+  tx: DomainEventTx,
+  params: {
+    actor: { id: string; role: string };
+    claimId: string;
+    createdAt: Date;
+    hasDocuments: boolean;
+    initialStatus: ClaimStatus;
+    tenantId: string;
+  }
+): Promise<void> {
+  await appendEvent(tx, {
+    actor: { id: params.actor.id, role: params.actor.role.trim() || 'member' },
+    aggregateVersion: 1,
+    correlationId: crypto.randomUUID(),
+    createdAt: params.createdAt,
+    entity: { id: params.claimId, type: 'case' },
+    eventName: 'case.created',
+    eventVersion: 1,
+    payload: {
+      hasDocuments: params.hasDocuments,
+      initialStatus: params.initialStatus,
+    },
+    tenantId: params.tenantId,
+  });
+}

--- a/packages/domain-claims/src/claims/create.ts
+++ b/packages/domain-claims/src/claims/create.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { formatZodFieldErrors, extractBranchIdFromSetting } from './create-helpers';
 import { resolveClaimIncidentCountry } from './incident-country';
 import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
+import { recordCaseCreatedEvent } from './case-created-event';
 import type { ClaimsDeps, ClaimsSession } from './types';
 
 const claimSchema = z.object({
@@ -104,6 +105,15 @@ export async function createClaimCore(
         tenantId,
         claimId,
         createdAt: now,
+      });
+
+      await recordCaseCreatedEvent(tx, {
+        actor: { id: session.user.id, role: session.user.role ?? 'member' },
+        claimId,
+        createdAt: now,
+        hasDocuments: false,
+        initialStatus: 'draft',
+        tenantId,
       });
     });
 

--- a/packages/domain-claims/src/claims/lifecycle-initialization.test.ts
+++ b/packages/domain-claims/src/claims/lifecycle-initialization.test.ts
@@ -68,6 +68,7 @@ vi.mock('./ai-workflows', () => ({
   queueClaimDocumentAiWorkflows: vi.fn().mockResolvedValue([]),
 }));
 
+import { appendEvent } from '@interdomestik/database';
 import { createClaimCore } from './create';
 import { submitClaimCore } from './submit';
 
@@ -106,6 +107,17 @@ describe('claim lifecycle state initialization', () => {
         caseLifecycleState: 'draft',
         recoveryLifecycleState: 'not_started',
         status: 'draft',
+      })
+    );
+    const claimRow = hoisted.txInsertValues.mock.calls[0]?.[0] as { createdAt?: Date };
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ insert: hoisted.txInsert }),
+      expect.objectContaining({
+        createdAt: claimRow.createdAt,
+        entity: { id: 'claim-1', type: 'case' },
+        eventName: 'case.created',
+        payload: { hasDocuments: false, initialStatus: 'draft' },
+        tenantId: 'tenant-1',
       })
     );
   });

--- a/packages/domain-claims/src/claims/transition-side-effects.ts
+++ b/packages/domain-claims/src/claims/transition-side-effects.ts
@@ -2,6 +2,7 @@ import { appendEvent, claimStageHistory, db } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { SQLWrapper } from 'drizzle-orm';
 import type { AuthorizedTransition, ClaimTransitionActor } from './transition-guard';
+import { recordCaseCreatedEvent } from './case-created-event';
 import type { CreateClaimValues } from '../validators/claims';
 import type { PaymentAuthorizationState } from '../staff-claims/types';
 
@@ -82,18 +83,12 @@ export async function recordSubmittedClaimLifecycle(
     isPublic: true,
     createdAt: args.createdAt,
   });
-  await appendEvent(tx, {
+  await recordCaseCreatedEvent(tx, {
     actor: { id: args.userId, role: args.changedByRole.trim() || 'member' },
-    aggregateVersion: 1,
-    correlationId: crypto.randomUUID(),
+    claimId: args.claimId,
     createdAt: args.createdAt,
-    entity: { id: args.claimId, type: 'case' },
-    eventName: 'case.created',
-    eventVersion: 1,
-    payload: {
-      hasDocuments: Boolean(args.data.files?.length),
-      initialStatus: 'submitted',
-    },
+    hasDocuments: Boolean(args.data.files?.length),
+    initialStatus: 'submitted',
     tenantId: args.tenantId,
   });
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35501716,
-  "maxTrackedFiles": 4138,
+  "maxTrackedBytes": 35503665,
+  "maxTrackedFiles": 4139,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689633,
-    "source/scripts": 6613098,
+    "source/scripts": 6614183,
     "docs/text": 5087043,
-    "tests/e2e": 4433106,
+    "tests/e2e": 4433970,
     "config/data/messages": 1549671,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Emits `case.created@1` for draft claim creation from the existing `createClaim` transaction seam.
- Reuses the submitted-claim event helper so draft and submitted case creation stay on the same sanitized contract.
- Adds focused unit/allowlist coverage for the draft payload: `{ hasDocuments: false, initialStatus: "draft" }`.

## Design Gate
- Confirmed `origin/main` at `c6a862aea6edcdaed2d91865d62c9582254b2083`.
- Confirmed the prior `case.created@1` submit path is already merged through the contained `codex/t105-case-created-event` branch.
- Found the smallest remaining safe seam in `packages/domain-claims/src/claims/create.ts`: draft claim creation already runs inside a DB transaction but only wrote post-commit audit, with no domain outbox event.
- Did not touch `apps/web/src/proxy.ts`, canonical routes, clarity markers, README/AGENTS, architecture docs, or T-204/T-209/T-408 work.

## Verification
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/lifecycle-initialization.test.ts src/claims/submit.test.ts src/claims/incident-country-writers.test.ts`
- `pnpm --filter @interdomestik/domain-claims type-check`
- `git diff --check`
- `pnpm --filter @interdomestik/database test:unit -- --test-reporter=spec test/domain-event-payload-allowlist.test.ts`
- `pnpm --filter @interdomestik/domain-claims test:unit`
- `pnpm check:modularity-guard`
- `pnpm --filter @interdomestik/database type-check`
- `pnpm repo:size:check`
- `pnpm slice:verify`
- `pnpm security:guard`
- `git diff --cached --check`
- `pnpm pr:verify`
- `pnpm e2e:gate`

## Review / Risk
- Codex senior review: no discrete correctness issues found.
- Payload remains allowlisted and sanitized; no claimant/member PII added.
- Event is emitted only from an existing transaction seam.

## Rollback
- Revert this commit to remove draft claim creation event emission while leaving the existing submitted claim event behavior intact.
