### PR TITLE
feat: complete T-105 domain event coverage

### DIFF
--- a/apps/web/src/lib/paddle-webhooks/subscriptions-handler.test.ts
+++ b/apps/web/src/lib/paddle-webhooks/subscriptions-handler.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   insertValues: vi.fn((_vals?: unknown) => ({ onConflictDoUpdate: vi.fn(async () => undefined) })),
   selectResults: [] as unknown[][],
   findSubscription: vi.fn<() => Promise<Record<string, unknown> | null>>(() =>
@@ -24,38 +25,41 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@interdomestik/database', async () => {
   const helper = await import('@/test/canonical-membership-db-mock');
+  const dbMock = {
+    select: helper.createQueuedSelectMock(mocks.selectResults),
+    query: {
+      subscriptions: {
+        findFirst: () => mocks.findSubscription(),
+      },
+      user: {
+        findFirst: () => mocks.findUser(),
+      },
+      tenantSettings: {
+        findFirst: () => mocks.findTenantSetting(),
+      },
+      membershipPlans: {
+        findFirst: () => mocks.findMembershipPlan(),
+      },
+      referrals: {
+        findFirst: () => mocks.findReferral(),
+      },
+    },
+    insert: () => ({
+      values: (vals: unknown) => {
+        return mocks.insertValues(vals) as unknown as { onConflictDoUpdate: () => Promise<void> };
+      },
+    }),
+    transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(dbMock)),
+  };
 
   return {
+    appendEvent: mocks.appendEvent,
     and: vi.fn((...conditions: unknown[]) => ({ kind: 'and', conditions })),
     asc: vi.fn((value: unknown) => ({ kind: 'asc', value })),
     eq: vi.fn((column: unknown, value: unknown) => ({ kind: 'eq', column, value })),
     membershipPlans: helper.CANONICAL_MEMBERSHIP_PLAN_COLUMNS,
     subscriptions: { id: 'id' },
-    db: {
-      select: helper.createQueuedSelectMock(mocks.selectResults),
-      query: {
-        subscriptions: {
-          findFirst: () => mocks.findSubscription(),
-        },
-        user: {
-          findFirst: () => mocks.findUser(),
-        },
-        tenantSettings: {
-          findFirst: () => mocks.findTenantSetting(),
-        },
-        membershipPlans: {
-          findFirst: () => mocks.findMembershipPlan(),
-        },
-        referrals: {
-          findFirst: () => mocks.findReferral(),
-        },
-      },
-      insert: () => ({
-        values: (vals: unknown) => {
-          return mocks.insertValues(vals) as unknown as { onConflictDoUpdate: () => Promise<void> };
-        },
-      }),
-    },
+    db: dbMock,
   };
 });
 
