### PR TITLE
fix: bind Paddle billing to stored snapshots

### DIFF
--- a/apps/web/src/app/api/webhooks/paddle/[entity]/_core.snapshot.test.ts
+++ b/apps/web/src/app/api/webhooks/paddle/[entity]/_core.snapshot.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  dbSubscriptionFindFirst: vi.fn(),
+  dbUserFindFirst: vi.fn(),
+  handlePaddleWebhookCore: vi.fn(),
+  parsePaddleWebhookBody: vi.fn(),
+  verifyPaddleWebhook: vi.fn(),
+}));
+
+vi.mock('../_core', () => ({ handlePaddleWebhookCore: hoisted.handlePaddleWebhookCore }));
+vi.mock('@interdomestik/domain-membership-billing/paddle-webhooks', async () => {
+  const actual = await vi.importActual<
+    typeof import('@interdomestik/domain-membership-billing/paddle-webhooks')
+  >('@interdomestik/domain-membership-billing/paddle-webhooks');
+  return {
+    ...actual,
+    parsePaddleWebhookBody: hoisted.parsePaddleWebhookBody,
+    verifyPaddleWebhook: hoisted.verifyPaddleWebhook,
+  };
+});
+vi.mock('@interdomestik/database', () => ({
+  db: {
+    query: {
+      subscriptions: { findFirst: hoisted.dbSubscriptionFindFirst },
+      user: { findFirst: hoisted.dbUserFindFirst },
+    },
+  },
+}));
+
+import { handlePaddleWebhookEntityCore } from './_core';
+
+describe('handlePaddleWebhookEntityCore billing snapshots', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.handlePaddleWebhookCore.mockResolvedValue({ status: 200, body: { success: true } });
+    hoisted.parsePaddleWebhookBody.mockReturnValue({
+      eventIdFromPayload: 'evt_mk',
+      eventTimestampFromPayload: new Date('2026-02-23T00:00:00.000Z'),
+      eventTypeFromPayload: 'transaction.completed',
+      parsedPayload: { data: {}, event_type: 'transaction.completed' },
+    });
+  });
+
+  it('uses the stored subscription billing snapshot before custom tenant metadata', async () => {
+    hoisted.verifyPaddleWebhook.mockResolvedValue({
+      eventData: {
+        data: {
+          customData: { tenantId: 'tenant_ks', userId: 'user_ks' },
+          subscriptionId: 'sub_paddle_mk',
+        },
+        eventId: 'evt_mk',
+        eventType: 'transaction.completed',
+      },
+      signatureBypassed: false,
+      signatureValid: true,
+    });
+    hoisted.dbSubscriptionFindFirst.mockResolvedValue({
+      billingEntity: 'mk',
+      legalTenantId: 'tenant_mk',
+      tenantId: 'tenant_ks',
+      userId: 'user_ks',
+    });
+
+    const result = await handlePaddleWebhookEntityCore({
+      bodyText: '{"event_type":"transaction.completed"}',
+      expectedEntity: 'mk',
+      headers: new Headers({ 'paddle-signature': 'sig_mk' }),
+      paddle: { mocked: true } as never,
+      secret: 'whsec_mk',
+      signature: 'sig_mk',
+    });
+
+    expect(result).toEqual({ status: 200, body: { success: true } });
+    expect(hoisted.dbSubscriptionFindFirst).toHaveBeenCalledTimes(1);
+    expect(hoisted.dbUserFindFirst).not.toHaveBeenCalled();
+    expect(hoisted.handlePaddleWebhookCore).toHaveBeenCalledWith(
+      expect.objectContaining({ billingEntity: 'mk' })
+    );
+  });
+});

--- a/apps/web/src/app/api/webhooks/paddle/[entity]/_core.ts
+++ b/apps/web/src/app/api/webhooks/paddle/[entity]/_core.ts
@@ -1,106 +1,13 @@
-import { db } from '@interdomestik/database';
-import {
-  resolveBillingEntityForTenantId,
-  resolveBillingEntityFromPathSegment,
-  type BillingEntity,
-} from '@interdomestik/domain-membership-billing/paddle-server';
+import type { BillingEntity } from '@interdomestik/domain-membership-billing/paddle-server';
 import {
   parsePaddleWebhookBody,
   verifyPaddleWebhook,
 } from '@interdomestik/domain-membership-billing/paddle-webhooks';
-import { findSubscriptionByProviderReference } from '@interdomestik/domain-membership-billing/subscription';
 
 import type { Paddle } from '@paddle/paddle-node-sdk';
 
 import { handlePaddleWebhookCore, type PaddleWebhookCoreResult } from '../_core';
