### PR TITLE
[codex] address e2e runner Copilot feedback

### DIFF
--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -11,24 +11,29 @@ const secretPath = path.join(rootDir, 'apps/web/.playwright/better-auth-secret')
 
 function readSecret() {
   try {
-    return fs.readFileSync(secretPath, 'utf8').trim();
+    return fs.readFileSync(secretPath, 'utf8').trim() || null;
   } catch (error) {
-    if (error?.code === 'ENOENT') return '';
+    if (error?.code === 'ENOENT') return null;
     throw error;
   }
+}
+
+function assertSecret(secret) {
+  if (!secret || secret.length < 32) throw new Error(`Invalid BETTER_AUTH_SECRET at ${secretPath}`);
+  return secret;
 }
 
 function loadSecret() {
   fs.mkdirSync(path.dirname(secretPath), { recursive: true });
   const secret = readSecret();
-  if (secret) return secret;
+  if (secret) return assertSecret(secret);
   const next = randomBytes(32).toString('base64url');
   try {
     fs.writeFileSync(secretPath, `${next}\n`, { flag: 'wx', mode: 0o600 });
     return next;
   } catch (error) {
     if (error?.code !== 'EEXIST') throw error;
-    return readSecret();
+    return assertSecret(readSecret());
   }
 }
 
@@ -40,60 +45,43 @@ const gateArgs = ['e2e/gate', ...strictWorkers];
 const setupArgs = ['e2e/setup.state.spec.ts', '--project=setup-ks', '--project=setup-mk'];
 const mergeArgs = ['e2e/gate', 'e2e/golden', '--grep-invert', '@quarantine|@visual|@legacy'];
 const pwArgs = ['--filter', '@interdomestik/web', 'exec', 'playwright', 'test'];
+const fastEnv = { PW_FAST_GATES: '1' };
+const ksSq = '--project=gate-ks-sq';
+const mkMk = '--project=gate-mk-mk';
+const mkContract = '--project=gate-mk-contract';
+const gateLane = (projects, state = false) => ({
+  gatekeeper: true,
+  state,
+  env: fastEnv,
+  playwrightArgs: [...gateArgs, ...projects],
+});
+const projectLane = (project, env) => ({
+  gatekeeper: true,
+  ...(env && { env }),
+  playwrightArgs: ['e2e/gate', project, ...strictArgs],
+});
 
 const laneDefinitions = {
   state: {
     playwrightArgs: [...setupArgs, ...strictWorkers],
   },
-  gate: {
-    gatekeeper: true,
-    state: true,
-    env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...gateArgs, '--project=gate-ks-sq', '--project=gate-mk-mk'],
-  },
-  pr: {
-    gatekeeper: true,
-    state: true,
-    env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...gateArgs, '--project=gate-ks-sq', '--project=gate-mk-contract'],
-  },
-  'gate-fast': {
-    gatekeeper: true,
-    env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...gateArgs, '--project=gate-ks-sq', '--project=gate-mk-mk'],
-  },
-  'pr-fast': {
-    gatekeeper: true,
-    env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...gateArgs, '--project=gate-ks-sq', '--project=gate-mk-contract'],
-  },
+  gate: gateLane([ksSq, mkMk], true),
+  pr: gateLane([ksSq, mkContract], true),
+  'gate-fast': gateLane([ksSq, mkMk]),
+  'pr-fast': gateLane([ksSq, mkContract]),
   merge: {
     gatekeeper: true,
     playwrightArgs: [...mergeArgs, '--project=ks-sq', '--project=mk-mk', ...workerArgs],
   },
   'merge-fast': {
     gatekeeper: true,
-    env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...mergeArgs, '--project=gate-ks-sq', '--project=gate-mk-mk', ...workerArgs],
+    env: fastEnv,
+    playwrightArgs: [...mergeArgs, ksSq, mkMk, ...workerArgs],
   },
