### PR TITLE
ci: harden E2E lane cleanup

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -79,7 +79,7 @@ jobs:
       # ---- Run suites ----
       - name: Generate Playwright Gate Auth State (KS+MK)
         if: matrix.shardIndex == 1
-        run: pnpm --filter @interdomestik/web exec playwright test --project=setup-ks --project=setup-mk
+        run: pnpm e2e:state:setup
 
       # Gate is fast and tells you immediately if infra drifted.
       - name: E2E Gate (KS+MK)

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         shardIndex: [1, 2, 3]
         shardTotal: [3]

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -104,7 +104,7 @@ jobs:
         run: pnpm --filter @interdomestik/web run build:ci
 
       - name: Generate Playwright auth states
-        run: pnpm --filter @interdomestik/web exec playwright test --project=setup-ks --project=setup-mk
+        run: pnpm e2e:state:setup
 
       - name: RC check - security guard
         shell: bash

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,15 +1,12 @@
 name: Release Candidate
-
 on:
   push:
     branches:
       - 'rc/*'
   workflow_dispatch:
-
 concurrency:
   group: release-candidate-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
 
@@ -59,7 +56,6 @@ jobs:
       RELEASE_GATE_REQUIRE_STAFF_CLAIM_URL: 'false'
     steps:
       - uses: actions/checkout@v5
-
       - uses: ./.github/actions/setup
         with:
           install-playwright: true
@@ -105,6 +101,9 @@ jobs:
 
       - name: Generate Playwright auth states
         run: pnpm e2e:state:setup
+        env:
+          E2E_DATABASE_URL: ${{ env.DATABASE_URL }}
+          E2E_DATABASE_URL_RLS: ${{ env.DATABASE_URL }}
 
       - name: RC check - security guard
         shell: bash

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ci:local:sonar:pr": "node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh sonar-pr",
     "ci:local:ready": "node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh ready",
     "ci:local:clean": "bash scripts/ci-local-parity.sh clean",