@@ -68,6 +72,7 @@ import { handleSubscriptionChanged } from '@interdomestik/domain-membership-bill
 describe('handleSubscriptionChanged tenant guardrail', () => {
   beforeEach(() => {
     mocks.insertValues.mockClear();
+    mocks.appendEvent.mockClear();
     mocks.selectResults.length = 0;
     mocks.findSubscription.mockClear();
     mocks.findUser.mockClear();

--- a/packages/database/src/domain-event-membership-payloads.ts
+++ b/packages/database/src/domain-event-membership-payloads.ts
@@ -1,11 +1,26 @@
 import {
+  assertBooleanPayloadField,
   assertNoUnexpectedPayloadFields,
   assertStringSetPayloadField,
 } from './domain-event-payload-helpers';
 
 const MEMBERSHIP_AGENT_CLIENT_BOUND_KEYS = new Set(['bindingStatus', 'ownershipSource']);
+const MEMBERSHIP_SUBSCRIPTION_CHANGED_KEYS = new Set([
+  'cancelAtPeriodEnd',
+  'fromStatus',
+  'toStatus',
+]);
 const MEMBERSHIP_AGENT_CLIENT_BINDING_STATUSES = new Set(['active']);
 const MEMBERSHIP_OWNERSHIP_SOURCES = new Set(['user.agentId', 'checkout.customData.agentId']);
+const MEMBERSHIP_SUBSCRIPTION_STATUSES = new Set([
+  'none',
+  'active',
+  'past_due',
+  'paused',
+  'canceled',
+  'trialing',
+  'expired',
+]);
 
 export function membershipAgentClientBoundPayload(
   payload: Record<string, unknown>
@@ -28,6 +43,32 @@ export function membershipAgentClientBoundPayload(
       'ownershipSource',
       MEMBERSHIP_OWNERSHIP_SOURCES,
       'a membership ownership source'
+    ),
+  };
+}
+
+export function membershipSubscriptionChangedPayload(
+  payload: Record<string, unknown>
+): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(
+    payload,
+    'membership.subscription_changed',
+    MEMBERSHIP_SUBSCRIPTION_CHANGED_KEYS
+  );
+
+  return {
+    cancelAtPeriodEnd: assertBooleanPayloadField(payload, 'cancelAtPeriodEnd'),
+    fromStatus: assertStringSetPayloadField(
+      payload,
+      'fromStatus',
+      MEMBERSHIP_SUBSCRIPTION_STATUSES,
+      'a membership subscription status'
+    ),
+    toStatus: assertStringSetPayloadField(
+      payload,
+      'toStatus',
+      MEMBERSHIP_SUBSCRIPTION_STATUSES,
+      'a membership subscription status'
     ),
   };
 }

--- a/packages/database/src/domain-event-payloads.ts
+++ b/packages/database/src/domain-event-payloads.ts
@@ -1,4 +1,11 @@
-import { CLAIM_STATUSES, type ClaimStatus } from './constants';
+import {
+  CLAIM_CASE_LIFECYCLE_STATES,
+  CLAIM_RECOVERY_LIFECYCLE_STATES,
+  CLAIM_STATUSES,
+  type ClaimCaseLifecycleState,
+  type ClaimRecoveryLifecycleState,
+  type ClaimStatus,
+} from './constants';
 import {
   assertBooleanPayloadField,
   assertNoUnexpectedPayloadFields,
@@ -9,16 +16,41 @@ import {
   recoveryEscalationAgreementRecordedPayload,
   recoverySuccessFeeCollectedPayload,
 } from './domain-event-recovery-payloads';
-import { membershipAgentClientBoundPayload } from './domain-event-membership-payloads';
+import {
+  membershipAgentClientBoundPayload,
+  membershipSubscriptionChangedPayload,
+} from './domain-event-membership-payloads';
 import type { AppendEventParams } from './domain-events';
 
 const CASE_CREATED_KEYS = new Set(['hasDocuments', 'initialStatus']);
+const CASE_LIFECYCLE_CHANGED_KEYS = new Set(['fromState', 'fromStatus', 'toState', 'toStatus']);
 const CLAIM_STATUS_CHANGED_KEYS = new Set(['fromStatus', 'toStatus']);
+const RECOVERY_LIFECYCLE_CHANGED_KEYS = CASE_LIFECYCLE_CHANGED_KEYS;
+const CASE_LIFECYCLE_STATE_SET = new Set<string>(CLAIM_CASE_LIFECYCLE_STATES);
 const CLAIM_STATUS_SET = new Set<string>(CLAIM_STATUSES);
+const RECOVERY_LIFECYCLE_STATE_SET = new Set<string>(CLAIM_RECOVERY_LIFECYCLE_STATES);
 
 function assertClaimStatus(value: unknown, field: string): asserts value is ClaimStatus {
   if (typeof value !== 'string' || !CLAIM_STATUS_SET.has(value)) {
     throw new Error(`appendEvent requires payload.${field} to be a claim status`);
+  }
+}
+
+function assertCaseLifecycleState(
+  value: unknown,
+  field: string
+): asserts value is ClaimCaseLifecycleState {
+  if (typeof value !== 'string' || !CASE_LIFECYCLE_STATE_SET.has(value)) {
+    throw new Error(`appendEvent requires payload.${field} to be a case lifecycle state`);
+  }
+}
+
+function assertRecoveryLifecycleState(
+  value: unknown,
+  field: string
+): asserts value is ClaimRecoveryLifecycleState {
+  if (typeof value !== 'string' || !RECOVERY_LIFECYCLE_STATE_SET.has(value)) {
+    throw new Error(`appendEvent requires payload.${field} to be a recovery lifecycle state`);
   }
 }
 
@@ -41,16 +73,54 @@ function caseCreatedPayload(payload: Record<string, unknown>): Record<string, un
   };
 }
 
+function lifecycleChangedPayload(
+  payload: Record<string, unknown>,
+  eventName: string,
+  keys: Set<string>,
+  assertState: (value: unknown, field: string) => void
+): Record<string, unknown> {
+  assertNoUnexpectedPayloadFields(payload, eventName, keys);
+  for (const field of ['fromStatus', 'toStatus'] as const) {
+    assertRequiredPayloadField(payload, field);
+    assertClaimStatus(payload[field], field);
+  }
+  for (const field of ['fromState', 'toState'] as const) {
+    assertRequiredPayloadField(payload, field);
+    assertState(payload[field], field);
+  }
+  return {
+    fromState: payload.fromState,
+    fromStatus: payload.fromStatus,
+    toState: payload.toState,
+    toStatus: payload.toStatus,
+  };
+}
+
 const PAYLOAD_VALIDATORS: Record<
   string,
   (payload: Record<string, unknown>) => Record<string, unknown>
 > = {
   'case.created@1': caseCreatedPayload,
+  'case.lifecycle_changed@1': payload =>
+    lifecycleChangedPayload(
+      payload,
+      'case.lifecycle_changed',
+      CASE_LIFECYCLE_CHANGED_KEYS,
+      assertCaseLifecycleState
+    ),
   'claim.status_changed@1': claimStatusChangedPayload,
+  'recovery.lifecycle_changed@1': payload =>
+    lifecycleChangedPayload(
+      payload,
+      'recovery.lifecycle_changed',
+      RECOVERY_LIFECYCLE_CHANGED_KEYS,
+      assertRecoveryLifecycleState
+    ),
   'recovery.decision_recorded@1': recoveryDecisionRecordedPayload,
   'recovery.escalation_agreement_recorded@1': recoveryEscalationAgreementRecordedPayload,
   'recovery.success_fee_collected@1': recoverySuccessFeeCollectedPayload,
   'membership.agent_client_bound@1': membershipAgentClientBoundPayload,
+  'membership.subscription_changed@1': membershipSubscriptionChangedPayload,
 };
 
 export function assertAllowlistedPayload(params: AppendEventParams): Record<string, unknown> {

--- a/packages/database/test/domain-event-lifecycle-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-lifecycle-payload-allowlist.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { appendEvent } from '../src/domain-events';
+import { makeEventTx } from './domain-event-test-utils';
+
+function makeLifecycleEvent(overrides: Partial<Parameters<typeof appendEvent>[1]> = {}) {
+  return {
+    actor: { id: 'staff-1', role: 'staff' },
+    aggregateVersion: 7,
+    correlationId: 'corr-1',
+    entity: { id: 'claim-1', type: 'case' },
+    eventName: 'case.lifecycle_changed',
+    eventVersion: 1,
+    id: 'event-1',
+    payload: {
+      fromState: 'evaluation',
+      fromStatus: 'evaluation',
+      toState: 'recovery',
+      toStatus: 'negotiation',
+    },
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+describe('appendEvent lifecycle payload allowlist', () => {
+  it('rejects extra case lifecycle fields before inserting', async () => {
+    const { capture, tx } = makeEventTx();
+    await assert.rejects(
+      () =>
+        appendEvent(
+          tx,
+          makeLifecycleEvent({
+            payload: {
+              fromState: 'evaluation',
+              fromStatus: 'evaluation',
+              memberEmail: 'member@example.invalid',
+              toState: 'recovery',
+              toStatus: 'negotiation',
+            },
+          })
+        ),
+      /memberEmail is not allowlisted/
+    );
+    assert.equal(capture.row, undefined);
+  });
+
+  it('rejects invalid recovery lifecycle states before inserting', async () => {
+    const { capture, tx } = makeEventTx();
+    await assert.rejects(
+      () =>
+        appendEvent(
+          tx,
+          makeLifecycleEvent({
+            entity: { id: 'claim-1', type: 'recovery' },
+            eventName: 'recovery.lifecycle_changed',
+            payload: {
+              fromState: 'evaluation',
+              fromStatus: 'evaluation',
+              toState: 'recovery',
+              toStatus: 'negotiation',
+            },
+          })
+        ),
+      /payload\.fromState to be a recovery lifecycle state/
+    );
+    assert.equal(capture.row, undefined);
+  });
+
+  it('allows sanitized case lifecycle event payload fields', async () => {
+    const { capture, tx } = makeEventTx();
+    await appendEvent(tx, makeLifecycleEvent());
+    assert.deepEqual(capture.row?.payload, {
+      fromState: 'evaluation',
+      fromStatus: 'evaluation',
+      toState: 'recovery',
+      toStatus: 'negotiation',
+    });
+  });
+});

--- a/packages/database/test/domain-event-membership-payload-allowlist.test.ts
+++ b/packages/database/test/domain-event-membership-payload-allowlist.test.ts
@@ -24,6 +24,23 @@ function makeMembershipAgentClientBoundEvent(
   };
 }
 
+function makeMembershipSubscriptionChangedEvent(
+  overrides: Partial<Parameters<typeof appendEvent>[1]> = {}
+) {
+  return {
+    actor: { id: 'paddle-webhook', role: 'system' },
+    aggregateVersion: 0,
+    correlationId: 'corr-2',
+    entity: { id: 'sub-1', type: 'subscription' },
+    eventName: 'membership.subscription_changed',
+    eventVersion: 1,
+    id: 'event-2',
+    payload: { cancelAtPeriodEnd: false, fromStatus: 'none', toStatus: 'active' },
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
 describe('appendEvent membership payload allowlist', () => {
   for (const [name, event, error] of [
     [
@@ -65,6 +82,25 @@ describe('appendEvent membership payload allowlist', () => {
       }),
       /payload\.bindingStatus to be an agent-client binding status/,
     ],
+    [
+      'extra subscription fields',
+      makeMembershipSubscriptionChangedEvent({
+        payload: {
+          cancelAtPeriodEnd: false,
+          fromStatus: 'none',
+          memberEmail: 'member@example.invalid',
+          toStatus: 'active',
+        },
+      }),
+      /memberEmail is not allowlisted/,
+    ],
+    [
+      'unsupported subscription status',
+      makeMembershipSubscriptionChangedEvent({
+        payload: { cancelAtPeriodEnd: false, fromStatus: 'pending', toStatus: 'active' },
+      }),
+      /payload\.fromStatus to be a membership subscription status/,
+    ],
   ] as const) {
     it(`rejects ${name} before inserting`, async () => {
       const { capture, tx } = makeEventTx();
@@ -79,6 +115,16 @@ describe('appendEvent membership payload allowlist', () => {
     assert.deepEqual(capture.row?.payload, {
       bindingStatus: 'active',
       ownershipSource: 'checkout.customData.agentId',
+    });
+  });
+
+  it('allows sanitized subscription changed payload fields', async () => {
+    const { capture, tx } = makeEventTx();
+    await appendEvent(tx, makeMembershipSubscriptionChangedEvent());
+    assert.deepEqual(capture.row?.payload, {
+      cancelAtPeriodEnd: false,
+      fromStatus: 'none',
+      toStatus: 'active',
     });
   });
 });

--- a/packages/domain-claims/src/claims/transition-domain-events.ts
+++ b/packages/domain-claims/src/claims/transition-domain-events.ts
@@ -1,0 +1,82 @@
+import { appendEvent, type DomainEventTx } from '@interdomestik/database';
+import type { ClaimStatus } from '@interdomestik/database/constants';
+
+import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
+import type { ClaimTransitionActor } from './transition-guard';
+
+type TransitionEventArgs = {
+  actor: ClaimTransitionActor;
+  claimId: string;
+  correlationId?: string;
+  fromStatus: ClaimStatus;
+  lifecycleVersion: number;
+  now: Date;
+  tenantId: string;
+  toStatus: ClaimStatus;
+  tx: DomainEventTx;
+};
+
+async function appendTransitionEvent(
+  args: TransitionEventArgs & {
+    entityType: 'case' | 'claim' | 'recovery';
+    eventName: string;
+    payload: Record<string, unknown>;
+  }
+) {
+  await appendEvent(args.tx, {
+    actor: { id: args.actor.id, role: args.actor.role?.trim() || 'unknown' },
+    aggregateVersion: args.lifecycleVersion,
+    correlationId: args.correlationId ?? crypto.randomUUID(),
+    createdAt: args.now,
+    entity: { id: args.claimId, type: args.entityType },
+    eventName: args.eventName,
+    eventVersion: 1,
+    payload: args.payload,
+    tenantId: args.tenantId,
+  });
+}
+
+export async function recordTransitionDomainEvents(args: TransitionEventArgs): Promise<void> {
+  if (args.fromStatus === args.toStatus) return;
+
+  const correlationId = args.correlationId ?? crypto.randomUUID();
+  const fromLifecycle = mapClaimStatusToLifecycleStates(args.fromStatus);
+  const toLifecycle = mapClaimStatusToLifecycleStates(args.toStatus);
+  const statusPayload = { fromStatus: args.fromStatus, toStatus: args.toStatus };
+
+  await appendTransitionEvent({
+    ...args,
+    correlationId,
+    entityType: 'claim',
+    eventName: 'claim.status_changed',
+    payload: statusPayload,
+  });
+
+  if (fromLifecycle.caseLifecycleState !== toLifecycle.caseLifecycleState) {
+    await appendTransitionEvent({
+      ...args,
+      correlationId,
+      entityType: 'case',
+      eventName: 'case.lifecycle_changed',
+      payload: {
+        ...statusPayload,
+        fromState: fromLifecycle.caseLifecycleState,
+        toState: toLifecycle.caseLifecycleState,
+      },
+    });
+  }
+
+  if (fromLifecycle.recoveryLifecycleState !== toLifecycle.recoveryLifecycleState) {
+    await appendTransitionEvent({
+      ...args,
+      correlationId,
+      entityType: 'recovery',
+      eventName: 'recovery.lifecycle_changed',
+      payload: {
+        ...statusPayload,
+        fromState: fromLifecycle.recoveryLifecycleState,
+        toState: toLifecycle.recoveryLifecycleState,
+      },
+    });
+  }
+}

--- a/packages/domain-claims/src/claims/transition-events-test-support.ts
+++ b/packages/domain-claims/src/claims/transition-events-test-support.ts
@@ -1,0 +1,100 @@
+import { claimStageHistory, domainEvents } from '@interdomestik/database';
+import type { ClaimStatus } from '@interdomestik/database/constants';
+
+import { transitionClaimStatusInTransaction, type TransitionTx } from './transition';
+
+type Row = Record<string, unknown>;
+export type ClaimState = {
+  events: Row[];
+  histories: Row[];
+  lifecycleVersion: number;
+  status: ClaimStatus;
+};
+type FailOn = 'history' | 'event';
+
+export const initialState = (): ClaimState => ({
+  events: [],
+  histories: [],
+  lifecycleVersion: 6,
+  status: 'evaluation',
+});
+
+class FakeSelect {
+  constructor(private readonly state: ClaimState) {}
+  from(): this {
+    return this;
+  }
+  where(): this {
+    return this;
+  }
+  async limit(): Promise<Row[]> {
+    return [{ ...this.state, id: 'claim-1' }];
+  }
+}
+
+class FakeUpdate {
+  private values: Row = {};
+  constructor(private readonly staged: ClaimState) {}
+  set(values: Row): this {
+    this.values = values;
+    return this;
+  }
+  where(): this {
+    return this;
+  }
+  async returning(): Promise<Row[]> {
+    if (typeof this.values.status === 'string')
+      this.staged.status = this.values.status as ClaimStatus;
+    if ('lifecycleVersion' in this.values) this.staged.lifecycleVersion += 1;
+    return [{ id: 'claim-1', lifecycleVersion: this.staged.lifecycleVersion }];
+  }
+}
+
+class FakeInsert {
+  constructor(
+    private readonly staged: ClaimState,
+    private readonly table: unknown,
+    private readonly failOn?: FailOn
+  ) {}
+  values(values: Row) {
+    if (this.table === claimStageHistory) {
+      if (this.failOn === 'history') throw new Error('history failed');
+      this.staged.histories.push(values);
+    }
+    if (this.table === domainEvents) {
+      if (this.failOn === 'event') throw new Error('event failed');
+      this.staged.events.push(values);
+    }
+    return { returning: async () => [{ id: values.id }] };
+  }
+}
+
+function makeParams() {
+  return {
+    actor: { id: 'staff-1', role: 'staff' },
+    claimId: 'claim-1',
+    correlationId: 'corr-1',
+    isPublic: false,
+    note: 'member-visible status note',
+    paymentAuthorizationState: 'authorized' as const,
+    tenantId: 'tenant-1',
+    toStatus: 'negotiation' as const,
+  };
+}
+
+function makeTx(state: ClaimState, failOn?: FailOn) {
+  const staged = { ...state, events: [...state.events], histories: [...state.histories] };
+  const tx = {
+    select: () => new FakeSelect(state),
+    update: () => new FakeUpdate(staged),
+    insert: (table: unknown) => new FakeInsert(staged, table, failOn),
+  };
+  return { commit: () => Object.assign(state, staged), tx: tx as unknown as TransitionTx };
+}
+
+export async function runTransaction(state: ClaimState, failOn?: FailOn) {
+  const { commit, tx } = makeTx(state, failOn);
+  const result = await transitionClaimStatusInTransaction(tx, makeParams());
+  commit();
+  return result;
+}

--- a/packages/domain-claims/src/claims/transition-events.test.ts
+++ b/packages/domain-claims/src/claims/transition-events.test.ts
@@ -1,106 +1,9 @@
-import { claimStageHistory, domainEvents } from '@interdomestik/database';
-import type { ClaimStatus } from '@interdomestik/database/constants';
 import { describe, expect, it } from 'vitest';
 
-import { transitionClaimStatusInTransaction, type TransitionTx } from './transition';
-
-type Row = Record<string, unknown>;
-type ClaimState = {
-  events: Row[];
-  histories: Row[];
-  lifecycleVersion: number;
-  status: ClaimStatus;
-};
-type FailOn = 'history' | 'event';
-const initialState = (): ClaimState => ({
-  events: [],
-  histories: [],
-  lifecycleVersion: 6,
-  status: 'evaluation',
-});
-
-class FakeSelect {
-  constructor(private readonly state: ClaimState) {}
-  from(): this {
-    return this;
-  }
-  where(): this {
-    return this;
-  }
-  async limit(): Promise<Row[]> {
-    return [{ ...this.state, id: 'claim-1' }];
-  }
-}
-
-class FakeUpdate {
-  private values: Row = {};
-  constructor(private readonly staged: ClaimState) {}
-  set(values: Row): this {
-    this.values = values;
-    return this;
-  }
-  where(): this {
-    return this;
-  }
-  async returning(): Promise<Row[]> {
-    if (typeof this.values.status === 'string')
-      this.staged.status = this.values.status as ClaimStatus;
-    if ('lifecycleVersion' in this.values) this.staged.lifecycleVersion += 1;
-    return [{ id: 'claim-1', lifecycleVersion: this.staged.lifecycleVersion }];
-  }
-}
-
-class FakeInsert {
-  constructor(
-    private readonly staged: ClaimState,
-    private readonly table: unknown,
-    private readonly failOn?: FailOn
-  ) {}
-  values(values: Row) {
-    if (this.table === claimStageHistory) {
-      if (this.failOn === 'history') throw new Error('history failed');
-      this.staged.histories.push(values);
-    }
-    if (this.table === domainEvents) {
-      if (this.failOn === 'event') throw new Error('event failed');
-      this.staged.events.push(values);
-    }
-    return { returning: async () => [{ id: values.id }] };
-  }
-}
-
-function makeParams() {
-  return {
-    actor: { id: 'staff-1', role: 'staff' },
-    claimId: 'claim-1',
-    correlationId: 'corr-1',
-    isPublic: false,
-    note: 'member-visible status note',
-    paymentAuthorizationState: 'authorized' as const,
-    tenantId: 'tenant-1',
-    toStatus: 'negotiation' as const,
-  };
-}
-
-function makeTx(state: ClaimState, failOn?: FailOn) {
-  const staged = { ...state, events: [...state.events], histories: [...state.histories] };
-  const tx = {
-    select: () => new FakeSelect(state),
-    update: () => new FakeUpdate(staged),
-    insert: (table: unknown) => new FakeInsert(staged, table, failOn),
-  };
-  return { commit: () => Object.assign(state, staged), tx: tx as unknown as TransitionTx };
-}
-
-async function runTransaction(state: ClaimState, failOn?: 'history' | 'event') {
-  const { commit, tx } = makeTx(state, failOn);
-  const result = await transitionClaimStatusInTransaction(tx, makeParams());
-  commit();
-  return result;
-}
+import { initialState, runTransaction } from './transition-events-test-support';
 
 describe('transitionClaimStatusInTransaction event atomicity', () => {
-  it('commits status, history, and exactly one event for a successful transition', async () => {
+  it('commits status, history, and domain events for a successful transition', async () => {
     const state = initialState();
 
     await expect(runTransaction(state)).resolves.toMatchObject({ success: true });
@@ -109,27 +12,40 @@ describe('transitionClaimStatusInTransaction event atomicity', () => {
     expect(state.lifecycleVersion).toBe(7);
     expect(state.histories).toHaveLength(1);
     expect(state.histories[0]).toEqual(
-      expect.objectContaining({
-        isPublic: false,
-        note: 'member-visible status note',
-      })
+      expect.objectContaining({ isPublic: false, note: 'member-visible status note' })
     );
-    expect(state.events).toHaveLength(1);
-    expect(state.events[0]).toEqual(
+    expect(state.events).toEqual([
       expect.objectContaining({
         aggregateVersion: 7,
-        actorId: 'staff-1',
-        correlationId: 'corr-1',
-        entityId: 'claim-1',
         entityType: 'claim',
         eventName: 'claim.status_changed',
-        eventVersion: 1,
         payload: { fromStatus: 'evaluation', toStatus: 'negotiation' },
-        tenantId: 'tenant-1',
-      })
-    );
-    expect(state.events[0].payload).not.toHaveProperty('isPublic');
-    expect(state.events[0].payload).not.toHaveProperty('note');
+      }),
+      expect.objectContaining({
+        entityType: 'case',
+        eventName: 'case.lifecycle_changed',
+        payload: {
+          fromState: 'evaluation',
+          fromStatus: 'evaluation',
+          toState: 'recovery',
+          toStatus: 'negotiation',
+        },
+      }),
+      expect.objectContaining({
+        entityType: 'recovery',
+        eventName: 'recovery.lifecycle_changed',
+        payload: {
+          fromState: 'not_started',
+          fromStatus: 'evaluation',
+          toState: 'negotiation',
+          toStatus: 'negotiation',
+        },
+      }),
+    ]);
+    for (const event of state.events) {
+      expect(event).toEqual(expect.objectContaining({ actorId: 'staff-1', tenantId: 'tenant-1' }));
+      expect(event.payload).not.toHaveProperty('note');
+    }
   });
 
   it('rolls back status and history when event append fails', async () => {

--- a/packages/domain-claims/src/claims/transition-side-effects.ts
+++ b/packages/domain-claims/src/claims/transition-side-effects.ts
@@ -1,8 +1,9 @@
-import { appendEvent, claimStageHistory, db } from '@interdomestik/database';
+import { claimStageHistory, db } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { SQLWrapper } from 'drizzle-orm';
 import type { AuthorizedTransition, ClaimTransitionActor } from './transition-guard';
 import { recordCaseCreatedEvent } from './case-created-event';
+import { recordTransitionDomainEvents } from './transition-domain-events';
 import type { CreateClaimValues } from '../validators/claims';
 import type { PaymentAuthorizationState } from '../staff-claims/types';
 
@@ -125,20 +126,15 @@ export async function recordTransitionSideEffects(
     isPublic,
     createdAt: now,
   });
-  if (fromStatus !== toStatus) {
-    await appendEvent(tx, {
-      actor: { id: actor.id, role: actor.role?.trim() || 'unknown' },
-      aggregateVersion: lifecycleVersion,
-      correlationId: correlationId ?? crypto.randomUUID(),
-      createdAt: now,
-      entity: { id: claimId, type: 'claim' },
-      eventName: 'claim.status_changed',
-      eventVersion: 1,
-      payload: {
-        fromStatus,
-        toStatus,
-      },
-      tenantId,
-    });
-  }
+  await recordTransitionDomainEvents({
+    actor,
+    claimId,
+    correlationId,
+    fromStatus,
+    lifecycleVersion,
+    now,
+    tenantId,
+    toStatus,
+    tx,
+  });
 }

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-event.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-event.ts
@@ -1,0 +1,35 @@
+import { appendEvent, type DomainEventTx } from '@interdomestik/database';
+
+import type { InternalSubscriptionStatus } from '../subscription-status';
+
+export type SubscriptionEventStatus = InternalSubscriptionStatus | 'none';
+
+export async function recordMembershipSubscriptionChangedEvent(params: {
+  actor?: { id: string; role: string };
+  cancelAtPeriodEnd: boolean;
+  correlationId?: string;
+  fromStatus: SubscriptionEventStatus;
+  now: Date;
+  subscriptionId: string;
+  tenantId: string;
+  toStatus: InternalSubscriptionStatus;
+  tx: DomainEventTx;
+}) {
+  await appendEvent(params.tx, {
+    actor: params.actor ?? { id: 'paddle-webhook', role: 'system' },
+    aggregateVersion: 0,
+    correlationId:
+      params.correlationId ??
+      `membership:${params.subscriptionId}:subscription-changed:${crypto.randomUUID()}`,
+    createdAt: params.now,
+    entity: { id: params.subscriptionId, type: 'subscription' },
+    eventName: 'membership.subscription_changed',
+    eventVersion: 1,
+    payload: {
+      cancelAtPeriodEnd: params.cancelAtPeriodEnd,
+      fromStatus: params.fromStatus,
+      toStatus: params.toStatus,
+    },
+    tenantId: params.tenantId,
+  });
+}

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-upsert.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-upsert.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const returning = vi.fn();
+  const where = vi.fn().mockReturnValue({ returning });
+  const set = vi.fn().mockReturnValue({ where });
+  const tx = { insert: vi.fn(), update: vi.fn().mockReturnValue({ set }) };
+  return {
+    and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+    appendEvent: vi.fn(),
+    db: {
+      query: { subscriptions: { findFirst: vi.fn() } },
+      transaction: vi.fn(async callback => callback(tx)),
+    },
+    eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+    returning,
+    set,
+    subscriptions: { id: 'subscriptions.id', tenantId: 'subscriptions.tenant_id' },
+    tx,
+    where,
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  and: hoisted.and,
+  appendEvent: hoisted.appendEvent,
+  db: hoisted.db,
+  eq: hoisted.eq,
+  subscriptions: hoisted.subscriptions,
+}));
+
+vi.mock('../../subscription', () => ({ findSubscriptionByProviderReference: vi.fn() }));
+
+import { upsertSubscription } from './subscription-upsert';
+
+describe('upsertSubscription tenant-scoped update guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.returning.mockResolvedValue([]);
+  });
+
+  it('does not emit a subscription event when the update matches no tenant row', async () => {
+    await expect(
+      upsertSubscription({
+        existingSub: { id: 'sub_existing', tenantId: 'tenant_abc', userId: 'user_123' },
+        mappedStatus: 'active',
+        planState: { planId: 'standard', planKey: 'mk-standard-plan' },
+        sub: {
+          id: 'sub_paddle_456',
+          customerId: 'ctm_1',
+          currentBillingPeriod: { startsAt: '2026-01-01', endsAt: '2027-01-01' },
+        },
+        tenantId: 'tenant_abc',
+        userId: 'user_123',
+      })
+    ).rejects.toThrow('update matched no tenant-scoped row');
+
+    expect(hoisted.set).toHaveBeenCalled();
+    expect(hoisted.appendEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-upsert.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-upsert.ts
@@ -1,0 +1,150 @@
+import { and, db, eq, subscriptions, type DomainEventTx } from '@interdomestik/database';
+
+import { findSubscriptionByProviderReference } from '../../subscription';
+import type { InternalSubscriptionStatus } from '../subscription-status';
+import { recordMembershipSubscriptionChangedEvent } from './subscription-event';
+import {
+  assertSubscriptionMatchesContext,
+  isUniqueViolation,
+  mapToSubscriptionValues,
+  normalizeExistingStatus,
+  type CanonicalMembershipPlanState,
+  type ExistingSubscription,
+} from './subscription-values';
+
+type UpsertSubscriptionArgs = {
+  agentId?: string | null;
+  branchId?: string;
+  existingSub?: ExistingSubscription | null;
+  mappedStatus: InternalSubscriptionStatus;
+  planState: CanonicalMembershipPlanState;
+  sub: any;
+  tenantId: string;
+  userId: string;
+};
+
+export async function upsertSubscription(args: UpsertSubscriptionArgs) {
+  const { sub, tenantId, userId, agentId, branchId, existingSub, mappedStatus, planState } = args;
+  const values = mapToSubscriptionValues(sub, mappedStatus, planState);
+  const existingSubscription =
+    existingSub ?? (await findExistingSubscriptionForUser(userId, tenantId));
+
+  if (existingSubscription) {
+    await persistSubscriptionUpdate(existingSubscription, {
+      agentId,
+      branchId,
+      sub,
+      tenantId,
+      userId,
+      values,
+    });
+    return existingSubscription.id;
+  }
+
+  try {
+    await persistSubscriptionInsert({ agentId, branchId, sub, tenantId, userId, values });
+    return sub.id as string;
+  } catch (error) {
+    if (!isUniqueViolation(error)) throw error;
+
+    const racedSubscription = await findExistingSubscription(sub.id, userId, tenantId);
+    if (!racedSubscription) throw error;
+
+    await persistSubscriptionUpdate(racedSubscription, {
+      agentId,
+      branchId,
+      sub,
+      tenantId,
+      userId,
+      values,
+    });
+    return racedSubscription.id;
+  }
+}
+
+async function persistSubscriptionInsert(args: {
+  agentId?: string | null;
+  branchId?: string;
+  sub: any;
+  tenantId: string;
+  userId: string;
+  values: ReturnType<typeof mapToSubscriptionValues>;
+}) {
+  // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values.
+  await db.transaction(async tx => {
+    // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle context is inserted.
+    await tx.insert(subscriptions).values({
+      id: args.sub.id,
+      tenantId: args.tenantId,
+      userId: args.userId,
+      agentId: args.agentId,
+      branchId: args.branchId,
+      providerSubscriptionId: args.sub.id,
+      ...args.values,
+    });
+    await recordMembershipSubscriptionChangedEvent({
+      cancelAtPeriodEnd: args.values.cancelAtPeriodEnd,
+      fromStatus: 'none',
+      now: args.values.updatedAt,
+      subscriptionId: args.sub.id,
+      tenantId: args.tenantId,
+      toStatus: args.values.status,
+      tx: tx as DomainEventTx,
+    });
+  });
+}
+
+async function persistSubscriptionUpdate(
+  subscription: ExistingSubscription,
+  args: Omit<Parameters<typeof persistSubscriptionInsert>[0], 'values'> & {
+    values: ReturnType<typeof mapToSubscriptionValues>;
+  }
+) {
+  assertSubscriptionMatchesContext(subscription, {
+    subId: args.sub.id,
+    tenantId: args.tenantId,
+    userId: args.userId,
+  });
+  await db.transaction(async tx => {
+    // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle context constrains update.
+    const updatedRows = await tx
+      .update(subscriptions)
+      .set({
+        tenantId: args.tenantId,
+        userId: args.userId,
+        agentId: args.agentId,
+        branchId: args.branchId,
+        providerSubscriptionId: args.sub.id,
+        ...args.values,
+      })
+      .where(and(eq(subscriptions.id, subscription.id), eq(subscriptions.tenantId, args.tenantId)))
+      .returning({ id: subscriptions.id });
+    if (updatedRows.length !== 1)
+      throw new Error(`Paddle subscription ${args.sub.id} update matched no tenant-scoped row`);
+    await recordMembershipSubscriptionChangedEvent({
+      cancelAtPeriodEnd: args.values.cancelAtPeriodEnd,
+      fromStatus: normalizeExistingStatus(subscription.status),
+      now: args.values.updatedAt,
+      subscriptionId: subscription.id,
+      tenantId: args.tenantId,
+      toStatus: args.values.status,
+      tx: tx as DomainEventTx,
+    });
+  });
+}
+
+async function findExistingSubscription(subId: string, userId: string, tenantId: string) {
+  return (
+    (await findSubscriptionByProviderReference(subId, { tenantId })) ??
+    (await findExistingSubscriptionForUser(userId, tenantId))
+  );
+}
+
+async function findExistingSubscriptionForUser(userId: string, tenantId: string) {
+  // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle context constrains fallback lookup.
+  return db.query.subscriptions.findFirst({
+    where: (subs, { and: andFn, eq: eqFn }) =>
+      andFn(eqFn(subs.userId, userId), eqFn(subs.tenantId, tenantId)),
+    columns: { id: true, status: true, tenantId: true, userId: true },
+  });
+}

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-values.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-values.ts
@@ -1,0 +1,100 @@
+import type { InternalSubscriptionStatus } from '../subscription-status';
+
+const SUBSCRIPTION_EVENT_STATUSES = new Set([
+  'active',
+  'past_due',
+  'paused',
+  'canceled',
+  'trialing',
+  'expired',
+]);
+
+export type CanonicalMembershipPlanState = {
+  planId: string;
+  planKey: string | null;
+};
+
+export type ExistingSubscription = {
+  id: string;
+  status?: InternalSubscriptionStatus | string | null;
+  tenantId?: string | null;
+  userId?: string | null;
+};
+
+export function assertSubscriptionMatchesContext(
+  subscription: ExistingSubscription,
+  context: { subId: string; tenantId: string; userId: string }
+) {
+  if (!subscription.tenantId || subscription.tenantId !== context.tenantId) {
+    throw new Error(
+      `Paddle subscription ${context.subId} tenant conflict: existing=${subscription.tenantId} resolved=${context.tenantId}`
+    );
+  }
+  if (!subscription.userId || subscription.userId !== context.userId) {
+    throw new Error(
+      `Paddle subscription ${context.subId} user conflict: existing=${subscription.userId} resolved=${context.userId}`
+    );
+  }
+}
+
+export function normalizeExistingStatus(
+  status: ExistingSubscription['status']
+): InternalSubscriptionStatus | 'none' {
+  if (typeof status !== 'string') return 'none';
+  const normalized = status.trim();
+  return SUBSCRIPTION_EVENT_STATUSES.has(normalized)
+    ? (normalized as InternalSubscriptionStatus)
+    : 'none';
+}
+
+export function mapToSubscriptionValues(
+  sub: any,
+  mappedStatus: InternalSubscriptionStatus,
+  planState: CanonicalMembershipPlanState
+) {
+  const currentStartsAt =
+    sub.currentBillingPeriod?.startsAt || sub.current_billing_period?.starts_at;
+  const currentEndsAt = sub.currentBillingPeriod?.endsAt || sub.current_billing_period?.ends_at;
+  const baseValues = {
+    status: mappedStatus,
+    ...createCanonicalMembershipPlanState(planState.planId, planState.planKey),
+    providerCustomerId: (sub.customerId || sub.customer_id) as string | null,
+    currentPeriodStart: parseDate(currentStartsAt),
+    currentPeriodEnd: parseDate(currentEndsAt),
+    cancelAtPeriodEnd:
+      sub.scheduledChange?.action === 'cancel' || sub.scheduled_change?.action === 'cancel',
+    canceledAt: mappedStatus === 'canceled' ? new Date() : null,
+    updatedAt: new Date(),
+  };
+
+  if (mappedStatus === 'active') {
+    Object.assign(baseValues, {
+      pastDueAt: null,
+      gracePeriodEndsAt: null,
+      dunningAttemptCount: 0,
+      lastDunningAt: null,
+    });
+  }
+
+  return baseValues;
+}
+
+export function isUniqueViolation(error: unknown): error is { code: string } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === '23505'
+  );
+}
+
+function createCanonicalMembershipPlanState(planId: string, planKey?: string | null) {
+  return {
+    planId,
+    ...(planKey ? { planKey } : {}),
+  };
+}
+
+function parseDate(dateStr: string | undefined | null): Date | null {
+  return dateStr ? new Date(dateStr) : null;
+}

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-values.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscription-values.ts
@@ -16,7 +16,7 @@ export type CanonicalMembershipPlanState = {
 
 export type ExistingSubscription = {
   id: string;
-  status?: InternalSubscriptionStatus | string | null;
+  status?: string | null;
   tenantId?: string | null;
   userId?: string | null;
 };

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.test.ts
@@ -54,13 +54,15 @@ describe('handleSubscriptionChanged', () => {
       { logAuditEvent, sendThankYouLetter }
     );
 
-    // Verify Zod allowed it -> DB called
-    expect(hoisted.db.insert).toHaveBeenCalled();
-
-    // Verify Tenant Resolved
+    expect(hoisted.tx.insert).toHaveBeenCalled();
+    expect(hoisted.appendEvent).toHaveBeenCalledWith(
+      hoisted.tx,
+      expect.objectContaining({
+        eventName: 'membership.subscription_changed',
+        payload: { cancelAtPeriodEnd: false, fromStatus: 'none', toStatus: 'active' },
+      })
+    );
     expect(hoisted.db.query.user.findFirst).toHaveBeenCalledWith(expect.anything());
-
-    // Verify Audit Log
     expect(logAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'subscription.updated',
@@ -83,7 +85,7 @@ describe('handleSubscriptionChanged', () => {
       { logAuditEvent }
     );
 
-    expect(hoisted.db.insert).not.toHaveBeenCalled();
+    expect(hoisted.tx.insert).not.toHaveBeenCalled();
     expect(logAuditEvent).not.toHaveBeenCalled();
   });
 
@@ -143,8 +145,8 @@ describe('handleSubscriptionChanged', () => {
       email: 'buyer@example.com',
       tenantId: 'tenant_mk',
     });
-    expect(hoisted.db.transaction).toHaveBeenCalledTimes(2);
-    expect(hoisted.db.insert).toHaveBeenCalled();
+    expect(hoisted.db.transaction).toHaveBeenCalledTimes(3);
+    expect(hoisted.tx.insert).toHaveBeenCalled();
   });
 
   it('throws when a valid subscription event cannot resolve tenant context', async () => {
@@ -171,7 +173,7 @@ describe('handleSubscriptionChanged', () => {
       )
     ).rejects.toThrow('Unable to resolve subscription context');
 
-    expect(hoisted.db.insert).not.toHaveBeenCalled();
+    expect(hoisted.tx.insert).not.toHaveBeenCalled();
     expect(logAuditEvent).not.toHaveBeenCalled();
   });
 
@@ -209,8 +211,8 @@ describe('handleSubscriptionChanged', () => {
       )
     ).rejects.toThrow('customData tenant=tenant_bad conflicts with canonical tenant=tenant_real');
 
-    expect(hoisted.db.insert).not.toHaveBeenCalled();
-    expect(hoisted.db.update).not.toHaveBeenCalled();
+    expect(hoisted.tx.insert).not.toHaveBeenCalled();
+    expect(hoisted.tx.update).not.toHaveBeenCalled();
     expect(logAuditEvent).not.toHaveBeenCalled();
     expect(warnSpy).not.toHaveBeenCalled();
 
@@ -251,14 +253,16 @@ describe('handleSubscriptionChanged', () => {
     ).rejects.toThrow('customData tenant=tenant_bad conflicts with canonical tenant=tenant_real');
 
     expect(hoisted.db.query.webhookEvents.findFirst).not.toHaveBeenCalled();
-    expect(hoisted.db.insert).not.toHaveBeenCalled();
+    expect(hoisted.tx.insert).not.toHaveBeenCalled();
     expect(logAuditEvent).not.toHaveBeenCalled();
   });
 
   it('uses existing subscription canonical user when provider customData omits userId', async () => {
-    const mockWhere = vi.fn().mockResolvedValue(undefined);
+    const mockWhere = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'mock_sub_existing' }]),
+    });
     const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-    hoisted.db.update.mockReturnValue({ set: mockSet });
+    hoisted.tx.update.mockReturnValue({ set: mockSet });
 
     hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
       id: 'sub_existing',
@@ -290,18 +294,17 @@ describe('handleSubscriptionChanged', () => {
     );
 
     expect(mockSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tenantId: 'tenant_abc',
-        userId: 'user_canonical',
-      })
+      expect.objectContaining({ tenantId: 'tenant_abc', userId: 'user_canonical' })
     );
     expect(mockWhere).toHaveBeenCalled();
   });
 
   it('updates an existing user-scoped subscription row instead of inserting a second row', async () => {
-    const mockWhere = vi.fn().mockResolvedValue(undefined);
+    const mockWhere = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'mock_sub_existing' }]),
+    });
     const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-    hoisted.db.update.mockReturnValue({ set: mockSet });
