### PR TITLE
feat: split case recovery lifecycle contracts

### DIFF
--- a/packages/domain-case/src/index.test.ts
+++ b/packages/domain-case/src/index.test.ts
@@ -1,9 +1,34 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { CASE_LIFECYCLE_FIELD, DOMAIN_CASE_BOUNDARY } from './index';
+import { CLAIM_STATUSES } from '@interdomestik/database/constants';
+
+import {
+  CASE_LIFECYCLE_FIELD,
+  CASE_STATUS_LIFECYCLE_STATE_MAP,
+  DOMAIN_CASE_BOUNDARY,
+  mapCaseStatusToLifecycleState,
+} from './index';
 
 test('domain-case exposes a bounded case lifecycle contract', () => {
   assert.equal(DOMAIN_CASE_BOUNDARY, 'domain-case');
   assert.equal(CASE_LIFECYCLE_FIELD, 'claims.case_lifecycle_state');
+});
+
+test('domain-case owns the case status to lifecycle mapping', () => {
+  assert.deepEqual(
+    Object.keys(CASE_STATUS_LIFECYCLE_STATE_MAP).sort((left, right) => left.localeCompare(right)),
+    [...CLAIM_STATUSES].sort((left, right) => left.localeCompare(right))
+  );
+  assert.deepEqual(CASE_STATUS_LIFECYCLE_STATE_MAP, {
+    draft: 'draft',
+    submitted: 'submitted',
+    verification: 'verification',
+    evaluation: 'evaluation',
+    negotiation: 'recovery',
+    court: 'recovery',
+    resolved: 'resolved',
+    rejected: 'rejected',
+  });
+  assert.equal(mapCaseStatusToLifecycleState('negotiation'), 'recovery');
 });

--- a/packages/domain-case/src/types.ts
+++ b/packages/domain-case/src/types.ts
@@ -5,8 +5,23 @@ export const CASE_LIFECYCLE_FIELD = 'claims.case_lifecycle_state' as const;
 
 export type CaseLifecycleState = ClaimCaseLifecycleState;
 
+export const CASE_STATUS_LIFECYCLE_STATE_MAP = {
+  draft: 'draft',
+  submitted: 'submitted',
+  verification: 'verification',
+  evaluation: 'evaluation',
+  negotiation: 'recovery',
+  court: 'recovery',
+  resolved: 'resolved',
+  rejected: 'rejected',
+} as const satisfies Record<ClaimStatus, CaseLifecycleState>;
+
 export type CaseLifecycleSnapshot = {
   claimId: string;
   status: ClaimStatus;
   caseLifecycleState: CaseLifecycleState;
 };
+
+export function mapCaseStatusToLifecycleState(status: ClaimStatus): CaseLifecycleState {
+  return CASE_STATUS_LIFECYCLE_STATE_MAP[status];
+}

--- a/packages/domain-claims/src/claims/lifecycle-state.test.ts
+++ b/packages/domain-claims/src/claims/lifecycle-state.test.ts
@@ -95,6 +95,16 @@ describe('claim lifecycle state mapping', () => {
       caseLifecycleState: 'resolved',
       recoveryLifecycleState: 'resolved',
     });
