### PR TITLE
feat: add T-301 role boundary contracts

### DIFF
--- a/apps/web/src/actions/admin-access.test.ts
+++ b/apps/web/src/actions/admin-access.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getActionContext: vi.fn(),
+  requireTenantAdminOrBranchManagerSession: vi.fn(),
+}));
+
+vi.mock('./admin-users/context', () => ({
+  getActionContext: mocks.getActionContext,
+}));
+
+vi.mock('@interdomestik/domain-users/admin/access', () => ({
+  requireTenantAdminOrBranchManagerSession: mocks.requireTenantAdminOrBranchManagerSession,
+}));
+
+import { canAccessAdmin } from './admin-access';
+
+describe('canAccessAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows primary super admin to enter the admin portal', async () => {
+    const session = { user: { role: 'super_admin' } };
+    mocks.getActionContext.mockResolvedValueOnce({
+      requestHeaders: new Headers(),
+      session,
+    });
+    mocks.requireTenantAdminOrBranchManagerSession.mockResolvedValueOnce(session);
+
+    await expect(canAccessAdmin()).resolves.toBe(true);
+    expect(mocks.requireTenantAdminOrBranchManagerSession).toHaveBeenCalledWith(session);
+  });
+
+  it('requires tenant validation for primary admin roles', async () => {
+    const session = { user: { role: 'admin' } };
+    mocks.getActionContext.mockResolvedValueOnce({
+      requestHeaders: new Headers(),
+      session,
+    });
+    mocks.requireTenantAdminOrBranchManagerSession.mockRejectedValueOnce(
+      new Error('Missing tenant')
+    );
+
+    await expect(canAccessAdmin()).resolves.toBe(false);
+    expect(mocks.requireTenantAdminOrBranchManagerSession).toHaveBeenCalledWith(session);
+  });
+
+  it('delegates branch manager access to the domain guard', async () => {
+    const session = {
+      user: { role: 'branch_manager', tenantId: 'tenant-1', branchId: 'branch-1' },
+    };
+    mocks.getActionContext.mockResolvedValueOnce({
+      requestHeaders: new Headers(),
+      session,
+    });
+    mocks.requireTenantAdminOrBranchManagerSession.mockResolvedValueOnce(session);
+
+    await expect(canAccessAdmin()).resolves.toBe(true);
+    expect(mocks.requireTenantAdminOrBranchManagerSession).toHaveBeenCalledWith(session);
+  });
+
+  it('allows explicit tenant admin RBAC grants', async () => {
+    const session = { user: { role: 'staff' } };
+    mocks.getActionContext.mockResolvedValueOnce({
+      requestHeaders: new Headers(),
+      session,
+    });
+    mocks.requireTenantAdminOrBranchManagerSession.mockResolvedValueOnce(session);
+
+    await expect(canAccessAdmin()).resolves.toBe(true);
+    expect(mocks.requireTenantAdminOrBranchManagerSession).toHaveBeenCalledWith(session);
+  });
+
+  it('denies staff users from entering the admin portal', async () => {
+    mocks.getActionContext.mockResolvedValueOnce({
+      requestHeaders: new Headers(),
+      session: { user: { role: 'staff' } },
+    });
+    mocks.requireTenantAdminOrBranchManagerSession.mockRejectedValueOnce(new Error('Unauthorized'));
+
+    await expect(canAccessAdmin()).resolves.toBe(false);
+  });
+});

--- a/apps/web/src/actions/admin-access.test.ts
+++ b/apps/web/src/actions/admin-access.test.ts
@@ -60,7 +60,7 @@ describe('canAccessAdmin', () => {
     expect(mocks.requireTenantAdminOrBranchManagerSession).toHaveBeenCalledWith(session);
   });
 