+    hoisted.tx.update.mockReturnValue({ set: mockSet });
 
     hoisted.db.query.subscriptions.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({
       id: 'mock_sub_existing',
@@ -316,12 +319,10 @@ describe('handleSubscriptionChanged', () => {
 
     await handleSubscriptionChanged(createActiveSubscriptionUpdatedEvent(), { logAuditEvent });
 
-    expect(hoisted.db.insert).not.toHaveBeenCalled();
-    expect(hoisted.db.update).toHaveBeenCalled();
+    expect(hoisted.tx.insert).not.toHaveBeenCalled();
+    expect(hoisted.tx.update).toHaveBeenCalled();
     expect(mockSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        providerSubscriptionId: 'sub_paddle_456',
-      })
+      expect.objectContaining({ providerSubscriptionId: 'sub_paddle_456' })
     );
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -329,9 +330,7 @@ describe('handleSubscriptionChanged', () => {
   it('stores the canonical annual plan id instead of the Paddle price id', async () => {
     const insertedValues = vi.fn().mockResolvedValue(undefined);
 
-    hoisted.db.insert.mockReturnValue({
-      values: insertedValues,
-    });
+    hoisted.tx.insert.mockReturnValue({ values: insertedValues });
     hoisted.db.query.subscriptions.findFirst.mockResolvedValueOnce(null);
     hoisted.db.query.user.findFirst.mockResolvedValue({
       id: 'user_123',
@@ -362,10 +361,7 @@ describe('handleSubscriptionChanged', () => {
     );
 
     expect(insertedValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        planId: 'standard',
-        planKey: 'mk-standard-plan',
-      })
+      expect.objectContaining({ planId: 'standard', planKey: 'mk-standard-plan' })
     );
   });
 
@@ -389,11 +385,17 @@ describe('handleSubscriptionChanged', () => {
 
     await handleSubscriptionChanged(createActiveSubscriptionUpdatedEvent(), { logAuditEvent });
 
-    expect(hoisted.db.insert).toHaveBeenCalled();
-    expect(mockSet).toHaveBeenCalledWith(
+    expect(hoisted.tx.insert).toHaveBeenCalled();
+    expect(hoisted.appendEvent).toHaveBeenCalledTimes(1);
+    expect(hoisted.appendEvent).toHaveBeenCalledWith(
+      hoisted.tx,
       expect.objectContaining({
-        providerSubscriptionId: 'sub_paddle_456',
+        eventName: 'membership.subscription_changed',
+        payload: { cancelAtPeriodEnd: false, fromStatus: 'none', toStatus: 'active' },
       })
+    );
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({ providerSubscriptionId: 'sub_paddle_456' })
     );
     expect(mockWhere).toHaveBeenCalled();
   });
@@ -412,9 +414,7 @@ describe('handleSubscriptionChanged', () => {
   ])('$name', async ({ resolvedAgentId, subscriptionId }) => {
     const insertedValues = vi.fn().mockResolvedValue(undefined);
 
-    hoisted.db.insert.mockReturnValue({
-      values: insertedValues,
-    });
+    hoisted.tx.insert.mockReturnValue({ values: insertedValues });
     hoisted.db.query.subscriptions.findFirst.mockResolvedValueOnce(null);
     hoisted.db.query.user.findFirst
       .mockResolvedValueOnce({
@@ -447,10 +447,7 @@ describe('handleSubscriptionChanged', () => {
     );
 
     expect(insertedValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: 'user_123',
-        agentId: resolvedAgentId,
-      })
+      expect.objectContaining({ userId: 'user_123', agentId: resolvedAgentId })
     );
   });
 });

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/subscriptions.ts
@@ -1,13 +1,9 @@
-import { and, db, eq, subscriptions } from '@interdomestik/database';
-import { findSubscriptionByProviderReference } from '../../subscription';
-import {
-  createCanonicalMembershipPlanState,
-  resolveCanonicalMembershipPlanState,
-} from '../../annual-membership';
+import { resolveCanonicalMembershipPlanState } from '../../annual-membership';
 import { subscriptionEventDataSchema } from '../schemas';
-import { mapPaddleStatus, type InternalSubscriptionStatus } from '../subscription-status';
+import { mapPaddleStatus } from '../subscription-status';
 
 import type { PaddleWebhookAuditDeps, PaddleWebhookDeps } from '../types';
+import { upsertSubscription } from './subscription-upsert';
 import { resolveSubscriptionContext } from './utils/context';
 import { handleNewSubscriptionExtras } from './utils/extras';
 import { reconcileCheckoutUser } from './utils/reconcile-checkout-user';
@@ -95,123 +91,6 @@ export async function handleSubscriptionChanged(
   }
 }
 
-async function upsertSubscription(args: {
-  sub: any;
-  tenantId: string;
-  userId: string;
-  agentId?: string | null;
-  branchId?: string;
-  existingSub?: { id: string; tenantId?: string | null; userId?: string | null } | null;
-  mappedStatus: InternalSubscriptionStatus;
-  planState: {
-    planId: string;
-    planKey: string | null;
-  };
-}) {
-  const { sub, tenantId, userId, agentId, branchId, existingSub, mappedStatus, planState } = args;
-  const values = mapToSubscriptionValues(sub, mappedStatus, planState);
-  const existingSubscription =
-    existingSub ?? (await findExistingSubscriptionForUser(userId, tenantId));
-
-  if (existingSubscription) {
-    assertSubscriptionMatchesContext(existingSubscription, { subId: sub.id, tenantId, userId });
-    await updateSubscription(existingSubscription.id, tenantId, {
-      tenantId,
-      userId,
-      agentId,
-      branchId,
-      providerSubscriptionId: sub.id,
-      ...values,
-    });
-
-    return existingSubscription.id;
-  }
-
-  const insertValues = {
-    id: sub.id,
-    tenantId,
-    userId,
-    agentId,
-    branchId,
-    providerSubscriptionId: sub.id,
-    ...values,
-  };
-
-  try {
-    // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle subscription context is included in insert values
-    await db.insert(subscriptions).values(insertValues);
-  } catch (error) {
-    if (!isUniqueViolation(error)) {
-      throw error;
-    }
-
-    const racedSubscription = await findExistingSubscription(sub.id, userId, tenantId);
-    if (!racedSubscription) {
-      throw error;
-    }
-
-    assertSubscriptionMatchesContext(racedSubscription, { subId: sub.id, tenantId, userId });
-    await updateSubscription(racedSubscription.id, tenantId, {
-      tenantId,
-      userId,
-      agentId,
-      branchId,
-      providerSubscriptionId: sub.id,
-      ...values,
-    });
-
-    return racedSubscription.id;
-  }
-
-  return sub.id as string;
-}
-
-async function findExistingSubscription(subId: string, userId: string, tenantId: string) {
-  return (
-    (await findSubscriptionByProviderReference(subId)) ??
-    (await findExistingSubscriptionForUser(userId, tenantId))
-  );
-}
-
-async function findExistingSubscriptionForUser(userId: string, tenantId: string) {
-  return (
-    // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle subscription context constrains fallback user lookup
-    await db.query.subscriptions.findFirst({
-      where: (subs, { and, eq }) => and(eq(subs.userId, userId), eq(subs.tenantId, tenantId)),
-      columns: { id: true, tenantId: true, userId: true },
-    })
-  );
-}
-
-async function updateSubscription(
-  subscriptionId: string,
-  tenantId: string,
-  values: Record<string, unknown>
-) {
-  // db-access-guard: tenant-scoped -- reason: tenantId from canonical Paddle subscription context constrains subscription update
-  await db
-    .update(subscriptions)
-    .set(values)
-    .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.tenantId, tenantId)));
-}
-
-function assertSubscriptionMatchesContext(
-  subscription: { id: string; tenantId?: string | null; userId?: string | null },
-  context: { subId: string; tenantId: string; userId: string }
-) {
-  if (subscription.tenantId && subscription.tenantId !== context.tenantId) {
-    throw new Error(
-      `Paddle subscription ${context.subId} tenant conflict: existing=${subscription.tenantId} resolved=${context.tenantId}`
-    );
-  }
-
-  if (subscription.userId && subscription.userId !== context.userId) {
-    throw new Error(
-      `Paddle subscription ${context.subId} user conflict: existing=${subscription.userId} resolved=${context.userId}`
-    );
-  }
-}
-
 function normalizeAgentId(agentId: string | null | undefined): string | null {
   if (typeof agentId !== 'string') {
     return null;
@@ -230,58 +109,6 @@ function resolveSubscriptionAgentId(args: {
   }
 
   return normalizeAgentId(args.customData?.agentId);
-}
-
-function mapToSubscriptionValues(
-  sub: any,
-  mappedStatus: InternalSubscriptionStatus,
-  planState: {
-    planId: string;
-    planKey: string | null;
-  }
-) {
-  const currentStartsAt =
-    sub.currentBillingPeriod?.startsAt || (sub.current_billing_period?.starts_at as string);
-  const currentEndsAt =
-    sub.currentBillingPeriod?.endsAt || (sub.current_billing_period?.ends_at as string);
-
-  const baseValues = {
-    status: mappedStatus,
-    ...createCanonicalMembershipPlanState(planState.planId, planState.planKey),
-    providerCustomerId: (sub.customerId || sub.customer_id) as string | null,
-    currentPeriodStart: parseDate(currentStartsAt),
-    currentPeriodEnd: parseDate(currentEndsAt),
-    cancelAtPeriodEnd:
-      sub.scheduledChange?.action === 'cancel' || sub.scheduled_change?.action === 'cancel',
-    canceledAt: mappedStatus === 'canceled' ? new Date() : null,
-    updatedAt: new Date(),
-  };
-
-  if (mappedStatus === 'active') {
-    Object.assign(baseValues, {
-      pastDueAt: null,
-      gracePeriodEndsAt: null,
-      dunningAttemptCount: 0,
-      lastDunningAt: null,
-    });
-    console.log(`[Webhook] Subscription ${sub.id} recovered - clearing dunning fields`);
-  }
-
-  return baseValues;
-}
-
-function parseDate(dateStr: string | undefined | null): Date | null {
-  return dateStr ? new Date(dateStr) : null;
-}
-
-function isUniqueViolation(error: unknown): error is { code: string } {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof (error as { code?: unknown }).code === 'string' &&
-    (error as { code: string }).code === '23505'
-  );
 }
 
 function canReconcileCheckoutUser(sub: {

--- a/packages/domain-membership-billing/src/paddle-webhooks/handlers/test-support.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/handlers/test-support.ts
@@ -33,10 +33,7 @@ interface PaddleHandlerMocks {
     interval: string;
     isActive: string;
   };
-  tx: {
-    insert: MockFunction;
-    update: MockFunction;
-  };
+  tx: { insert: MockFunction; update: MockFunction };
   insertedUserValues: MockFunction;
   updatedUserValues: MockFunction;
 }
@@ -74,10 +71,7 @@ interface MemberNumberMockModule {
   generateMemberNumber: MockFunction;
 }
 
-interface RacedSubscriptionInsertMocks {
-  mockSet: MockFunction;
-  mockWhere: MockFunction;
-}
+type RacedSubscriptionInsertMocks = { mockSet: MockFunction; mockWhere: MockFunction };
 
 export function createHoistedPaddleHandlerMocks(): PaddleHandlerMocks {
   return {
@@ -225,11 +219,17 @@ export function mockRacedSubscriptionInsert(
   hoisted: ReturnType<typeof createHoistedPaddleHandlerMocks>
 ): RacedSubscriptionInsertMocks {
   const uniqueViolation = Object.assign(new Error('duplicate key'), { code: '23505' });
-  const mockWhere = vi.fn().mockResolvedValue(undefined);
+  const mockWhere = vi
+    .fn()
+    .mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sub' }]) });
   const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
 
   hoisted.db.update.mockReturnValue({ set: mockSet });
   hoisted.db.insert.mockReturnValue({
+    values: vi.fn().mockRejectedValue(uniqueViolation),
+  });
+  hoisted.tx.update.mockReturnValue({ set: mockSet });
+  hoisted.tx.insert.mockReturnValue({
     values: vi.fn().mockRejectedValue(uniqueViolation),
   });
 
@@ -272,6 +272,6 @@ export function resetPaddleHandlerMocks(
     set: hoisted.updatedUserValues,
   }));
   hoisted.updatedUserValues.mockReturnValue({
-    where: async () => undefined,
+    where: () => ({ returning: async () => [{ id: 'sub' }] }),
   });
 }

--- a/packages/domain-membership-billing/src/subscription-provider-reference.test.ts
+++ b/packages/domain-membership-billing/src/subscription-provider-reference.test.ts
@@ -58,4 +58,27 @@ describe('findSubscriptionByProviderReference tenant scope', () => {
       findSubscriptionByProviderReference('sub_provider_123', { tenantId: 'tenant_abc' })
     ).resolves.toEqual({ id: 'sub_internal_1', tenantId: 'tenant_abc' });
   });
+
+  it('keeps the payment-provider fallback lookup unscoped when tenant is unknown', async () => {
+    hoisted.findSubscriptionFirst.mockImplementationOnce(async (args: FindFirstArgs) => {
+      const whereNode = args.where?.(hoisted.subscriptions, hoisted);
+      expect(whereNode).toEqual({
+        op: 'or',
+        args: [
+          { op: 'eq', left: 'subscriptions.id', right: 'sub_provider_123' },
+          {
+            op: 'eq',
+            left: 'subscriptions.provider_subscription_id',
+            right: 'sub_provider_123',
+          },
+        ],
+      });
+      return { id: 'sub_internal_1', tenantId: 'tenant_abc' };
+    });
+
+    await expect(findSubscriptionByProviderReference('sub_provider_123')).resolves.toEqual({
+      id: 'sub_internal_1',
+      tenantId: 'tenant_abc',
+    });
+  });
 });