-    "test:ci:contracts": "node --test scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs",
+    "test:ci:contracts": "node --test --test-concurrency=1 scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs",
     "sonar:start": "docker compose --profile sonar up -d sonarqube db",
     "sonar:stop": "docker compose --profile sonar stop sonarqube db",
     "sonar:down": "docker compose --profile sonar down --remove-orphans",

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -16,7 +16,8 @@ test('E2E lane runner delegates subprocess cleanup to the detached command helpe
 test('detached command helper terminates active process groups on exit and cancellation', () => {
   assert.match(helper, /detached: true/);
   assert.match(helper, /stdio: \['ignore', 'inherit', 'inherit'\]/);
-  assert.match(helper, /process\.kill\(-pid, signal\)/);
+  assert.match(helper, /process\.platform === 'win32' \? pid : -pid/);
+  assert.match(helper, /process\.kill\(target, signal\)/);
   assert.match(helper, /error\?\.code === 'ESRCH'/);
   assert.match(helper, /process\.once\('exit', \(\) => stopActiveProcessGroups\(\)\)/);
   assert.match(helper, /process\.on\(signal, \(\) => \{/);
@@ -25,4 +26,11 @@ test('detached command helper terminates active process groups on exit and cance
 
 test('root package script exposes the hardened E2E state setup lane', () => {
   assert.equal(packageJson.scripts['e2e:state:setup'], 'node scripts/run-e2e-lane.mjs state');
+});
+
+test('root package script serializes CI contracts without dropping files', () => {
+  assert.equal(
+    packageJson.scripts['test:ci:contracts'],
+    'node --test --test-concurrency=1 scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs'
+  );
 });

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -3,13 +3,26 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const runner = readFileSync(new URL('../run-e2e-lane.mjs', import.meta.url), 'utf8');
+const helper = readFileSync(new URL('run-detached-command.mjs', import.meta.url), 'utf8');
+const packageJson = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+);
 
-test('E2E lane runner terminates leftover child process groups after subprocess exits', () => {
-  assert.match(runner, /function stopProcessGroup\(pid\)/);
-  assert.match(runner, /process\.kill\(-pid, 'SIGTERM'\)/);
-  assert.match(
-    runner,
-    /spawnSync\(command, args, \{ cwd: rootDir, detached: true, env, stdio: 'inherit' \}\)/
-  );
-  assert.match(runner, /stopProcessGroup\(result\.pid\)/);
+test('E2E lane runner delegates subprocess cleanup to the detached command helper', () => {
+  assert.match(runner, /import \{ runDetachedCommand \} from '\.\/ci\/run-detached-command\.mjs'/);
+  assert.match(runner, /await runDetachedCommand\(command, args, \{ cwd: rootDir, env \}\)/);
+});
+
+test('detached command helper terminates active process groups on exit and cancellation', () => {
+  assert.match(helper, /detached: true/);
+  assert.match(helper, /stdio: \['ignore', 'inherit', 'inherit'\]/);
+  assert.match(helper, /process\.kill\(-pid, signal\)/);
+  assert.match(helper, /error\?\.code === 'ESRCH'/);
+  assert.match(helper, /process\.once\('exit', \(\) => stopActiveProcessGroups\(\)\)/);
+  assert.match(helper, /process\.on\(signal, \(\) => \{/);
+  assert.match(helper, /stopActiveProcessGroups\(signal\)/);
+});
+
+test('root package script exposes the hardened E2E state setup lane', () => {
+  assert.equal(packageJson.scripts['e2e:state:setup'], 'node scripts/run-e2e-lane.mjs state');
 });

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const runner = readFileSync(new URL('../run-e2e-lane.mjs', import.meta.url), 'utf8');
+
+test('E2E lane runner terminates leftover child process groups after subprocess exits', () => {
+  assert.match(runner, /function stopProcessGroup\(pid\)/);
+  assert.match(runner, /process\.kill\(-pid, 'SIGTERM'\)/);
+  assert.match(
+    runner,
+    /spawnSync\(command, args, \{ cwd: rootDir, detached: true, env, stdio: 'inherit' \}\)/
+  );
+  assert.match(runner, /stopProcessGroup\(result\.pid\)/);
+});

--- a/scripts/ci/run-detached-command.mjs
+++ b/scripts/ci/run-detached-command.mjs
@@ -16,7 +16,8 @@ export function stopProcessGroup(pid, signal = 'SIGTERM') {
   if (!Number.isInteger(pid) || pid <= 0) return;
 
   try {
-    process.kill(-pid, signal);
+    const target = process.platform === 'win32' ? pid : -pid;
+    process.kill(target, signal);
   } catch (error) {
     if (error?.code === 'ESRCH') return;
     console.warn(
@@ -26,7 +27,7 @@ export function stopProcessGroup(pid, signal = 'SIGTERM') {
 }
 
 function stopActiveProcessGroups(signal = 'SIGTERM') {
-  for (const pid of [...activeProcessGroups]) {
+  for (const pid of activeProcessGroups) {
     activeProcessGroups.delete(pid);
     stopProcessGroup(pid, signal);
   }
@@ -77,9 +78,8 @@ export async function runDetachedCommand(command, args, { cwd, env }) {
         return;
       }
 
-      const error = new Error(
-        `${command} exited with ${signal ? `signal ${signal}` : `status ${code}`}`
-      );
+      const status = signal ? `signal ${signal}` : `status ${code}`;
+      const error = new Error(`${command} exited with ${status}`);
       error.exitCode = code ?? signalExitCode(signal);
       reject(error);
     });

--- a/scripts/ci/run-detached-command.mjs
+++ b/scripts/ci/run-detached-command.mjs
@@ -1,0 +1,87 @@
+import { spawn } from 'node:child_process';
+
+const activeProcessGroups = new Set();
+const terminationSignals = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+let cleanupHandlersInstalled = false;
+let terminationInProgress = false;
+
+function signalExitCode(signal) {
+  if (signal === 'SIGINT') return 130;
+  if (signal === 'SIGTERM') return 143;
+  if (signal === 'SIGHUP') return 129;
+  return 1;
+}
+
+export function stopProcessGroup(pid, signal = 'SIGTERM') {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+
+  try {
+    process.kill(-pid, signal);
+  } catch (error) {
+    if (error?.code === 'ESRCH') return;
+    console.warn(
+      `Unable to send ${signal} to process group ${pid}: ${error?.code || error?.message || error}`
+    );
+  }
+}
+
+function stopActiveProcessGroups(signal = 'SIGTERM') {
+  for (const pid of [...activeProcessGroups]) {
+    activeProcessGroups.delete(pid);
+    stopProcessGroup(pid, signal);
+  }
+}
+
+function installCleanupHandlers() {
+  if (cleanupHandlersInstalled) return;
+  cleanupHandlersInstalled = true;
+
+  process.once('exit', () => stopActiveProcessGroups());
+  for (const signal of terminationSignals) {
+    process.on(signal, () => {
+      if (terminationInProgress) return;
+      terminationInProgress = true;
+      stopActiveProcessGroups(signal);
+      process.exit(signalExitCode(signal));
+    });
+  }
+}
+
+export async function runDetachedCommand(command, args, { cwd, env }) {
+  installCleanupHandlers();
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      detached: true,
+      env,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    if (Number.isInteger(child.pid) && child.pid > 0) activeProcessGroups.add(child.pid);
+    let spawnError = false;
+
+    child.once('error', error => {
+      spawnError = true;
+      activeProcessGroups.delete(child.pid);
+      stopProcessGroup(child.pid);
+      reject(error);
+    });
+
+    child.once('close', (code, signal) => {
+      if (spawnError) return;
+      stopProcessGroup(child.pid);
+      activeProcessGroups.delete(child.pid);
+
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const error = new Error(
+        `${command} exited with ${signal ? `signal ${signal}` : `status ${code}`}`
+      );
+      error.exitCode = code ?? signalExitCode(signal);
+      reject(error);
+    });
+  });
+}

--- a/scripts/ci/run-detached-command.test.mjs
+++ b/scripts/ci/run-detached-command.test.mjs
@@ -87,7 +87,7 @@ test('runDetachedCommand rejects spawn failures without a secondary close error'
 
 test(
   'runDetachedCommand signal handler terminates an active child process group',
-  { timeout: 15000 },
+  { timeout: 25000 },
   async t => {
     if (process.platform === 'win32') {
       t.skip('process groups use POSIX signal semantics');

--- a/scripts/ci/run-detached-command.test.mjs
+++ b/scripts/ci/run-detached-command.test.mjs
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { once } from 'node:events';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import test from 'node:test';
+import { spawn } from 'node:child_process';
+import { runDetachedCommand } from './run-detached-command.mjs';
+
+function nodeTestEnv() {
+  return { PATH: process.env.PATH || '' };
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+async function waitForStopped(pid) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (!isProcessAlive(pid)) return;
+    await delay(100);
+  }
+  assert.equal(isProcessAlive(pid), false);
+}
+
+async function waitForFile(file) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(file)) return;
+    await delay(100);
+  }
+  assert.fail(`Timed out waiting for ${file}`);
+}
+
+test('runDetachedCommand terminates orphaned descendants from the child process group', async t => {
+  if (process.platform === 'win32') {
+    t.skip('process groups use POSIX signal semantics');
+    return;
+  }
+
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'run-detached-command-'));
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  const pidFile = path.join(tempDir, 'descendant.pid');
+  const script = `
+    const { spawn } = require('node:child_process');
+    const { writeFileSync } = require('node:fs');
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+    });
+    writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));
+    setTimeout(() => process.exit(0), 100);
+  `;
+
+  await runDetachedCommand(process.execPath, ['-e', script], { cwd: tempDir, env: nodeTestEnv() });
+  const descendantPid = Number(readFileSync(pidFile, 'utf8'));
+
+  assert.ok(Number.isInteger(descendantPid));
+  await waitForStopped(descendantPid);
+});
+
+test('runDetachedCommand propagates non-zero child exit status', async () => {
+  await assert.rejects(
+    runDetachedCommand(process.execPath, ['-e', 'process.exit(7)'], {
+      cwd: process.cwd(),
+      env: nodeTestEnv(),
+    }),
+    error => error?.exitCode === 7
+  );
+});
+
+test('runDetachedCommand rejects spawn failures without a secondary close error', async () => {
+  await assert.rejects(
+    runDetachedCommand('/definitely/missing/interdomestik-command', [], {
+      cwd: process.cwd(),
+      env: nodeTestEnv(),
+    }),
+    error => error?.code === 'ENOENT'
+  );
+});
+
+test(
+  'runDetachedCommand signal handler terminates an active child process group',
+  { timeout: 15000 },
+  async t => {
+    if (process.platform === 'win32') {
+      t.skip('process groups use POSIX signal semantics');
+      return;
+    }
+
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'run-detached-command-signal-'));
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const pidFile = path.join(tempDir, 'signal-descendant.pid');
+    const helperUrl = new URL('run-detached-command.mjs', import.meta.url).href;
+    const controllerScript = `
+    import { runDetachedCommand } from ${JSON.stringify(helperUrl)};
+    await runDetachedCommand(process.execPath, ['-e', ${JSON.stringify(`
+      const { spawn } = require('node:child_process');
+      const { writeFileSync } = require('node:fs');
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+        stdio: 'ignore',
+      });
+      writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));
+      setInterval(() => {}, 1000);
+    `)}], { cwd: ${JSON.stringify(tempDir)}, env: process.env });
+  `;
+
+    const controller = spawn(process.execPath, ['--input-type=module', '-e', controllerScript], {
+      cwd: tempDir,
+      env: nodeTestEnv(),
+      stdio: 'ignore',
+    });
+
+    await waitForFile(pidFile);
+    const descendantPid = Number(readFileSync(pidFile, 'utf8'));
+    process.kill(controller.pid, 'SIGTERM');
+
+    const [code] = await once(controller, 'exit');
+    assert.equal(code, 143);
+    await waitForStopped(descendantPid);
+  }
+);

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -314,6 +314,7 @@ test('Nightly E2E runs on an available hosted runner while preserving full stric
 
   assert.equal(nightlyJob['runs-on'], 'ubuntu-latest');
   assert.deepEqual(nightlyWorkflow.on.schedule, [{ cron: '10 2 * * *' }]);
+  assert.equal(nightlyJob.strategy['max-parallel'], 2);
   assert.deepEqual(nightlyJob.strategy.matrix, {
     shardIndex: [1, 2, 3],
     shardTotal: [3],

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -237,10 +237,10 @@ test('Release candidate gate includes blocking AI eval fixture proof', () => {
     findStepIndex(releaseCandidateSteps, 'RC check - AI eval fixtures') <
       findStepIndex(releaseCandidateSteps, 'Prepare CI database')
   );
-  assert.equal(
-    findStep(releaseCandidateSteps, 'Generate Playwright auth states').run,
-    'pnpm e2e:state:setup'
-  );
+  const rcAuthStateStep = findStep(releaseCandidateSteps, 'Generate Playwright auth states');
+  assert.equal(rcAuthStateStep.run, 'pnpm e2e:state:setup');
+  assert.equal(rcAuthStateStep.env.E2E_DATABASE_URL, '${{ env.DATABASE_URL }}');
+  assert.equal(rcAuthStateStep.env.E2E_DATABASE_URL_RLS, '${{ env.DATABASE_URL }}');
 });
 
 test('CI unit lane runs the blocking repository coverage gate', () => {

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -93,42 +93,36 @@ test('seeded CI workflows generate masked per-run E2E credentials before seeded 
     assert.match(source, /name:\s*Generate ephemeral E2E credentials/u, workflowPath);
     assert.match(source, /bash scripts\/ci\/export-e2e-credentials\.sh/u, workflowPath);
   }
-
   const ciWorkflow = readWorkflow('.github/workflows/ci.yml');
   const ciSteps = ciWorkflow.jobs['e2e-gate'].steps;
   assert.ok(
     findStepIndex(ciSteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(ciSteps, 'Prepare E2E Database')
   );
-
   const prE2eWorkflow = readWorkflow('.github/workflows/e2e-pr.yml');
   const prE2eSteps = prE2eWorkflow.jobs.e2e.steps;
   assert.ok(
     findStepIndex(prE2eSteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(prE2eSteps, 'Run PR E2E Gate')
   );
-
   const nightlyWorkflow = readWorkflow('.github/workflows/e2e-nightly.yml');
   const nightlySteps = nightlyWorkflow.jobs.e2e.steps;
   assert.ok(
     findStepIndex(nightlySteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(nightlySteps, 'Seed E2E DB')
   );
-
   const releaseCandidateWorkflow = readWorkflow('.github/workflows/release-candidate.yml');
   const releaseCandidateSteps = releaseCandidateWorkflow.jobs['rc-gate'].steps;
   assert.ok(
     findStepIndex(releaseCandidateSteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(releaseCandidateSteps, 'Prepare CI database')
   );
-
   const pilotGateWorkflow = readWorkflow('.github/workflows/pilot-gate.yml');
   const pilotGateSteps = pilotGateWorkflow.jobs['pilot-gate-runner'].steps;
   assert.ok(
     findStepIndex(pilotGateSteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(pilotGateSteps, 'Prepare CI database')
   );
-
   const multiAgentWorkflow = readWorkflow('.github/workflows/multi-agent-pr-hardening.yml');
   const multiAgentSteps = multiAgentWorkflow.jobs['multi-agent-pr-hardening'].steps;
   assert.ok(
@@ -243,6 +237,10 @@ test('Release candidate gate includes blocking AI eval fixture proof', () => {
     findStepIndex(releaseCandidateSteps, 'RC check - AI eval fixtures') <
       findStepIndex(releaseCandidateSteps, 'Prepare CI database')
   );
+  assert.equal(
+    findStep(releaseCandidateSteps, 'Generate Playwright auth states').run,
+    'pnpm e2e:state:setup'
+  );
 });
 
 test('CI unit lane runs the blocking repository coverage gate', () => {
@@ -319,15 +317,16 @@ test('Nightly E2E runs on an available hosted runner while preserving full stric
     shardIndex: [1, 2, 3],
     shardTotal: [3],
   });
-  assert.equal(
-    nightlyJob.env.DATABASE_URL_RLS,
-    "${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}"
+  const e2eDatabaseUrl =
+    "${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}";
+  assert.equal(nightlyJob.env.DATABASE_URL_RLS, e2eDatabaseUrl);
+  assert.equal(nightlyJob.env.E2E_DATABASE_URL_RLS, e2eDatabaseUrl);
+  const nightlyStateStep = findStep(
+    nightlyJob.steps,
+    'Generate Playwright Gate Auth State (KS+MK)'
   );
-  assert.equal(
-    nightlyJob.env.E2E_DATABASE_URL_RLS,
-    "${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}"
-  );
-  assert.ok(findStep(nightlyJob.steps, 'Generate Playwright Gate Auth State (KS+MK)'));
+  assert.ok(nightlyStateStep);
+  assert.equal(nightlyStateStep.run, 'pnpm e2e:state:setup');
   assert.ok(findStep(nightlyJob.steps, 'E2E Gate (KS+MK)'));
   assert.match(
     findStep(nightlyJob.steps, 'E2E Subscription Lifecycle (KS+MK)').run,

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -238,11 +238,11 @@ test('Release candidate gate includes blocking AI eval fixture proof', () => {
       findStepIndex(releaseCandidateSteps, 'Prepare CI database')
   );
   const rcAuthStateStep = findStep(releaseCandidateSteps, 'Generate Playwright auth states');
+  assert.ok(rcAuthStateStep, 'release candidate auth-state setup step should exist');
   assert.equal(rcAuthStateStep.run, 'pnpm e2e:state:setup');
   assert.equal(rcAuthStateStep.env.E2E_DATABASE_URL, '${{ env.DATABASE_URL }}');
   assert.equal(rcAuthStateStep.env.E2E_DATABASE_URL_RLS, '${{ env.DATABASE_URL }}');
 });
-
 test('CI unit lane runs the blocking repository coverage gate', () => {
   const ciWorkflow = readWorkflow('.github/workflows/ci.yml');
   const unitJob = ciWorkflow.jobs.unit;

--- a/scripts/package-e2e-scripts.test.mjs
+++ b/scripts/package-e2e-scripts.test.mjs
@@ -72,7 +72,7 @@ test('web package exposes full and PR gate lanes separately', () => {
 });
 
 test('root package exposes the scripts/ci contract suite', () => {
-  assert.match(packageJson.scripts['test:ci:contracts'], /--test-concurrency=1/u);
+  assert.equal(packageJson.scripts['test:ci:contracts'].includes('--test-concurrency=1'), true);
 });
 
 test('pilot readiness commands keep local verification and production proof distinct', () => {

--- a/scripts/package-e2e-scripts.test.mjs
+++ b/scripts/package-e2e-scripts.test.mjs
@@ -72,7 +72,7 @@ test('web package exposes full and PR gate lanes separately', () => {
 });
 
 test('root package exposes the scripts/ci contract suite', () => {
-  assert.equal(packageJson.scripts['test:ci:contracts'], 'node --test scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs');
+  assert.match(packageJson.scripts['test:ci:contracts'], /--test-concurrency=1/u);
 });
 
 test('pilot readiness commands keep local verification and production proof distinct', () => {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35682210,
-  "maxTrackedFiles": 4187,
+  "maxTrackedBytes": 35690260,
+  "maxTrackedFiles": 4190,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
-    "source/scripts": 6666221,
+    "source/scripts": 6668517,
     "docs/text": 5100703,
-    "tests/e2e": 4509152,
-    "config/data/messages": 1549316,
+    "tests/e2e": 4515005,
+    "config/data/messages": 1549217,
     "other": 129165
   },
   "maxLargestFileBytes": 2872365,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35690904,
+  "maxTrackedBytes": 35690989,
   "maxTrackedFiles": 4190,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
     "source/scripts": 6668589,
     "docs/text": 5100703,
-    "tests/e2e": 4515460,
+    "tests/e2e": 4515545,
     "config/data/messages": 1549334,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35690260,
+  "maxTrackedBytes": 35690904,
   "maxTrackedFiles": 4190,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
-    "source/scripts": 6668517,
+    "source/scripts": 6668589,
     "docs/text": 5100703,
-    "tests/e2e": 4515005,
-    "config/data/messages": 1549217,
+    "tests/e2e": 4515460,
+    "config/data/messages": 1549334,
     "other": 129165
   },
   "maxLargestFileBytes": 2872365,

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -60,9 +60,7 @@ const projectLane = (project, env) => ({
   playwrightArgs: ['e2e/gate', project, ...strictArgs],
 });
 const laneDefinitions = {
-  state: {
-    playwrightArgs: [...setupArgs, ...strictWorkers],
-  },
+  state: { playwrightArgs: [...setupArgs, ...strictWorkers] },
   gate: gateLane([ksSq, mkMk], true),
   pr: gateLane([ksSq, mkContract], true),
   'gate-fast': gateLane([ksSq, mkMk]),
@@ -125,8 +123,16 @@ const baseEnv = {
 const laneEnv = lane.env ? { ...baseEnv, ...lane.env } : baseEnv;
 const stateEnv = { ...laneEnv, PW_FAST_GATES: '0' };
 const finalEnv = laneName === 'state' ? stateEnv : laneEnv;
+
+function stopProcessGroup(pid) {
+  try {
+    if (pid) process.kill(-pid, 'SIGTERM');
+  } catch {}
+}
+
 function run(command, args, env = baseEnv) {
-  const result = spawnSync(command, args, { cwd: rootDir, env, stdio: 'inherit' });
+  const result = spawnSync(command, args, { cwd: rootDir, detached: true, env, stdio: 'inherit' });
+  stopProcessGroup(result.pid);
 
   if (result.error) {
     console.error(result.error);
@@ -138,11 +144,6 @@ function run(command, args, env = baseEnv) {
   }
 }
 
-if (lane.gatekeeper) {
-  run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
-}
-
-if (lane.state) {
-  run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
-}
+if (lane.gatekeeper) run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
+if (lane.state) run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
 run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
-import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { runDetachedCommand } from './ci/run-detached-command.mjs';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const dbUrl = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
@@ -124,26 +124,15 @@ const laneEnv = lane.env ? { ...baseEnv, ...lane.env } : baseEnv;
 const stateEnv = { ...laneEnv, PW_FAST_GATES: '0' };
 const finalEnv = laneName === 'state' ? stateEnv : laneEnv;
 
-function stopProcessGroup(pid) {
+async function run(command, args, env = baseEnv) {
   try {
-    if (pid) process.kill(-pid, 'SIGTERM');
-  } catch {}
-}
-
-function run(command, args, env = baseEnv) {
-  const result = spawnSync(command, args, { cwd: rootDir, detached: true, env, stdio: 'inherit' });
-  stopProcessGroup(result.pid);
-
-  if (result.error) {
-    console.error(result.error);
-    process.exit(1);
-  }
-
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+    await runDetachedCommand(command, args, { cwd: rootDir, env });
+  } catch (error) {
+    console.error(error);
+    process.exit(error?.exitCode ?? 1);
   }
 }
 
-if (lane.gatekeeper) run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
-if (lane.state) run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
-run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);
+if (lane.gatekeeper) await run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
+if (lane.state) await run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
+await run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);


### PR DESCRIPTION
Summary
- Limit nightly E2E startup pressure and reuse the hardened E2E state setup lane in nightly/RC workflows.
- Add a detached process-group runner for E2E lanes so cancellation, failures, and normal exits clean up descendant processes.
- Add contract tests for the E2E lane runner, workflow wiring, detached cleanup, serialized CI contract tests, and repo-size accounting.

Changed Areas
- `.github/workflows/e2e-nightly.yml`
- `.github/workflows/release-candidate.yml`
- `scripts/run-e2e-lane.mjs`
- `scripts/ci/*contracts*.test.mjs`
- `scripts/ci/run-detached-command.mjs`
- `package.json`
- `scripts/repo-size-budget.json`

Verification
- `git diff --check origin/main...HEAD && git diff --check`: pass
- `node --test scripts/ci/run-detached-command.test.mjs scripts/ci/e2e-lane-runner-contracts.test.mjs scripts/ci/workflow-contracts.test.mjs`: pass, 25 tests
- `pnpm test:ci:contracts`: pass, 213 tests
- `pnpm check:e2e-contracts`: pass
- `pnpm repo:size:check`: pass
- `pnpm security:guard`: pass

Review/Security
- Codex senior review: blocked by `quota_or_rate_limit` through the bounded reviewer wrapper with Supabase MCP disabled. No Supabase MCP needed; this diff has no schema, RLS, Edge Function, auth-provider config, or live database scope.
- Claude Sonnet 4.6 independent review: ran. Initial findings led to fixes for undefined PID tracking, non-observable process-group cleanup errors, detached stdin, signal-test flake budget, minimal child-process env, root script contract coverage, and serialized CI contract tests.
- Claude Sonnet 4.6 follow-up review: ran. No hard blockers remained; noted only non-blocking constraints around warning output from exit handlers and the helper being one-shot CLI infrastructure.
- Codex Security: covered by `pnpm security:guard` locally; PR checks still authoritative.
- Sonar/reviewer: pending PR checks and automated PR feedback.

Operational Evidence
- `test:ci:contracts` is serialized with `--test-concurrency=1` because the suite includes repo-mutating contract tests and a live `security:guard` runtime contract.
- Detached E2E lane subprocesses now use process groups and cleanup on close, spawn failure, normal process exit, and SIGINT/SIGTERM/SIGHUP.

Rollback/Mitigation
- Revert this PR to restore previous workflow commands and runner behavior.
- If detached process cleanup causes unexpected CI behavior, revert `scripts/run-e2e-lane.mjs` to direct `spawn`/`exit` behavior and keep the workflow changes separate.

Residual Risk
- Full heavyweight E2E lanes are expected to run in PR/CI; local proof was focused on CI contracts and guard hygiene.
- The detached helper is designed for one-shot CLI use, not long-lived daemon reuse.