-  it('allows explicit tenant admin RBAC grants', async () => {
+  it('returns true when the domain guard resolves for any primary role', async () => {
     const session = { user: { role: 'staff' } };
     mocks.getActionContext.mockResolvedValueOnce({
       requestHeaders: new Headers(),

--- a/apps/web/src/actions/admin-access.ts
+++ b/apps/web/src/actions/admin-access.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { requireTenantAdminSession } from '@interdomestik/domain-users/admin/access';
+import { requireTenantAdminOrBranchManagerSession } from '@interdomestik/domain-users/admin/access';
 import type { UserSession } from '@interdomestik/domain-users/types';
 
 import { getActionContext } from './admin-users/context';
@@ -9,7 +9,7 @@ export async function canAccessAdmin(): Promise<boolean> {
   const { session } = await getActionContext();
 
   try {
-    await requireTenantAdminSession(session as unknown as UserSession | null);
+    await requireTenantAdminOrBranchManagerSession(session as unknown as UserSession | null);
     return true;
   } catch {
     return false;

--- a/apps/web/src/actions/analytics/v2.test.ts
+++ b/apps/web/src/actions/analytics/v2.test.ts
@@ -19,15 +19,20 @@ vi.mock('@interdomestik/domain-analytics', () => ({
 import { getBranchKPIsAction, getTenantAdminKPIsAction } from './v2';
 
 describe('analytics v2 actions role boundaries', () => {
+  let actionContext: {
+    userRole: string;
+    tenantId: string;
+    scope: { branchId?: string | null };
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.runAuthenticatedAction.mockImplementation(async callback =>
-      callback({
-        userRole: 'super_admin',
-        tenantId: 'tenant-1',
-        scope: { branchId: 'branch-1' },
-      })
-    );
+    actionContext = {
+      userRole: 'super_admin',
+      tenantId: 'tenant-1',
+      scope: { branchId: 'branch-1' },
+    };
+    mocks.runAuthenticatedAction.mockImplementation(async callback => callback(actionContext));
     mocks.getBranchKPIs.mockResolvedValue({ branchId: 'branch-2' });
     mocks.getTenantAdminKPIs.mockResolvedValue({ tenantId: 'tenant-1' });
   });
@@ -40,5 +45,14 @@ describe('analytics v2 actions role boundaries', () => {
   it('keeps super admins authorized for branch KPIs', async () => {
     await expect(getBranchKPIsAction('branch-2')).resolves.toEqual({ branchId: 'branch-2' });
     expect(mocks.getBranchKPIs).toHaveBeenCalledWith('tenant-1', 'branch-2');
+  });
+
+  it('rejects branch managers from tenant admin KPIs', async () => {
+    actionContext = { ...actionContext, userRole: 'branch_manager' };
+
+    await expect(getTenantAdminKPIsAction()).rejects.toThrow(
+      'Unauthorized: Tenant Admin or Staff access required'
+    );
+    expect(mocks.getTenantAdminKPIs).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/actions/analytics/v2.test.ts
+++ b/apps/web/src/actions/analytics/v2.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getBranchKPIs: vi.fn(),
+  getTenantAdminKPIs: vi.fn(),
+  runAuthenticatedAction: vi.fn(),
+}));
+
+vi.mock('@/lib/safe-action', () => ({
+  runAuthenticatedAction: mocks.runAuthenticatedAction,
+}));
+
+vi.mock('@interdomestik/domain-analytics', () => ({
+  getBranchKPIs: mocks.getBranchKPIs,
+  getSuperAdminKPIs: vi.fn(),
+  getTenantAdminKPIs: mocks.getTenantAdminKPIs,
+}));
+
+import { getBranchKPIsAction, getTenantAdminKPIsAction } from './v2';
+
+describe('analytics v2 actions role boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runAuthenticatedAction.mockImplementation(async callback =>
+      callback({
+        userRole: 'super_admin',
+        tenantId: 'tenant-1',
+        scope: { branchId: 'branch-1' },
+      })
+    );
+    mocks.getBranchKPIs.mockResolvedValue({ branchId: 'branch-2' });
+    mocks.getTenantAdminKPIs.mockResolvedValue({ tenantId: 'tenant-1' });
+  });
+
+  it('keeps super admins authorized for tenant admin KPIs', async () => {
+    await expect(getTenantAdminKPIsAction()).resolves.toEqual({ tenantId: 'tenant-1' });
+    expect(mocks.getTenantAdminKPIs).toHaveBeenCalledWith('tenant-1');
+  });
+
+  it('keeps super admins authorized for branch KPIs', async () => {
+    await expect(getBranchKPIsAction('branch-2')).resolves.toEqual({ branchId: 'branch-2' });
+    expect(mocks.getBranchKPIs).toHaveBeenCalledWith('tenant-1', 'branch-2');
+  });
+});

--- a/apps/web/src/actions/analytics/v2.ts
+++ b/apps/web/src/actions/analytics/v2.ts
@@ -22,7 +22,7 @@ export async function getSuperAdminKPIsAction() {
 export async function getTenantAdminKPIsAction() {
   return runAuthenticatedAction(async ({ userRole, tenantId }) => {
     // Tenant Admin / Staff Dashboard
-    const hasAccess = isTenantAdmin(userRole) || userRole === 'staff';
+    const hasAccess = isSuperAdmin(userRole) || isTenantAdmin(userRole) || userRole === 'staff';
 
     if (!hasAccess) {
       throw new Error('Unauthorized: Tenant Admin or Staff access required');
@@ -40,7 +40,7 @@ export async function getBranchKPIsAction(branchId: string) {
 
     let allowed = false;
 
-    if (isTenantAdmin(userRole) || userRole === 'staff') {
+    if (isSuperAdmin(userRole) || isTenantAdmin(userRole) || userRole === 'staff') {
       allowed = true;
     } else if (isBranchManager(userRole)) {
       // Must match their assigned branch

--- a/apps/web/src/actions/analytics/v3.test.ts
+++ b/apps/web/src/actions/analytics/v3.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getAgentCapacitySignal: vi.fn(),
+  getBranchStressIndex: vi.fn(),
+  runAuthenticatedAction: vi.fn(),
+}));
+
+vi.mock('@/lib/safe-action', () => ({
+  runAuthenticatedAction: mocks.runAuthenticatedAction,
+}));
+
+vi.mock('@interdomestik/domain-analytics', () => ({
+  getAgentCapacitySignal: mocks.getAgentCapacitySignal,
+  getBranchStressIndex: mocks.getBranchStressIndex,
+  getClaimLoadForecast: vi.fn(),
+}));
+
+import { getAgentCapacityAction, getBranchStressAction } from './v3';
+
+describe('analytics v3 actions role boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runAuthenticatedAction.mockImplementation(async callback =>
+      callback({
+        userRole: 'super_admin',
+        tenantId: 'tenant-1',
+      })
+    );
+    mocks.getAgentCapacitySignal.mockResolvedValue({ agentId: 'agent-1' });
+    mocks.getBranchStressIndex.mockResolvedValue({ branchId: 'branch-1' });
+  });
+
+  it('keeps super admins authorized for branch stress', async () => {
+    await expect(getBranchStressAction('branch-1')).resolves.toEqual({ branchId: 'branch-1' });
+    expect(mocks.getBranchStressIndex).toHaveBeenCalledWith('tenant-1', 'branch-1');
+  });
+
+  it('keeps super admins authorized for agent capacity', async () => {
+    await expect(getAgentCapacityAction('agent-1')).resolves.toEqual({ agentId: 'agent-1' });
+    expect(mocks.getAgentCapacitySignal).toHaveBeenCalledWith('agent-1');
+  });
+});

--- a/apps/web/src/actions/analytics/v3.test.ts
+++ b/apps/web/src/actions/analytics/v3.test.ts
@@ -19,14 +19,18 @@ vi.mock('@interdomestik/domain-analytics', () => ({
 import { getAgentCapacityAction, getBranchStressAction } from './v3';
 
 describe('analytics v3 actions role boundaries', () => {
+  let actionContext: {
+    userRole: string;
+    tenantId: string;
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.runAuthenticatedAction.mockImplementation(async callback =>
-      callback({
-        userRole: 'super_admin',
-        tenantId: 'tenant-1',
-      })
-    );
+    actionContext = {
+      userRole: 'super_admin',
+      tenantId: 'tenant-1',
+    };
+    mocks.runAuthenticatedAction.mockImplementation(async callback => callback(actionContext));
     mocks.getAgentCapacitySignal.mockResolvedValue({ agentId: 'agent-1' });
     mocks.getBranchStressIndex.mockResolvedValue({ branchId: 'branch-1' });
   });
@@ -39,5 +43,12 @@ describe('analytics v3 actions role boundaries', () => {
   it('keeps super admins authorized for agent capacity', async () => {
     await expect(getAgentCapacityAction('agent-1')).resolves.toEqual({ agentId: 'agent-1' });
     expect(mocks.getAgentCapacitySignal).toHaveBeenCalledWith('agent-1');
+  });
+
+  it('rejects branch managers from agent capacity analytics', async () => {
+    actionContext = { ...actionContext, userRole: 'branch_manager' };
+
+    await expect(getAgentCapacityAction('agent-1')).rejects.toThrow('Unauthorized');
+    expect(mocks.getAgentCapacitySignal).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/actions/analytics/v3.ts
+++ b/apps/web/src/actions/analytics/v3.ts
@@ -25,7 +25,7 @@ export async function getBranchStressAction(branchId: string) {
     // Branch Managers should also be able to see their own stress?
     // Let's stick to Tenant Admin / Staff for V3 dashboards per requirements.
 
-    if (!isTenantAdmin(userRole) && userRole !== 'staff') {
+    if (!isSuperAdmin(userRole) && !isTenantAdmin(userRole) && userRole !== 'staff') {
       throw new Error('Unauthorized');
     }
 
@@ -38,7 +38,7 @@ export async function getBranchStressAction(branchId: string) {
 // 3. Tenant Admin: Agent Capacity
 export async function getAgentCapacityAction(agentId: string) {
   return runAuthenticatedAction(async ({ userRole }) => {
-    if (!isTenantAdmin(userRole) && userRole !== 'staff') {
+    if (!isSuperAdmin(userRole) && !isTenantAdmin(userRole) && userRole !== 'staff') {
       throw new Error('Unauthorized');
     }
     // Again, implicit safety via tenant scoping would be better, but domain query assumes agent exists.

--- a/apps/web/src/lib/roles.core.test.ts
+++ b/apps/web/src/lib/roles.core.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isAdmin,
+  isBranchManager,
+  isStaffOrAdmin,
+  isTenantAdmin,
+  ROLE_AUDITOR,
+  ROLE_ADMIN,
+  ROLE_GLOBAL_SUPPORT,
+  ROLE_SUPER_ADMIN,
+  ROLE_TENANT_ADMIN,
+} from './roles.core';
+
+describe('roles.core boundaries', () => {
+  it('keeps super_admin distinct from tenant_admin', () => {
+    expect(isAdmin(ROLE_SUPER_ADMIN)).toBe(true);
+    expect(isTenantAdmin(ROLE_SUPER_ADMIN)).toBe(false);
+    expect(isBranchManager(ROLE_SUPER_ADMIN)).toBe(false);
+  });
+
+  it('treats admin and tenant_admin as tenant administrators', () => {
+    expect(isTenantAdmin(ROLE_ADMIN)).toBe(true);
+    expect(isTenantAdmin(ROLE_TENANT_ADMIN)).toBe(true);
+  });
+
+  it('does not classify global support or auditor as admin operators', () => {
+    for (const role of [ROLE_GLOBAL_SUPPORT, ROLE_AUDITOR]) {
+      expect(isAdmin(role)).toBe(false);
+      expect(isTenantAdmin(role)).toBe(false);
+      expect(isBranchManager(role)).toBe(false);
+      expect(isStaffOrAdmin(role)).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/roles.core.ts
+++ b/apps/web/src/lib/roles.core.ts
@@ -1,7 +1,10 @@
 export type RoleLike = string | null | undefined;
 
 export const ROLE_SUPER_ADMIN = 'super_admin' as const;
+export const ROLE_ADMIN = 'admin' as const;
 export const ROLE_TENANT_ADMIN = 'tenant_admin' as const;
+export const ROLE_GLOBAL_SUPPORT = 'global_support' as const;
+export const ROLE_AUDITOR = 'auditor' as const;
 export const ROLE_STAFF = 'staff' as const;
 export const ROLE_BRANCH_MANAGER = 'branch_manager' as const;
 export const ROLE_AGENT = 'agent' as const;
@@ -17,7 +20,7 @@ export function isStaff(role: RoleLike): boolean {
 }
 
 export function isAdmin(role: RoleLike): boolean {
-  return role === 'admin' || role === ROLE_TENANT_ADMIN || role === ROLE_SUPER_ADMIN;
+  return role === ROLE_ADMIN || role === ROLE_TENANT_ADMIN || role === ROLE_SUPER_ADMIN;
 }
 
 export function isStaffOrAdmin(role: RoleLike): boolean {
@@ -29,7 +32,7 @@ export function isSuperAdmin(role: RoleLike): boolean {
 }
 
 export function isTenantAdmin(role: RoleLike): boolean {
-  return role === ROLE_TENANT_ADMIN || isSuperAdmin(role);
+  return role === ROLE_ADMIN || role === ROLE_TENANT_ADMIN;
 }
 
 export function isBranchManager(role: RoleLike): boolean {

--- a/packages/domain-users/src/admin/access.test.ts
+++ b/packages/domain-users/src/admin/access.test.ts
@@ -100,6 +100,13 @@ describe('admin access role boundaries', () => {
     expect(dbMock.select).not.toHaveBeenCalled();
   });
 
+  it('rejects primary branch managers missing branch context', async () => {
+    await expect(
+      requireTenantAdminOrBranchManagerSession(session('branch_manager'))
+    ).rejects.toThrow('Unauthorized');
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
   it('does not let super_admin implicitly satisfy every tenant role', async () => {
     await expect(
       userHasRole({

--- a/packages/domain-users/src/admin/access.test.ts
+++ b/packages/domain-users/src/admin/access.test.ts
@@ -88,6 +88,12 @@ describe('admin access role boundaries', () => {
     expect(dbMock.select).not.toHaveBeenCalled();
   });
 
+  it('accepts explicit tenant super admin grants', async () => {
+    dbMock.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 'role-1' }]);
+    await expect(requireTenantAdminSession(session('staff'))).resolves.toEqual(session('staff'));
+    expect(eq).toHaveBeenCalledWith('role', 'super_admin');
+  });
+
   it('allows primary branch managers only when tenant and branch scoped', async () => {
     const scopedSession = {
       ...session('branch_manager'),

--- a/packages/domain-users/src/admin/access.test.ts
+++ b/packages/domain-users/src/admin/access.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { eq } from '@interdomestik/database';
+
 import {
   requireTenantAdminOrBranchManagerSession,
   requireTenantAdminSession,
@@ -76,6 +78,16 @@ describe('admin access role boundaries', () => {
     expect(dbMock.select).not.toHaveBeenCalled();
   });
 
+  it('requires tenant context for primary tenant admin roles', async () => {
+    await expect(requireTenantAdminSession(session('tenant_admin', null))).rejects.toThrow(
+      'Session missing tenantId'
+    );
+    await expect(requireTenantAdminSession(session('admin', null))).rejects.toThrow(
+      'Session missing tenantId'
+    );
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
   it('allows primary branch managers only when tenant and branch scoped', async () => {
     const scopedSession = {
       ...session('branch_manager'),
@@ -105,6 +117,13 @@ describe('admin access role boundaries', () => {
       requireTenantAdminOrBranchManagerSession(session('branch_manager'))
     ).rejects.toThrow('Unauthorized');
     expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('does not query tenant-wide branch manager RBAC grants without branch context', async () => {
+    await expect(requireTenantAdminOrBranchManagerSession(session('staff'))).rejects.toThrow(
+      'Unauthorized'
+    );
+    expect(eq).not.toHaveBeenCalledWith('role', 'branch_manager');
   });
 
   it('does not let super_admin implicitly satisfy every tenant role', async () => {

--- a/packages/domain-users/src/admin/access.test.ts
+++ b/packages/domain-users/src/admin/access.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  requireTenantAdminOrBranchManagerSession,
+  requireTenantAdminSession,
+  userHasRole,
+} from './access';
+import type { UserSession } from '../types';
+
+const dbMock = vi.hoisted(() => {
+  const limit = vi.fn();
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+
+  return { from, limit, select, where };
+});
+
+vi.mock('@interdomestik/database', () => ({
+  and: vi.fn((...conditions: unknown[]) => conditions),
+  db: { select: dbMock.select },
+  eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
+  userRoles: {
+    id: 'id',
+    userId: 'userId',
+    tenantId: 'tenantId',
+    role: 'role',
+    branchId: 'branchId',
+  },
+}));
+
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: vi.fn((_tenantId: string, _column: unknown, condition: unknown) => condition),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  isNull: vi.fn((column: unknown) => ({ isNull: column })),
+}));
+
+function session(role: string, tenantId = 'tenant-1'): UserSession {
+  return {
+    user: {
+      id: 'user-1',
+      email: 'user@example.com',
+      role,
+      tenantId,
+    },
+  } as UserSession;
+}
+
+describe('admin access role boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.limit.mockResolvedValue([]);
+  });
+
+  it('preserves primary super_admin admin operations without tenant role lookup', async () => {
+    await expect(requireTenantAdminSession(session('super_admin'))).resolves.toEqual(
+      session('super_admin')
+    );
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('preserves primary super_admin admin-or-branch operations without tenant role lookup', async () => {
+    await expect(requireTenantAdminOrBranchManagerSession(session('super_admin'))).resolves.toEqual(
+      session('super_admin')
+    );
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('keeps primary tenant admin roles authorized', async () => {
+    await expect(requireTenantAdminSession(session('tenant_admin'))).resolves.toEqual(
+      session('tenant_admin')
+    );
+    await expect(requireTenantAdminSession(session('admin'))).resolves.toEqual(session('admin'));
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('does not let super_admin implicitly satisfy every tenant role', async () => {
+    await expect(
+      userHasRole({
+        session: session('super_admin'),
+        role: 'branch_manager',
+        branchId: null,
+      })
+    ).resolves.toBe(false);
+    expect(dbMock.select).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/domain-users/src/admin/access.test.ts
+++ b/packages/domain-users/src/admin/access.test.ts
@@ -37,13 +37,13 @@ vi.mock('drizzle-orm', () => ({
   isNull: vi.fn((column: unknown) => ({ isNull: column })),
 }));
 
-function session(role: string, tenantId = 'tenant-1'): UserSession {
+function session(role: string, tenantId: string | null = 'tenant-1'): UserSession {
   return {
     user: {
       id: 'user-1',
       email: 'user@example.com',
       role,
-      tenantId,
+      ...(tenantId === null ? {} : { tenantId }),
     },
   } as UserSession;
 }
@@ -73,6 +73,30 @@ describe('admin access role boundaries', () => {
       session('tenant_admin')
     );
     await expect(requireTenantAdminSession(session('admin'))).resolves.toEqual(session('admin'));
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('allows primary branch managers only when tenant and branch scoped', async () => {
+    const scopedSession = {
+      ...session('branch_manager'),
+      user: { ...session('branch_manager').user, branchId: 'branch-1' },
+    } as UserSession;
+
+    await expect(requireTenantAdminOrBranchManagerSession(scopedSession)).resolves.toEqual(
+      scopedSession
+    );
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects primary branch managers missing tenant context', async () => {
+    const scopedSession = {
+      ...session('branch_manager', null),
+      user: { ...session('branch_manager', null).user, branchId: 'branch-1' },
+    } as UserSession;
+
+    await expect(requireTenantAdminOrBranchManagerSession(scopedSession)).rejects.toThrow(
+      'Session missing tenantId'
+    );
     expect(dbMock.select).not.toHaveBeenCalled();
   });
 

--- a/packages/domain-users/src/admin/access.test.ts
+++ b/packages/domain-users/src/admin/access.test.ts
@@ -47,7 +47,7 @@ function session(role: string, tenantId: string | null = 'tenant-1'): UserSessio
       role,
       ...(tenantId === null ? {} : { tenantId }),
     },
-  } as UserSession;
+  };
 }
 
 describe('admin access role boundaries', () => {

--- a/packages/domain-users/src/admin/access.ts
+++ b/packages/domain-users/src/admin/access.ts
@@ -105,6 +105,7 @@ export async function requireTenantAdminOrBranchManagerSession(
     if (!session.user.branchId) {
       throw new Error('Unauthorized');
     }
+    ensureTenantId(session);
     return session;
   }
 

--- a/packages/domain-users/src/admin/access.ts
+++ b/packages/domain-users/src/admin/access.ts
@@ -117,17 +117,15 @@ export async function requireTenantAdminOrBranchManagerSession(
     return requireTenantAdminSession(session);
   }
 
-  // If branch_manager is granted via tenant RBAC roles, allow.
+  // If branch_manager is granted via tenant RBAC roles, allow only with branch scope.
   if (
-    await userHasRole({
+    session.user.branchId &&
+    (await userHasRole({
       session,
       role: 'branch_manager',
-      branchId: session.user.branchId ?? null,
-    })
+      branchId: session.user.branchId,
+    }))
   ) {
-    if (!session.user.branchId) {
-      throw new Error('Unauthorized');
-    }
     return session;
   }
 

--- a/packages/domain-users/src/admin/access.ts
+++ b/packages/domain-users/src/admin/access.ts
@@ -75,14 +75,10 @@ export async function requireTenantAdminSession(session: UserSession | null): Pr
   const tenantId = ensureTenantId(session);
   const userId = session.user.id;
 
-  if (
-    await hasTenantRole({
-      tenantId,
-      userId,
-      role: 'tenant_admin',
-    })
-  ) {
-    return session;
+  for (const role of ['tenant_admin', GLOBAL_SUPER_ADMIN_ROLE]) {
+    if (await hasTenantRole({ tenantId, userId, role })) {
+      return session;
+    }
   }
 
   throw new Error('Unauthorized');

--- a/packages/domain-users/src/admin/access.ts
+++ b/packages/domain-users/src/admin/access.ts
@@ -5,7 +5,6 @@ import { isNull } from 'drizzle-orm';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import type { UserSession } from '../types';
 
-const TENANT_ADMIN_ROLES = ['tenant_admin', 'super_admin'] as const;
 const GLOBAL_SUPER_ADMIN_ROLE = 'super_admin' as const;
 
 async function hasTenantRole(params: {
@@ -56,7 +55,7 @@ export async function requireTenantAdminSession(session: UserSession | null): Pr
     throw new Error('Unauthorized');
   }
 
-  // Platform-wide super admin (best-practice: global scope).
+  // Technical super admins retain admin-portal operations, but do not inherit tenant RBAC grants.
   if (session.user.role === GLOBAL_SUPER_ADMIN_ROLE) {
     return session;
   }
@@ -76,16 +75,14 @@ export async function requireTenantAdminSession(session: UserSession | null): Pr
   const tenantId = ensureTenantId(session);
   const userId = session.user.id;
 
-  for (const role of TENANT_ADMIN_ROLES) {
-    if (
-      await hasTenantRole({
-        tenantId,
-        userId,
-        role,
-      })
-    ) {
-      return session;
-    }
+  if (
+    await hasTenantRole({
+      tenantId,
+      userId,
+      role: 'tenant_admin',
+    })
+  ) {
+    return session;
   }
 
   throw new Error('Unauthorized');
@@ -109,6 +106,14 @@ export async function requireTenantAdminOrBranchManagerSession(
       throw new Error('Unauthorized');
     }
     return session;
+  }
+
+  if (
+    session.user.role === GLOBAL_SUPER_ADMIN_ROLE ||
+    session.user.role === 'tenant_admin' ||
+    session.user.role === 'admin'
+  ) {
+    return requireTenantAdminSession(session);
   }
 
   // If branch_manager is granted via tenant RBAC roles, allow.
@@ -136,9 +141,6 @@ export async function userHasRole(params: {
 }): Promise<boolean> {
   const { session, role, branchId } = params;
   if (!session?.user) return false;
-
-  // Global super admin implicitly has all roles.
-  if (session.user.role === GLOBAL_SUPER_ADMIN_ROLE) return true;
 
   const tenantId = ensureTenantId(session);
   return hasTenantRole({ tenantId, userId: session.user.id, role, branchId });

--- a/packages/shared-auth/src/governance.test.ts
+++ b/packages/shared-auth/src/governance.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BREAK_GLASS_AUDIT_EVENT,
+  canApproveGovernanceAction,
+  validateBreakGlassContext,
+} from './governance';
+import { ROLES } from './permissions';
+
+describe('governance role boundaries', () => {
+  it('blocks technical super admin from fee, payment, and terms approvals', () => {
+    for (const actorRole of [ROLES.super_admin, ROLES.global_support, ROLES.auditor]) {
+      expect(
+        canApproveGovernanceAction({
+          actorRole,
+          actorUserId: 'actor-1',
+          requestedByUserId: 'requester-1',
+        })
+      ).toBe(false);
+    }
+  });
+
+  it('requires separation of duties for governance approvals', () => {
+    expect(
+      canApproveGovernanceAction({
+        actorRole: ROLES.tenant_admin,
+        actorUserId: 'user-1',
+        requestedByUserId: 'user-1',
+      })
+    ).toBe(false);
+    expect(
+      canApproveGovernanceAction({
+        actorRole: ROLES.tenant_admin,
+        actorUserId: 'approver-1',
+        requestedByUserId: 'requester-1',
+      })
+    ).toBe(true);
+  });
+
+  it('requires reason and future expiry for break-glass audit evidence', () => {
+    const now = new Date('2026-06-14T10:00:00.000Z');
+
+    expect(
+      validateBreakGlassContext({
+        reason: '   ',
+        expiresAt: new Date('2026-06-14T11:00:00.000Z'),
+        now,
+      })
+    ).toEqual({ success: false, error: 'reason_required' });
+    expect(
+      validateBreakGlassContext({
+        reason: 'Investigate production access incident',
+        expiresAt: new Date('2026-06-14T09:59:59.000Z'),
+        now,
+      })
+    ).toEqual({ success: false, error: 'expiry_not_future' });
+  });
+
+  it('returns security break-glass audit metadata when valid', () => {
+    expect(
+      validateBreakGlassContext({
+        reason: ' Investigate production access incident ',
+        expiresAt: new Date('2026-06-14T11:00:00.000Z'),
+        now: new Date('2026-06-14T10:00:00.000Z'),
+        reviewerUserId: 'reviewer-1',
+      })
+    ).toEqual({
+      success: true,
+      auditEvent: BREAK_GLASS_AUDIT_EVENT,
+      metadata: {
+        reason: 'Investigate production access incident',
+        expiresAt: '2026-06-14T11:00:00.000Z',
+        reviewerUserId: 'reviewer-1',
+      },
+    });
+  });
+});

--- a/packages/shared-auth/src/governance.test.ts
+++ b/packages/shared-auth/src/governance.test.ts
@@ -8,8 +8,14 @@ import {
 import { ROLES } from './permissions';
 
 describe('governance role boundaries', () => {
-  it('blocks technical super admin from fee, payment, and terms approvals', () => {
-    for (const actorRole of [ROLES.super_admin, ROLES.global_support, ROLES.auditor]) {
+  it('blocks non-governance operators from fee, payment, and terms approvals', () => {
+    for (const actorRole of [
+      ROLES.super_admin,
+      ROLES.global_support,
+      ROLES.auditor,
+      ROLES.branch_manager,
+      ROLES.staff,
+    ]) {
       expect(
         canApproveGovernanceAction({
           actorRole,

--- a/packages/shared-auth/src/governance.ts
+++ b/packages/shared-auth/src/governance.ts
@@ -32,7 +32,13 @@ export function canApproveGovernanceAction({
   actorUserId,
   requestedByUserId,
 }: GovernanceApprovalContext): boolean {
-  if (actorRole === ROLES.super_admin) return false;
+  if (
+    actorRole === ROLES.super_admin ||
+    actorRole === ROLES.global_support ||
+    actorRole === ROLES.auditor
+  ) {
+    return false;
+  }
   if (actorUserId === requestedByUserId) return false;
   return hasPermission(actorRole, PERMISSIONS['governance.approve']);
 }

--- a/packages/shared-auth/src/governance.ts
+++ b/packages/shared-auth/src/governance.ts
@@ -1,0 +1,64 @@
+import { hasPermission, PERMISSIONS, ROLES } from './permissions';
+
+export const BREAK_GLASS_AUDIT_EVENT = 'security.break_glass_used' as const;
+
+export type GovernanceAction = 'fees.approve' | 'payments.approve' | 'terms.approve';
+
+export interface GovernanceApprovalContext {
+  actorRole: string | null | undefined;
+  actorUserId: string;
+  requestedByUserId: string;
+}
+
+export interface BreakGlassContext {
+  reason: string | null | undefined;
+  expiresAt: Date;
+  now?: Date;
+  reviewerUserId?: string | null;
+}
+
+export type BreakGlassValidation =
+  | { success: true; auditEvent: typeof BREAK_GLASS_AUDIT_EVENT; metadata: BreakGlassAuditMetadata }
+  | { success: false; error: 'reason_required' | 'expiry_required' | 'expiry_not_future' };
+
+export interface BreakGlassAuditMetadata {
+  reason: string;
+  expiresAt: string;
+  reviewerUserId?: string;
+}
+
+export function canApproveGovernanceAction({
+  actorRole,
+  actorUserId,
+  requestedByUserId,
+}: GovernanceApprovalContext): boolean {
+  if (actorRole === ROLES.super_admin) return false;
+  if (actorUserId === requestedByUserId) return false;
+  return hasPermission(actorRole, PERMISSIONS['governance.approve']);
+}
+
+export function validateBreakGlassContext({
+  reason,
+  expiresAt,
+  now = new Date(),
+  reviewerUserId,
+}: BreakGlassContext): BreakGlassValidation {
+  const trimmedReason = reason?.trim();
+  if (!trimmedReason) return { success: false, error: 'reason_required' };
+  if (!(expiresAt instanceof Date) || Number.isNaN(expiresAt.getTime())) {
+    return { success: false, error: 'expiry_required' };
+  }
+  if (expiresAt.getTime() <= now.getTime()) {
+    return { success: false, error: 'expiry_not_future' };
+  }
+
+  return {
+    success: true,
+    auditEvent: BREAK_GLASS_AUDIT_EVENT,
+    metadata: {
+      reason: trimmedReason,
+      expiresAt: expiresAt.toISOString(),
+      ...(reviewerUserId ? { reviewerUserId } : {}),
+    },
+  };
+}

--- a/packages/shared-auth/src/index.ts
+++ b/packages/shared-auth/src/index.ts
@@ -12,3 +12,4 @@ export { ensureTenantId, type SessionWithTenant } from './session';
 // RBAC and Scoping
 export * from './permissions';
 export * from './scope';
+export * from './governance';

--- a/packages/shared-auth/src/permissions.test.ts
+++ b/packages/shared-auth/src/permissions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getRolePermissions,
+  isStaffOrHigher,
   isTenantAdmin,
   PERMISSIONS,
   ROLE_PERMISSIONS,
@@ -45,20 +46,76 @@ describe('ROLE_PERMISSIONS', () => {
   it('keeps admin and tenant_admin distinct from super_admin', () => {
     const superAdminPermissions = sortedPermissions(getRolePermissions(ROLES.super_admin));
 
-    expect(superAdminPermissions).toContain(PERMISSIONS['tenants.manage']);
+    expect(superAdminPermissions).toEqual(
+      sortedPermissions([
+        PERMISSIONS['members.read'],
+        PERMISSIONS['members.write'],
+        PERMISSIONS['claims.read'],
+        PERMISSIONS['claims.update'],
+        PERMISSIONS['claims.assign'],
+        PERMISSIONS['roles.manage'],
+        PERMISSIONS['branches.manage'],
+        PERMISSIONS['analytics.read'],
+        PERMISSIONS['settings.manage'],
+        PERMISSIONS['tenants.manage'],
+        PERMISSIONS['support.cross_tenant_read'],
+        PERMISSIONS['audit.read'],
+        PERMISSIONS['break_glass.use'],
+      ])
+    );
 
     for (const role of [ROLES.admin, ROLES.tenant_admin]) {
       const permissions = sortedPermissions(getRolePermissions(role));
 
       expect(permissions).not.toEqual(superAdminPermissions);
       expect(permissions).not.toContain(PERMISSIONS['tenants.manage']);
+      expect(permissions).not.toContain(PERMISSIONS['break_glass.use']);
+      expect(permissions).toContain(PERMISSIONS['governance.approve']);
+    }
+  });
+
+  it('keeps global support and auditor read-only', () => {
+    const mutationPermissions = [
+      PERMISSIONS['members.write'],
+      PERMISSIONS['claims.update'],
+      PERMISSIONS['claims.assign'],
+      PERMISSIONS['roles.manage'],
+      PERMISSIONS['branches.manage'],
+      PERMISSIONS['settings.manage'],
+      PERMISSIONS['tenants.manage'],
+      PERMISSIONS['governance.approve'],
+    ];
+
+    expect(getRolePermissions(ROLES.global_support)).toEqual([
+      PERMISSIONS['members.read'],
+      PERMISSIONS['claims.read'],
+      PERMISSIONS['analytics.read'],
+      PERMISSIONS['support.cross_tenant_read'],
+    ]);
+    expect(getRolePermissions(ROLES.auditor)).toEqual([
+      PERMISSIONS['analytics.read'],
+      PERMISSIONS['audit.read'],
+    ]);
+
+    for (const role of [ROLES.global_support, ROLES.auditor]) {
+      for (const permission of mutationPermissions) {
+        expect(getRolePermissions(role)).not.toContain(permission);
+      }
     }
   });
 
   it('treats admin and tenant_admin as tenant-level administrators', () => {
     expect(isTenantAdmin(ROLES.admin)).toBe(true);
     expect(isTenantAdmin(ROLES.tenant_admin)).toBe(true);
-    expect(isTenantAdmin(ROLES.super_admin)).toBe(true);
+    expect(isTenantAdmin(ROLES.super_admin)).toBe(false);
+    expect(isTenantAdmin(ROLES.global_support)).toBe(false);
+    expect(isTenantAdmin(ROLES.auditor)).toBe(false);
     expect(isTenantAdmin(ROLES.staff)).toBe(false);
+  });
+
+  it('does not treat support or auditor roles as staff-or-higher operators', () => {
+    expect(isStaffOrHigher(ROLES.global_support)).toBe(false);
+    expect(isStaffOrHigher(ROLES.auditor)).toBe(false);
+    expect(isStaffOrHigher(ROLES.staff)).toBe(true);
   });
 });

--- a/packages/shared-auth/src/permissions.ts
+++ b/packages/shared-auth/src/permissions.ts
@@ -19,6 +19,10 @@ export const PERMISSIONS = {
   'analytics.read': 'analytics.read',
   'settings.manage': 'settings.manage',
   'tenants.manage': 'tenants.manage',
+  'support.cross_tenant_read': 'support.cross_tenant_read',
+  'audit.read': 'audit.read',
+  'break_glass.use': 'break_glass.use',
+  'governance.approve': 'governance.approve',
 } as const;
 
 export type Permission = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];
@@ -28,6 +32,8 @@ export const ROLES = {
   super_admin: 'super_admin',
   admin: 'admin',
   tenant_admin: 'tenant_admin',
+  global_support: 'global_support',
+  auditor: 'auditor',
   branch_manager: 'branch_manager',
   staff: 'staff',
   agent: 'agent',
@@ -37,8 +43,6 @@ export const ROLES = {
 export type Role = (typeof ROLES)[keyof typeof ROLES];
 
 type RolePermissions = Readonly<Record<Role, readonly Permission[]>>;
-
-const ALL_PERMISSIONS: readonly Permission[] = Object.freeze(Object.values(PERMISSIONS));
 
 const TENANT_ADMIN_PERMISSIONS: readonly Permission[] = Object.freeze([
   PERMISSIONS['members.read'],
@@ -50,13 +54,31 @@ const TENANT_ADMIN_PERMISSIONS: readonly Permission[] = Object.freeze([
   PERMISSIONS['branches.manage'],
   PERMISSIONS['analytics.read'],
   PERMISSIONS['settings.manage'],
+  PERMISSIONS['governance.approve'],
+]);
+
+const SUPER_ADMIN_PERMISSIONS: readonly Permission[] = Object.freeze([
+  ...TENANT_ADMIN_PERMISSIONS.filter(
+    permission => permission !== PERMISSIONS['governance.approve']
+  ),
+  PERMISSIONS['tenants.manage'],
+  PERMISSIONS['support.cross_tenant_read'],
+  PERMISSIONS['audit.read'],
+  PERMISSIONS['break_glass.use'],
 ]);
 
 // Permission matrix: which roles have which permissions
 export const ROLE_PERMISSIONS: RolePermissions = Object.freeze({
-  [ROLES.super_admin]: ALL_PERMISSIONS,
+  [ROLES.super_admin]: SUPER_ADMIN_PERMISSIONS,
   [ROLES.admin]: TENANT_ADMIN_PERMISSIONS,
   [ROLES.tenant_admin]: TENANT_ADMIN_PERMISSIONS,
+  [ROLES.global_support]: Object.freeze([
+    PERMISSIONS['members.read'],
+    PERMISSIONS['claims.read'],
+    PERMISSIONS['analytics.read'],
+    PERMISSIONS['support.cross_tenant_read'],
+  ]),
+  [ROLES.auditor]: Object.freeze([PERMISSIONS['analytics.read'], PERMISSIONS['audit.read']]),
   [ROLES.branch_manager]: Object.freeze([
     PERMISSIONS['members.read'],
     PERMISSIONS['members.write'],
@@ -102,7 +124,7 @@ export function isSuperAdmin(role: string | null | undefined): boolean {
  * Check if role is tenant-level admin
  */
 export function isTenantAdmin(role: string | null | undefined): boolean {
-  return role === ROLES.admin || role === ROLES.tenant_admin || role === ROLES.super_admin;
+  return role === ROLES.admin || role === ROLES.tenant_admin;
 }
 
 /**

--- a/packages/shared-auth/src/scope.test.ts
+++ b/packages/shared-auth/src/scope.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { MissingTenantError } from './errors';
+import { ROLES } from './permissions';
+import { scopeFilter } from './scope';
+import type { SessionWithTenant } from './session';
+
+function session(role: string, tenantId?: string): SessionWithTenant {
+  return {
+    user: {
+      id: 'user-1',
+      email: 'user@example.com',
+      role,
+      ...(tenantId ? { tenantId } : {}),
+    },
+  } as SessionWithTenant;
+}
+
+describe('scopeFilter', () => {
+  it('allows global support to read an explicitly selected tenant', () => {
+    expect(scopeFilter(session(ROLES.global_support, 'tenant-1'))).toEqual({
+      tenantId: 'tenant-1',
+      isFullTenantScope: true,
+      isCrossTenantScope: false,
+    });
+  });
+
+  it('allows auditor to read an explicitly selected tenant', () => {
+    expect(scopeFilter(session(ROLES.auditor, 'tenant-1'))).toEqual({
+      tenantId: 'tenant-1',
+      isFullTenantScope: true,
+      isCrossTenantScope: false,
+    });
+  });
+
+  it('requires tenant context for non-super-admin roles', () => {
+    expect(() => scopeFilter(session(ROLES.staff))).toThrow(MissingTenantError);
+    expect(() => scopeFilter(session(ROLES.global_support))).toThrow(MissingTenantError);
+    expect(() => scopeFilter(session(ROLES.auditor))).toThrow(MissingTenantError);
+  });
+});

--- a/packages/shared-auth/src/scope.ts
+++ b/packages/shared-auth/src/scope.ts
@@ -33,10 +33,6 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
 
   const { id: userId, role, tenantId, branchId } = session.user;
 
-  if (!tenantId && !isSuperAdmin(role)) {
-    throw new MissingTenantError();
-  }
-
   // Super admin: cross-tenant access
   if (isSuperAdmin(role)) {
     return {
@@ -46,10 +42,14 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
     };
   }
 
+  if (!tenantId) {
+    throw new MissingTenantError();
+  }
+
   // Tenant admin: full tenant scope
   if (isTenantAdmin(role)) {
     return {
-      tenantId: tenantId!,
+      tenantId,
       isFullTenantScope: true,
       isCrossTenantScope: false,
     };
@@ -58,7 +58,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   // Read-only global support and auditor roles inspect an explicitly selected tenant.
   if (role === ROLES.global_support || role === ROLES.auditor) {
     return {
-      tenantId: tenantId!,
+      tenantId,
       isFullTenantScope: true,
       isCrossTenantScope: false,
     };
@@ -67,7 +67,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   // Staff: full tenant scope for claims
   if (role === ROLES.staff) {
     return {
-      tenantId: tenantId!,
+      tenantId,
       isFullTenantScope: true,
       isCrossTenantScope: false,
     };
@@ -76,7 +76,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   // Branch manager: branch-scoped
   if (role === ROLES.branch_manager) {
     return {
-      tenantId: tenantId!,
+      tenantId,
       branchId: branchId ?? null,
       isFullTenantScope: false,
       isCrossTenantScope: false,
@@ -86,7 +86,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   // Agent: agent-scoped (only their assigned members/claims)
   if (role === ROLES.agent) {
     return {
-      tenantId: tenantId!,
+      tenantId,
       agentId: userId ?? null,
       isFullTenantScope: false,
       isCrossTenantScope: false,
@@ -95,7 +95,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
 
   // Member: self only
   return {
-    tenantId: tenantId!,
+    tenantId,
     userId: userId ?? null,
     isFullTenantScope: false,
     isCrossTenantScope: false,

--- a/packages/shared-auth/src/scope.ts
+++ b/packages/shared-auth/src/scope.ts
@@ -55,6 +55,15 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
     };
   }
 
+  // Read-only global support and auditor roles inspect an explicitly selected tenant.
+  if (role === ROLES.global_support || role === ROLES.auditor) {
+    return {
+      tenantId: tenantId!,
+      isFullTenantScope: true,
+      isCrossTenantScope: false,
+    };
+  }
+
   // Staff: full tenant scope for claims
   if (role === ROLES.staff) {
     return {

--- a/scripts/raw-role-array-allowlist.json
+++ b/scripts/raw-role-array-allowlist.json
@@ -48,7 +48,6 @@
     "packages/domain-membership-billing/src/commissions/admin/access.ts:5:29:admin,tenant_admin,super_admin",
     "packages/domain-membership-billing/src/commissions/get-my.ts:21:8:agent,staff,admin",
     "packages/domain-membership-billing/src/commissions/summary.ts:15:8:agent,staff,admin",
-    "packages/domain-users/src/admin/access.ts:8:28:tenant_admin,super_admin",
     "packages/domain-users/src/admin/get-staff.ts:15:67:staff,admin",
     "packages/domain-users/src/admin/role-rules.ts:1:38:agent,branch_manager",
     "scripts/release-gate/config.ts:33:16:member,agent,staff,admin",

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35666856,
-  "maxTrackedFiles": 4185,
+  "maxTrackedBytes": 35672729,
+  "maxTrackedFiles": 4187,
   "maxCategoryBytes": {
     "large support/generated-ish": 17720397,
-    "source/scripts": 6666190,
+    "source/scripts": 6666192,
     "docs/text": 5098118,
-    "tests/e2e": 4502980,
+    "tests/e2e": 4508851,
     "config/data/messages": 1550006,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35651549,
-  "maxTrackedFiles": 4179,
+  "maxTrackedBytes": 35666856,
+  "maxTrackedFiles": 4185,
   "maxCategoryBytes": {
     "large support/generated-ish": 17720397,
-    "source/scripts": 6662968,
+    "source/scripts": 6666190,
     "docs/text": 5098118,
-    "tests/e2e": 4490816,
-    "config/data/messages": 1550085,
+    "tests/e2e": 4502980,
+    "config/data/messages": 1550006,
     "other": 129165
   },
   "maxLargestFileBytes": 2865109,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35672729,
+  "maxTrackedBytes": 35673059,
   "maxTrackedFiles": 4187,
   "maxCategoryBytes": {
     "large support/generated-ish": 17720397,
-    "source/scripts": 6666192,
+    "source/scripts": 6666221,
     "docs/text": 5098118,
-    "tests/e2e": 4508851,
+    "tests/e2e": 4509152,
     "config/data/messages": 1550006,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Implements T-301 role boundary contracts for Phase C Operating-Business Readiness.
- Splits `super_admin` from tenant governance approval and branch-manager inheritance while preserving super-admin portal operations.
- Adds read-only `global_support` and `auditor` roles, break-glass/governance contract helpers, selected-tenant scoping, and focused tests.
- Keeps `/member`, `/agent`, `/staff`, `/admin` routing and clarity markers unchanged.

## Scope Controls
- `apps/web/src/proxy.ts` untouched.
- README, AGENTS.md, architecture docs, and tracker docs untouched in this implementation PR.
- T-209 remains blocked on T-302b.
- T-202, M3, M5, ida-host, AI posture, UI/UX overhaul, WS-F/G/H, OMG, DOM, and structural-only work were not promoted.
- Governance helpers are shared contracts only; no fee/payment/terms runtime flow wiring in this slice.
- `global_support` and `auditor` fail closed without a selected tenant. Unbounded cross-tenant routing remains deferred to T-302b because current `withTenant()` paths cannot safely express all-tenant reads.

## Review Evidence
- Codex review findings fixed: preserved super-admin portal operations and explicit tenant/branch grants.
- Sonnet review findings fixed: tenant check bypass, analytics super-admin access regression, support/auditor sentinel scoping, branch-manager JWT bypass, and raw super-admin bypass.
- Final Sonnet targeted review reported no findings against the two final requirements.
- One Codex review route timed out/stalled in the wrapper; Sonnet normal review was used as requested.

## Local Verification
- `pnpm security:guard` passed on commit `b08224fa`.
- `pnpm e2e:gate` passed: 134 passed, 8 skipped.
- Final exact `pnpm pr:verify` passed: PR gate 134 passed/8 skipped, smoke 13 passed/1 skipped.
- Earlier local runner SIGKILL/SIGTERM interruptions were rerun cleanly before this PR was opened.