--- a/packages/domain-membership-billing/src/subscription-provider-reference.test.ts
+++ b/packages/domain-membership-billing/src/subscription-provider-reference.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  findSubscriptionFirst: vi.fn(),
+  or: vi.fn((...args: unknown[]) => ({ op: 'or', args })),
+  subscriptions: {
+    id: 'subscriptions.id',
+    providerSubscriptionId: 'subscriptions.provider_subscription_id',
+    tenantId: 'subscriptions.tenant_id',
+  },
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  and: hoisted.and,
+  db: { query: { subscriptions: { findFirst: hoisted.findSubscriptionFirst } } },
+  eq: hoisted.eq,
+  or: hoisted.or,
+  subscriptions: hoisted.subscriptions,
+}));
+
+import { findSubscriptionByProviderReference } from './subscription';
+
+type FindFirstArgs = {
+  where?: (subs: typeof hoisted.subscriptions, operators: typeof hoisted) => unknown;
+};
+
+describe('findSubscriptionByProviderReference tenant scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('can constrain provider-reference lookup by tenant for race recovery', async () => {
+    hoisted.findSubscriptionFirst.mockImplementationOnce(async (args: FindFirstArgs) => {
+      const whereNode = args.where?.(hoisted.subscriptions, hoisted);
+      expect(whereNode).toEqual({
+        op: 'and',
+        args: [
+          { op: 'eq', left: 'subscriptions.tenant_id', right: 'tenant_abc' },
+          {
+            op: 'or',
+            args: [
+              { op: 'eq', left: 'subscriptions.id', right: 'sub_provider_123' },
+              {
+                op: 'eq',
+                left: 'subscriptions.provider_subscription_id',
+                right: 'sub_provider_123',
+              },
+            ],
+          },
+        ],
+      });
+      return { id: 'sub_internal_1', tenantId: 'tenant_abc' };
+    });
+
+    await expect(
+      findSubscriptionByProviderReference('sub_provider_123', { tenantId: 'tenant_abc' })
+    ).resolves.toEqual({ id: 'sub_internal_1', tenantId: 'tenant_abc' });
+  });
+});