-  ks: {
-    gatekeeper: true,
-    playwrightArgs: ['e2e/gate', '--project=gate-ks-sq', ...strictArgs],
-  },
-  mk: {
-    gatekeeper: true,
-    playwrightArgs: ['e2e/gate', '--project=gate-mk-mk', ...strictArgs],
-  },
-  'ks-fast': {
-    gatekeeper: true,
-    env: { PW_FAST_GATES: '1' },
-    playwrightArgs: ['e2e/gate', '--project=gate-ks-sq', ...strictArgs],
-  },
-  'mk-fast': {
-    gatekeeper: true,
-    env: { PW_FAST_GATES: '1' },
-    playwrightArgs: ['e2e/gate', '--project=gate-mk-mk', ...strictArgs],
-  },
+  ks: projectLane(ksSq),
+  mk: projectLane(mkMk),
+  'ks-fast': projectLane(ksSq, fastEnv),
+  'mk-fast': projectLane(mkMk, fastEnv),
   'front-door': {
     env: { PW_FRONT_DOOR: '1' },
     playwrightArgs: [
@@ -158,6 +146,6 @@ if (lane.gatekeeper) {
 }
 
 if (lane.state) {
-  run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs]);
+  run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], laneEnv);
 }
 run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], laneEnv);

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -6,33 +6,44 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const defaultDbUrl = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+const dbUrl = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
 const secretPath = path.join(rootDir, 'apps/web/.playwright/better-auth-secret');
 
-function loadLocalAuthSecret() {
+function readSecret() {
+  try {
+    return fs.readFileSync(secretPath, 'utf8').trim();
+  } catch (error) {
+    if (error?.code === 'ENOENT') return '';
+    throw error;
+  }
+}
+
+function loadSecret() {
   fs.mkdirSync(path.dirname(secretPath), { recursive: true });
-  let secret = fs.existsSync(secretPath) ? fs.readFileSync(secretPath, 'utf8').trim() : '';
+  const secret = readSecret();
   if (secret) return secret;
-  secret = randomBytes(32).toString('base64url');
-  fs.writeFileSync(secretPath, `${secret}\n`, { mode: 0o600 });
-  return secret;
+  const next = randomBytes(32).toString('base64url');
+  try {
+    fs.writeFileSync(secretPath, `${next}\n`, { flag: 'wx', mode: 0o600 });
+    return next;
+  } catch (error) {
+    if (error?.code !== 'EEXIST') throw error;
+    return readSecret();
+  }
 }
 
 const reportArgs = ['--trace=retain-on-failure', '--reporter=line'];
 const strictArgs = ['--max-failures=1', ...reportArgs];
 const workerArgs = ['--workers=1', ...reportArgs];
-const strictWorkerArgs = ['--workers=1', ...strictArgs];
-const gateArgs = ['e2e/gate', ...strictWorkerArgs];
-const pwCommandArgs = ['--filter', '@interdomestik/web', 'exec', 'playwright', 'test'];
+const strictWorkers = ['--workers=1', ...strictArgs];
+const gateArgs = ['e2e/gate', ...strictWorkers];
+const setupArgs = ['e2e/setup.state.spec.ts', '--project=setup-ks', '--project=setup-mk'];
+const mergeArgs = ['e2e/gate', 'e2e/golden', '--grep-invert', '@quarantine|@visual|@legacy'];
+const pwArgs = ['--filter', '@interdomestik/web', 'exec', 'playwright', 'test'];
 
 const laneDefinitions = {
   state: {
-    playwrightArgs: [
-      'e2e/setup.state.spec.ts',
-      '--project=setup-ks',
-      '--project=setup-mk',
-      ...strictWorkerArgs,
-    ],
+    playwrightArgs: [...setupArgs, ...strictWorkers],
   },
   gate: {
     gatekeeper: true,
@@ -58,28 +69,12 @@ const laneDefinitions = {
   },
   merge: {
     gatekeeper: true,
-    playwrightArgs: [
-      'e2e/gate',
-      'e2e/golden',
-      '--grep-invert',
-      '@quarantine|@visual|@legacy',
-      '--project=ks-sq',
-      '--project=mk-mk',
-      ...workerArgs,
-    ],
+    playwrightArgs: [...mergeArgs, '--project=ks-sq', '--project=mk-mk', ...workerArgs],
   },
   'merge-fast': {
     gatekeeper: true,
     env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [
-      'e2e/gate',
-      'e2e/golden',
-      '--grep-invert',
-      '@quarantine|@visual|@legacy',
-      '--project=gate-ks-sq',
-      '--project=gate-mk-mk',
-      ...workerArgs,
-    ],
+    playwrightArgs: [...mergeArgs, '--project=gate-ks-sq', '--project=gate-mk-mk', ...workerArgs],
   },
   ks: {
     gatekeeper: true,
@@ -105,7 +100,7 @@ const laneDefinitions = {
       'e2e/gate/front-door-session-context.spec.ts',
       '--project=front-door-ida-ks',
       '--project=front-door-ida-mk',
-      ...strictWorkerArgs,
+      ...strictWorkers,
     ],
   },
 };
@@ -132,12 +127,11 @@ if (!lane) {
   process.exit(2);
 }
 
-process.env.BETTER_AUTH_SECRET ||= loadLocalAuthSecret();
+process.env.BETTER_AUTH_SECRET ||= loadSecret();
 const baseEnv = {
   ...process.env,
-  E2E_DATABASE_URL: process.env.E2E_DATABASE_URL || defaultDbUrl,
-  E2E_DATABASE_URL_RLS:
-    process.env.E2E_DATABASE_URL_RLS || process.env.E2E_DATABASE_URL || defaultDbUrl,
+  E2E_DATABASE_URL: process.env.E2E_DATABASE_URL || dbUrl,
+  E2E_DATABASE_URL_RLS: process.env.E2E_DATABASE_URL_RLS || process.env.E2E_DATABASE_URL || dbUrl,
   NEXT_PUBLIC_BILLING_TEST_MODE: '1',
 };
 const laneEnv = lane.env ? { ...baseEnv, ...lane.env } : baseEnv;
@@ -164,6 +158,6 @@ if (lane.gatekeeper) {
 }
 
 if (lane.state) {
-  run('pnpm', [...pwCommandArgs, ...laneDefinitions.state.playwrightArgs]);
+  run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs]);
 }
