### PR TITLE
Prove T-201 case/recovery boundary contracts

### DIFF
--- a/packages/domain-claims/src/staff-claims/save-success-fee-collection.ts
+++ b/packages/domain-claims/src/staff-claims/save-success-fee-collection.ts
@@ -11,8 +11,8 @@ import { withTenant } from '@interdomestik/database/tenant-security';
 import {
   buildRecoverySuccessFeeCollectionSnapshot,
   normalizeRecoveryCurrencyCode,
+  recordRecoverySuccessFeeCollectedEvent,
 } from '@interdomestik/domain-recovery';
-import { recordRecoverySuccessFeeCollectedEvent } from '@interdomestik/domain-recovery/success-fee-collection-event';
 import {
   calculateSuccessFeeAmount,
   resolveSuccessFeeCollectionPlan,

--- a/packages/domain-claims/src/staff-claims/success-fee-collection-event.ts
+++ b/packages/domain-claims/src/staff-claims/success-fee-collection-event.ts
@@ -1,1 +1,2 @@
-export { recordRecoverySuccessFeeCollectedEvent as recordSuccessFeeCollectionEvent } from '@interdomestik/domain-recovery/success-fee-collection-event';
+// Compatibility facade preserving the domain-claims staff API while recovery owns the event.
+export { recordRecoverySuccessFeeCollectedEvent as recordSuccessFeeCollectionEvent } from '@interdomestik/domain-recovery';

--- a/packages/domain-recovery/src/index.ts
+++ b/packages/domain-recovery/src/index.ts
@@ -4,4 +4,18 @@ export * from './law-pack-schema';
 export * from './law-pack-registry';
 export * from './law-pack-resolution';
 export * from './success-fee-collection';
+export { buildRecoverySuccessFeeCollectedPayload } from './success-fee-collection-event-payload';
 export * from './success-fee-collection-resolution';
+
+type RecordRecoverySuccessFeeCollectedEventParams = Parameters<
+  typeof import('./success-fee-collection-event').recordRecoverySuccessFeeCollectedEvent
+>[0];
+
+export async function recordRecoverySuccessFeeCollectedEvent(
+  params: RecordRecoverySuccessFeeCollectedEventParams
+) {
+  const { recordRecoverySuccessFeeCollectedEvent: recordEvent } =
+    await import('./success-fee-collection-event');
+
+  await recordEvent(params);
+}

--- a/packages/domain-recovery/src/success-fee-collection-event-payload.ts
+++ b/packages/domain-recovery/src/success-fee-collection-event-payload.ts
@@ -1,0 +1,22 @@
+import type {
+  PaymentAuthorizationState,
+  SuccessFeeCollectionMethod,
+} from './success-fee-collection';
+
+export function buildRecoverySuccessFeeCollectedPayload(params: {
+  collectionMethod: SuccessFeeCollectionMethod;
+  currencyCode: string;
+  deductionAllowed: boolean;
+  hasStoredPaymentMethod: boolean;
+  invoiceDueAt: Date | null;
+  paymentAuthorizationState: PaymentAuthorizationState;
+}) {
+  return {
+    collectionMethod: params.collectionMethod,
+    currencyCode: params.currencyCode,
+    deductionAllowed: params.deductionAllowed,
+    hasInvoiceDueDate: Boolean(params.invoiceDueAt),
+    hasStoredPaymentMethod: params.hasStoredPaymentMethod,
+    paymentAuthorizationState: params.paymentAuthorizationState,
+  };
+}

--- a/packages/domain-recovery/src/success-fee-collection-event.ts
+++ b/packages/domain-recovery/src/success-fee-collection-event.ts
@@ -4,24 +4,7 @@ import type {
   PaymentAuthorizationState,
   SuccessFeeCollectionMethod,
 } from './success-fee-collection';
-
-export function buildRecoverySuccessFeeCollectedPayload(params: {
-  collectionMethod: SuccessFeeCollectionMethod;
-  currencyCode: string;
-  deductionAllowed: boolean;
-  hasStoredPaymentMethod: boolean;
-  invoiceDueAt: Date | null;
-  paymentAuthorizationState: PaymentAuthorizationState;
-}) {
-  return {
-    collectionMethod: params.collectionMethod,
-    currencyCode: params.currencyCode,
-    deductionAllowed: params.deductionAllowed,
-    hasInvoiceDueDate: Boolean(params.invoiceDueAt),
-    hasStoredPaymentMethod: params.hasStoredPaymentMethod,
-    paymentAuthorizationState: params.paymentAuthorizationState,
-  };
-}
+import { buildRecoverySuccessFeeCollectedPayload } from './success-fee-collection-event-payload';
 
 export async function recordRecoverySuccessFeeCollectedEvent(params: {
   actor: { id: string; role?: string | null };

--- a/packages/domain-recovery/src/success-fee-collection.test.ts
+++ b/packages/domain-recovery/src/success-fee-collection.test.ts
@@ -2,14 +2,12 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  buildRecoverySuccessFeeCollectedPayload,
   buildRecoverySuccessFeeCollectionSnapshot,
   normalizeRecoveryCurrencyCode,
+  recordRecoverySuccessFeeCollectedEvent,
   resolveRecoverySuccessFeeCollectionSnapshot,
 } from './index';
-import {
-  buildRecoverySuccessFeeCollectedPayload,
-  recordRecoverySuccessFeeCollectedEvent,
-} from './success-fee-collection-event';
 
 test('domain-recovery owns success-fee collection snapshot normalization', () => {
   assert.deepEqual(

--- a/scripts/check-case-recovery-boundaries.mjs
+++ b/scripts/check-case-recovery-boundaries.mjs
@@ -10,15 +10,15 @@ const boundaries = [
     name: 'domain-case',
     packageName: '@interdomestik/domain-case',
     root: 'packages/domain-case',
-    forbiddenPackage: '@interdomestik/domain-recovery',
-    forbiddenPathPart: 'domain-recovery',
+    forbiddenPackages: ['@interdomestik/domain-claims', '@interdomestik/domain-recovery'],
+    forbiddenPathParts: ['domain-claims', 'domain-recovery'],
   },
   {
     name: 'domain-recovery',
     packageName: '@interdomestik/domain-recovery',
     root: 'packages/domain-recovery',
-    forbiddenPackage: '@interdomestik/domain-case',
-    forbiddenPathPart: 'domain-case',
+    forbiddenPackages: ['@interdomestik/domain-case', '@interdomestik/domain-claims'],
+    forbiddenPathParts: ['domain-case', 'domain-claims'],
   },
 ];
 
@@ -67,9 +67,23 @@ function assertBoundaryPackage(boundary, failures) {
     packageJson.peerDependencies,
   ];
 
-  if (dependencyBlocks.some(block => block && boundary.forbiddenPackage in block)) {
-    failures.push(`${packagePath} must not depend on ${boundary.forbiddenPackage}.`);
+  for (const forbiddenPackage of boundary.forbiddenPackages) {
+    if (dependencyBlocks.some(block => block && forbiddenPackage in block)) {
+      failures.push(`${packagePath} must not depend on ${forbiddenPackage}.`);
+    }
   }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+}
+
+function importsPackage(source, packageName) {
+  const escapedPackage = escapeRegExp(packageName);
+  return new RegExp(
+    String.raw`(?:from\s+|import\s*\(\s*|import\s+)['"]${escapedPackage}(?:/[^'"]*)?['"]`,
+    'u'
+  ).test(source);
 }
 
 function assertNoCrossImports(boundary, failures) {
@@ -78,13 +92,21 @@ function assertNoCrossImports(boundary, failures) {
   for (const file of files) {
     const source = fs.readFileSync(file, 'utf8');
     const relativePath = toPosix(path.relative(repoRoot, file));
-    if (source.includes(boundary.forbiddenPackage)) {
-      failures.push(`${relativePath} imports forbidden ${boundary.forbiddenPackage}.`);
+    for (const forbiddenPackage of boundary.forbiddenPackages) {
+      if (importsPackage(source, forbiddenPackage)) {
+        failures.push(`${relativePath} imports forbidden ${forbiddenPackage}.`);
+      }
     }
 
-    const relativeForbidden = new RegExp(`from ['"][^'"]*${boundary.forbiddenPathPart}`, 'u');
-    if (relativeForbidden.test(source)) {
-      failures.push(`${relativePath} imports through forbidden ${boundary.forbiddenPathPart}.`);
+    for (const forbiddenPathPart of boundary.forbiddenPathParts) {
+      const escapedPathPart = escapeRegExp(forbiddenPathPart);
+      const relativeForbidden = new RegExp(
+        String.raw`(?:from\s+|import\s*\(\s*|require\s*\(\s*|import\s+)['"][.][^'"]*${escapedPathPart}(?:/|['"])`,
+        'u'
+      );
+      if (relativeForbidden.test(source)) {
+        failures.push(`${relativePath} imports through forbidden ${forbiddenPathPart}.`);
+      }
     }
   }
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35541793,
-  "maxTrackedFiles": 4153,
+  "maxTrackedBytes": 35543197,
+  "maxTrackedFiles": 4154,
   "maxCategoryBytes": {
     "large support/generated-ish": 17689633,
-    "source/scripts": 6631734,
+    "source/scripts": 6633188,
     "docs/text": 5087043,
     "tests/e2e": 4454468,
     "config/data/messages": 1549750,


### PR DESCRIPTION
## Summary
- Export the recovery success-fee event helpers from the `@interdomestik/domain-recovery` public package contract.
- Keep the `domain-claims` staff compatibility facade while moving its event dependency to the public recovery root.
- Strengthen the case/recovery boundary guard so `domain-case` and `domain-recovery` cannot backslide into `domain-claims`, without moving the physical claims table.
- Keep the recovery package root free of DB-backed event side effects by exposing a pure payload module plus a lazy recorder wrapper.

## Verification
- `node scripts/check-case-recovery-boundaries.mjs`
- `pnpm --filter @interdomestik/domain-recovery test:unit`
- `pnpm --filter @interdomestik/domain-claims test:unit -- src/staff-claims/save-success-fee-collection-events.test.ts src/staff-claims/save-success-fee-collection.test.ts`
- `pnpm --filter @interdomestik/domain-recovery type-check`
- `pnpm --filter @interdomestik/domain-claims type-check`
- `pnpm check:architecture-boundaries`
- `pnpm check:modularity-guard`
- `git diff --check`
- `pnpm repo:size:check`
- `pnpm slice:verify`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate` (rerun passed: 134 passed, 8 skipped)
- `pnpm exec tsx -e "void import('@interdomestik/domain-recovery').then(() => console.log('domain-recovery root import ok'))"`

## Review Notes
- Codex review route was attempted locally but blocked by timeout/MCP auth refresh failures.
- External Claude Sonnet 4.6 re-review found no blockers after remediation.
- Copilot comments addressed in `922d963b`.
- Codex PR review comment addressed in `922d963b` by removing the DB-backed static barrel re-export.
- Sonar S7780 comments addressed in `922d963b` by using `String.raw` for regex/replacement strings.
- Codex Security diff-scan tool was unavailable; `security:guard` passed.