--- a/packages/domain-membership-billing/src/subscription.ts
+++ b/packages/domain-membership-billing/src/subscription.ts
@@ -34,19 +34,25 @@ export async function hasActiveMembership(
   return membershipLifecycleGrantsAccess(getMembershipLifecycleBucket({ subscription: sub }));
 }
 
-export async function findSubscriptionByProviderReference(reference: string | null | undefined) {
+export async function findSubscriptionByProviderReference(
+  reference: string | null | undefined,
+  options: { tenantId?: string | null } = {}
+) {
   const normalizedReference = reference?.trim();
   if (!normalizedReference) {
     return null;
   }
+  const tenantId = options.tenantId?.trim();
 
   // db-access-guard: system-exempt -- reason: provider reference lookup resolves tenant from payment provider event
   return db.query.subscriptions.findFirst({
-    where: (subs, { eq: eqFn, or: orFn }) =>
-      orFn(
+    where: (subs, { and: andFn, eq: eqFn, or: orFn }) => {
+      const referenceMatch = orFn(
         eqFn(subs.id, normalizedReference),
         eqFn(subs.providerSubscriptionId, normalizedReference)
-      ),
+      );
+      return tenantId ? andFn(eqFn(subs.tenantId, tenantId), referenceMatch) : referenceMatch;
+    },
   });
 }
 

--- a/packages/domain-membership-billing/src/subscription.ts
+++ b/packages/domain-membership-billing/src/subscription.ts
@@ -44,15 +44,27 @@ export async function findSubscriptionByProviderReference(
   }
   const tenantId = options.tenantId?.trim();
 
+  if (tenantId) {
+    // db-access-guard: tenant-scoped -- reason: tenantId constrains race-recovery provider reference lookup.
+    return db.query.subscriptions.findFirst({
+      where: (subs, { and: andFn, eq: eqFn, or: orFn }) =>
+        andFn(
+          eqFn(subs.tenantId, tenantId),
+          orFn(
+            eqFn(subs.id, normalizedReference),
+            eqFn(subs.providerSubscriptionId, normalizedReference)
+          )
+        ),
+    });
+  }
+
   // db-access-guard: system-exempt -- reason: provider reference lookup resolves tenant from payment provider event
   return db.query.subscriptions.findFirst({
-    where: (subs, { and: andFn, eq: eqFn, or: orFn }) => {
-      const referenceMatch = orFn(
+    where: (subs, { eq: eqFn, or: orFn }) =>
+      orFn(
         eqFn(subs.id, normalizedReference),
         eqFn(subs.providerSubscriptionId, normalizedReference)
-      );
-      return tenantId ? andFn(eqFn(subs.tenantId, tenantId), referenceMatch) : referenceMatch;
-    },
+      ),
   });
 }
 