-
-type PaddleWebhookCustomData = {
-  userId?: string;
-  tenantId?: string;
-  tenant_id?: string;
-  entity?: string;
-  billingEntity?: string;
-  billing_entity?: string;
-};
-
-type PaddleWebhookData = {
-  id?: string;
-  subscriptionId?: string | null;
-  subscription_id?: string | null;
-  customData?: PaddleWebhookCustomData;
-  custom_data?: PaddleWebhookCustomData;
-};
-
-function resolveCustomData(payload: PaddleWebhookData): PaddleWebhookCustomData {
-  return (payload.customData || payload.custom_data || {}) as PaddleWebhookCustomData;
-}
-
-function resolveExplicitTenantId(data: unknown): string | null {
-  const payload = (data ?? {}) as PaddleWebhookData;
-  const customData = resolveCustomData(payload);
-  const tenantId = customData.tenantId || customData.tenant_id;
-  if (!tenantId || typeof tenantId !== 'string') return null;
-  const normalized = tenantId.trim();
-  return normalized.length > 0 ? normalized : null;
-}
-
-function resolveExplicitEntity(data: unknown): BillingEntity | null {
-  const payload = (data ?? {}) as PaddleWebhookData;
-  const customData = resolveCustomData(payload);
-  const entityValue = customData.entity || customData.billingEntity || customData.billing_entity;
-  return resolveBillingEntityFromPathSegment(entityValue);
-}
-
-async function resolveTenantIdFromWebhookData(data: unknown): Promise<string | null> {
-  try {
-    const payload = (data ?? {}) as PaddleWebhookData;
-    const customData = resolveCustomData(payload);
-    const userId = customData.userId;
-
-    if (userId) {
-      // db-access-guard: tenant-scoped -- reason: tenantId resolved into local variable before this DB call
-      const userRecord = await db.query.user.findFirst({
-        where: (users, { eq }) => eq(users.id, userId),
-        columns: { tenantId: true },
-      });
-      if (userRecord?.tenantId) return userRecord.tenantId;
-    }
-
-    const subscriptionId = payload.id || payload.subscriptionId || payload.subscription_id;
-    if (!subscriptionId) return null;
-
-    const subscription = await findSubscriptionByProviderReference(subscriptionId);
-
-    return subscription?.tenantId ?? null;
-  } catch {
-    return null;
-  }
-}
-
-async function isEntityMismatch(expectedEntity: BillingEntity, data: unknown): Promise<boolean> {
-  const explicitEntity = resolveExplicitEntity(data);
-  if (explicitEntity && explicitEntity !== expectedEntity) {
-    return true;
-  }
-
-  const explicitTenantId = resolveExplicitTenantId(data);
-  if (explicitTenantId) {
-    const explicitTenantEntity = resolveBillingEntityForTenantId(explicitTenantId);
-    if (explicitTenantEntity && explicitTenantEntity !== expectedEntity) {
-      return true;
-    }
-  }
-
-  try {
-    const tenantId = await resolveTenantIdFromWebhookData(data);
-    if (!tenantId) return false;
-
-    const tenantEntity = resolveBillingEntityForTenantId(tenantId);
-    return Boolean(tenantEntity && tenantEntity !== expectedEntity);
-  } catch {
-    return false;
-  }
-}
+import { isEntityMismatch } from './entity-mismatch';
 
 async function preflightEntityMismatchCheck(args: {
   expectedEntity: BillingEntity;

--- a/apps/web/src/app/api/webhooks/paddle/[entity]/entity-mismatch.ts
+++ b/apps/web/src/app/api/webhooks/paddle/[entity]/entity-mismatch.ts
@@ -1,0 +1,92 @@
+import { db } from '@interdomestik/database';
+import {
+  normalizeBillingText,
+  resolveBillingScopeFromSnapshot,
+  type BillingScopeSnapshot,
+} from '@interdomestik/domain-membership-billing/billing-snapshot';
+import {
+  resolveBillingEntityFromPathSegment,
+  type BillingEntity,
+} from '@interdomestik/domain-membership-billing/paddle-server';
+import { findSubscriptionByProviderReference } from '@interdomestik/domain-membership-billing';
+
+type PaddleWebhookCustomData = {
+  billingEntity?: string;
+  billing_entity?: string;
+  entity?: string;
+  tenantId?: string;
+  tenant_id?: string;
+  userId?: string;
+};
+
+type PaddleWebhookData = {
+  id?: string;
+  subscriptionId?: string | null;
+  subscription_id?: string | null;
+  customData?: PaddleWebhookCustomData;
+  custom_data?: PaddleWebhookCustomData;
+};
+
+function resolveCustomData(payload: PaddleWebhookData): PaddleWebhookCustomData {
+  return payload.customData || payload.custom_data || {};
+}
+
+function resolveExplicitEntity(payload: PaddleWebhookData): BillingEntity | null {
+  const customData = resolveCustomData(payload);
+  return resolveBillingEntityFromPathSegment(
+    customData.entity || customData.billingEntity || customData.billing_entity
+  );
+}
+
+function resolveEntityFromSnapshot(snapshot: BillingScopeSnapshot): BillingEntity | null {
+  try {
+    return resolveBillingScopeFromSnapshot(snapshot, 'webhook entity preflight snapshot')
+      .billingEntity;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveSnapshotEntity(payload: PaddleWebhookData): Promise<BillingEntity | null> {
+  const subscriptionId =
+    normalizeBillingText(payload.subscriptionId) ||
+    normalizeBillingText(payload.subscription_id) ||
+    normalizeBillingText(payload.id);
+  if (!subscriptionId) return null;
+
+  const subscription = await findSubscriptionByProviderReference(subscriptionId);
+  if (!subscription) return null;
+
+  return resolveEntityFromSnapshot(subscription);
+}
+
+async function resolveFallbackEntity(payload: PaddleWebhookData): Promise<BillingEntity | null> {
+  const customData = resolveCustomData(payload);
+  const explicitTenantId = normalizeBillingText(customData.tenantId || customData.tenant_id);
+  if (explicitTenantId) return resolveEntityFromSnapshot({ legalTenantId: explicitTenantId });
+
+  const userId = normalizeBillingText(customData.userId);
+  if (!userId) return null;
+
+  // db-access-guard: system-exempt -- reason: Paddle userId lookup bootstraps route preflight
+  const userRecord = await db.query.user.findFirst({
+    where: (users, { eq }) => eq(users.id, userId),
+    columns: { tenantId: true },
+  });
+  return resolveEntityFromSnapshot({ legalTenantId: userRecord?.tenantId });
+}
+
+export async function isEntityMismatch(
+  expectedEntity: BillingEntity,
+  data: unknown
+): Promise<boolean> {
+  const payload = (data ?? {}) as PaddleWebhookData;
+  const snapshotEntity = await resolveSnapshotEntity(payload);
+  if (snapshotEntity) return snapshotEntity !== expectedEntity;
+
+  const explicitEntity = resolveExplicitEntity(payload);
+  if (explicitEntity) return explicitEntity !== expectedEntity;
+
+  const fallbackEntity = await resolveFallbackEntity(payload);
+  return Boolean(fallbackEntity && fallbackEntity !== expectedEntity);
+}

--- a/packages/domain-membership-billing/package.json
+++ b/packages/domain-membership-billing/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./annual-membership": "./src/annual-membership.ts",
+    "./billing-snapshot": "./src/billing-snapshot.ts",
     "./paddle": "./src/paddle.ts",
     "./paddle-server": "./src/paddle-server.ts",
     "./subscription": "./src/subscription.ts",

--- a/packages/domain-membership-billing/src/billing-snapshot.ts
+++ b/packages/domain-membership-billing/src/billing-snapshot.ts
@@ -1,0 +1,57 @@
+import {
+  resolveBillingEntityForLegalTenantId,
+  resolveBillingEntityFromPathSegment,
+  type BillingEntity,
+} from './paddle-server';
+
+export type BillingScopeSnapshot = {
+  billingEntity?: string | null;
+  legalTenantId?: string | null;
+  tenantId?: string | null;
+};
+
+export type ResolvedBillingScope = {
+  billingEntity: BillingEntity;
+  legalTenantId: string;
+  tenantId: string;
+};
+
+export function normalizeBillingText(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function resolveBillingScopeFromSnapshot(
+  snapshot: BillingScopeSnapshot,
+  label = 'billing snapshot'
+): ResolvedBillingScope {
+  const legalTenantId =
+    normalizeBillingText(snapshot.legalTenantId) ?? normalizeBillingText(snapshot.tenantId);
+  if (!legalTenantId) {
+    throw new Error(`${label} is missing legal tenant scope`);
+  }
+
+  const snapshotEntity = resolveBillingEntityFromPathSegment(snapshot.billingEntity);
+  if (snapshot.billingEntity && !snapshotEntity) {
+    throw new Error(`${label} has unsupported billing entity ${snapshot.billingEntity}`);
+  }
+
+  const legalTenantEntity = resolveBillingEntityForLegalTenantId(legalTenantId);
+  if (snapshotEntity && legalTenantEntity && snapshotEntity !== legalTenantEntity) {
+    throw new Error(
+      `${label} billing entity ${snapshotEntity} conflicts with legal tenant ${legalTenantId}`
+    );
+  }
+
+  const billingEntity = snapshotEntity ?? legalTenantEntity;
+  if (!billingEntity) {
+    throw new Error(`${label} cannot resolve billing entity for legal tenant ${legalTenantId}`);
+  }
+
+  return {
+    billingEntity,
+    legalTenantId,
+    tenantId: legalTenantId,
+  };
+}

--- a/packages/domain-membership-billing/src/paddle-server.ts
+++ b/packages/domain-membership-billing/src/paddle-server.ts
@@ -142,7 +142,6 @@ function shouldAllowLegacyFallback(options: ResolveBillingEntityConfigOptions): 
 
 function resolvePaddleEnvironment(): Environment {
   const value = getOptionalEnv('NEXT_PUBLIC_PADDLE_ENV');
-  // The env var is string-based; map known values to SDK Environment values explicitly.
   if (!value || value === 'sandbox') {
     return Environment.sandbox;
   }
@@ -170,6 +169,7 @@ export function resolveBillingEntityForTenantId(
   if (!tenantId || !isBillingTenantId(tenantId)) return null;
   return BILLING_ENTITY_BY_TENANT[tenantId];
 }
+export const resolveBillingEntityForLegalTenantId = resolveBillingEntityForTenantId;
 
 export function resolveBillingTenantIdForEntity(entity: BillingEntity): BillingTenantId {
   return BILLING_TENANT_BY_ENTITY[entity];

--- a/packages/domain-membership-billing/src/paddle-webhooks/invariant-scope.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/invariant-scope.ts
@@ -1,0 +1,113 @@
+import { findSubscriptionByProviderReference } from '../subscription';
+import { resolveBillingEntityFromPathSegment, type BillingEntity } from '../paddle-server';
+import {
+  normalizeBillingText,
+  resolveBillingScopeFromSnapshot,
+  type ResolvedBillingScope,
+} from '../billing-snapshot';
+import { RECOVERY_SUCCESS_FEE_BILLING_CONSUMER } from '../success-fees/success-fee-consumer';
+
+type ScopeCustomData = {
+  billingEntity?: string;
+  billing_entity?: string;
+  domainEventConsumer?: string;
+  entity?: string;
+  legalTenantId?: string;
+  legal_tenant_id?: string;
+  recoveryLegalTenantId?: string;
+  recovery_legal_tenant_id?: string;
+  tenantId?: string;
+  tenant_id?: string;
+};
+
+type ScopePayload = {
+  subscriptionId?: string | null;
+  subscription_id?: string | null;
+  customData?: ScopeCustomData;
+  custom_data?: ScopeCustomData;
+};
+
+function resolveCustomData(payload: ScopePayload): ScopeCustomData {
+  return payload.customData || payload.custom_data || {};
+}
+
+function resolveCustomEntity(customData: ScopeCustomData): BillingEntity | null {
+  const rawEntity = normalizeBillingText(
+    customData.billingEntity || customData.billing_entity || customData.entity
+  );
+  if (!rawEntity) return null;
+  const entity = resolveBillingEntityFromPathSegment(rawEntity);
+  if (!entity) {
+    throw new Error(`Unsupported webhook billing entity metadata: ${rawEntity}`);
+  }
+  return entity;
+}
+
+function assertRouteEntityMatches(
+  scope: ResolvedBillingScope,
+  routeEntity?: BillingEntity | null
+): ResolvedBillingScope {
+  if (routeEntity && routeEntity !== scope.billingEntity) {
+    throw new Error(
+      `Billing entity mismatch for legal tenant ${scope.legalTenantId}: expected ${scope.billingEntity}, received ${routeEntity}`
+    );
+  }
+  return scope;
+}
+
+export async function resolveInvariantScope(params: {
+  billingEntity?: BillingEntity | null;
+  data: unknown;
+  tenantId?: string | null;
+}): Promise<ResolvedBillingScope> {
+  const payload = (params.data ?? {}) as ScopePayload;
+  const customData = resolveCustomData(payload);
+  const customEntity = resolveCustomEntity(customData);
+  const customTenantId = normalizeBillingText(customData.tenantId || customData.tenant_id);
+  const customLegalTenantId = normalizeBillingText(
+    customData.recoveryLegalTenantId ||
+      customData.recovery_legal_tenant_id ||
+      customData.legalTenantId ||
+      customData.legal_tenant_id
+  );
+  if (
+    customData.domainEventConsumer === RECOVERY_SUCCESS_FEE_BILLING_CONSUMER &&
+    customLegalTenantId
+  ) {
+    return assertRouteEntityMatches(
+      resolveBillingScopeFromSnapshot(
+        {
+          billingEntity: customEntity ?? params.billingEntity,
+          legalTenantId: customLegalTenantId,
+          tenantId: customTenantId,
+        },
+        'recovery success-fee billing snapshot'
+      ),
+      params.billingEntity
+    );
+  }
+
+  const subscriptionId = normalizeBillingText(payload.subscriptionId || payload.subscription_id);
+  if (subscriptionId) {
+    const subscription = await findSubscriptionByProviderReference(subscriptionId);
+    if (subscription) {
+      return assertRouteEntityMatches(
+        resolveBillingScopeFromSnapshot(subscription, 'subscription billing snapshot'),
+        params.billingEntity
+      );
+    }
+  }
+
+  return assertRouteEntityMatches(
+    resolveBillingScopeFromSnapshot(
+      {
+        billingEntity: customEntity ?? params.billingEntity,
+        legalTenantId:
+          customLegalTenantId ?? normalizeBillingText(params.tenantId) ?? customTenantId,
+        tenantId: normalizeBillingText(params.tenantId) ?? customTenantId,
+      },
+      'webhook billing snapshot'
+    ),
+    params.billingEntity
+  );
+}

--- a/packages/domain-membership-billing/src/paddle-webhooks/invariants-snapshot-scope.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/invariants-snapshot-scope.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  billingInvoices: {
+    billingEntity: 'invoice_billing_entity_col',
+    id: 'invoice_id_col',
+    providerTransactionId: 'invoice_provider_transaction_id_col',
+    tenantId: 'invoice_tenant_id_col',
+    updatedAt: 'invoice_updated_at_col',
+  },
+  billingLedgerEntries: { id: 'ledger_id_col' },
+  invoiceOnConflictDoUpdate: vi.fn(),
+  invoiceReturning: vi.fn(),
+  invoiceValues: vi.fn(),
+  ledgerOnConflictDoNothing: vi.fn(),
+  ledgerReturning: vi.fn(),
+  ledgerValues: vi.fn(),
+  sql: vi.fn(() => ({ mockedSql: true })),
+  subscriptionFindFirst: vi.fn(),
+  transaction: vi.fn(),
+  txInsert: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  billingInvoices: hoisted.billingInvoices,
+  billingLedgerEntries: hoisted.billingLedgerEntries,
+  db: {
+    query: { subscriptions: { findFirst: hoisted.subscriptionFindFirst } },
+    transaction: hoisted.transaction,
+  },
+  sql: hoisted.sql,
+}));
+
+import { persistInvoiceAndLedgerInvariants } from './invariants';
+
+function transactionInput(customData?: Record<string, string>) {
+  return {
+    billingEntity: 'mk' as const,
+    data: {
+      customData,
+      details: { totals: { currencyCode: 'eur', total: '1000' } },
+      subscriptionId: 'sub_paddle_1',
+    },
+    eventId: 'evt_1',
+    eventType: 'transaction.completed',
+    headers: new Headers(),
+    providerTransactionId: 'tx_1',
+    tenantId: 'tenant_ks',
+    webhookEventRowId: 'we_1',
+  };
+}
+
+describe('persistInvoiceAndLedgerInvariants snapshot scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const tx = { insert: hoisted.txInsert };
+    hoisted.transaction.mockImplementation(async callback => callback(tx));
+    hoisted.txInsert.mockImplementation(table => {
+      if (table === hoisted.billingInvoices) return { values: hoisted.invoiceValues };
+      if (table === hoisted.billingLedgerEntries) return { values: hoisted.ledgerValues };
+      throw new Error(`Unexpected table insert target: ${String(table)}`);
+    });
+    hoisted.invoiceValues.mockReturnValue({
+      onConflictDoUpdate: hoisted.invoiceOnConflictDoUpdate,
+    });
+    hoisted.invoiceOnConflictDoUpdate.mockReturnValue({ returning: hoisted.invoiceReturning });
+    hoisted.invoiceReturning.mockResolvedValue([{ id: 'inv_1' }]);
+    hoisted.ledgerValues.mockReturnValue({
+      onConflictDoNothing: hoisted.ledgerOnConflictDoNothing,
+    });
+    hoisted.ledgerOnConflictDoNothing.mockReturnValue({ returning: hoisted.ledgerReturning });
+    hoisted.ledgerReturning.mockResolvedValue([{ id: 'led_1' }]);
+  });
+
+  it('uses stored subscription legal tenant and billing entity for invoice scope', async () => {
+    hoisted.subscriptionFindFirst.mockResolvedValue({
+      billingEntity: 'mk',
+      id: 'sub_1',
+      legalTenantId: 'tenant_mk',
+      tenantId: 'tenant_ks',
+    });
+
+    await persistInvoiceAndLedgerInvariants(transactionInput());
+
+    expect(hoisted.invoiceValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingEntity: 'mk',
+        subscriptionId: 'sub_paddle_1',
+        tenantId: 'tenant_mk',
+      })
+    );
+    expect(hoisted.ledgerValues).toHaveBeenCalledWith(
+      expect.objectContaining({ billingEntity: 'mk', tenantId: 'tenant_mk' })
+    );
+  });
+
+  it('uses recovery success-fee legal tenant metadata before subscription scope', async () => {
+    hoisted.subscriptionFindFirst.mockResolvedValue({
+      billingEntity: 'ks',
+      id: 'sub_1',
+      legalTenantId: 'tenant_ks',
+      tenantId: 'tenant_ks',
+    });
+
+    await persistInvoiceAndLedgerInvariants(
+      transactionInput({
+        billingEntity: 'mk',
+        domainEventConsumer: 'billing.recovery_success_fee_collected.paddle',
+        recoveryLegalTenantId: 'tenant_mk',
+        tenantId: 'tenant_ks',
+      })
+    );
+
+    expect(hoisted.invoiceValues).toHaveBeenCalledWith(
+      expect.objectContaining({ billingEntity: 'mk', tenantId: 'tenant_mk' })
+    );
+  });
+
+  it('rejects route entity conflicts when subscription lookup misses', async () => {
+    hoisted.subscriptionFindFirst.mockResolvedValue(null);
+
+    await expect(
+      persistInvoiceAndLedgerInvariants(
+        transactionInput({
+          tenantId: 'tenant_ks',
+        })
+      )
+    ).rejects.toThrow('conflicts with legal tenant');
+    expect(hoisted.subscriptionFindFirst).toHaveBeenCalledTimes(1);
+    expect(hoisted.invoiceValues).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported explicit billing entity metadata', async () => {
+    await expect(
+      persistInvoiceAndLedgerInvariants(transactionInput({ billingEntity: 'zz' }))
+    ).rejects.toThrow('Unsupported webhook billing entity metadata');
+    expect(hoisted.invoiceValues).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-membership-billing/src/paddle-webhooks/invariants.test.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/invariants.test.ts
@@ -101,7 +101,7 @@ describe('persistInvoiceAndLedgerInvariants', () => {
         providerTransactionId: 'tx_1',
         data: {},
       })
-    ).rejects.toThrow('Missing tenantId');
+    ).rejects.toThrow('missing legal tenant scope');
   });
 
   it('rejects transaction events when provided entity mismatches tenant entity', async () => {
@@ -116,7 +116,7 @@ describe('persistInvoiceAndLedgerInvariants', () => {
         providerTransactionId: 'tx_1',
         data: {},
       })
-    ).rejects.toThrow('Billing entity mismatch');
+    ).rejects.toThrow('conflicts with legal tenant');
   });
 
   it('rejects transaction events without a valid amount total', async () => {
@@ -172,7 +172,6 @@ describe('persistInvoiceAndLedgerInvariants', () => {
       tenantId: 'tenant_ks',
       providerTransactionId: 'tx_1',
       data: {
-        subscriptionId: 'sub_1',
         details: {
           totals: {
             total: '1000',

--- a/packages/domain-membership-billing/src/paddle-webhooks/invariants.ts
+++ b/packages/domain-membership-billing/src/paddle-webhooks/invariants.ts
@@ -1,7 +1,8 @@
 import { billingInvoices, billingLedgerEntries, db, sql } from '@interdomestik/database';
 import { nanoid } from 'nanoid';
 
-import { resolveBillingEntityForTenantId, type BillingEntity } from '../paddle-server';
+import type { BillingEntity } from '../paddle-server';
+import { resolveInvariantScope } from './invariant-scope';
 import type { PaddleWebhookAuditDeps } from './types';
 
 type TransactionTotalsPayload = {
@@ -35,30 +36,6 @@ function normalizeCurrencyCode(value: string | null | undefined): string | null 
   if (!normalized) return null;
   const uppercase = normalized.toUpperCase();
   return /^[A-Z]{3}$/.test(uppercase) ? uppercase : null;
-}
-
-function resolveInvariantScope(params: {
-  tenantId?: string | null;
-  billingEntity?: BillingEntity | null;
-}): { tenantId: string; billingEntity: BillingEntity } {
-  const tenantId = normalizeText(params.tenantId);
-  if (!tenantId) {
-    throw new Error('Missing tenantId for invoice/ledger invariant persistence');
-  }
-
-  const mappedEntity = resolveBillingEntityForTenantId(tenantId);
-  if (params.billingEntity && mappedEntity && mappedEntity !== params.billingEntity) {
-    throw new Error(
-      `Billing entity mismatch for tenant ${tenantId}: expected ${mappedEntity}, received ${params.billingEntity}`
-    );
-  }
-
-  const billingEntity = params.billingEntity ?? mappedEntity;
-  if (!billingEntity) {
-    throw new Error(`Unable to resolve billing entity for tenant ${tenantId}`);
-  }
-
-  return { tenantId, billingEntity };
 }
 
 export type PersistInvoiceAndLedgerInvariantsResult =
@@ -102,12 +79,13 @@ export async function persistInvoiceAndLedgerInvariants(
     throw new Error('Missing provider transaction id for invoice/ledger invariant persistence');
   }
 
-  const { tenantId, billingEntity } = resolveInvariantScope({
+  const payload = (params.data ?? {}) as TransactionInvariantPayload;
+  const { tenantId, billingEntity } = await resolveInvariantScope({
+    data: payload,
     tenantId: params.tenantId,
     billingEntity: params.billingEntity,
   });
 
-  const payload = (params.data ?? {}) as TransactionInvariantPayload;
   const totals = payload.details?.totals || {};
   const amount = normalizeAmount(totals.total);
   if (!amount) {

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-charge.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-charge.ts
@@ -7,11 +7,13 @@ import {
   buildPaddleInvoiceTransactionRequest,
   buildPaddleSubscriptionChargeRequest,
 } from './paddle-success-fee-request';
+import type { BillingEntity } from '../paddle-server';
 
 export type RecoverySuccessFeeCollectionMethod = 'deduction' | 'payment_method_charge' | 'invoice';
 
 export type RecoverySuccessFeeBillingSnapshot = Readonly<{
   claimId: string;
+  billingEntity: BillingEntity;
   collectionMethod: RecoverySuccessFeeCollectionMethod;
   currencyCode: string;
   feeAmount: string;
@@ -19,6 +21,8 @@ export type RecoverySuccessFeeBillingSnapshot = Readonly<{
   paymentAuthorizationState: 'pending' | 'authorized' | 'revoked';
   providerCustomerId: string | null;
   providerSubscriptionId: string | null;
+  recoveryLegalTenantId: string;
+  subscriptionBillingEntity: BillingEntity | null;
   tenantId: string;
 }>;
 

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-request.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-request.ts
@@ -9,9 +9,11 @@ export function buildSuccessFeeCustomData(
 ) {
   return {
     claimId: snapshot.claimId,
+    billingEntity: snapshot.billingEntity,
     domainEventConsumer: RECOVERY_SUCCESS_FEE_BILLING_CONSUMER,
     idempotencyKey,
     originSubscriptionId: snapshot.providerSubscriptionId,
+    recoveryLegalTenantId: snapshot.recoveryLegalTenantId,
     tenantId: snapshot.tenantId,
   };
 }

--- a/packages/domain-membership-billing/src/success-fees/paddle-success-fee-test-helpers.ts
+++ b/packages/domain-membership-billing/src/success-fees/paddle-success-fee-test-helpers.ts
@@ -13,8 +13,70 @@ export type PaddleSuccessFeeClientMock = PaddleSuccessFeeClient & {
   transactions: { create: Mock; list: Mock };
 };
 
+type DbTableProxy = Record<string, string>;
+
+export type RecoverySuccessFeeDbMocks = {
+  and: Mock;
+  claims: DbTableProxy;
+  claimEscalationAgreements: DbTableProxy;
+  domainEventDeliveries: DbTableProxy;
+  domainEventDeliveryIdempotencyKey: Mock;
+  domainEvents: DbTableProxy;
+  eq: Mock;
+  recordDomainEventDelivery: Mock;
+  selectDomainEventsForRelay: Mock;
+  sql: Mock;
+  subscriptions: DbTableProxy;
+};
+
 export async function* paddleTransactions(rows: PaddleTransaction[]) {
   yield* rows;
+}
+
+export function createRecoverySuccessFeeDbMocks(): RecoverySuccessFeeDbMocks {
+  const table = (name: string): DbTableProxy =>
+    new Proxy({}, { get: (_target, prop) => `${name}.${String(prop)}` });
+  return {
+    and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+    claims: table('claims'),
+    claimEscalationAgreements: table('agreement'),
+    domainEventDeliveries: table('deliveries'),
+    domainEventDeliveryIdempotencyKey: vi.fn(
+      (eventId: string, consumerName = 'billing') => `domain-event:${consumerName}:${eventId}`
+    ),
+    domainEvents: table('events'),
+    eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+    recordDomainEventDelivery: vi.fn(),
+    selectDomainEventsForRelay: vi.fn(),
+    sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
+    subscriptions: table('subscriptions'),
+  };
+}
+
+export function successFeeCollectedEvent(
+  overrides: Record<string, unknown> = {},
+  payloadOverrides: Record<string, unknown> = {}
+) {
+  return {
+    aggregateVersion: 1,
+    createdAt: new Date('2026-06-01T10:00:00Z'),
+    entityId: 'claim-1',
+    entityType: 'claim',
+    eventName: 'recovery.success_fee_collected',
+    eventVersion: 1,
+    id: 'event-1',
+    payload: {
+      collectionMethod: 'payment_method_charge',
+      currencyCode: 'EUR',
+      deductionAllowed: false,
+      hasInvoiceDueDate: false,
+      hasStoredPaymentMethod: true,
+      paymentAuthorizationState: 'authorized',
+      ...payloadOverrides,
+    },
+    tenantId: 'tenant_ks',
+    ...overrides,
+  };
 }
 
 export function paddleMock(
@@ -40,6 +102,7 @@ export function paymentMethodSnapshot(
   overrides: Partial<RecoverySuccessFeeBillingSnapshot> = {}
 ): RecoverySuccessFeeBillingSnapshot {
   return {
+    billingEntity: 'ks',
     claimId: 'claim-1',
     collectionMethod: 'payment_method_charge',
     currencyCode: 'EUR',
@@ -48,6 +111,8 @@ export function paymentMethodSnapshot(
     paymentAuthorizationState: 'authorized',
     providerCustomerId: 'ctm_123',
     providerSubscriptionId: 'sub_123',
+    recoveryLegalTenantId: 'tenant_ks',
+    subscriptionBillingEntity: 'ks',
     tenantId: 'tenant_ks',
     ...overrides,
   };

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billable-snapshot.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billable-snapshot.ts
@@ -1,0 +1,22 @@
+import type { DomainEventRelayEvent } from '@interdomestik/database';
+
+import type { RecoverySuccessFeeBillingSnapshot } from './paddle-success-fee-charge';
+
+export function resolveBillableSuccessFeeSnapshot(
+  snapshot: RecoverySuccessFeeBillingSnapshot,
+  event: DomainEventRelayEvent
+): RecoverySuccessFeeBillingSnapshot {
+  if (
+    snapshot.collectionMethod !== 'payment_method_charge' ||
+    !snapshot.subscriptionBillingEntity ||
+    snapshot.subscriptionBillingEntity === snapshot.billingEntity
+  ) {
+    return snapshot;
+  }
+
+  return {
+    ...snapshot,
+    collectionMethod: 'invoice',
+    invoiceDueAt: snapshot.invoiceDueAt ?? event.createdAt,
+  };
+}

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing-entity.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing-entity.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = await vi.hoisted(async () => {
+  const helper = await import('./paddle-success-fee-test-helpers');
+  return helper.createRecoverySuccessFeeDbMocks();
+});
+const paddleServerMocks = vi.hoisted(() => ({ getPaddle: vi.fn() }));
+
+vi.mock('@interdomestik/database', () => dbMocks);
+vi.mock('../paddle-server', async () => {
+  const actual = await vi.importActual<typeof import('../paddle-server')>('../paddle-server');
+  return { ...actual, getPaddle: paddleServerMocks.getPaddle };
+});
+vi.mock('../subscription', () => ({
+  resolveProviderSubscriptionHandle: (sub: { id: string; providerSubscriptionId?: string }) =>
+    sub.providerSubscriptionId || sub.id,
+}));
+
+import { getPaddle } from '../paddle-server';
+import { relayRecoverySuccessFeeBillingEvents } from './recovery-success-fee-billing';
+import { paddleMock, successFeeCollectedEvent } from './paddle-success-fee-test-helpers';
+
+type RelayTx = Parameters<typeof relayRecoverySuccessFeeBillingEvents>[0];
+const event = successFeeCollectedEvent({}, { collectionMethod: 'deduction' });
+
+const rowsQuery = (rows: unknown[]) => ({ limit: () => Promise.resolve(rows) });
+const whereRows = (rows: unknown[]) => ({ where: () => rowsQuery(rows) });
+
+function fakeTx(
+  options: {
+    deliveryRows?: unknown[];
+    snapshotCurrency?: string;
+    snapshotOverrides?: Record<string, unknown>;
+  } = {}
+): RelayTx {
+  const snapshotRow = {
+    collectionMethod: 'deduction',
+    currencyCode: options.snapshotCurrency ?? 'EUR',
+    feeAmount: '15.50',
+    invoiceDueAt: null,
+    paymentAuthorizationState: 'authorized',
+    providerCustomerId: 'ctm_123',
+    providerSubscriptionId: 'sub_paddle_123',
+    recoveryLegalTenantId: 'tenant_mk',
+    subscriptionId: 'sub-1',
+    subscriptionBillingEntity: 'mk',
+    subscriptionLegalTenantId: 'tenant_mk',
+    subscriptionTenantId: 'tenant_ks',
+    ...options.snapshotOverrides,
+  };
+  const snapshotQuery = {
+    innerJoin: () => snapshotQuery,
+    leftJoin: () => snapshotQuery,
+    where: () => rowsQuery([snapshotRow]),
+  };
+  return {
+    select: vi.fn(() => ({
+      from: (table: unknown) => {
+        if (table === dbMocks.domainEvents) return whereRows([]);
+        if (table === dbMocks.domainEventDeliveries) return whereRows(options.deliveryRows ?? []);
+        return snapshotQuery;
+      },
+    })),
+    execute: vi.fn(),
+  } as unknown as RelayTx;
+}
+
+describe('relayRecoverySuccessFeeBillingEvents recovery entity', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('uses the recovery legal tenant entity when constructing the Paddle client', async () => {
+    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([event]);
+    dbMocks.recordDomainEventDelivery.mockResolvedValueOnce({ status: 'delivered' });
+
+    const result = await relayRecoverySuccessFeeBillingEvents(fakeTx(), {
+      limit: 10,
+      tenantId: 'tenant_ks',
+    });
+
+    expect(getPaddle).toHaveBeenCalledWith({ entity: 'mk' });
+    expect(result.billingResults).toEqual([{ status: 'skipped_deduction' }]);
+    expect(result).toMatchObject({ delivered: 1, selected: 1 });
+  });
+
+  it('invoices in the recovery entity when the stored payment subscription belongs elsewhere', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'txn_invoice' });
+    const createOneTimeCharge = vi.fn();
+    paddleServerMocks.getPaddle.mockReturnValue(paddleMock({ create, createOneTimeCharge }));
+    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([successFeeCollectedEvent()]);
+    dbMocks.recordDomainEventDelivery.mockResolvedValueOnce({ status: 'delivered' });
+
+    const result = await relayRecoverySuccessFeeBillingEvents(
+      fakeTx({
+        snapshotOverrides: {
+          collectionMethod: 'payment_method_charge',
+          subscriptionBillingEntity: 'ks',
+          subscriptionLegalTenantId: 'tenant_ks',
+        },
+      }),
+      { limit: 10, tenantId: 'tenant_ks' }
+    );
+
+    expect(getPaddle).toHaveBeenCalledWith({ entity: 'mk' });
+    expect(createOneTimeCharge).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionMode: 'manual', status: 'billed' })
+    );
+    expect(result.billingResults).toEqual([
+      { providerTransactionId: 'txn_invoice', status: 'paddle_invoice_billed' },
+    ]);
+  });
+
+  it('skips Paddle work when replay selects an already delivered event', async () => {
+    const billSuccessFee = vi.fn();
+    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([event]);
+
+    const result = await relayRecoverySuccessFeeBillingEvents(
+      fakeTx({ deliveryRows: [{ id: 'delivery-1' }] }),
+      { deps: { billSuccessFee }, limit: 10, mode: 'replay', tenantId: 'tenant_ks' }
+    );
+
+    expect(billSuccessFee).not.toHaveBeenCalled();
+    expect(dbMocks.recordDomainEventDelivery).not.toHaveBeenCalled();
+    expect(result.skippedAlreadyDelivered).toBe(1);
+  });
+
+  it('rejects payload and snapshot mismatches before marking delivery', async () => {
+    const badEvent = { ...event, payload: { ...event.payload, currencyCode: 'USD' } };
+    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([badEvent]);
+
+    await expect(
+      relayRecoverySuccessFeeBillingEvents(fakeTx({ snapshotCurrency: 'EUR' }), {
+        deps: { billSuccessFee: vi.fn() },
+        limit: 10,
+        tenantId: 'tenant_ks',
+      })
+    ).rejects.toThrow(/snapshot does not match/);
+    expect(dbMocks.recordDomainEventDelivery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing-stale.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing-stale.test.ts
@@ -1,24 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const dbMocks = vi.hoisted(() => {
-  const table = (name: string) =>
-    new Proxy({}, { get: (_target, prop) => `${name}.${String(prop)}` });
-  return {
-    and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
-    claimEscalationAgreements: table('agreement'),
-    domainEventDeliveries: table('deliveries'),
-    domainEventDeliveryIdempotencyKey: vi.fn((eventId: string) => `key:${eventId}`),
-    domainEvents: table('events'),
-    eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
-    recordDomainEventDelivery: vi.fn(),
-    selectDomainEventsForRelay: vi.fn(),
-    sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
-    subscriptions: table('subscriptions'),
-  };
+const dbMocks = await vi.hoisted(async () => {
+  const helper = await import('./paddle-success-fee-test-helpers');
+  return helper.createRecoverySuccessFeeDbMocks();
 });
 
 vi.mock('@interdomestik/database', () => dbMocks);
-vi.mock('../paddle-server', () => ({ getPaddle: vi.fn() }));
+vi.mock('../paddle-server', async () => {
+  const actual = await vi.importActual<typeof import('../paddle-server')>('../paddle-server');
+  return { ...actual, getPaddle: vi.fn() };
+});
 vi.mock('../subscription', () => ({
   resolveProviderSubscriptionHandle: (sub: {
     id: string;
@@ -27,31 +18,18 @@ vi.mock('../subscription', () => ({
 }));
 
 import { relayRecoverySuccessFeeBillingEvents } from './recovery-success-fee-billing';
+import { successFeeCollectedEvent } from './paddle-success-fee-test-helpers';
 
 type RelayTx = Parameters<typeof relayRecoverySuccessFeeBillingEvents>[0];
 
 function event(id: string, aggregateVersion: number) {
-  return {
+  return successFeeCollectedEvent({
     actorId: 'staff-1',
     actorRole: 'staff',
     aggregateVersion,
     correlationId: id,
-    createdAt: new Date('2026-06-01T10:00:00Z'),
-    entityId: 'claim-1',
-    entityType: 'claim',
-    eventName: 'recovery.success_fee_collected',
-    eventVersion: 1,
     id,
-    payload: {
-      collectionMethod: 'payment_method_charge',
-      currencyCode: 'EUR',
-      deductionAllowed: false,
-      hasInvoiceDueDate: false,
-      hasStoredPaymentMethod: true,
-      paymentAuthorizationState: 'authorized',
-    },
-    tenantId: 'tenant_ks',
-  };
+  });
 }
 
 function rowsQuery(rows: unknown[]) {
@@ -63,7 +41,12 @@ function whereRows(rows: unknown[]) {
 }
 
 function snapshotQuery(row: unknown) {
-  return { leftJoin: () => ({ where: () => rowsQuery([row]) }) };
+  const query = {
+    innerJoin: () => query,
+    leftJoin: () => query,
+    where: () => rowsQuery([row]),
+  };
+  return query;
 }
 
 function fakeTx(newerRows: unknown[][]): RelayTx {
@@ -75,7 +58,11 @@ function fakeTx(newerRows: unknown[][]): RelayTx {
     paymentAuthorizationState: 'authorized',
     providerCustomerId: 'ctm_123',
     providerSubscriptionId: 'sub_paddle_123',
+    recoveryLegalTenantId: 'tenant_ks',
     subscriptionId: 'sub-1',
+    subscriptionBillingEntity: 'ks',
+    subscriptionLegalTenantId: 'tenant_ks',
+    subscriptionTenantId: 'tenant_ks',
   };
   return {
     select: vi.fn(() => ({

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing.test.ts
@@ -1,26 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const dbMocks = vi.hoisted(() => {
-  const table = (name: string) =>
-    new Proxy({}, { get: (_target, prop) => `${name}.${String(prop)}` });
-  return {
-    and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
-    claimEscalationAgreements: table('agreement'),
-    domainEventDeliveries: table('deliveries'),
-    domainEventDeliveryIdempotencyKey: vi.fn(
-      (eventId: string, consumerName: string) => `domain-event:${consumerName}:${eventId}`
-    ),
-    domainEvents: table('events'),
-    eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
-    recordDomainEventDelivery: vi.fn(),
-    selectDomainEventsForRelay: vi.fn(),
-    sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
-    subscriptions: table('subscriptions'),
-  };
+const dbMocks = await vi.hoisted(async () => {
+  const helper = await import('./paddle-success-fee-test-helpers');
+  return helper.createRecoverySuccessFeeDbMocks();
 });
 
 vi.mock('@interdomestik/database', () => dbMocks);
-vi.mock('../paddle-server', () => ({ getPaddle: vi.fn() }));
+vi.mock('../paddle-server', async () => {
+  const actual = await vi.importActual<typeof import('../paddle-server')>('../paddle-server');
+  return { ...actual, getPaddle: vi.fn() };
+});
 type Sub = { id: string; providerSubscriptionId?: string | null };
 vi.mock('../subscription', () => ({
   resolveProviderSubscriptionHandle: (sub: Sub) => sub.providerSubscriptionId || sub.id,
@@ -30,30 +19,21 @@ import {
   RECOVERY_SUCCESS_FEE_BILLING_CONSUMER,
   relayRecoverySuccessFeeBillingEvents,
 } from './recovery-success-fee-billing';
+import { successFeeCollectedEvent } from './paddle-success-fee-test-helpers';
 
 type RelayTx = Parameters<typeof relayRecoverySuccessFeeBillingEvents>[0];
-const event = {
-  aggregateVersion: 1,
-  createdAt: new Date('2026-06-01T10:00:00Z'),
-  entityId: 'claim-1',
-  entityType: 'claim',
-  eventName: 'recovery.success_fee_collected',
-  eventVersion: 1,
-  id: 'event-1',
-  payload: {
-    collectionMethod: 'payment_method_charge',
-    currencyCode: 'EUR',
-    deductionAllowed: false,
-    hasInvoiceDueDate: false,
-    hasStoredPaymentMethod: true,
-    paymentAuthorizationState: 'authorized',
-  },
-  tenantId: 'tenant_ks',
-};
+const event = successFeeCollectedEvent();
 
 const rowsQuery = (rows: unknown[]) => ({ limit: () => Promise.resolve(rows) });
 const whereRows = (rows: unknown[]) => ({ where: () => rowsQuery(rows) });
-const snapshotQuery = (rows: unknown[]) => ({ leftJoin: () => ({ where: () => rowsQuery(rows) }) });
+const snapshotQuery = (rows: unknown[]) => {
+  const query = {
+    innerJoin: () => query,
+    leftJoin: () => query,
+    where: () => rowsQuery(rows),
+  };
+  return query;
+};
 
 function snapshotRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -64,7 +44,11 @@ function snapshotRow(overrides: Record<string, unknown> = {}) {
     paymentAuthorizationState: 'authorized',
     providerCustomerId: 'ctm_123',
     providerSubscriptionId: 'sub_paddle_123',
+    recoveryLegalTenantId: 'tenant_ks',
     subscriptionId: 'sub-1',
+    subscriptionBillingEntity: 'ks',
+    subscriptionLegalTenantId: 'tenant_ks',
+    subscriptionTenantId: 'tenant_ks',
     ...overrides,
   };
 }
@@ -111,8 +95,10 @@ describe('relayRecoverySuccessFeeBillingEvents', () => {
       expect.objectContaining({
         idempotencyKey: `domain-event:${RECOVERY_SUCCESS_FEE_BILLING_CONSUMER}:event-1`,
         snapshot: expect.objectContaining({
+          billingEntity: 'ks',
           providerCustomerId: 'ctm_123',
           providerSubscriptionId: 'sub_paddle_123',
+          recoveryLegalTenantId: 'tenant_ks',
           tenantId: 'tenant_ks',
         }),
       })
@@ -120,31 +106,5 @@ describe('relayRecoverySuccessFeeBillingEvents', () => {
     expect(dbMocks.recordDomainEventDelivery).toHaveBeenCalledTimes(1);
     expect(result.billingResults).toEqual([{ status: 'skipped_deduction' }]);
     expect(result).toMatchObject({ delivered: 1, selected: 1, skippedAlreadyDelivered: 0 });
-  });
-
-  it('skips Paddle work when replay selects an already delivered event', async () => {
-    const billSuccessFee = vi.fn();
-    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([event]);
-    const result = await relayRecoverySuccessFeeBillingEvents(
-      fakeTx({ deliveryRows: [{ id: 'delivery-1' }] }),
-      { deps: { billSuccessFee }, limit: 10, mode: 'replay', tenantId: 'tenant_ks' }
-    );
-
-    expect(billSuccessFee).not.toHaveBeenCalled();
-    expect(dbMocks.recordDomainEventDelivery).not.toHaveBeenCalled();
-    expect(result.skippedAlreadyDelivered).toBe(1);
-  });
-
-  it('rejects payload and snapshot mismatches before marking delivery', async () => {
-    const badEvent = { ...event, payload: { ...event.payload, currencyCode: 'USD' } };
-    dbMocks.selectDomainEventsForRelay.mockResolvedValueOnce([badEvent]);
-
-    await expect(
-      relayRecoverySuccessFeeBillingEvents(
-        fakeTx({ snapshotRows: [snapshotRow({ currencyCode: 'EUR' })] }),
-        { deps: { billSuccessFee: vi.fn() }, limit: 10, tenantId: 'tenant_ks' }
-      )
-    ).rejects.toThrow(/snapshot does not match/);
-    expect(dbMocks.recordDomainEventDelivery).not.toHaveBeenCalled();
   });
 });

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-billing.ts
@@ -18,6 +18,7 @@ import {
   type PaddleSuccessFeeBillingResult,
   type RecoverySuccessFeeBillingSnapshot,
 } from './paddle-success-fee-charge';
+import { resolveBillableSuccessFeeSnapshot } from './recovery-success-fee-billable-snapshot';
 import {
   assertPayloadMatchesSnapshot,
   requireSuccessFeePayload,
@@ -77,11 +78,13 @@ async function deliverSuccessFeeBillingEvent(
   const payload = requireSuccessFeePayload(event);
   const snapshot = await resolveSuccessFeeBillingSnapshot(tx, event);
   assertPayloadMatchesSnapshot(payload, snapshot);
-  if (deps.billSuccessFee) return deps.billSuccessFee({ event, idempotencyKey, snapshot });
+  const billableSnapshot = resolveBillableSuccessFeeSnapshot(snapshot, event);
+  if (deps.billSuccessFee)
+    return deps.billSuccessFee({ event, idempotencyKey, snapshot: billableSnapshot });
   return createPaddleSuccessFeeTransaction({
     idempotencyKey,
-    paddle: getPaddle({ tenantId: event.tenantId }) as never,
-    snapshot,
+    paddle: getPaddle({ entity: billableSnapshot.billingEntity }) as never,
+    snapshot: billableSnapshot,
   });
 }
 

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-snapshot.test.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-snapshot.test.ts
@@ -5,6 +5,7 @@ const dbMocks = vi.hoisted(() => {
     new Proxy({}, { get: (_target, prop) => `${name}.${String(prop)}` });
   return {
     and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+    claims: table('claims'),
     claimEscalationAgreements: table('agreement'),
     eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
     subscriptions: table('subscriptions'),
@@ -47,10 +48,15 @@ function rowsQuery(rows: unknown[]) {
 }
 
 function snapshotQuery(rows: unknown[]) {
-  return { leftJoin: () => ({ where: () => rowsQuery(rows) }) };
+  const query = {
+    innerJoin: () => query,
+    leftJoin: () => query,
+    where: () => rowsQuery(rows),
+  };
+  return query;
 }
 
-function fakeTx(): SnapshotTx {
+function fakeTx(overrides: Record<string, unknown> = {}): SnapshotTx {
   return {
     select: vi.fn(() => ({
       from: () =>
@@ -63,7 +69,12 @@ function fakeTx(): SnapshotTx {
             paymentAuthorizationState: 'authorized',
             providerCustomerId: 'ctm_123',
             providerSubscriptionId: 'sub_paddle_123',
+            recoveryLegalTenantId: 'tenant_mk',
             subscriptionId: 'sub-1',
+            subscriptionBillingEntity: 'mk',
+            subscriptionLegalTenantId: 'tenant_mk',
+            subscriptionTenantId: 'tenant_foreign',
+            ...overrides,
           },
         ]),
     })),
@@ -74,15 +85,25 @@ describe('resolveSuccessFeeBillingSnapshot', () => {
   it('scopes the snapshot and subscription lookup to the event tenant', async () => {
     await expect(resolveSuccessFeeBillingSnapshot(fakeTx(), event)).resolves.toEqual(
       expect.objectContaining({
+        billingEntity: 'mk',
         claimId: 'claim-1',
         providerSubscriptionId: 'sub_paddle_123',
+        recoveryLegalTenantId: 'tenant_mk',
+        subscriptionBillingEntity: 'mk',
         tenantId: 'tenant_foreign',
       })
     );
 
     expect(dbMocks.eq).toHaveBeenCalledWith('agreement.tenantId', 'tenant_foreign');
     expect(dbMocks.eq).toHaveBeenCalledWith('agreement.claimId', 'claim-1');
+    expect(dbMocks.eq).toHaveBeenCalledWith('claims.tenantId', 'tenant_foreign');
     expect(dbMocks.eq).toHaveBeenCalledWith('subscriptions.tenantId', 'tenant_foreign');
+  });
+
+  it('treats missing recovery legal tenant as an unavailable billing snapshot', async () => {
+    await expect(
+      resolveSuccessFeeBillingSnapshot(fakeTx({ recoveryLegalTenantId: null }), event)
+    ).rejects.toThrow('success-fee billing snapshot is unavailable for collected event');
   });
 
   it('rejects success-fee events missing boolean payload fields', () => {

--- a/packages/domain-membership-billing/src/success-fees/recovery-success-fee-snapshot.ts
+++ b/packages/domain-membership-billing/src/success-fees/recovery-success-fee-snapshot.ts
@@ -1,5 +1,6 @@
 import {
   and,
+  claims,
   claimEscalationAgreements,
   eq,
   subscriptions,
@@ -7,6 +8,7 @@ import {
   type DomainEventTx,
 } from '@interdomestik/database';
 
+import { resolveBillingScopeFromSnapshot } from '../billing-snapshot';
 import { resolveProviderSubscriptionHandle } from '../subscription';
 import type { RecoverySuccessFeeBillingSnapshot } from './paddle-success-fee-charge';
 
@@ -18,6 +20,23 @@ type SuccessFeePayload = {
   hasStoredPaymentMethod: boolean;
   paymentAuthorizationState: RecoverySuccessFeeBillingSnapshot['paymentAuthorizationState'];
 };
+
+function resolveSubscriptionBillingEntity(row: {
+  subscriptionBillingEntity?: string | null;
+  subscriptionId?: string | null;
+  subscriptionLegalTenantId?: string | null;
+  subscriptionTenantId?: string | null;
+}) {
+  if (!row.subscriptionId) return null;
+  return resolveBillingScopeFromSnapshot(
+    {
+      billingEntity: row.subscriptionBillingEntity,
+      legalTenantId: row.subscriptionLegalTenantId,
+      tenantId: row.subscriptionTenantId,
+    },
+    'success-fee subscription billing snapshot'
+  ).billingEntity;
+}
 
 function assertBooleanPayloadField(
   payload: Partial<SuccessFeePayload>,
@@ -75,9 +94,17 @@ export async function resolveSuccessFeeBillingSnapshot(
       paymentAuthorizationState: claimEscalationAgreements.paymentAuthorizationState,
       providerCustomerId: subscriptions.providerCustomerId,
       providerSubscriptionId: subscriptions.providerSubscriptionId,
+      recoveryLegalTenantId: claims.recoveryLegalTenantId,
+      subscriptionBillingEntity: subscriptions.billingEntity,
       subscriptionId: subscriptions.id,
+      subscriptionLegalTenantId: subscriptions.legalTenantId,
+      subscriptionTenantId: subscriptions.tenantId,
     })
     .from(claimEscalationAgreements)
+    .innerJoin(
+      claims,
+      and(eq(claimEscalationAgreements.claimId, claims.id), eq(claims.tenantId, event.tenantId))
+    )
     .leftJoin(
       subscriptions,
       and(
@@ -93,11 +120,16 @@ export async function resolveSuccessFeeBillingSnapshot(
     )
     .limit(1);
 
-  if (!row?.collectionMethod || !row.currencyCode || !row.feeAmount) {
+  if (!row?.collectionMethod || !row.currencyCode || !row.feeAmount || !row.recoveryLegalTenantId) {
     throw new Error('success-fee billing snapshot is unavailable for collected event');
   }
+  const billingScope = resolveBillingScopeFromSnapshot(
+    { legalTenantId: row.recoveryLegalTenantId },
+    'success-fee recovery billing snapshot'
+  );
 
   return {
+    billingEntity: billingScope.billingEntity,
     claimId: event.entityId,
     collectionMethod: row.collectionMethod,
     currencyCode: row.currencyCode,
@@ -111,6 +143,8 @@ export async function resolveSuccessFeeBillingSnapshot(
           providerSubscriptionId: row.providerSubscriptionId,
         })
       : null,
+    recoveryLegalTenantId: billingScope.legalTenantId,
+    subscriptionBillingEntity: resolveSubscriptionBillingEntity(row),
     tenantId: event.tenantId,
   };
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35606415,
-  "maxTrackedFiles": 4171,
+  "maxTrackedBytes": 35628086,
+  "maxTrackedFiles": 4178,
   "maxCategoryBytes": {
     "large support/generated-ish": 17706319,
-    "source/scripts": 6653611,
+    "source/scripts": 6662968,
     "docs/text": 5088809,
-    "tests/e2e": 4479171,
-    "config/data/messages": 1549954,
+    "tests/e2e": 4490816,
+    "config/data/messages": 1550009,
     "other": 129165
   },
   "maxLargestFileBytes": 2851031,


### PR DESCRIPTION
## Summary
- bind Paddle webhook invoice/ledger writes to the stored membership billing snapshot instead of host/session-derived tenant scope
- bind recovery success-fee Paddle charges to the recovery agreement legal tenant and billing entity
- keep billing on the billing-side consumer path without adding direct domain-claims coupling; the success-fee snapshot reads the physical claims table through the database boundary

## Verification
- `pnpm pr:verify` passed locally on 3ad776db
- `pnpm security:guard` passed locally
- `pnpm e2e:gate` passed locally: 134 passed, 8 skipped
- focused web webhook unit tests passed: 2 files, 9 tests
- focused domain membership-billing unit tests passed: 7 files, 30 tests
- modularity guard passed for 19 changed text files against origin/main
- repo size budget sync/check passed

## Reviewer notes
- Codex senior reviewer passed before remediation with no correctness findings
- Claude Sonnet 4.6 external review findings were addressed: semantic legal-tenant resolver export restored, subscription lookup assertions added, subscription-miss route mismatch covered, and recovery snapshot test fixtures made less rigid
- Codex senior reviewer passed after remediation

## Phase C constraints
- `apps/web/src/proxy.ts` untouched
- canonical routes unchanged
- Paddle-only billing preserved
- no README, AGENTS, or architecture docs changed in this implementation PR
- domain-claims package compatibility preserved; no claims-to-billing package coupling added

Note: the MCP e2e gate wrapper timed out after 120s while the underlying command continued. A clean shell fallback captured the passing `pnpm e2e:gate` result above.