+    expect(CLAIM_STATUS_LIFECYCLE_STATE_MAP).toEqual({
+      draft: { caseLifecycleState: 'draft', recoveryLifecycleState: 'not_started' },
+      submitted: { caseLifecycleState: 'submitted', recoveryLifecycleState: 'not_started' },
+      verification: { caseLifecycleState: 'verification', recoveryLifecycleState: 'not_started' },
+      evaluation: { caseLifecycleState: 'evaluation', recoveryLifecycleState: 'not_started' },
+      negotiation: { caseLifecycleState: 'recovery', recoveryLifecycleState: 'negotiation' },
+      court: { caseLifecycleState: 'recovery', recoveryLifecycleState: 'court' },
+      resolved: { caseLifecycleState: 'resolved', recoveryLifecycleState: 'resolved' },
+      rejected: { caseLifecycleState: 'rejected', recoveryLifecycleState: 'closed' },
+    });
   });
 
   it('persists mapped states during status-changing transitions', async () => {

--- a/packages/domain-claims/src/claims/lifecycle-state.ts
+++ b/packages/domain-claims/src/claims/lifecycle-state.ts
@@ -1,5 +1,11 @@
-import type { CaseLifecycleState } from '@interdomestik/domain-case';
-import type { RecoveryLifecycleState } from '@interdomestik/domain-recovery';
+import {
+  CASE_STATUS_LIFECYCLE_STATE_MAP,
+  type CaseLifecycleState,
+} from '@interdomestik/domain-case';
+import {
+  RECOVERY_STATUS_LIFECYCLE_STATE_MAP,
+  type RecoveryLifecycleState,
+} from '@interdomestik/domain-recovery';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 
 export type ClaimLifecycleStates = {
@@ -10,14 +16,38 @@ export type ClaimLifecycleStates = {
 export type { CaseLifecycleState, RecoveryLifecycleState };
 
 export const CLAIM_STATUS_LIFECYCLE_STATE_MAP = {
-  draft: { caseLifecycleState: 'draft', recoveryLifecycleState: 'not_started' },
-  submitted: { caseLifecycleState: 'submitted', recoveryLifecycleState: 'not_started' },
-  verification: { caseLifecycleState: 'verification', recoveryLifecycleState: 'not_started' },
-  evaluation: { caseLifecycleState: 'evaluation', recoveryLifecycleState: 'not_started' },
-  negotiation: { caseLifecycleState: 'recovery', recoveryLifecycleState: 'negotiation' },
-  court: { caseLifecycleState: 'recovery', recoveryLifecycleState: 'court' },
-  resolved: { caseLifecycleState: 'resolved', recoveryLifecycleState: 'resolved' },
-  rejected: { caseLifecycleState: 'rejected', recoveryLifecycleState: 'closed' },
+  draft: {
+    caseLifecycleState: CASE_STATUS_LIFECYCLE_STATE_MAP.draft,
+    recoveryLifecycleState: RECOVERY_STATUS_LIFECYCLE_STATE_MAP.draft,
+  },
+  submitted: {
+    caseLifecycleState: CASE_STATUS_LIFECYCLE_STATE_MAP.submitted,
+    recoveryLifecycleState: RECOVERY_STATUS_LIFECYCLE_STATE_MAP.submitted,
+  },
+  verification: {
+    caseLifecycleState: CASE_STATUS_LIFECYCLE_STATE_MAP.verification,
+    recoveryLifecycleState: RECOVERY_STATUS_LIFECYCLE_STATE_MAP.verification,
+  },
+  evaluation: {
+    caseLifecycleState: CASE_STATUS_LIFECYCLE_STATE_MAP.evaluation,
+    recoveryLifecycleState: RECOVERY_STATUS_LIFECYCLE_STATE_MAP.evaluation,
+  },
+  negotiation: {
+    caseLifecycleState: CASE_STATUS_LIFECYCLE_STATE_MAP.negotiation,
+    recoveryLifecycleState: RECOVERY_STATUS_LIFECYCLE_STATE_MAP.negotiation,
+  },
+  court: {
+    caseLifecycleState: CASE_STATUS_LIFECYCLE_STATE_MAP.court,
+    recoveryLifecycleState: RECOVERY_STATUS_LIFECYCLE_STATE_MAP.court,
+  },
+  resolved: {
+    caseLifecycleState: CASE_STATUS_LIFECYCLE_STATE_MAP.resolved,
+    recoveryLifecycleState: RECOVERY_STATUS_LIFECYCLE_STATE_MAP.resolved,
+  },
+  rejected: {
+    caseLifecycleState: CASE_STATUS_LIFECYCLE_STATE_MAP.rejected,
+    recoveryLifecycleState: RECOVERY_STATUS_LIFECYCLE_STATE_MAP.rejected,
+  },
 } as const satisfies Record<ClaimStatus, ClaimLifecycleStates>;
 
 export function mapClaimStatusToLifecycleStates(status: ClaimStatus): ClaimLifecycleStates {

--- a/packages/domain-recovery/src/index.test.ts
+++ b/packages/domain-recovery/src/index.test.ts
@@ -1,12 +1,16 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
+import { CLAIM_STATUSES } from '@interdomestik/database/constants';
+
 import {
   DEFAULT_RECOVERY_JURISDICTIONS,
   DOMAIN_RECOVERY_BOUNDARY,
   RECOVERY_LEGAL_TENANT_FIELD,
   RECOVERY_LIFECYCLE_FIELD,
   RECOVERY_LAW_FIELD,
+  RECOVERY_STATUS_LIFECYCLE_STATE_MAP,
+  mapRecoveryStatusToLifecycleState,
   recoveryLawClaimValues,
   resolveRecoveryLaw,
 } from './index';
@@ -16,6 +20,26 @@ test('domain-recovery exposes a bounded recovery lifecycle contract', () => {
   assert.equal(RECOVERY_LIFECYCLE_FIELD, 'claims.recovery_lifecycle_state');
   assert.equal(RECOVERY_LAW_FIELD, 'claims.recovery_law');
   assert.equal(RECOVERY_LEGAL_TENANT_FIELD, 'claims.recovery_legal_tenant_id');
+});
+
+test('domain-recovery owns the recovery status to lifecycle mapping', () => {
+  assert.deepEqual(
+    Object.keys(RECOVERY_STATUS_LIFECYCLE_STATE_MAP).sort((left, right) =>
+      left.localeCompare(right)
+    ),
+    [...CLAIM_STATUSES].sort((left, right) => left.localeCompare(right))
+  );
+  assert.deepEqual(RECOVERY_STATUS_LIFECYCLE_STATE_MAP, {
+    draft: 'not_started',
+    submitted: 'not_started',
+    verification: 'not_started',
+    evaluation: 'not_started',
+    negotiation: 'negotiation',
+    court: 'court',
+    resolved: 'resolved',
+    rejected: 'closed',
+  });
+  assert.equal(mapRecoveryStatusToLifecycleState('rejected'), 'closed');
 });
 
 test('resolves recovery law from explicit incident country', () => {

--- a/packages/domain-recovery/src/types.ts
+++ b/packages/domain-recovery/src/types.ts
@@ -5,6 +5,17 @@ export const RECOVERY_LIFECYCLE_FIELD = 'claims.recovery_lifecycle_state' as con
 
 export type RecoveryLifecycleState = ClaimRecoveryLifecycleState;
 
+export const RECOVERY_STATUS_LIFECYCLE_STATE_MAP = {
+  draft: 'not_started',
+  submitted: 'not_started',
+  verification: 'not_started',
+  evaluation: 'not_started',
+  negotiation: 'negotiation',
+  court: 'court',
+  resolved: 'resolved',
+  rejected: 'closed',
+} as const satisfies Record<ClaimStatus, RecoveryLifecycleState>;
+
 export type RecoveryLifecycleSnapshot = {
   claimId: string;
   status: ClaimStatus;
@@ -12,3 +23,7 @@ export type RecoveryLifecycleSnapshot = {
   recoveryLaw: string | null;
   recoveryLegalTenantId: string | null;
 };
+
+export function mapRecoveryStatusToLifecycleState(status: ClaimStatus): RecoveryLifecycleState {
+  return RECOVERY_STATUS_LIFECYCLE_STATE_MAP[status];
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35528735,
+  "maxTrackedBytes": 35532691,
   "maxTrackedFiles": 4148,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689633,
-    "source/scripts": 6628373,
+    "source/scripts": 6629981,
     "docs/text": 5087043,
-    "tests/e2e": 4444850,
+    "tests/e2e": 4447198,
     "config/data/messages": 1549671,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Move the minimum case and recovery lifecycle status mappings into their public domain contracts.
- Keep the domain-claims compatibility facade and physical claims table semantics intact.
- Add focused coverage for case, recovery, and composed claims lifecycle mappings.

## Verification
- pnpm --filter @interdomestik/domain-case test:unit
- pnpm --filter @interdomestik/domain-recovery test:unit
- pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/lifecycle-state.test.ts
- pnpm --filter @interdomestik/domain-case type-check
- pnpm --filter @interdomestik/domain-recovery type-check
- pnpm --filter @interdomestik/domain-claims type-check
- pnpm check:modularity-guard
- pnpm check:architecture-boundaries
- node scripts/repo-size-budget-sync.mjs --check && pnpm repo:size:check
- pnpm slice:verify
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate

## Review and Scope
- Interdomestik scope audit passed for domain-case, domain-recovery, domain-claims, and repo-size budget only.
- Forbidden Phase C files are untouched, including apps/web/src/proxy.ts and architecture tracker docs.
- Codex review passed before remediation and after remediation.
- External Claude Sonnet review findings were addressed: removed unsafe Object.fromEntries cast, added complete mapping coverage, avoided runtime CLAIM_STATUSES import, and kept claims compatibility explicit.

## Notes
- pnpm ci:local:pr hit Docker exit 137 during the web build TypeScript phase after compile, consistent with local Docker resource pressure. Host pnpm pr:verify passed the same required PR surface.
- One full e2e:gate attempt had a transient support-handoff redirect failure outside this slice; the focused rerun passed and the decisive full rerun passed: 134 passed, 8 skipped.