--- a/packages/domain-membership-billing/src/subscription/cancel-row-guard.test.ts
+++ b/packages/domain-membership-billing/src/subscription/cancel-row-guard.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cancelSubscriptionCore } from './cancel';
+import type { SubscriptionSession } from './types';
+
+const hoisted = vi.hoisted(() => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
+  db: {
+    query: { subscriptions: { findFirst: vi.fn() } },
+    select: vi.fn(),
+    transaction: vi.fn(),
+    update: vi.fn(),
+  },
+  subscriptions: { id: 'id', tenantId: 'tenantId' },
+  claims: { id: 'claim_id', userId: 'claim_user_id', tenantId: 'claim_tenant_id' },
+  claimEscalationAgreements: {
+    claimId: 'agreement_claim_id',
+    acceptedAt: 'agreement_accepted_at',
+    tenantId: 'agreement_tenant_id',
+  },
+  ensureTenantId: vi.fn(),
+  paddle: { subscriptions: { cancel: vi.fn() } },
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  appendEvent: hoisted.appendEvent,
+  db: hoisted.db,
+  subscriptions: hoisted.subscriptions,
+  claims: hoisted.claims,
+  claimEscalationAgreements: hoisted.claimEscalationAgreements,
+  and: vi.fn(),
+  eq: vi.fn(),
+  desc: vi.fn(),
+}));
+
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureTenantId: hoisted.ensureTenantId,
+}));
+
+vi.mock('../paddle-server', () => ({
+  getPaddle: () => hoisted.paddle,
+}));
+
+describe('cancelSubscriptionCore row guard', () => {
+  const logAuditEvent = vi.fn();
+  const session: SubscriptionSession = { user: { id: 'user_123' } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.ensureTenantId.mockReturnValue('tenant_abc');
+    hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
+      id: 'sub_123',
+      userId: 'user_123',
+      tenantId: 'tenant_abc',
+      createdAt: new Date('2026-03-01T00:00:00.000Z'),
+      currentPeriodEnd: new Date('2027-03-01T00:00:00.000Z'),
+      cancelAtPeriodEnd: false,
+      status: 'active',
+    });
+    const mockLimit = vi.fn().mockResolvedValue([]);
+    const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+    const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+    hoisted.db.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({ innerJoin: mockInnerJoin }),
+    });
+    hoisted.db.transaction.mockImplementation(async callback => callback(hoisted.db));
+    hoisted.paddle.subscriptions.cancel.mockResolvedValue({});
+  });
+
+  it('does not emit a cancellation event when the tenant-scoped update matches no rows', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mockReturning = vi.fn().mockResolvedValue([]);
+    const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+    hoisted.db.update.mockReturnValue({ set: vi.fn().mockReturnValue({ where: mockWhere }) });
+
+    try {
+      const result = await cancelSubscriptionCore(
+        {
+          session,
+          subscriptionId: 'sub_123',
+          now: new Date('2026-03-12T00:00:00.000Z'),
+        },
+        { logAuditEvent }
+      );
+
+      expect(result.success).toBe(true);
+      expect(hoisted.appendEvent).not.toHaveBeenCalled();
+      expect(logAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ localPersistenceFailed: true }),
+        })
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/packages/domain-membership-billing/src/subscription/cancel.test.ts
+++ b/packages/domain-membership-billing/src/subscription/cancel.test.ts
@@ -61,7 +61,6 @@ describe('cancelSubscriptionCore', () => {
       cancelAtPeriodEnd: false,
       status: 'active',
     });
