### PR TITLE
feat: bridge success fee events to paddle billing

### DIFF
--- a/packages/domain-membership-billing/package.json
+++ b/packages/domain-membership-billing/package.json
@@ -25,6 +25,8 @@
     "./paddle-webhooks/handlers/dunning": "./src/paddle-webhooks/handlers/dunning.ts",
     "./paddle-webhooks/handlers/transaction": "./src/paddle-webhooks/handlers/transaction.ts",
     "./success-fees/policy": "./src/success-fees/policy.ts",
+    "./success-fees/paddle-success-fee-charge": "./src/success-fees/paddle-success-fee-charge.ts",
+    "./success-fees/recovery-success-fee-billing": "./src/success-fees/recovery-success-fee-billing.ts",
     "./commissions/types": "./src/commissions/types.ts",
     "./commissions/create": "./src/commissions/create.ts",
     "./commissions/get-my": "./src/commissions/get-my.ts",

--- a/packages/domain-membership-billing/src/index.ts
+++ b/packages/domain-membership-billing/src/index.ts
@@ -23,6 +23,8 @@ export * from './paddle-webhooks/subscription-status';
 export * from './paddle-webhooks/types';
 export * from './paddle-webhooks/verify';
 export * from './success-fees/policy';
+export * from './success-fees/paddle-success-fee-charge';
+export * from './success-fees/recovery-success-fee-billing';
 export * from './subscription';
 export * from './subscription/cancel';
 export * from './subscription/get-payment-update-url';