-run('pnpm', [...pwCommandArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], laneEnv);
+run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], laneEnv);

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -113,10 +113,9 @@ if (!lane) {
   process.exit(2);
 }
 
-process.env.BETTER_AUTH_SECRET = assertSecret(
-  process.env.BETTER_AUTH_SECRET || loadSecret(),
-  'environment'
-);
+const envSecret = process.env.BETTER_AUTH_SECRET;
+process.env.BETTER_AUTH_SECRET =
+  envSecret === undefined ? loadSecret() : assertSecret(envSecret, 'environment');
 const baseEnv = {
   ...process.env,
   E2E_DATABASE_URL: process.env.E2E_DATABASE_URL || dbUrl,

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -18,25 +18,24 @@ function readSecret() {
   }
 }
 
-function assertSecret(secret) {
-  if (!secret || secret.length < 32) throw new Error(`Invalid BETTER_AUTH_SECRET at ${secretPath}`);
+function assertSecret(secret, source) {
+  if (!secret || secret.length < 32) throw new Error(`Invalid BETTER_AUTH_SECRET from ${source}`);
   return secret;
 }
 
 function loadSecret() {
   fs.mkdirSync(path.dirname(secretPath), { recursive: true });
   const secret = readSecret();
-  if (secret) return assertSecret(secret);
+  if (secret) return assertSecret(secret, secretPath);
   const next = randomBytes(32).toString('base64url');
   try {
     fs.writeFileSync(secretPath, `${next}\n`, { flag: 'wx', mode: 0o600 });
     return next;
   } catch (error) {
     if (error?.code !== 'EEXIST') throw error;
-    return assertSecret(readSecret());
+    return assertSecret(readSecret(), secretPath);
   }
 }
-
 const reportArgs = ['--trace=retain-on-failure', '--reporter=line'];
 const strictArgs = ['--max-failures=1', ...reportArgs];
 const workerArgs = ['--workers=1', ...reportArgs];
@@ -60,7 +59,6 @@ const projectLane = (project, env) => ({
   ...(env && { env }),
   playwrightArgs: ['e2e/gate', project, ...strictArgs],
 });
-
 const laneDefinitions = {
   state: {
     playwrightArgs: [...setupArgs, ...strictWorkers],
@@ -115,7 +113,10 @@ if (!lane) {
   process.exit(2);
 }
 
-process.env.BETTER_AUTH_SECRET ||= loadSecret();
+process.env.BETTER_AUTH_SECRET = assertSecret(
+  process.env.BETTER_AUTH_SECRET || loadSecret(),
+  'environment'
+);
 const baseEnv = {
   ...process.env,
   E2E_DATABASE_URL: process.env.E2E_DATABASE_URL || dbUrl,
@@ -125,13 +126,8 @@ const baseEnv = {
 const laneEnv = lane.env ? { ...baseEnv, ...lane.env } : baseEnv;
 const stateEnv = { ...laneEnv, PW_FAST_GATES: '0' };
 const finalEnv = laneName === 'state' ? stateEnv : laneEnv;
-
 function run(command, args, env = baseEnv) {
-  const result = spawnSync(command, args, {
-    cwd: rootDir,
-    env,
-    stdio: 'inherit',
-  });
+  const result = spawnSync(command, args, { cwd: rootDir, env, stdio: 'inherit' });
 
   if (result.error) {
     console.error(result.error);

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -1,30 +1,30 @@
 #!/usr/bin/env node
+import { randomBytes } from 'node:crypto';
+import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const defaultDbUrl = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
-process.env.BETTER_AUTH_SECRET ||= '12345678901234567890123456789012';
-const baseEnv = {
-  ...process.env,
-  E2E_DATABASE_URL: process.env.E2E_DATABASE_URL || defaultDbUrl,
-  E2E_DATABASE_URL_RLS:
-    process.env.E2E_DATABASE_URL_RLS || process.env.E2E_DATABASE_URL || defaultDbUrl,
-  NEXT_PUBLIC_BILLING_TEST_MODE: '1',
-};
+const localAuthSecretPath = path.join(rootDir, 'apps/web/.playwright/better-auth-secret');
 
-const commonGateArgs = [
-  'e2e/gate',
-  '--workers=1',
-  '--max-failures=1',
-  '--trace=retain-on-failure',
-  '--reporter=line',
-];
+function loadLocalBetterAuthSecret() {
+  fs.mkdirSync(path.dirname(localAuthSecretPath), { recursive: true });
+  const existingSecret = fs.existsSync(localAuthSecretPath)
+    ? fs.readFileSync(localAuthSecretPath, 'utf8').trim()
+    : '';
+  if (existingSecret) return existingSecret;
+  const generatedSecret = randomBytes(32).toString('base64url');
+  fs.writeFileSync(localAuthSecretPath, `${generatedSecret}\n`, { mode: 0o600 });
+  return generatedSecret;
+}
+
 const reportArgs = ['--trace=retain-on-failure', '--reporter=line'];
 const strictArgs = ['--max-failures=1', ...reportArgs];
 const singleWorkerArgs = ['--workers=1', ...reportArgs];
 const strictSingleWorkerArgs = ['--workers=1', ...strictArgs];
+const commonGateArgs = ['e2e/gate', ...strictSingleWorkerArgs];
 const playwrightCommandArgs = ['--filter', '@interdomestik/web', 'exec', 'playwright', 'test'];
 
 const laneDefinitions = {
@@ -94,24 +94,12 @@ const laneDefinitions = {
   'ks-fast': {
     gatekeeper: true,
     env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [
-      'e2e/gate',
-      '--project=gate-ks-sq',
-      '--max-failures=1',
-      '--trace=retain-on-failure',
-      '--reporter=line',
-    ],
+    playwrightArgs: ['e2e/gate', '--project=gate-ks-sq', ...strictArgs],
   },
   'mk-fast': {
     gatekeeper: true,
     env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [
-      'e2e/gate',
-      '--project=gate-mk-mk',
-      '--max-failures=1',
-      '--trace=retain-on-failure',
-      '--reporter=line',
-    ],
+    playwrightArgs: ['e2e/gate', '--project=gate-mk-mk', ...strictArgs],
   },
   'front-door': {
     env: { PW_FRONT_DOOR: '1' },
@@ -125,24 +113,10 @@ const laneDefinitions = {
 };
 
 function usage() {
-  console.error(`Lanes: ${Object.keys(laneDefinitions).join(', ')}`);
-}
-
-function run(command, args, env = baseEnv) {
-  const result = spawnSync(command, args, {
-    cwd: rootDir,
-    env,
-    stdio: 'inherit',
-  });
-
-  if (result.error) {
-    console.error(result.error);
-    process.exit(1);
-  }
-
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
+  const lanes = Object.keys(laneDefinitions).join(', ');
+  console.error(
+    `Usage: node scripts/run-e2e-lane.mjs <lane> [playwright args...]\n\nLanes: ${lanes}`
+  );
 }
 
 const laneName = process.argv[2] || 'gate';
@@ -160,7 +134,32 @@ if (!lane) {
   process.exit(2);
 }
 
+process.env.BETTER_AUTH_SECRET ||= loadLocalBetterAuthSecret();
+const baseEnv = {
+  ...process.env,
+  E2E_DATABASE_URL: process.env.E2E_DATABASE_URL || defaultDbUrl,
+  E2E_DATABASE_URL_RLS:
+    process.env.E2E_DATABASE_URL_RLS || process.env.E2E_DATABASE_URL || defaultDbUrl,
+  NEXT_PUBLIC_BILLING_TEST_MODE: '1',
+};
 const laneEnv = lane.env ? { ...baseEnv, ...lane.env } : baseEnv;
+
+function run(command, args, env = baseEnv) {
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
 
 if (lane.gatekeeper) {
   run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -7,25 +7,23 @@ import { fileURLToPath } from 'node:url';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const defaultDbUrl = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
-const localAuthSecretPath = path.join(rootDir, 'apps/web/.playwright/better-auth-secret');
+const secretPath = path.join(rootDir, 'apps/web/.playwright/better-auth-secret');
 
-function loadLocalBetterAuthSecret() {
-  fs.mkdirSync(path.dirname(localAuthSecretPath), { recursive: true });
-  const existingSecret = fs.existsSync(localAuthSecretPath)
-    ? fs.readFileSync(localAuthSecretPath, 'utf8').trim()
-    : '';
-  if (existingSecret) return existingSecret;
-  const generatedSecret = randomBytes(32).toString('base64url');
-  fs.writeFileSync(localAuthSecretPath, `${generatedSecret}\n`, { mode: 0o600 });
-  return generatedSecret;
+function loadLocalAuthSecret() {
+  fs.mkdirSync(path.dirname(secretPath), { recursive: true });
+  let secret = fs.existsSync(secretPath) ? fs.readFileSync(secretPath, 'utf8').trim() : '';
+  if (secret) return secret;
+  secret = randomBytes(32).toString('base64url');
+  fs.writeFileSync(secretPath, `${secret}\n`, { mode: 0o600 });
+  return secret;
 }
 
 const reportArgs = ['--trace=retain-on-failure', '--reporter=line'];
 const strictArgs = ['--max-failures=1', ...reportArgs];
-const singleWorkerArgs = ['--workers=1', ...reportArgs];
-const strictSingleWorkerArgs = ['--workers=1', ...strictArgs];
-const commonGateArgs = ['e2e/gate', ...strictSingleWorkerArgs];
-const playwrightCommandArgs = ['--filter', '@interdomestik/web', 'exec', 'playwright', 'test'];
+const workerArgs = ['--workers=1', ...reportArgs];
+const strictWorkerArgs = ['--workers=1', ...strictArgs];
+const gateArgs = ['e2e/gate', ...strictWorkerArgs];
+const pwCommandArgs = ['--filter', '@interdomestik/web', 'exec', 'playwright', 'test'];
 
 const laneDefinitions = {
   state: {
@@ -33,30 +31,30 @@ const laneDefinitions = {
       'e2e/setup.state.spec.ts',
       '--project=setup-ks',
       '--project=setup-mk',
-      ...strictSingleWorkerArgs,
+      ...strictWorkerArgs,
     ],
   },
   gate: {
     gatekeeper: true,
     state: true,
     env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...commonGateArgs, '--project=gate-ks-sq', '--project=gate-mk-mk'],
+    playwrightArgs: [...gateArgs, '--project=gate-ks-sq', '--project=gate-mk-mk'],
   },
   pr: {
     gatekeeper: true,
     state: true,
     env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...commonGateArgs, '--project=gate-ks-sq', '--project=gate-mk-contract'],
+    playwrightArgs: [...gateArgs, '--project=gate-ks-sq', '--project=gate-mk-contract'],
   },
   'gate-fast': {
     gatekeeper: true,
     env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...commonGateArgs, '--project=gate-ks-sq', '--project=gate-mk-mk'],
+    playwrightArgs: [...gateArgs, '--project=gate-ks-sq', '--project=gate-mk-mk'],
   },
   'pr-fast': {
     gatekeeper: true,
     env: { PW_FAST_GATES: '1' },
-    playwrightArgs: [...commonGateArgs, '--project=gate-ks-sq', '--project=gate-mk-contract'],
+    playwrightArgs: [...gateArgs, '--project=gate-ks-sq', '--project=gate-mk-contract'],
   },
   merge: {
     gatekeeper: true,
@@ -67,7 +65,7 @@ const laneDefinitions = {
       '@quarantine|@visual|@legacy',
       '--project=ks-sq',
       '--project=mk-mk',
-      ...singleWorkerArgs,
+      ...workerArgs,
     ],
   },
   'merge-fast': {
@@ -80,7 +78,7 @@ const laneDefinitions = {
       '@quarantine|@visual|@legacy',
       '--project=gate-ks-sq',
       '--project=gate-mk-mk',
-      ...singleWorkerArgs,
+      ...workerArgs,
     ],
   },
   ks: {
@@ -107,7 +105,7 @@ const laneDefinitions = {
       'e2e/gate/front-door-session-context.spec.ts',
       '--project=front-door-ida-ks',
       '--project=front-door-ida-mk',
-      ...strictSingleWorkerArgs,
+      ...strictWorkerArgs,
     ],
   },
 };
@@ -134,7 +132,7 @@ if (!lane) {
   process.exit(2);
 }
 
-process.env.BETTER_AUTH_SECRET ||= loadLocalBetterAuthSecret();
+process.env.BETTER_AUTH_SECRET ||= loadLocalAuthSecret();
 const baseEnv = {
   ...process.env,
   E2E_DATABASE_URL: process.env.E2E_DATABASE_URL || defaultDbUrl,
@@ -166,6 +164,6 @@ if (lane.gatekeeper) {
 }
 
 if (lane.state) {
-  run('pnpm', [...playwrightCommandArgs, ...laneDefinitions.state.playwrightArgs]);
+  run('pnpm', [...pwCommandArgs, ...laneDefinitions.state.playwrightArgs]);
 }
-run('pnpm', [...playwrightCommandArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], laneEnv);
+run('pnpm', [...pwCommandArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], laneEnv);

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -123,6 +123,8 @@ const baseEnv = {
   NEXT_PUBLIC_BILLING_TEST_MODE: '1',
 };
 const laneEnv = lane.env ? { ...baseEnv, ...lane.env } : baseEnv;
+const stateEnv = { ...laneEnv, PW_FAST_GATES: '0' };
+const finalEnv = laneName === 'state' ? stateEnv : laneEnv;
 
 function run(command, args, env = baseEnv) {
   const result = spawnSync(command, args, {
@@ -146,6 +148,6 @@ if (lane.gatekeeper) {
 }
 
 if (lane.state) {
-  run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], laneEnv);
+  run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
 }
-run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], laneEnv);
+run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);


### PR DESCRIPTION
## Summary
- Replace the committed hardcoded E2E BETTER_AUTH_SECRET fallback with a generated local-only secret stored under the existing gitignored Playwright cache path.
- Restore full run-e2e-lane usage output, including additional Playwright args.
- Consolidate duplicated Playwright arg constants so reporter/trace settings have one source of truth.

## Context
Follow-up to #1054 after Copilot review comments arrived post-merge.

## Validation
- pnpm security:guard
- node --test scripts/package-e2e-scripts.test.mjs
- node scripts/run-e2e-lane.mjs --help
- pnpm e2e:state:setup
- pnpm exec prettier --check scripts/run-e2e-lane.mjs
- git diff --check

## Merge note
Do not merge until Copilot review/comments on this PR have appeared and been checked.