-
     const mockLimit = vi.fn().mockResolvedValue(params?.acceptedEscalationRows ?? []);
     const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
     const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
@@ -73,7 +72,9 @@ describe('cancelSubscriptionCore', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const mockWhere = vi.fn().mockResolvedValue(undefined);
+    const mockWhere = vi
+      .fn()
+      .mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sub_123' }]) });
     const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
     hoisted.db.update.mockReturnValue({ set: mockSet });
     hoisted.db.transaction.mockImplementation(async callback => callback(hoisted.db));
@@ -83,7 +84,6 @@ describe('cancelSubscriptionCore', () => {
     const session: SubscriptionSession = { user: { id: 'user_123' } };
 
     mockCancellationContext();
-
     const result = await cancelSubscriptionCore(
       {
         session,

--- a/packages/domain-membership-billing/src/subscription/cancel.test.ts
+++ b/packages/domain-membership-billing/src/subscription/cancel.test.ts
@@ -2,13 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cancelSubscriptionCore } from './cancel';
 import type { SubscriptionSession } from './types';
 
-// Mock DB
 const hoisted = vi.hoisted(() => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   db: {
     query: {
       subscriptions: { findFirst: vi.fn() },
     },
     select: vi.fn(),
+    transaction: vi.fn(),
     update: vi.fn(),
   },
   subscriptions: { id: 'id', tenantId: 'tenantId' },
@@ -25,6 +26,7 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  appendEvent: hoisted.appendEvent,
   db: hoisted.db,
   subscriptions: hoisted.subscriptions,
   claims: hoisted.claims,
@@ -57,6 +59,7 @@ describe('cancelSubscriptionCore', () => {
       createdAt: params?.subscriptionCreatedAt ?? new Date('2026-03-01T00:00:00.000Z'),
       currentPeriodEnd: new Date('2027-03-01T00:00:00.000Z'),
       cancelAtPeriodEnd: false,
+      status: 'active',
     });
 
     const mockLimit = vi.fn().mockResolvedValue(params?.acceptedEscalationRows ?? []);
@@ -73,12 +76,11 @@ describe('cancelSubscriptionCore', () => {
     const mockWhere = vi.fn().mockResolvedValue(undefined);
     const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
     hoisted.db.update.mockReturnValue({ set: mockSet });
+    hoisted.db.transaction.mockImplementation(async callback => callback(hoisted.db));
   });
 
   it('schedules next-term cancellation, persists cancelAtPeriodEnd, and returns refund eligibility', async () => {
-    const session: SubscriptionSession = {
-      user: { id: 'user_123' },
-    };
+    const session: SubscriptionSession = { user: { id: 'user_123' } };
 
     mockCancellationContext();
 
@@ -104,7 +106,15 @@ describe('cancelSubscriptionCore', () => {
       success: true,
     });
     expect(hoisted.paddle.subscriptions.cancel).toHaveBeenCalledWith('sub_123', expect.anything());
+    expect(hoisted.db.transaction).toHaveBeenCalled();
     expect(hoisted.db.update).toHaveBeenCalledWith(hoisted.subscriptions);
+    expect(hoisted.appendEvent).toHaveBeenCalledWith(
+      hoisted.db,
+      expect.objectContaining({
+        actor: { id: 'user_123', role: 'member' },
+        eventName: 'membership.subscription_changed',
+      })
+    );
 
     expect(logAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -118,9 +128,7 @@ describe('cancelSubscriptionCore', () => {
   });
 
   it('returns the accepted-escalation refund lock when a recovery matter has already been accepted', async () => {
-    const session: SubscriptionSession = {
-      user: { id: 'user_123' },
-    };
+    const session: SubscriptionSession = { user: { id: 'user_123' } };
 
     mockCancellationContext({
       acceptedEscalationRows: [{ acceptedAt: new Date('2026-03-05T00:00:00.000Z') }],
@@ -143,9 +151,7 @@ describe('cancelSubscriptionCore', () => {
   });
 
   it('does not treat accepted escalations from an earlier membership term as blocking', async () => {
-    const session: SubscriptionSession = {
-      user: { id: 'user_123' },
-    };
+    const session: SubscriptionSession = { user: { id: 'user_123' } };
 
     mockCancellationContext({
       acceptedEscalationRows: [{ acceptedAt: new Date('2026-02-15T00:00:00.000Z') }],
@@ -169,9 +175,7 @@ describe('cancelSubscriptionCore', () => {
   });
 
   it('returns success after provider cancellation even if local persistence fails', async () => {
-    const session: SubscriptionSession = {
-      user: { id: 'user_123' },
-    };
+    const session: SubscriptionSession = { user: { id: 'user_123' } };
 
     mockCancellationContext();
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -207,9 +211,7 @@ describe('cancelSubscriptionCore', () => {
   });
 
   it('denies access if user mismatch', async () => {
-    const session: SubscriptionSession = {
-      user: { id: 'user_123' },
-    };
+    const session: SubscriptionSession = { user: { id: 'user_123' } };
 
     hoisted.ensureTenantId.mockReturnValue('tenant_abc');
     hoisted.db.query.subscriptions.findFirst.mockResolvedValue({
@@ -228,9 +230,7 @@ describe('cancelSubscriptionCore', () => {
   });
 
   it('uses the stored provider subscription id when present', async () => {
-    const session: SubscriptionSession = {
-      user: { id: 'user_123' },
-    };
+    const session: SubscriptionSession = { user: { id: 'user_123' } };
 
     mockCancellationContext();
     hoisted.db.query.subscriptions.findFirst.mockResolvedValue({

--- a/packages/domain-membership-billing/src/subscription/cancel.ts
+++ b/packages/domain-membership-billing/src/subscription/cancel.ts
@@ -6,11 +6,13 @@ import {
   desc,
   eq,
   subscriptions,
+  type DomainEventTx,
 } from '@interdomestik/database';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { getPaddle } from '../paddle-server';
 import { buildCancellationTermsSummary } from './cancellation-policy';
 import { resolveProviderSubscriptionHandle } from '../subscription';
+import { recordMembershipSubscriptionChangedEvent } from '../paddle-webhooks/handlers/subscription-event';
 
 import type { CancelSubscriptionResult, SubscriptionDeps, SubscriptionSession } from './types';
 
@@ -71,13 +73,27 @@ export async function cancelSubscriptionCore(
 
     let localPersistenceFailed = false;
     try {
-      await db
-        .update(subscriptions)
-        .set({
+      const now = new Date();
+      await db.transaction(async tx => {
+        // db-access-guard: tenant-scoped -- reason: tenantId constrains local cancellation persistence.
+        await tx
+          .update(subscriptions)
+          .set({
+            cancelAtPeriodEnd: true,
+            updatedAt: now,
+          })
+          .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.tenantId, tenantId)));
+        await recordMembershipSubscriptionChangedEvent({
+          actor: { id: session.user.id, role: 'member' },
           cancelAtPeriodEnd: true,
-          updatedAt: new Date(),
-        })
-        .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.tenantId, tenantId)));
+          fromStatus: normalizeSubscriptionStatus(sub.status),
+          now,
+          subscriptionId,
+          tenantId,
+          toStatus: normalizeSubscriptionStatus(sub.status, 'active'),
+          tx: tx as DomainEventTx,
+        });
+      });
     } catch (error) {
       localPersistenceFailed = true;
       console.error('Failed to persist scheduled subscription cancellation:', error);
@@ -109,4 +125,21 @@ export async function cancelSubscriptionCore(
     console.error('Failed to cancel subscription:', error);
     return { error: 'Failed to cancel subscription', success: undefined };
   }
+}
+
+function normalizeSubscriptionStatus(
+  status: string | null | undefined,
+  fallback: 'active' | 'canceled' = 'canceled'
+) {
+  if (
+    status === 'active' ||
+    status === 'past_due' ||
+    status === 'paused' ||
+    status === 'canceled' ||
+    status === 'trialing' ||
+    status === 'expired'
+  ) {
+    return status;
+  }
+  return fallback;
 }

--- a/packages/domain-membership-billing/src/subscription/cancel.ts
+++ b/packages/domain-membership-billing/src/subscription/cancel.ts
@@ -76,13 +76,17 @@ export async function cancelSubscriptionCore(
       const now = new Date();
       await db.transaction(async tx => {
         // db-access-guard: tenant-scoped -- reason: tenantId constrains local cancellation persistence.
-        await tx
+        const updatedRows = await tx
           .update(subscriptions)
           .set({
             cancelAtPeriodEnd: true,
             updatedAt: now,
           })
-          .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.tenantId, tenantId)));
+          .where(and(eq(subscriptions.id, subscriptionId), eq(subscriptions.tenantId, tenantId)))
+          .returning({ id: subscriptions.id });
+        if (updatedRows.length === 0) {
+          throw new Error('Scheduled cancellation update matched no subscription rows');
+        }
         await recordMembershipSubscriptionChangedEvent({
           actor: { id: session.user.id, role: 'member' },
           cancelAtPeriodEnd: true,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35524035,
-  "maxTrackedFiles": 4147,
+  "maxTrackedBytes": 35528735,
+  "maxTrackedFiles": 4148,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689633,
-    "source/scripts": 6627879,
+    "source/scripts": 6628373,
     "docs/text": 5087043,
-    "tests/e2e": 4440644,
+    "tests/e2e": 4444850,
     "config/data/messages": 1549671,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35503665,
-  "maxTrackedFiles": 4139,
+  "maxTrackedBytes": 35524035,
+  "maxTrackedFiles": 4147,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689633,
-    "source/scripts": 6614183,
+    "source/scripts": 6627879,
     "docs/text": 5087043,
-    "tests/e2e": 4433970,
+    "tests/e2e": 4440644,
     "config/data/messages": 1549671,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Extend domain-event payload allowlists for case/recovery lifecycle changes and membership subscription changes.
- Emit claim, case, and recovery lifecycle events from claim status transitions when lifecycle state changes.
- Emit membership.subscription_changed events from Paddle subscription upsert/update paths and member cancellation scheduling inside the same persistence transaction.
- Harden subscription provider-reference lookup/update paths with tenant scoping and no-row update guards.

## Verification
- pnpm --filter @interdomestik/database test:unit --run domain-event-lifecycle-payload-allowlist.test.ts domain-event-membership-payload-allowlist.test.ts domain-event-payload-allowlist.test.ts
- pnpm --filter @interdomestik/domain-claims test:unit --run claims/transition-events.test.ts
- pnpm --filter @interdomestik/domain-membership-billing test:unit --run subscription-provider-reference.test.ts subscription.test.ts paddle-webhooks/handlers/subscription-upsert.test.ts paddle-webhooks/handlers/subscriptions.test.ts subscription/cancel.test.ts
- pnpm --filter @interdomestik/web test:unit --run src/lib/paddle-webhooks/subscriptions-handler.test.ts
- package type-checks for database, domain-claims, domain-membership-billing, and web
- pnpm check:modularity-guard
- pnpm check:db-access
- pnpm slice:verify
- pnpm security:guard
- pnpm pr:verify
- pnpm e2e:gate (134 passed, 8 skipped)

## Review And Security
- Sonnet external review completed; high findings around tenant-scoped subscription lookup/update paths were fixed.
- Codex senior review route was attempted but did not return and was interrupted after extended wait.
- Diff-scoped Codex Security scan tool was unavailable in this runtime; mandatory security:guard passed.

## Notes
- apps/web/src/proxy.ts was not modified.
- Recovery lifecycle events use the current claim-backed recovery aggregate id model.
- Subscription events retain existing aggregateVersion=0 behavior for this slice.