--- a/packages/domain-membership-billing/src/success-fees/invoice-payment-terms.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/invoice-payment-terms.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildInvoiceBillingDetails } from './invoice-payment-terms';
+
+describe('buildInvoiceBillingDetails', () => {
+  it('converts invoice due dates to Paddle day payment terms', () => {
+    expect(
+      buildInvoiceBillingDetails(new Date('2026-07-11T00:00:00Z'), new Date('2026-07-01T12:00:00Z'))
+    ).toEqual({
+      paymentTerms: {
+        frequency: 10,
+        interval: 'day',
+      },
+    });
+  });
+
+  it('uses at least one day when the due date has passed', () => {
+    expect(
+      buildInvoiceBillingDetails(new Date('2026-07-01T00:00:00Z'), new Date('2026-07-02T00:00:00Z'))
+    ).toEqual({
+      paymentTerms: {
+        frequency: 1,
+        interval: 'day',
+      },
+    });
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/invoice-payment-terms.ts
+++ b/packages/domain-membership-billing/src/success-fees/invoice-payment-terms.ts
@@ -1,0 +1,11 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function buildInvoiceBillingDetails(invoiceDueAt: Date, now = new Date()) {
+  const frequency = Math.max(1, Math.ceil((invoiceDueAt.getTime() - now.getTime()) / DAY_MS));
+  return {
+    paymentTerms: {
+      frequency,
+      interval: 'day',
+    },
+  };
+}

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-charge-edge.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-charge-edge.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createPaddleSuccessFeeTransaction } from './paddle-success-fee-charge';
+import {
+  paddleMock,
+  paymentMethodSnapshot,
+  SUCCESS_FEE_IDEMPOTENCY_KEY,
+} from './paddle-success-fee-test-helpers';
+
+describe('createPaddleSuccessFeeTransaction edge cases', () => {
+  it('rounds decimal amounts without floating point drift', async () => {
+    const createOneTimeCharge = vi.fn().mockResolvedValue({ id: 'sub_123' });
+
+    await createPaddleSuccessFeeTransaction({
+      idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+      paddle: paddleMock({ createOneTimeCharge }),
+      snapshot: paymentMethodSnapshot({ feeAmount: '2.675' }),
+    });
+
+    expect(createOneTimeCharge).toHaveBeenCalledWith(
+      'sub_123',
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            price: expect.objectContaining({
+              unitPrice: { amount: '268', currencyCode: 'EUR' },
+            }),
+          }),
+        ],
+      })
+    );
+  });
+
+  it('rejects missing Paddle transaction ids', async () => {
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: 'key-1',
+        paddle: paddleMock({ create: vi.fn().mockResolvedValue({}) }),
+        snapshot: paymentMethodSnapshot({
+          collectionMethod: 'invoice',
+          invoiceDueAt: new Date('2026-07-01'),
+        }),
+      })
+    ).rejects.toThrow(/requires a Paddle transaction id/);
+  });
+
+  it('does not reuse an idempotency match from another tenant', async () => {
+    const createOneTimeCharge = vi.fn().mockResolvedValue({ id: 'sub_123' });
+
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+        paddle: paddleMock({
+          createOneTimeCharge,
+          rows: [
+            {
+              customData: { idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY, tenantId: 'other' },
+              id: 'txn_other_tenant',
+            },
+          ],
+        }),
+        snapshot: paymentMethodSnapshot(),
+      })
+    ).resolves.toEqual({
+      providerSubscriptionId: 'sub_123',
+      status: 'paddle_subscription_charge_created',
+    });
+    expect(createOneTimeCharge).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses a one-time charge transaction by price idempotency metadata', async () => {
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+        paddle: paddleMock({
+          createOneTimeCharge: vi.fn(),
+          rows: [
+            {
+              id: 'txn_existing_charge',
+              items: [
+                {
+                  price: {
+                    customData: {
+                      idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+                      tenantId: 'tenant_ks',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+        snapshot: paymentMethodSnapshot(),
+      })
+    ).resolves.toEqual({
+      providerTransactionId: 'txn_existing_charge',
+      status: 'paddle_transaction_reused',
+    });
+  });
+
+  it('reuses a later iterable transaction from Paddle list pagination', async () => {
+    const rows = Array.from({ length: 55 }, (_, index) => ({
+      customData: { idempotencyKey: `old-${index}`, tenantId: 'tenant_ks' },
+      id: `txn_${index}`,
+    }));
+    rows.push({
+      customData: { idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY, tenantId: 'tenant_ks' },
+      id: 'txn_existing',
+    });
+
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+        paddle: paddleMock({ create: vi.fn(), rows }),
+        snapshot: paymentMethodSnapshot(),
+      })
+    ).resolves.toEqual({
+      providerTransactionId: 'txn_existing',
+      status: 'paddle_transaction_reused',
+    });
+  });
+
+  it('uses manual collection mode for invoice billing', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'txn_invoice' });
+
+    await createPaddleSuccessFeeTransaction({
+      idempotencyKey: 'key-1',
+      paddle: paddleMock({ create }),
+      snapshot: paymentMethodSnapshot({
+        collectionMethod: 'invoice',
+        invoiceDueAt: new Date('2026-07-01'),
+      }),
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionMode: 'manual', status: 'billed' })
+    );
+  });
+
+  it('rejects pending payment method charges before calling Paddle create', async () => {
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: 'key-1',
+        paddle: paddleMock(),
+        snapshot: paymentMethodSnapshot({ paymentAuthorizationState: 'pending' }),
+      })
+    ).rejects.toThrow(/requires authorized payment collection/);
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-charge.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-charge.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createPaddleSuccessFeeTransaction } from './paddle-success-fee-charge';
+import {
+  paddleMock,
+  paymentMethodSnapshot,
+  SUCCESS_FEE_IDEMPOTENCY_KEY,
+} from './paddle-success-fee-test-helpers';
+
+describe('createPaddleSuccessFeeTransaction', () => {
+  it('creates a Paddle transaction with dynamic success-fee amount and idempotency metadata', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'txn_123' });
+    const createOneTimeCharge = vi.fn().mockResolvedValue({ id: 'sub_123' });
+    const paddle = paddleMock({ create, createOneTimeCharge });
+
+    const result = await createPaddleSuccessFeeTransaction({
+      idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+      paddle,
+      snapshot: paymentMethodSnapshot(),
+    });
+
+    expect(result).toEqual({
+      providerSubscriptionId: 'sub_123',
+      status: 'paddle_subscription_charge_created',
+    });
+    expect(create).not.toHaveBeenCalled();
+    expect(createOneTimeCharge).toHaveBeenCalledWith(
+      'sub_123',
+      expect.objectContaining({
+        effectiveFrom: 'immediately',
+        items: [
+          expect.objectContaining({
+            price: expect.objectContaining({
+              customData: expect.objectContaining({
+                claimId: 'claim-1',
+                idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+                originSubscriptionId: 'sub_123',
+                tenantId: 'tenant_ks',
+              }),
+              unitPrice: { amount: '1550', currencyCode: 'EUR' },
+            }),
+            quantity: 1,
+          }),
+        ],
+        onPaymentFailure: 'prevent_change',
+      })
+    );
+    expect(paddle.transactions.list).toHaveBeenCalledWith(
+      expect.objectContaining({ customerId: ['ctm_123'], perPage: 50 })
+    );
+  });
+
+  it('reuses an existing Paddle transaction with the same idempotency key', async () => {
+    const create = vi.fn();
+
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+        paddle: paddleMock({
+          create,
+          rows: [
+            {
+              customData: {
+                idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+                tenantId: 'tenant_ks',
+              },
+              id: 'txn_existing',
+            },
+          ],
+        }),
+        snapshot: paymentMethodSnapshot(),
+      })
+    ).resolves.toEqual({
+      providerTransactionId: 'txn_existing',
+      status: 'paddle_transaction_reused',
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('does not call Paddle for deduction collection', async () => {
+    const create = vi.fn();
+    const createOneTimeCharge = vi.fn();
+
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: 'key-1',
+        paddle: paddleMock({ create, createOneTimeCharge }),
+        snapshot: paymentMethodSnapshot({ collectionMethod: 'deduction' }),
+      })
+    ).resolves.toEqual({ status: 'skipped_deduction' });
+    expect(create).not.toHaveBeenCalled();
+    expect(createOneTimeCharge).not.toHaveBeenCalled();
+  });
+
+  it('rejects without a Paddle customer so the event remains retryable', async () => {
+    const create = vi.fn();
+
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: 'key-1',
+        paddle: paddleMock({ create }),
+        snapshot: paymentMethodSnapshot({ providerCustomerId: null }),
+      })
+    ).rejects.toThrow(/requires a Paddle customer/);
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-charge.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-charge.ts
@@ -1,0 +1,134 @@
+import {
+  requirePaddleTransactionId,
+  transactionMatchesBillingEvent,
+  type PaddleTransaction,
+} from './paddle-transaction-idempotency';
+import {
+  buildPaddleInvoiceTransactionRequest,
+  buildPaddleSubscriptionChargeRequest,
+} from './paddle-success-fee-request';
+
+export type RecoverySuccessFeeCollectionMethod = 'deduction' | 'payment_method_charge' | 'invoice';
+
+export type RecoverySuccessFeeBillingSnapshot = Readonly<{
+  claimId: string;
+  collectionMethod: RecoverySuccessFeeCollectionMethod;
+  currencyCode: string;
+  feeAmount: string;
+  invoiceDueAt: Date | null;
+  paymentAuthorizationState: 'pending' | 'authorized' | 'revoked';
+  providerCustomerId: string | null;
+  providerSubscriptionId: string | null;
+  tenantId: string;
+}>;
+
+export type PaddleSuccessFeeClient = {
+  subscriptions: {
+    createOneTimeCharge(subscriptionId: string, input: Record<string, unknown>): Promise<unknown>;
+  };
+  transactions: {
+    create(input: Record<string, unknown>): Promise<Partial<PaddleTransaction> | undefined>;
+    list(input: Record<string, unknown>): AsyncIterable<PaddleTransaction>;
+  };
+};
+
+export type PaddleSuccessFeeBillingResult =
+  | { status: 'paddle_invoice_billed'; providerTransactionId: string }
+  | { status: 'paddle_subscription_charge_created'; providerSubscriptionId: string }
+  | { status: 'paddle_transaction_reused'; providerTransactionId: string }
+  | { status: 'skipped_deduction' };
+
+function assertBillableSnapshot(snapshot: RecoverySuccessFeeBillingSnapshot) {
+  if (snapshot.collectionMethod === 'payment_method_charge') {
+    if (!snapshot.providerCustomerId) {
+      throw new Error('success-fee billing requires a Paddle customer before delivery');
+    }
+    if (snapshot.paymentAuthorizationState !== 'authorized') {
+      throw new Error('success-fee billing requires authorized payment collection');
+    }
+    if (!snapshot.providerSubscriptionId) {
+      throw new Error('success-fee billing requires a subscription payment handle');
+    }
+  }
+  if (snapshot.collectionMethod === 'invoice' && !snapshot.invoiceDueAt) {
+    throw new Error('success-fee invoice billing requires an invoice due date');
+  }
+}
+
+async function findExistingSuccessFeeTransaction(params: {
+  idempotencyKey: string;
+  paddle: PaddleSuccessFeeClient;
+  providerCustomerId: string | null;
+  snapshot: RecoverySuccessFeeBillingSnapshot;
+}): Promise<PaddleTransaction | null> {
+  const transactions = params.paddle.transactions.list({
+    ...(params.providerCustomerId ? { customerId: [params.providerCustomerId] } : {}),
+    orderBy: '-created_at',
+    perPage: 50,
+  });
+
+  for await (const transaction of transactions) {
+    if (
+      transactionMatchesBillingEvent({
+        idempotencyKey: params.idempotencyKey,
+        snapshot: params.snapshot,
+        transaction,
+      })
+    ) {
+      return transaction;
+    }
+  }
+  return null;
+}
+
+export async function createPaddleSuccessFeeTransaction(params: {
+  idempotencyKey: string;
+  now?: Date;
+  paddle: PaddleSuccessFeeClient;
+  snapshot: RecoverySuccessFeeBillingSnapshot;
+}): Promise<PaddleSuccessFeeBillingResult> {
+  if (params.snapshot.collectionMethod === 'deduction') {
+    return { status: 'skipped_deduction' };
+  }
+  assertBillableSnapshot(params.snapshot);
+
+  const existing = await findExistingSuccessFeeTransaction({
+    idempotencyKey: params.idempotencyKey,
+    paddle: params.paddle,
+    providerCustomerId: params.snapshot.providerCustomerId,
+    snapshot: params.snapshot,
+  });
+  if (existing) {
+    return {
+      providerTransactionId: requirePaddleTransactionId(existing),
+      status: 'paddle_transaction_reused',
+    };
+  }
+
+  if (params.snapshot.collectionMethod === 'payment_method_charge') {
+    const providerSubscriptionId = params.snapshot.providerSubscriptionId;
+    if (!providerSubscriptionId) {
+      throw new Error('success-fee billing requires a subscription payment handle');
+    }
+    await params.paddle.subscriptions.createOneTimeCharge(
+      providerSubscriptionId,
+      buildPaddleSubscriptionChargeRequest(params.snapshot, params.idempotencyKey)
+    );
+    return {
+      providerSubscriptionId,
+      status: 'paddle_subscription_charge_created',
+    };
+  }
+
+  const transaction = await params.paddle.transactions.create(
+    buildPaddleInvoiceTransactionRequest(
+      params.snapshot,
+      params.idempotencyKey,
+      params.now ?? new Date()
+    )
+  );
+  return {
+    providerTransactionId: requirePaddleTransactionId(transaction),
+    status: 'paddle_invoice_billed',
+  };
+}

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-invoice.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-invoice.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createPaddleSuccessFeeTransaction } from './paddle-success-fee-charge';
+import {
+  invoiceSnapshot,
+  paddleMock,
+  SUCCESS_FEE_IDEMPOTENCY_KEY,
+} from './paddle-success-fee-test-helpers';
+
+describe('createPaddleSuccessFeeTransaction invoice fallback', () => {
+  it('creates a manual Paddle transaction without a stored customer', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'txn_invoice' });
+    const paddle = paddleMock({ create });
+
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+        now: new Date('2026-06-21T00:00:00Z'),
+        paddle,
+        snapshot: invoiceSnapshot(),
+      })
+    ).resolves.toEqual({
+      providerTransactionId: 'txn_invoice',
+      status: 'paddle_invoice_billed',
+    });
+    expect(paddle.transactions.list).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: '-created_at', perPage: 50 })
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.not.objectContaining({ customerId: expect.anything() })
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingDetails: { paymentTerms: { frequency: 10, interval: 'day' } },
+        collectionMode: 'manual',
+        status: 'billed',
+      })
+    );
+  });
+
+  it('reuses a customerless invoice transaction by tenant-scoped idempotency metadata', async () => {
+    const paddle = paddleMock({
+      create: vi.fn(),
+      rows: [
+        {
+          customData: { idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY, tenantId: 'tenant_ks' },
+          id: 'txn_existing',
+        },
+      ],
+    });
+
+    await expect(
+      createPaddleSuccessFeeTransaction({
+        idempotencyKey: SUCCESS_FEE_IDEMPOTENCY_KEY,
+        paddle,
+        snapshot: invoiceSnapshot(),
+      })
+    ).resolves.toEqual({
+      providerTransactionId: 'txn_existing',
+      status: 'paddle_transaction_reused',
+    });
+    expect(paddle.transactions.create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-request.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-request.ts
@@ -1,0 +1,62 @@
+import { buildInvoiceBillingDetails } from './invoice-payment-terms';
+import type { RecoverySuccessFeeBillingSnapshot } from './paddle-success-fee-charge';
+import { RECOVERY_SUCCESS_FEE_BILLING_CONSUMER } from './success-fee-consumer';
+import { toMinorUnitAmount } from './success-fee-amount';
+
+export function buildSuccessFeeCustomData(
+  snapshot: RecoverySuccessFeeBillingSnapshot,
+  idempotencyKey: string
+) {
+  return {
+    claimId: snapshot.claimId,
+    domainEventConsumer: RECOVERY_SUCCESS_FEE_BILLING_CONSUMER,
+    idempotencyKey,
+    originSubscriptionId: snapshot.providerSubscriptionId,
+    tenantId: snapshot.tenantId,
+  };
+}
+
+function buildSuccessFeeLineItem(
+  snapshot: RecoverySuccessFeeBillingSnapshot,
+  idempotencyKey: string
+) {
+  return {
+    price: {
+      customData: buildSuccessFeeCustomData(snapshot, idempotencyKey),
+      description: `Recovery success fee for claim ${snapshot.claimId}`,
+      name: 'Recovery success fee',
+      product: { name: 'Interdomestik recovery services' },
+      unitPrice: {
+        amount: toMinorUnitAmount(snapshot.feeAmount, snapshot.currencyCode),
+        currencyCode: snapshot.currencyCode,
+      },
+    },
+    quantity: 1,
+  };
+}
+
+export function buildPaddleInvoiceTransactionRequest(
+  snapshot: RecoverySuccessFeeBillingSnapshot,
+  idempotencyKey: string,
+  now: Date
+) {
+  return {
+    billingDetails: buildInvoiceBillingDetails(snapshot.invoiceDueAt ?? now, now),
+    collectionMode: 'manual',
+    currencyCode: snapshot.currencyCode,
+    customData: buildSuccessFeeCustomData(snapshot, idempotencyKey),
+    items: [buildSuccessFeeLineItem(snapshot, idempotencyKey)],
+    status: 'billed',
+  };
+}
+
+export function buildPaddleSubscriptionChargeRequest(
+  snapshot: RecoverySuccessFeeBillingSnapshot,
+  idempotencyKey: string
+) {
+  return {
+    effectiveFrom: 'immediately',
+    items: [buildSuccessFeeLineItem(snapshot, idempotencyKey)],
+    onPaymentFailure: 'prevent_change',
+  };
+}

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-test-helpers.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-test-helpers.ts
@@ -1,0 +1,67 @@
+import { vi, type Mock } from 'vitest';
+
+import type {
+  PaddleSuccessFeeClient,
+  RecoverySuccessFeeBillingSnapshot,
+} from './paddle-success-fee-charge';
+import type { PaddleTransaction } from './paddle-transaction-idempotency';
+
+export const SUCCESS_FEE_IDEMPOTENCY_KEY = 'domain-event:billing:event-1';
+
+export type PaddleSuccessFeeClientMock = PaddleSuccessFeeClient & {
+  subscriptions: { createOneTimeCharge: Mock };
+  transactions: { create: Mock; list: Mock };
+};
+
+export async function* paddleTransactions(rows: PaddleTransaction[]) {
+  yield* rows;
+}
+
+export function paddleMock(
+  params: {
+    create?: Mock;
+    createOneTimeCharge?: Mock;
+    rows?: PaddleTransaction[];
+  } = {}
+): PaddleSuccessFeeClientMock {
+  return {
+    subscriptions: {
+      createOneTimeCharge:
+        params.createOneTimeCharge ?? vi.fn().mockResolvedValue({ id: 'sub_123' }),
+    },
+    transactions: {
+      create: params.create ?? vi.fn().mockResolvedValue({ id: 'txn_123' }),
+      list: vi.fn(() => paddleTransactions(params.rows ?? [])),
+    },
+  };
+}
+
+export function paymentMethodSnapshot(
+  overrides: Partial<RecoverySuccessFeeBillingSnapshot> = {}
+): RecoverySuccessFeeBillingSnapshot {
+  return {
+    claimId: 'claim-1',
+    collectionMethod: 'payment_method_charge',
+    currencyCode: 'EUR',
+    feeAmount: '15.50',
+    invoiceDueAt: null,
+    paymentAuthorizationState: 'authorized',
+    providerCustomerId: 'ctm_123',
+    providerSubscriptionId: 'sub_123',
+    tenantId: 'tenant_ks',
+    ...overrides,
+  };
+}
+
+export function invoiceSnapshot(
+  overrides: Partial<RecoverySuccessFeeBillingSnapshot> = {}
+): RecoverySuccessFeeBillingSnapshot {
+  return paymentMethodSnapshot({
+    collectionMethod: 'invoice',
+    invoiceDueAt: new Date('2026-07-01'),
+    paymentAuthorizationState: 'pending',
+    providerCustomerId: null,
+    providerSubscriptionId: null,
+    ...overrides,
+  });
+}

--- a/packages/domain-membership-billing/src/success-fees/paddle-transaction-idempotency.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-transaction-idempotency.ts
@@ -1,0 +1,52 @@
+import type { RecoverySuccessFeeBillingSnapshot } from './paddle-success-fee-charge';
+
+export type PaddleTransaction = {
+  customData?: Record<string, unknown> | null;
+  custom_data?: Record<string, unknown> | null;
+  id: string;
+  items?: Array<{
+    price?: {
+      customData?: Record<string, unknown> | null;
+      custom_data?: Record<string, unknown> | null;
+    } | null;
+  }>;
+};
+
+type PaddleCustomDataCarrier = {
+  customData?: Record<string, unknown> | null;
+  custom_data?: Record<string, unknown> | null;
+};
+
+function transactionCustomData(carrier: PaddleCustomDataCarrier): Record<string, unknown> | null {
+  return carrier.customData ?? carrier.custom_data ?? null;
+}
+
+function transactionCustomDataEntries(
+  transaction: PaddleTransaction
+): Array<Record<string, unknown>> {
+  return [
+    transactionCustomData(transaction),
+    ...(transaction.items ?? []).map(item =>
+      item.price ? transactionCustomData(item.price) : null
+    ),
+  ].filter((customData): customData is Record<string, unknown> => Boolean(customData));
+}
+
+export function transactionMatchesBillingEvent(params: {
+  idempotencyKey: string;
+  snapshot: RecoverySuccessFeeBillingSnapshot;
+  transaction: PaddleTransaction;
+}): boolean {
+  return transactionCustomDataEntries(params.transaction).some(
+    customData =>
+      customData?.idempotencyKey === params.idempotencyKey &&
+      customData?.tenantId === params.snapshot.tenantId
+  );
+}
+
+export function requirePaddleTransactionId(
+  transaction: Partial<PaddleTransaction> | undefined
+): string {
+  if (!transaction?.id) throw new Error('success-fee billing requires a Paddle transaction id');
+  return transaction.id;
+}

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing-stale.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing-stale.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => {
+  const table = (name: string) =>
+    new Proxy({}, { get: (_target, prop) => `${name}.${String(prop)}` });
+  return {
+    and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+    claimEscalationAgreements: table('agreement'),
+    domainEventDeliveries: table('deliveries'),
+    domainEventDeliveryIdempotencyKey: vi.fn((eventId: string) => `key:${eventId}`),
+    domainEvents: table('events'),
+    eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+    recordDomainEventDelivery: vi.fn(),
+    selectDomainEventsForRelay: vi.fn(),
+    sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
+    subscriptions: table('subscriptions'),
+  };
+});
+
+vi.mock('@interdomestik/database', () => dbMocks);
+vi.mock('../paddle-server', () => ({ getPaddle: vi.fn() }));
+vi.mock('../subscription', () => ({
+  resolveProviderSubscriptionHandle: (sub: {
+    id: string;
+    providerSubscriptionId?: string | null;
+  }) => sub.providerSubscriptionId || sub.id,
+}));
+
+import { relayRecoverySuccessFeeBillingEvents } from './recovery-success-fee-billing';
+
+type RelayTx = Parameters<typeof relayRecoverySuccessFeeBillingEvents>[0];
+
+function event(id: string, aggregateVersion: number) {
+  return {
+    actorId: 'staff-1',
+    actorRole: 'staff',
+    aggregateVersion,
+    correlationId: id,
+    createdAt: new Date('2026-06-01T10:00:00Z'),
+    entityId: 'claim-1',
+    entityType: 'claim',
+    eventName: 'recovery.success_fee_collected',
+    eventVersion: 1,
+    id,
+    payload: {
+      collectionMethod: 'payment_method_charge',
+      currencyCode: 'EUR',
+      deductionAllowed: false,
+      hasInvoiceDueDate: false,
+      hasStoredPaymentMethod: true,
+      paymentAuthorizationState: 'authorized',
+    },
+    tenantId: 'tenant_ks',
+  };
+}
+
+function rowsQuery(rows: unknown[]) {
+  return { limit: () => Promise.resolve(rows) };
+}
+
+function whereRows(rows: unknown[]) {
+  return { where: () => rowsQuery(rows) };
+}
+
+function snapshotQuery(row: unknown) {
+  return { leftJoin: () => ({ where: () => rowsQuery([row]) }) };
+}
+
+function fakeTx(newerRows: unknown[][]): RelayTx {
+  const snapshotRow = {
+    collectionMethod: 'payment_method_charge',
+    currencyCode: 'EUR',
+    feeAmount: '25.00',
+    invoiceDueAt: null,
+    paymentAuthorizationState: 'authorized',
+    providerCustomerId: 'ctm_123',
+    providerSubscriptionId: 'sub_paddle_123',
+    subscriptionId: 'sub-1',
+  };
+  return {
+    select: vi.fn(() => ({
+      from: (table: unknown) => {
+        if (table === dbMocks.domainEvents) {
+          return whereRows(newerRows.shift() ?? []);
+        }
+        if (table === dbMocks.domainEventDeliveries) {
+          return whereRows([]);
+        }
+        return snapshotQuery(snapshotRow);
+      },
+    })),
+    execute: vi.fn(),
+  } as unknown as RelayTx;
+}
+
+describe('relayRecoverySuccessFeeBillingEvents stale event suppression', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('records stale older collection events without charging Paddle', async () => {
+    const older = event('event-1', 1);
+    const newer = event('event-2', 2);
+    const billSuccessFee = vi
+      .fn()
+      .mockResolvedValue({ status: 'paddle_subscription_charge_created' });
+    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([older, newer]);
+    dbMocks.recordDomainEventDelivery.mockResolvedValue({ status: 'delivered' });
+
+    const result = await relayRecoverySuccessFeeBillingEvents(fakeTx([[{ id: 'event-2' }], []]), {
+      deps: { billSuccessFee },
+      limit: 10,
+      tenantId: 'tenant_ks',
+    });
+
+    expect(billSuccessFee).toHaveBeenCalledTimes(1);
+    expect(billSuccessFee).toHaveBeenCalledWith(expect.objectContaining({ event: newer }));
+    expect(dbMocks.recordDomainEventDelivery).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ delivered: 1, selected: 2, skippedStale: 1 });
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => {
+  const table = (name: string) =>
+    new Proxy({}, { get: (_target, prop) => `${name}.${String(prop)}` });
+  return {
+    and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+    claimEscalationAgreements: table('agreement'),
+    domainEventDeliveries: table('deliveries'),
+    domainEventDeliveryIdempotencyKey: vi.fn(
+      (eventId: string, consumerName: string) => `domain-event:${consumerName}:${eventId}`
+    ),
+    domainEvents: table('events'),
+    eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+    recordDomainEventDelivery: vi.fn(),
+    selectDomainEventsForRelay: vi.fn(),
+    sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
+    subscriptions: table('subscriptions'),
+  };
+});
+
+vi.mock('@interdomestik/database', () => dbMocks);
+vi.mock('../paddle-server', () => ({ getPaddle: vi.fn() }));
+type Sub = { id: string; providerSubscriptionId?: string | null };
+vi.mock('../subscription', () => ({
+  resolveProviderSubscriptionHandle: (sub: Sub) => sub.providerSubscriptionId || sub.id,
+}));
+
+import {
+  RECOVERY_SUCCESS_FEE_BILLING_CONSUMER,
+  relayRecoverySuccessFeeBillingEvents,
+} from './recovery-success-fee-billing';
+
+type RelayTx = Parameters<typeof relayRecoverySuccessFeeBillingEvents>[0];
+const event = {
+  aggregateVersion: 1,
+  createdAt: new Date('2026-06-01T10:00:00Z'),
+  entityId: 'claim-1',
+  entityType: 'claim',
+  eventName: 'recovery.success_fee_collected',
+  eventVersion: 1,
+  id: 'event-1',
+  payload: {
+    collectionMethod: 'payment_method_charge',
+    currencyCode: 'EUR',
+    deductionAllowed: false,
+    hasInvoiceDueDate: false,
+    hasStoredPaymentMethod: true,
+    paymentAuthorizationState: 'authorized',
+  },
+  tenantId: 'tenant_ks',
+};
+
+const rowsQuery = (rows: unknown[]) => ({ limit: () => Promise.resolve(rows) });
+const whereRows = (rows: unknown[]) => ({ where: () => rowsQuery(rows) });
+const snapshotQuery = (rows: unknown[]) => ({ leftJoin: () => ({ where: () => rowsQuery(rows) }) });
+
+function snapshotRow(overrides: Record<string, unknown> = {}) {
+  return {
+    collectionMethod: 'payment_method_charge',
+    currencyCode: 'EUR',
+    feeAmount: '15.50',
+    invoiceDueAt: null,
+    paymentAuthorizationState: 'authorized',
+    providerCustomerId: 'ctm_123',
+    providerSubscriptionId: 'sub_paddle_123',
+    subscriptionId: 'sub-1',
+    ...overrides,
+  };
+}
+
+function fakeTx(options: { deliveryRows?: unknown[]; snapshotRows?: unknown[] } = {}): RelayTx {
+  return {
+    select: vi.fn(() => ({
+      from: (table: unknown) => {
+        if (table === dbMocks.domainEventDeliveries) {
+          return whereRows(options.deliveryRows ?? []);
+        }
+        if (table === dbMocks.domainEvents) {
+          return whereRows([]);
+        }
+        return snapshotQuery(options.snapshotRows ?? [snapshotRow()]);
+      },
+    })),
+    execute: vi.fn(),
+  } as unknown as RelayTx;
+}
+describe('relayRecoverySuccessFeeBillingEvents', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('bills an undelivered recovery.success_fee_collected@1 event then records delivery', async () => {
+    const billSuccessFee = vi.fn().mockResolvedValue({ status: 'skipped_deduction' });
+    const tx = fakeTx();
+    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([event]);
+    dbMocks.recordDomainEventDelivery.mockResolvedValueOnce({ status: 'delivered' });
+
+    const result = await relayRecoverySuccessFeeBillingEvents(tx, {
+      deps: { billSuccessFee },
+      limit: 10,
+      tenantId: 'tenant_ks',
+    });
+
+    expect(dbMocks.selectDomainEventsForRelay).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        consumerName: RECOVERY_SUCCESS_FEE_BILLING_CONSUMER,
+        tenantId: 'tenant_ks',
+      })
+    );
+    expect(billSuccessFee).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: `domain-event:${RECOVERY_SUCCESS_FEE_BILLING_CONSUMER}:event-1`,
+        snapshot: expect.objectContaining({
+          providerCustomerId: 'ctm_123',
+          providerSubscriptionId: 'sub_paddle_123',
+          tenantId: 'tenant_ks',
+        }),
+      })
+    );
+    expect(dbMocks.recordDomainEventDelivery).toHaveBeenCalledTimes(1);
+    expect(result.billingResults).toEqual([{ status: 'skipped_deduction' }]);
+    expect(result).toMatchObject({ delivered: 1, selected: 1, skippedAlreadyDelivered: 0 });
+  });
+
+  it('skips Paddle work when replay selects an already delivered event', async () => {
+    const billSuccessFee = vi.fn();
+    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([event]);
+    const result = await relayRecoverySuccessFeeBillingEvents(
+      fakeTx({ deliveryRows: [{ id: 'delivery-1' }] }),
+      { deps: { billSuccessFee }, limit: 10, mode: 'replay', tenantId: 'tenant_ks' }
+    );
+
+    expect(billSuccessFee).not.toHaveBeenCalled();
+    expect(dbMocks.recordDomainEventDelivery).not.toHaveBeenCalled();
+    expect(result.skippedAlreadyDelivered).toBe(1);
+  });
+
+  it('rejects payload and snapshot mismatches before marking delivery', async () => {
+    const badEvent = { ...event, payload: { ...event.payload, currencyCode: 'USD' } };
+    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([badEvent]);
+
+    await expect(
+      relayRecoverySuccessFeeBillingEvents(
+        fakeTx({ snapshotRows: [snapshotRow({ currencyCode: 'EUR' })] }),
+        { deps: { billSuccessFee: vi.fn() }, limit: 10, tenantId: 'tenant_ks' }
+      )
+    ).rejects.toThrow(/snapshot does not match/);
+    expect(dbMocks.recordDomainEventDelivery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing.ts
@@ -1,0 +1,143 @@
+import {
+  and,
+  domainEventDeliveries,
+  domainEventDeliveryIdempotencyKey,
+  domainEvents,
+  eq,
+  recordDomainEventDelivery,
+  selectDomainEventsForRelay,
+  sql,
+  type DomainEventRelayEvent,
+  type DomainEventTx,
+  type RelayMode,
+} from '@interdomestik/database';
+
+import { getPaddle } from '../paddle-server';
+import {
+  createPaddleSuccessFeeTransaction,
+  type PaddleSuccessFeeBillingResult,
+  type RecoverySuccessFeeBillingSnapshot,
+} from './paddle-success-fee-charge';
+import {
+  assertPayloadMatchesSnapshot,
+  requireSuccessFeePayload,
+  resolveSuccessFeeBillingSnapshot,
+} from './recovery-success-fee-snapshot';
+import { RECOVERY_SUCCESS_FEE_BILLING_CONSUMER } from './success-fee-consumer';
+
+export { RECOVERY_SUCCESS_FEE_BILLING_CONSUMER };
+
+type RelayTx = DomainEventTx & { execute<T>(query: unknown): Promise<T[]> };
+type BillingDeps = {
+  billSuccessFee?: (params: {
+    event: DomainEventRelayEvent;
+    idempotencyKey: string;
+    snapshot: RecoverySuccessFeeBillingSnapshot;
+  }) => Promise<PaddleSuccessFeeBillingResult>;
+};
+
+async function hasDelivery(tx: DomainEventTx, eventId: string) {
+  const [row] = await tx
+    .select({ id: domainEventDeliveries.id })
+    .from(domainEventDeliveries)
+    .where(
+      and(
+        eq(domainEventDeliveries.eventId, eventId),
+        eq(domainEventDeliveries.consumerName, RECOVERY_SUCCESS_FEE_BILLING_CONSUMER)
+      )
+    )
+    .limit(1);
+  return Boolean(row);
+}
+
+async function hasNewerCollectedEvent(tx: DomainEventTx, event: DomainEventRelayEvent) {
+  const [row] = await tx
+    .select({ id: domainEvents.id })
+    .from(domainEvents)
+    .where(
+      and(
+        eq(domainEvents.tenantId, event.tenantId),
+        eq(domainEvents.entityType, event.entityType),
+        eq(domainEvents.entityId, event.entityId),
+        eq(domainEvents.eventName, event.eventName),
+        eq(domainEvents.eventVersion, event.eventVersion),
+        sql`${domainEvents.aggregateVersion} > ${event.aggregateVersion}`
+      )
+    )
+    .limit(1);
+  return Boolean(row);
+}
+
+async function deliverSuccessFeeBillingEvent(
+  tx: DomainEventTx,
+  event: DomainEventRelayEvent,
+  idempotencyKey: string,
+  deps: BillingDeps
+) {
+  const payload = requireSuccessFeePayload(event);
+  const snapshot = await resolveSuccessFeeBillingSnapshot(tx, event);
+  assertPayloadMatchesSnapshot(payload, snapshot);
+  if (deps.billSuccessFee) return deps.billSuccessFee({ event, idempotencyKey, snapshot });
+  return createPaddleSuccessFeeTransaction({
+    idempotencyKey,
+    paddle: getPaddle({ tenantId: event.tenantId }) as never,
+    snapshot,
+  });
+}
+
+export async function relayRecoverySuccessFeeBillingEvents(
+  tx: RelayTx,
+  params: { deps?: BillingDeps; limit: number; mode?: RelayMode; tenantId: string }
+) {
+  const events = await selectDomainEventsForRelay(tx, {
+    consumerName: RECOVERY_SUCCESS_FEE_BILLING_CONSUMER,
+    eventName: 'recovery.success_fee_collected',
+    eventVersion: 1,
+    limit: params.limit,
+    mode: params.mode,
+    tenantId: params.tenantId,
+  });
+  let delivered = 0;
+  let skippedAlreadyDelivered = 0;
+  let skippedStale = 0;
+  const billingResults: PaddleSuccessFeeBillingResult[] = [];
+
+  for (const event of events) {
+    if (params.mode === 'replay' && (await hasDelivery(tx, event.id))) {
+      skippedAlreadyDelivered += 1;
+      continue;
+    }
+    if (await hasNewerCollectedEvent(tx, event)) {
+      const delivery = await recordDomainEventDelivery(tx, {
+        consumerName: RECOVERY_SUCCESS_FEE_BILLING_CONSUMER,
+        eventId: event.id,
+        tenantId: event.tenantId,
+      });
+      if (delivery.status === 'already_delivered') skippedAlreadyDelivered += 1;
+      else skippedStale += 1;
+      continue;
+    }
+    const idempotencyKey = domainEventDeliveryIdempotencyKey(
+      event.id,
+      RECOVERY_SUCCESS_FEE_BILLING_CONSUMER
+    );
+    billingResults.push(
+      await deliverSuccessFeeBillingEvent(tx, event, idempotencyKey, params.deps ?? {})
+    );
+    const delivery = await recordDomainEventDelivery(tx, {
+      consumerName: RECOVERY_SUCCESS_FEE_BILLING_CONSUMER,
+      eventId: event.id,
+      tenantId: event.tenantId,
+    });
+    if (delivery.status === 'already_delivered') skippedAlreadyDelivered += 1;
+    else delivered += 1;
+  }
+
+  return {
+    billingResults,
+    delivered,
+    selected: events.length,
+    skippedAlreadyDelivered,
+    skippedStale,
+  };
+}

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-snapshot.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-snapshot.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => {
+  const table = (name: string) =>
+    new Proxy({}, { get: (_target, prop) => `${name}.${String(prop)}` });
+  return {
+    and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+    claimEscalationAgreements: table('agreement'),
+    eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+    subscriptions: table('subscriptions'),
+  };
+});
+
+vi.mock('@interdomestik/database', () => dbMocks);
+vi.mock('../subscription', () => ({
+  resolveProviderSubscriptionHandle: (sub: {
+    id: string;
+    providerSubscriptionId?: string | null;
+  }) => sub.providerSubscriptionId || sub.id,
+}));
+
+import {
+  requireSuccessFeePayload,
+  resolveSuccessFeeBillingSnapshot,
+} from './recovery-success-fee-snapshot';
+
+type SnapshotEvent = Parameters<typeof resolveSuccessFeeBillingSnapshot>[1];
+type SnapshotTx = Parameters<typeof resolveSuccessFeeBillingSnapshot>[0];
+
+const event: SnapshotEvent = {
+  actorId: 'staff-1',
+  actorRole: 'staff',
+  aggregateVersion: 1,
+  correlationId: 'event-1',
+  createdAt: new Date('2026-06-01T10:00:00Z'),
+  entityId: 'claim-1',
+  entityType: 'claim',
+  eventName: 'recovery.success_fee_collected',
+  eventVersion: 1,
+  id: 'event-1',
+  payload: {},
+  tenantId: 'tenant_foreign',
+};
+
+function rowsQuery(rows: unknown[]) {
+  return { limit: () => Promise.resolve(rows) };
+}
+
+function snapshotQuery(rows: unknown[]) {
+  return { leftJoin: () => ({ where: () => rowsQuery(rows) }) };
+}
+
+function fakeTx(): SnapshotTx {
+  return {
+    select: vi.fn(() => ({
+      from: () =>
+        snapshotQuery([
+          {
+            collectionMethod: 'payment_method_charge',
+            currencyCode: 'EUR',
+            feeAmount: '15.50',
+            invoiceDueAt: null,
+            paymentAuthorizationState: 'authorized',
+            providerCustomerId: 'ctm_123',
+            providerSubscriptionId: 'sub_paddle_123',
+            subscriptionId: 'sub-1',
+          },
+        ]),
+    })),
+  } as unknown as SnapshotTx;
+}
+
+describe('resolveSuccessFeeBillingSnapshot', () => {
+  it('scopes the snapshot and subscription lookup to the event tenant', async () => {
+    await expect(resolveSuccessFeeBillingSnapshot(fakeTx(), event)).resolves.toEqual(
+      expect.objectContaining({
+        claimId: 'claim-1',
+        providerSubscriptionId: 'sub_paddle_123',
+        tenantId: 'tenant_foreign',
+      })
+    );
+
+    expect(dbMocks.eq).toHaveBeenCalledWith('agreement.tenantId', 'tenant_foreign');
+    expect(dbMocks.eq).toHaveBeenCalledWith('agreement.claimId', 'claim-1');
+    expect(dbMocks.eq).toHaveBeenCalledWith('subscriptions.tenantId', 'tenant_foreign');
+  });
+
+  it('rejects success-fee events missing boolean payload fields', () => {
+    expect(() =>
+      requireSuccessFeePayload({
+        ...event,
+        payload: {
+          collectionMethod: 'payment_method_charge',
+          currencyCode: 'EUR',
+          paymentAuthorizationState: 'authorized',
+        },
+      })
+    ).toThrow(/missing required payload fields/);
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-snapshot.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-snapshot.ts
@@ -1,0 +1,116 @@
+import {
+  and,
+  claimEscalationAgreements,
+  eq,
+  subscriptions,
+  type DomainEventRelayEvent,
+  type DomainEventTx,
+} from '@interdomestik/database';
+
+import { resolveProviderSubscriptionHandle } from '../subscription';
+import type { RecoverySuccessFeeBillingSnapshot } from './paddle-success-fee-charge';
+
+type SuccessFeePayload = {
+  collectionMethod: RecoverySuccessFeeBillingSnapshot['collectionMethod'];
+  currencyCode: string;
+  deductionAllowed: boolean;
+  hasInvoiceDueDate: boolean;
+  hasStoredPaymentMethod: boolean;
+  paymentAuthorizationState: RecoverySuccessFeeBillingSnapshot['paymentAuthorizationState'];
+};
+
+function assertBooleanPayloadField(
+  payload: Partial<SuccessFeePayload>,
+  field: 'deductionAllowed' | 'hasInvoiceDueDate' | 'hasStoredPaymentMethod'
+) {
+  if (typeof payload[field] !== 'boolean') {
+    throw new TypeError('success-fee billing event is missing required payload fields');
+  }
+}
+
+export function requireSuccessFeePayload(event: DomainEventRelayEvent): SuccessFeePayload {
+  if (
+    event.eventName !== 'recovery.success_fee_collected' ||
+    event.eventVersion !== 1 ||
+    event.entityType !== 'claim'
+  ) {
+    throw new Error('success-fee billing only consumes recovery.success_fee_collected@1');
+  }
+  const payload = event.payload as Partial<SuccessFeePayload>;
+  if (!payload.collectionMethod || !payload.currencyCode || !payload.paymentAuthorizationState) {
+    throw new Error('success-fee billing event is missing required payload fields');
+  }
+  assertBooleanPayloadField(payload, 'deductionAllowed');
+  assertBooleanPayloadField(payload, 'hasInvoiceDueDate');
+  assertBooleanPayloadField(payload, 'hasStoredPaymentMethod');
+  return payload as SuccessFeePayload;
+}
+
+export function assertPayloadMatchesSnapshot(
+  payload: SuccessFeePayload,
+  snapshot: RecoverySuccessFeeBillingSnapshot
+) {
+  const invoiceDueAtMatches = Boolean(snapshot.invoiceDueAt) === payload.hasInvoiceDueDate;
+  if (
+    payload.collectionMethod !== snapshot.collectionMethod ||
+    payload.currencyCode !== snapshot.currencyCode ||
+    payload.paymentAuthorizationState !== snapshot.paymentAuthorizationState ||
+    Boolean(snapshot.providerCustomerId) !== payload.hasStoredPaymentMethod ||
+    !invoiceDueAtMatches
+  ) {
+    throw new Error('success-fee billing snapshot does not match the collected event payload');
+  }
+}
+
+export async function resolveSuccessFeeBillingSnapshot(
+  tx: DomainEventTx,
+  event: DomainEventRelayEvent
+): Promise<RecoverySuccessFeeBillingSnapshot> {
+  const [row] = await tx
+    .select({
+      collectionMethod: claimEscalationAgreements.successFeeCollectionMethod,
+      currencyCode: claimEscalationAgreements.successFeeCurrencyCode,
+      feeAmount: claimEscalationAgreements.successFeeAmount,
+      invoiceDueAt: claimEscalationAgreements.successFeeInvoiceDueAt,
+      paymentAuthorizationState: claimEscalationAgreements.paymentAuthorizationState,
+      providerCustomerId: subscriptions.providerCustomerId,
+      providerSubscriptionId: subscriptions.providerSubscriptionId,
+      subscriptionId: subscriptions.id,
+    })
+    .from(claimEscalationAgreements)
+    .leftJoin(
+      subscriptions,
+      and(
+        eq(claimEscalationAgreements.successFeeSubscriptionId, subscriptions.id),
+        eq(subscriptions.tenantId, event.tenantId)
+      )
+    )
+    .where(
+      and(
+        eq(claimEscalationAgreements.tenantId, event.tenantId),
+        eq(claimEscalationAgreements.claimId, event.entityId)
+      )
+    )
+    .limit(1);
+
+  if (!row?.collectionMethod || !row.currencyCode || !row.feeAmount) {
+    throw new Error('success-fee billing snapshot is unavailable for collected event');
+  }
+
+  return {
+    claimId: event.entityId,
+    collectionMethod: row.collectionMethod,
+    currencyCode: row.currencyCode,
+    feeAmount: String(row.feeAmount),
+    invoiceDueAt: row.invoiceDueAt,
+    paymentAuthorizationState: row.paymentAuthorizationState,
+    providerCustomerId: row.providerCustomerId?.trim() || null,
+    providerSubscriptionId: row.subscriptionId
+      ? resolveProviderSubscriptionHandle({
+          id: row.subscriptionId,
+          providerSubscriptionId: row.providerSubscriptionId,
+        })
+      : null,
+    tenantId: event.tenantId,
+  };
+}

--- a/packages/domain-membership-billing/src/success-fees/success-fee-amount.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/success-fee-amount.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { toMinorUnitAmount } from './success-fee-amount';
+
+describe('toMinorUnitAmount', () => {
+  it('uses three decimal minor units for supported currencies', () => {
+    expect(toMinorUnitAmount('1.234', 'KWD')).toBe('1234');
+  });
+
+  it('uses zero decimal minor units for supported currencies', () => {
+    expect(toMinorUnitAmount('123.50', 'JPY')).toBe('124');
+  });
+
+  it('rejects unsupported currencies instead of guessing minor units', () => {
+    expect(() => toMinorUnitAmount('1.23', 'ZZZ')).toThrow(/currency is unsupported/);
+  });
+
+  it('normalizes currency code whitespace', () => {
+    expect(toMinorUnitAmount('1.23', ' EUR ')).toBe('123');
+  });
+
+  it('rejects zero or malformed amounts', () => {
+    expect(() => toMinorUnitAmount('0.00', 'EUR')).toThrow(/positive fee amount/);
+    expect(() => toMinorUnitAmount('not-money', 'EUR')).toThrow(/positive fee amount/);
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/success-fee-amount.ts
+++ b/packages/domain-membership-billing/src/success-fees/success-fee-amount.ts
@@ -1,0 +1,56 @@
+const CURRENCY_MINOR_UNITS: Record<string, number> = {
+  AED: 2,
+  AUD: 2,
+  BHD: 3,
+  BRL: 2,
+  CAD: 2,
+  CHF: 2,
+  CLP: 0,
+  CNY: 2,
+  CZK: 2,
+  DKK: 2,
+  EUR: 2,
+  GBP: 2,
+  HKD: 2,
+  HUF: 2,
+  ILS: 2,
+  INR: 2,
+  JOD: 3,
+  JPY: 0,
+  KRW: 0,
+  KWD: 3,
+  MXN: 2,
+  NOK: 2,
+  NZD: 2,
+  OMR: 3,
+  PLN: 2,
+  SEK: 2,
+  SGD: 2,
+  THB: 2,
+  TND: 3,
+  TRY: 2,
+  TWD: 2,
+  USD: 2,
+  ZAR: 2,
+};
+
+function pow10(decimals: number): bigint {
+  return BigInt(10 ** decimals);
+}
+
+export function toMinorUnitAmount(amount: string, currencyCode: string): string {
+  const decimals = CURRENCY_MINOR_UNITS[currencyCode.trim().toUpperCase()];
+  if (decimals == null) throw new Error('success-fee billing currency is unsupported');
+
+  const match = /^(\d+)(?:\.(\d+))?$/.exec(amount.trim());
+  if (!match) throw new Error('success-fee billing requires a positive fee amount');
+
+  const fractional = match[2] ?? '';
+  const minorDigits = (fractional + '0'.repeat(decimals)).slice(0, decimals);
+  const roundingDigit = fractional[decimals] ?? '0';
+  let minor = BigInt(match[1]) * pow10(decimals) + BigInt(minorDigits || '0');
+
+  if (roundingDigit >= '5') minor += 1n;
+  if (minor <= 0n) throw new Error('success-fee billing requires a positive fee amount');
+  return minor.toString();
+}

--- a/packages/domain-membership-billing/src/success-fees/success-fee-consumer.ts
+++ b/packages/domain-membership-billing/src/success-fees/success-fee-consumer.ts
@@ -1,0 +1,2 @@
+export const RECOVERY_SUCCESS_FEE_BILLING_CONSUMER =
+  'billing.recovery_success_fee_collected.paddle';

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35550391,
-  "maxTrackedFiles": 4154,
+  "maxTrackedBytes": 35596385,
+  "maxTrackedFiles": 4171,
   "maxCategoryBytes": {
     "large support/generated-ish": 17696728,
-    "source/scripts": 6633188,
+    "source/scripts": 6653611,
     "docs/text": 5087756,
-    "tests/e2e": 4454468,
-    "config/data/messages": 1549750,
+    "tests/e2e": 4479171,
+    "config/data/messages": 1549954,
     "other": 129165
   },
   "maxLargestFileBytes": 2844299,


### PR DESCRIPTION
## Summary
- Adds a billing-side consumer for `recovery.success_fee_collected@1` domain events.
- Bridges recovery success-fee collection to Paddle transactions without direct claims-to-billing coupling.
- Adds replay-safe delivery handling, stale-event suppression, tenant-scoped billing snapshot resolution, Paddle idempotency lookup, invoice payment terms, and exact minor-unit amount conversion.

## Changed Areas
- `packages/domain-membership-billing/src/success-fees/*`
- `packages/domain-membership-billing` exports
- `scripts/repo-size-budget.json` after size-budget sync

## Verification
- Focused billing unit tests: 8 files, 23 tests passed.
- `pnpm --filter @interdomestik/domain-membership-billing type-check` passed.
- `pnpm check:modularity-guard` passed.
- `pnpm repo:size:check` passed.
- `pnpm check:db-access` passed.
- `pnpm check:architecture-boundaries` passed.
- `pnpm slice:verify` passed.
- MCP `security_guard` passed.
- `pnpm pr:verify` passed.
- Standalone `pnpm e2e:gate` passed: 134 passed, 8 skipped.

## Reviewer and Security Disposition
- Claude Sonnet 4.6 external review ran; findings were fixed or dispositioned.
- Codex reviewer follow-up attempts blocked with repeated no-output hangs; final attempt was interrupted after repeated silent polls and produced no findings.
- Codex Security diff-scan tool was unavailable through tool discovery; repo `security_guard` passed.

## Phase C Boundaries
- No changes to `apps/web/src/proxy.ts`.
- No canonical route, auth, tenancy, or claims table changes.
- No `domain-claims` import from billing.
- Paddle-only billing preserved.

## Rollback
- Revert this PR to remove the new billing-side consumer and Paddle success-fee charge helpers. Existing recovery event emission remains untouched.