### PR TITLE
[codex] Harden E2E lane cleanup after failures

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -79,7 +79,7 @@ jobs:
       # ---- Run suites ----
       - name: Generate Playwright Gate Auth State (KS+MK)
         if: matrix.shardIndex == 1
-        run: pnpm --filter @interdomestik/web exec playwright test --project=setup-ks --project=setup-mk
+        run: pnpm e2e:state:setup
 
       # Gate is fast and tells you immediately if infra drifted.
       - name: E2E Gate (KS+MK)

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         shardIndex: [1, 2, 3]
         shardTotal: [3]

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -104,7 +104,7 @@ jobs:
         run: pnpm --filter @interdomestik/web run build:ci
 
       - name: Generate Playwright auth states
-        run: pnpm --filter @interdomestik/web exec playwright test --project=setup-ks --project=setup-mk
+        run: pnpm e2e:state:setup
 
       - name: RC check - security guard
         shell: bash

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,15 +1,12 @@
 name: Release Candidate
-
 on:
   push:
     branches:
       - 'rc/*'
   workflow_dispatch:
-
 concurrency:
   group: release-candidate-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
 
@@ -59,7 +56,6 @@ jobs:
       RELEASE_GATE_REQUIRE_STAFF_CLAIM_URL: 'false'
     steps:
       - uses: actions/checkout@v5
-
       - uses: ./.github/actions/setup
         with:
           install-playwright: true
@@ -105,6 +101,9 @@ jobs:
 
       - name: Generate Playwright auth states
         run: pnpm e2e:state:setup
+        env:
+          E2E_DATABASE_URL: ${{ env.DATABASE_URL }}
+          E2E_DATABASE_URL_RLS: ${{ env.DATABASE_URL }}
 
       - name: RC check - security guard
         shell: bash

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ci:local:sonar:pr": "node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh sonar-pr",
     "ci:local:ready": "node scripts/run-with-dotenv.mjs bash scripts/ci-local-parity.sh ready",
     "ci:local:clean": "bash scripts/ci-local-parity.sh clean",
-    "test:ci:contracts": "node --test scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs",
+    "test:ci:contracts": "node --test --test-concurrency=1 scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs",
     "sonar:start": "docker compose --profile sonar up -d sonarqube db",
     "sonar:stop": "docker compose --profile sonar stop sonarqube db",
     "sonar:down": "docker compose --profile sonar down --remove-orphans",

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -8,29 +8,33 @@ const packageJson = JSON.parse(
   readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
 );
 
-test('E2E lane runner delegates subprocess cleanup to the detached command helper', () => {
-  assert.match(runner, /import \{ runDetachedCommand \} from '\.\/ci\/run-detached-command\.mjs'/);
+test('E2E lane runner cleanup contracts', () => {
+  assert.match(runner, /\{ cleanupE2ePort, runDetachedCommand \}.*run-detached-command\.mjs/);
   assert.match(runner, /await runDetachedCommand\(command, args, \{ cwd: rootDir, env \}\)/);
+  assert.match(runner, /finally \{\s*cleanupE2ePort\(\{ env: finalEnv \}\);\s*\}/s);
+  assert.match(runner, /process\.exitCode = error\?\.exitCode \?\? 1/);
+  assert.doesNotMatch(runner, /process\.exit\(error\?\.exitCode \?\? 1\)/);
 });
 
-test('detached command helper terminates active process groups on exit and cancellation', () => {
-  assert.match(helper, /detached: true/);
-  assert.match(helper, /stdio: \['ignore', 'inherit', 'inherit'\]/);
-  assert.match(helper, /process\.platform === 'win32' \? pid : -pid/);
-  assert.match(helper, /process\.kill\(target, signal\)/);
-  assert.match(helper, /error\?\.code === 'ESRCH'/);
-  assert.match(helper, /process\.once\('exit', \(\) => stopActiveProcessGroups\(\)\)/);
-  assert.match(helper, /process\.on\(signal, \(\) => \{/);
-  assert.match(helper, /stopActiveProcessGroups\(signal\)/);
+test('detached helper cleanup contracts', () => {
+  for (const pattern of [
+    /detached: true/,
+    /process\.platform === 'win32' \? pid : -pid/,
+    /process\.once\('exit', \(\) => stopActiveProcessGroups\(\)\)/,
+    /stopActiveProcessGroups\(signal\)/,
+    /execFileSync\('lsof', \[`-tiTCP:\$\{port\}`, '-sTCP:LISTEN'\]/,
+    /env\.PW_EXTERNAL_SERVER === '1'/,
+    /stopProcessGroup\(pid, 'SIGKILL'\)/,
+  ]) {
+    assert.match(helper, pattern);
+  }
 });
 
-test('root package script exposes the hardened E2E state setup lane', () => {
-  assert.equal(packageJson.scripts['e2e:state:setup'], 'node scripts/run-e2e-lane.mjs state');
-});
-
-test('root package script serializes CI contracts without dropping files', () => {
+test('root package keeps E2E contract scripts wired', () => {
+  const scripts = packageJson.scripts;
+  assert.equal(scripts['e2e:state:setup'], 'node scripts/run-e2e-lane.mjs state');
   assert.equal(
-    packageJson.scripts['test:ci:contracts'],
+    scripts['test:ci:contracts'],
     'node --test --test-concurrency=1 scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs'
   );
 });

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -1,14 +1,14 @@
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
+import { cleanupE2ePort } from './run-detached-command.mjs';
 
-const runner = readFileSync(new URL('../run-e2e-lane.mjs', import.meta.url), 'utf8');
-const helper = readFileSync(new URL('run-detached-command.mjs', import.meta.url), 'utf8');
-const packageJson = JSON.parse(
-  readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
-);
+const read = file => readFileSync(new URL(file, import.meta.url), 'utf8');
+const runner = read('../run-e2e-lane.mjs');
 
-test('E2E lane runner cleanup contracts', () => {
+test('runner cleanup contracts', () => {
   assert.match(runner, /\{ cleanupE2ePort, runDetachedCommand \}.*run-detached-command\.mjs/);
   assert.match(runner, /await runDetachedCommand\(command, args, \{ cwd: rootDir, env \}\)/);
   assert.match(runner, /finally \{\s*cleanupE2ePort\(\{ env: finalEnv \}\);\s*\}/s);
@@ -16,25 +16,18 @@ test('E2E lane runner cleanup contracts', () => {
   assert.doesNotMatch(runner, /process\.exit\(error\?\.exitCode \?\? 1\)/);
 });
 
-test('detached helper cleanup contracts', () => {
-  for (const pattern of [
-    /detached: true/,
-    /process\.platform === 'win32' \? pid : -pid/,
-    /process\.once\('exit', \(\) => stopActiveProcessGroups\(\)\)/,
-    /stopActiveProcessGroups\(signal\)/,
-    /execFileSync\('lsof', \[`-tiTCP:\$\{port\}`, '-sTCP:LISTEN'\]/,
-    /env\.PW_EXTERNAL_SERVER === '1'/,
-    /stopProcessGroup\(pid, 'SIGKILL'\)/,
-  ]) {
-    assert.match(helper, pattern);
+test('port cleanup kills non-group-leader listeners', async () => {
+  const code =
+    "require('net').createServer().listen(0,'127.0.0.1',function(){console.log(this.address().port)})";
+  const child = spawn(process.execPath, ['-e', code], { stdio: ['ignore', 'pipe', 'ignore'] });
+  try {
+    const [line] = await once(child.stdout, 'data');
+    const port = Number.parseInt(String(line), 10);
+    assert.ok(port > 0);
+    assert.deepEqual(cleanupE2ePort({ env: {}, port }), [child.pid]);
+    await once(child, 'exit');
+    assert.deepEqual(cleanupE2ePort({ env: {}, port }), []);
+  } finally {
+    if (!child.killed) child.kill('SIGKILL');
   }
-});
-
-test('root package keeps E2E contract scripts wired', () => {
-  const scripts = packageJson.scripts;
-  assert.equal(scripts['e2e:state:setup'], 'node scripts/run-e2e-lane.mjs state');
-  assert.equal(
-    scripts['test:ci:contracts'],
-    'node --test --test-concurrency=1 scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs'
-  );
 });

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -16,7 +16,8 @@ test('E2E lane runner delegates subprocess cleanup to the detached command helpe
 test('detached command helper terminates active process groups on exit and cancellation', () => {
   assert.match(helper, /detached: true/);
   assert.match(helper, /stdio: \['ignore', 'inherit', 'inherit'\]/);
-  assert.match(helper, /process\.kill\(-pid, signal\)/);
+  assert.match(helper, /process\.platform === 'win32' \? pid : -pid/);
+  assert.match(helper, /process\.kill\(target, signal\)/);
   assert.match(helper, /error\?\.code === 'ESRCH'/);
   assert.match(helper, /process\.once\('exit', \(\) => stopActiveProcessGroups\(\)\)/);
   assert.match(helper, /process\.on\(signal, \(\) => \{/);
@@ -25,4 +26,11 @@ test('detached command helper terminates active process groups on exit and cance
 
 test('root package script exposes the hardened E2E state setup lane', () => {
   assert.equal(packageJson.scripts['e2e:state:setup'], 'node scripts/run-e2e-lane.mjs state');
+});
+
+test('root package script serializes CI contracts without dropping files', () => {
+  assert.equal(
+    packageJson.scripts['test:ci:contracts'],
+    'node --test --test-concurrency=1 scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs'
+  );
 });

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -3,13 +3,26 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const runner = readFileSync(new URL('../run-e2e-lane.mjs', import.meta.url), 'utf8');
+const helper = readFileSync(new URL('run-detached-command.mjs', import.meta.url), 'utf8');
+const packageJson = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+);
 
-test('E2E lane runner terminates leftover child process groups after subprocess exits', () => {
-  assert.match(runner, /function stopProcessGroup\(pid\)/);
-  assert.match(runner, /process\.kill\(-pid, 'SIGTERM'\)/);
-  assert.match(
-    runner,
-    /spawnSync\(command, args, \{ cwd: rootDir, detached: true, env, stdio: 'inherit' \}\)/
-  );
-  assert.match(runner, /stopProcessGroup\(result\.pid\)/);
+test('E2E lane runner delegates subprocess cleanup to the detached command helper', () => {
+  assert.match(runner, /import \{ runDetachedCommand \} from '\.\/ci\/run-detached-command\.mjs'/);
+  assert.match(runner, /await runDetachedCommand\(command, args, \{ cwd: rootDir, env \}\)/);
+});
+
+test('detached command helper terminates active process groups on exit and cancellation', () => {
+  assert.match(helper, /detached: true/);
+  assert.match(helper, /stdio: \['ignore', 'inherit', 'inherit'\]/);
+  assert.match(helper, /process\.kill\(-pid, signal\)/);
+  assert.match(helper, /error\?\.code === 'ESRCH'/);
+  assert.match(helper, /process\.once\('exit', \(\) => stopActiveProcessGroups\(\)\)/);
+  assert.match(helper, /process\.on\(signal, \(\) => \{/);
+  assert.match(helper, /stopActiveProcessGroups\(signal\)/);
+});
+
+test('root package script exposes the hardened E2E state setup lane', () => {
+  assert.equal(packageJson.scripts['e2e:state:setup'], 'node scripts/run-e2e-lane.mjs state');
 });

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const runner = readFileSync(new URL('../run-e2e-lane.mjs', import.meta.url), 'utf8');
+
+test('E2E lane runner terminates leftover child process groups after subprocess exits', () => {
+  assert.match(runner, /function stopProcessGroup\(pid\)/);
+  assert.match(runner, /process\.kill\(-pid, 'SIGTERM'\)/);
+  assert.match(
+    runner,
+    /spawnSync\(command, args, \{ cwd: rootDir, detached: true, env, stdio: 'inherit' \}\)/
+  );
+  assert.match(runner, /stopProcessGroup\(result\.pid\)/);
+});

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -7,6 +7,7 @@ import { cleanupE2ePort } from './run-detached-command.mjs';
 
 const read = file => readFileSync(new URL(file, import.meta.url), 'utf8');
 const runner = read('../run-e2e-lane.mjs');
+const gatekeeper = read('../m4-gatekeeper.sh');
 
 test('runner cleanup contracts', () => {
   assert.match(runner, /\{ cleanupE2ePort, runDetachedCommand \}.*run-detached-command\.mjs/);
@@ -14,6 +15,11 @@ test('runner cleanup contracts', () => {
   assert.match(runner, /finally \{\s*cleanupE2ePort\(\{ env: finalEnv \}\);\s*\}/s);
   assert.match(runner, /process\.exitCode = error\?\.exitCode \?\? 1/);
   assert.doesNotMatch(runner, /process\.exit\(error\?\.exitCode \?\? 1\)/);
+});
+
+test('gatekeeper only kills port 3000 listeners', () => {
+  assert.doesNotMatch(gatekeeper, /lsof -ti:3000/);
+  assert.match(gatekeeper, /lsof -tiTCP:3000 -sTCP:LISTEN/);
 });
 
 test('port cleanup kills non-group-leader listeners', async () => {

--- a/scripts/ci/run-detached-command.mjs
+++ b/scripts/ci/run-detached-command.mjs
@@ -16,7 +16,8 @@ export function stopProcessGroup(pid, signal = 'SIGTERM') {
   if (!Number.isInteger(pid) || pid <= 0) return;
 
   try {
-    process.kill(-pid, signal);
+    const target = process.platform === 'win32' ? pid : -pid;
+    process.kill(target, signal);
   } catch (error) {
     if (error?.code === 'ESRCH') return;
     console.warn(
@@ -26,7 +27,7 @@ export function stopProcessGroup(pid, signal = 'SIGTERM') {
 }
 
 function stopActiveProcessGroups(signal = 'SIGTERM') {
-  for (const pid of [...activeProcessGroups]) {
+  for (const pid of activeProcessGroups) {
     activeProcessGroups.delete(pid);
     stopProcessGroup(pid, signal);
   }
@@ -77,9 +78,8 @@ export async function runDetachedCommand(command, args, { cwd, env }) {
         return;
       }
 
-      const error = new Error(
-        `${command} exited with ${signal ? `signal ${signal}` : `status ${code}`}`
-      );
+      const status = signal ? `signal ${signal}` : `status ${code}`;
+      const error = new Error(`${command} exited with ${status}`);
       error.exitCode = code ?? signalExitCode(signal);
       reject(error);
     });

--- a/scripts/ci/run-detached-command.mjs
+++ b/scripts/ci/run-detached-command.mjs
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 
 const activeProcessGroups = new Set();
 const terminationSignals = ['SIGINT', 'SIGTERM', 'SIGHUP'];
@@ -31,6 +31,40 @@ function stopActiveProcessGroups(signal = 'SIGTERM') {
     activeProcessGroups.delete(pid);
     stopProcessGroup(pid, signal);
   }
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function portListenerPids(port) {
+  try {
+    return [
+      ...new Set(
+        execFileSync('lsof', [`-tiTCP:${port}`, '-sTCP:LISTEN'], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+          .split(/\s+/)
+          .map(value => Number.parseInt(value, 10))
+          .filter(pid => Number.isInteger(pid) && pid > 0)
+      ),
+    ];
+  } catch (error) {
+    if (error?.status === 1) return [];
+    throw error;
+  }
+}
+
+export function cleanupE2ePort({ env = process.env, port = 3000 } = {}) {
+  if (env.PW_EXTERNAL_SERVER === '1') return [];
+  const pids = portListenerPids(port);
+  for (const pid of pids) stopProcessGroup(pid);
+  if (pids.length > 0) sleepSync(1000);
+  for (const pid of portListenerPids(port).filter(pid => pids.includes(pid))) {
+    stopProcessGroup(pid, 'SIGKILL');
+  }
+  return pids;
 }
 
 function installCleanupHandlers() {

--- a/scripts/ci/run-detached-command.mjs
+++ b/scripts/ci/run-detached-command.mjs
@@ -13,17 +13,36 @@ function signalExitCode(signal) {
 }
 
 export function stopProcessGroup(pid, signal = 'SIGTERM') {
-  if (!Number.isInteger(pid) || pid <= 0) return;
+  if (!Number.isInteger(pid) || pid <= 0) return false;
 
   try {
     const target = process.platform === 'win32' ? pid : -pid;
     process.kill(target, signal);
+    return true;
   } catch (error) {
-    if (error?.code === 'ESRCH') return;
+    if (error?.code === 'ESRCH') return false;
     console.warn(
       `Unable to send ${signal} to process group ${pid}: ${error?.code || error?.message || error}`
     );
+    return false;
   }
+}
+
+function stopProcess(pid, signal = 'SIGTERM') {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+
+  try {
+    process.kill(pid, signal);
+  } catch (error) {
+    if (error?.code === 'ESRCH') return;
+    console.warn(
+      `Unable to send ${signal} to process ${pid}: ${error?.code || error?.message || error}`
+    );
+  }
+}
+
+function stopProcessGroupOrPid(pid, signal = 'SIGTERM') {
+  if (!stopProcessGroup(pid, signal)) stopProcess(pid, signal);
 }
 
 function stopActiveProcessGroups(signal = 'SIGTERM') {
@@ -59,10 +78,10 @@ function portListenerPids(port) {
 export function cleanupE2ePort({ env = process.env, port = 3000 } = {}) {
   if (env.PW_EXTERNAL_SERVER === '1') return [];
   const pids = portListenerPids(port);
-  for (const pid of pids) stopProcessGroup(pid);
+  for (const pid of pids) stopProcessGroupOrPid(pid);
   if (pids.length > 0) sleepSync(1000);
   for (const pid of portListenerPids(port).filter(pid => pids.includes(pid))) {
-    stopProcessGroup(pid, 'SIGKILL');
+    stopProcessGroupOrPid(pid, 'SIGKILL');
   }
   return pids;
 }

--- a/scripts/ci/run-detached-command.mjs
+++ b/scripts/ci/run-detached-command.mjs
@@ -1,0 +1,87 @@
+import { spawn } from 'node:child_process';
+
+const activeProcessGroups = new Set();
+const terminationSignals = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+let cleanupHandlersInstalled = false;
+let terminationInProgress = false;
+
+function signalExitCode(signal) {
+  if (signal === 'SIGINT') return 130;
+  if (signal === 'SIGTERM') return 143;
+  if (signal === 'SIGHUP') return 129;
+  return 1;
+}
+
+export function stopProcessGroup(pid, signal = 'SIGTERM') {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+
+  try {
+    process.kill(-pid, signal);
+  } catch (error) {
+    if (error?.code === 'ESRCH') return;
+    console.warn(
+      `Unable to send ${signal} to process group ${pid}: ${error?.code || error?.message || error}`
+    );
+  }
+}
+
+function stopActiveProcessGroups(signal = 'SIGTERM') {
+  for (const pid of [...activeProcessGroups]) {
+    activeProcessGroups.delete(pid);
+    stopProcessGroup(pid, signal);
+  }
+}
+
+function installCleanupHandlers() {
+  if (cleanupHandlersInstalled) return;
+  cleanupHandlersInstalled = true;
+
+  process.once('exit', () => stopActiveProcessGroups());
+  for (const signal of terminationSignals) {
+    process.on(signal, () => {
+      if (terminationInProgress) return;
+      terminationInProgress = true;
+      stopActiveProcessGroups(signal);
+      process.exit(signalExitCode(signal));
+    });
+  }
+}
+
+export async function runDetachedCommand(command, args, { cwd, env }) {
+  installCleanupHandlers();
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      detached: true,
+      env,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    if (Number.isInteger(child.pid) && child.pid > 0) activeProcessGroups.add(child.pid);
+    let spawnError = false;
+
+    child.once('error', error => {
+      spawnError = true;
+      activeProcessGroups.delete(child.pid);
+      stopProcessGroup(child.pid);
+      reject(error);
+    });
+
+    child.once('close', (code, signal) => {
+      if (spawnError) return;
+      stopProcessGroup(child.pid);
+      activeProcessGroups.delete(child.pid);
+
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const error = new Error(
+        `${command} exited with ${signal ? `signal ${signal}` : `status ${code}`}`
+      );
+      error.exitCode = code ?? signalExitCode(signal);
+      reject(error);
+    });
+  });
+}

--- a/scripts/ci/run-detached-command.test.mjs
+++ b/scripts/ci/run-detached-command.test.mjs
@@ -87,7 +87,7 @@ test('runDetachedCommand rejects spawn failures without a secondary close error'
 
 test(
   'runDetachedCommand signal handler terminates an active child process group',
-  { timeout: 15000 },
+  { timeout: 25000 },
   async t => {
     if (process.platform === 'win32') {
       t.skip('process groups use POSIX signal semantics');

--- a/scripts/ci/run-detached-command.test.mjs
+++ b/scripts/ci/run-detached-command.test.mjs
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { once } from 'node:events';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import test from 'node:test';
+import { spawn } from 'node:child_process';
+import { runDetachedCommand } from './run-detached-command.mjs';
+
+function nodeTestEnv() {
+  return { PATH: process.env.PATH || '' };
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+async function waitForStopped(pid) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (!isProcessAlive(pid)) return;
+    await delay(100);
+  }
+  assert.equal(isProcessAlive(pid), false);
+}
+
+async function waitForFile(file) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(file)) return;
+    await delay(100);
+  }
+  assert.fail(`Timed out waiting for ${file}`);
+}
+
+test('runDetachedCommand terminates orphaned descendants from the child process group', async t => {
+  if (process.platform === 'win32') {
+    t.skip('process groups use POSIX signal semantics');
+    return;
+  }
+
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'run-detached-command-'));
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  const pidFile = path.join(tempDir, 'descendant.pid');
+  const script = `
+    const { spawn } = require('node:child_process');
+    const { writeFileSync } = require('node:fs');
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+    });
+    writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));
+    setTimeout(() => process.exit(0), 100);
+  `;
+
+  await runDetachedCommand(process.execPath, ['-e', script], { cwd: tempDir, env: nodeTestEnv() });
+  const descendantPid = Number(readFileSync(pidFile, 'utf8'));
+
+  assert.ok(Number.isInteger(descendantPid));
+  await waitForStopped(descendantPid);
+});
+
+test('runDetachedCommand propagates non-zero child exit status', async () => {
+  await assert.rejects(
+    runDetachedCommand(process.execPath, ['-e', 'process.exit(7)'], {
+      cwd: process.cwd(),
+      env: nodeTestEnv(),
+    }),
+    error => error?.exitCode === 7
+  );
+});
+
+test('runDetachedCommand rejects spawn failures without a secondary close error', async () => {
+  await assert.rejects(
+    runDetachedCommand('/definitely/missing/interdomestik-command', [], {
+      cwd: process.cwd(),
+      env: nodeTestEnv(),
+    }),
+    error => error?.code === 'ENOENT'
+  );
+});
+
+test(
+  'runDetachedCommand signal handler terminates an active child process group',
+  { timeout: 15000 },
+  async t => {
+    if (process.platform === 'win32') {
+      t.skip('process groups use POSIX signal semantics');
+      return;
+    }
+
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'run-detached-command-signal-'));
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const pidFile = path.join(tempDir, 'signal-descendant.pid');
+    const helperUrl = new URL('run-detached-command.mjs', import.meta.url).href;
+    const controllerScript = `
+    import { runDetachedCommand } from ${JSON.stringify(helperUrl)};
+    await runDetachedCommand(process.execPath, ['-e', ${JSON.stringify(`
+      const { spawn } = require('node:child_process');
+      const { writeFileSync } = require('node:fs');
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+        stdio: 'ignore',
+      });
+      writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));
+      setInterval(() => {}, 1000);
+    `)}], { cwd: ${JSON.stringify(tempDir)}, env: process.env });
+  `;
+
+    const controller = spawn(process.execPath, ['--input-type=module', '-e', controllerScript], {
+      cwd: tempDir,
+      env: nodeTestEnv(),
+      stdio: 'ignore',
+    });
+
+    await waitForFile(pidFile);
+    const descendantPid = Number(readFileSync(pidFile, 'utf8'));
+    process.kill(controller.pid, 'SIGTERM');
+
+    const [code] = await once(controller, 'exit');
+    assert.equal(code, 143);
+    await waitForStopped(descendantPid);
+  }
+);

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -314,6 +314,7 @@ test('Nightly E2E runs on an available hosted runner while preserving full stric
 
   assert.equal(nightlyJob['runs-on'], 'ubuntu-latest');
   assert.deepEqual(nightlyWorkflow.on.schedule, [{ cron: '10 2 * * *' }]);
+  assert.equal(nightlyJob.strategy['max-parallel'], 2);
   assert.deepEqual(nightlyJob.strategy.matrix, {
     shardIndex: [1, 2, 3],
     shardTotal: [3],

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -237,10 +237,10 @@ test('Release candidate gate includes blocking AI eval fixture proof', () => {
     findStepIndex(releaseCandidateSteps, 'RC check - AI eval fixtures') <
       findStepIndex(releaseCandidateSteps, 'Prepare CI database')
   );
-  assert.equal(
-    findStep(releaseCandidateSteps, 'Generate Playwright auth states').run,
-    'pnpm e2e:state:setup'
-  );
+  const rcAuthStateStep = findStep(releaseCandidateSteps, 'Generate Playwright auth states');
+  assert.equal(rcAuthStateStep.run, 'pnpm e2e:state:setup');
+  assert.equal(rcAuthStateStep.env.E2E_DATABASE_URL, '${{ env.DATABASE_URL }}');
+  assert.equal(rcAuthStateStep.env.E2E_DATABASE_URL_RLS, '${{ env.DATABASE_URL }}');
 });
 
 test('CI unit lane runs the blocking repository coverage gate', () => {

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -93,42 +93,36 @@ test('seeded CI workflows generate masked per-run E2E credentials before seeded 
     assert.match(source, /name:\s*Generate ephemeral E2E credentials/u, workflowPath);
     assert.match(source, /bash scripts\/ci\/export-e2e-credentials\.sh/u, workflowPath);
   }
-
   const ciWorkflow = readWorkflow('.github/workflows/ci.yml');
   const ciSteps = ciWorkflow.jobs['e2e-gate'].steps;
   assert.ok(
     findStepIndex(ciSteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(ciSteps, 'Prepare E2E Database')
   );
-
   const prE2eWorkflow = readWorkflow('.github/workflows/e2e-pr.yml');
   const prE2eSteps = prE2eWorkflow.jobs.e2e.steps;
   assert.ok(
     findStepIndex(prE2eSteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(prE2eSteps, 'Run PR E2E Gate')
   );
-
   const nightlyWorkflow = readWorkflow('.github/workflows/e2e-nightly.yml');
   const nightlySteps = nightlyWorkflow.jobs.e2e.steps;
   assert.ok(
     findStepIndex(nightlySteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(nightlySteps, 'Seed E2E DB')
   );
-
   const releaseCandidateWorkflow = readWorkflow('.github/workflows/release-candidate.yml');
   const releaseCandidateSteps = releaseCandidateWorkflow.jobs['rc-gate'].steps;
   assert.ok(
     findStepIndex(releaseCandidateSteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(releaseCandidateSteps, 'Prepare CI database')
   );
-
   const pilotGateWorkflow = readWorkflow('.github/workflows/pilot-gate.yml');
   const pilotGateSteps = pilotGateWorkflow.jobs['pilot-gate-runner'].steps;
   assert.ok(
     findStepIndex(pilotGateSteps, 'Generate ephemeral E2E credentials') <
       findStepIndex(pilotGateSteps, 'Prepare CI database')
   );
-
   const multiAgentWorkflow = readWorkflow('.github/workflows/multi-agent-pr-hardening.yml');
   const multiAgentSteps = multiAgentWorkflow.jobs['multi-agent-pr-hardening'].steps;
   assert.ok(
@@ -243,6 +237,10 @@ test('Release candidate gate includes blocking AI eval fixture proof', () => {
     findStepIndex(releaseCandidateSteps, 'RC check - AI eval fixtures') <
       findStepIndex(releaseCandidateSteps, 'Prepare CI database')
   );
+  assert.equal(
+    findStep(releaseCandidateSteps, 'Generate Playwright auth states').run,
+    'pnpm e2e:state:setup'
+  );
 });
 
 test('CI unit lane runs the blocking repository coverage gate', () => {
@@ -319,15 +317,16 @@ test('Nightly E2E runs on an available hosted runner while preserving full stric
     shardIndex: [1, 2, 3],
     shardTotal: [3],
   });
-  assert.equal(
-    nightlyJob.env.DATABASE_URL_RLS,
-    "${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}"
+  const e2eDatabaseUrl =
+    "${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}";
+  assert.equal(nightlyJob.env.DATABASE_URL_RLS, e2eDatabaseUrl);
+  assert.equal(nightlyJob.env.E2E_DATABASE_URL_RLS, e2eDatabaseUrl);
+  const nightlyStateStep = findStep(
+    nightlyJob.steps,
+    'Generate Playwright Gate Auth State (KS+MK)'
   );
-  assert.equal(
-    nightlyJob.env.E2E_DATABASE_URL_RLS,
-    "${{ secrets.E2E_DATABASE_URL_RLS || secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}"
-  );
-  assert.ok(findStep(nightlyJob.steps, 'Generate Playwright Gate Auth State (KS+MK)'));
+  assert.ok(nightlyStateStep);
+  assert.equal(nightlyStateStep.run, 'pnpm e2e:state:setup');
   assert.ok(findStep(nightlyJob.steps, 'E2E Gate (KS+MK)'));
   assert.match(
     findStep(nightlyJob.steps, 'E2E Subscription Lifecycle (KS+MK)').run,

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -238,11 +238,11 @@ test('Release candidate gate includes blocking AI eval fixture proof', () => {
       findStepIndex(releaseCandidateSteps, 'Prepare CI database')
   );
   const rcAuthStateStep = findStep(releaseCandidateSteps, 'Generate Playwright auth states');
+  assert.ok(rcAuthStateStep, 'release candidate auth-state setup step should exist');
   assert.equal(rcAuthStateStep.run, 'pnpm e2e:state:setup');
   assert.equal(rcAuthStateStep.env.E2E_DATABASE_URL, '${{ env.DATABASE_URL }}');
   assert.equal(rcAuthStateStep.env.E2E_DATABASE_URL_RLS, '${{ env.DATABASE_URL }}');
 });
-
 test('CI unit lane runs the blocking repository coverage gate', () => {
   const ciWorkflow = readWorkflow('.github/workflows/ci.yml');
   const unitJob = ciWorkflow.jobs.unit;

--- a/scripts/m4-gatekeeper.sh
+++ b/scripts/m4-gatekeeper.sh
@@ -6,7 +6,6 @@ bash "${SCRIPT_DIR}/node-guard.sh"
 
 echo "🚧 [Gatekeeper] Starting Deterministic Reset..."
 
-# 0. Load env (Gatekeeper must be runnable in a fresh shell/CI)
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
@@ -29,8 +28,6 @@ if [ -n "${E2E_DATABASE_URL:-}" ]; then
 elif [ -n "${INHERITED_DATABASE_URL:-}" ]; then
   export DATABASE_URL="${INHERITED_DATABASE_URL}"
 else
-  # Ignore .env/.env.local DATABASE_URL for deterministic local parity when no
-  # explicit override is provided by caller shell or E2E_DATABASE_URL.
   if [ -n "${DATABASE_URL:-}" ]; then
     echo "ℹ️  [Gatekeeper] Ignoring env-file DATABASE_URL for Playwright gate parity"
   fi
@@ -41,7 +38,6 @@ fi
 if [ -n "${E2E_DATABASE_URL_RLS:-}" ]; then
   export DATABASE_URL_RLS="${E2E_DATABASE_URL_RLS}"
 else
-  # Keep RLS/admin reads on the same deterministic DB unless explicitly overridden.
   export DATABASE_URL_RLS="${DATABASE_URL}"
 fi
 
@@ -105,7 +101,6 @@ cleanup_stale_supabase_containers() {
   echo "${stale_supabase_containers}" | xargs docker rm -f >/dev/null 2>&1 || true
 }
 
-# 0. Kill stale processes
 cleanup_stale_playwright_processes
 
 echo "💀 [Gatekeeper] Killing stale processes on port 3000..."
@@ -118,8 +113,6 @@ echo "✅ [Gatekeeper] Port 3000 clear."
 ensure_disk_space
 
 ensure_supabase_running() {
-  # We use local Supabase (db on 54322). If it's not running, start it.
-  # First, if DB is already reachable via DATABASE_URL, do not try to start anything.
   if node - <<'NODE'
 const postgres = require('postgres');
 const url = process.env.DATABASE_URL;
@@ -148,7 +141,6 @@ NODE
   fi
 
   echo "⚠️  [Gatekeeper] Supabase not running. Starting local Supabase..."
-  # If a previous Supabase project is holding ports, stop it and retry.
   if ! pnpm --filter @interdomestik/database exec supabase start; then
     echo "⚠️  [Gatekeeper] Supabase start failed (likely port already allocated)."
     echo "   Attempting to stop Supabase project 'interdomestik' and retry..."
@@ -188,22 +180,13 @@ NODE
   echo "✅ [Gatekeeper] Postgres is READY."
 }
 
-# Run readiness check (assuming local Supabase or Docker wrapper)
-# We try lightweight check first
 echo "🔍 [Gatekeeper] Checking DB connectivity..."
 wait_for_postgres
 
-# 2. Deterministic Reset Strategy: "Migrate Down/Up" or "Seed Reset"
-# We adhere to the finding: "Supabase reset" is flaky. 
-# We prefer: "Truncate + Seed" (handled by seed:e2e --reset) OR "pnpm db:migrate" on top.
-
 echo "🏗️  [Gatekeeper] Applying Schema (Idempotent Migrate)..."
-# This ensures table structure is correct without nuking the container
 pnpm db:migrate
 
 echo "🌱 [Gatekeeper] Seeding Deterministic State (Reset Mode)..."
-# The --reset flag in our seed script handles TRUNCATE CASCADE
-# limiting the blast radius compared to a full DB drop.
 pnpm seed:e2e -- --reset
 
 echo "🏗️  [Gatekeeper] Building production-like standalone web artifact..."
@@ -217,7 +200,6 @@ echo "   - Schema: Synced"
 echo "   - Data: Deterministic (Version: E2E-Golden)"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-# 0. Kill stale processes to ensure fresh env/config
 echo "💀 Killing any stale processes on port 3000..."
 PIDS="$(lsof -ti:3000 2>/dev/null || true)"
 if [ -n "$PIDS" ]; then

--- a/scripts/m4-gatekeeper.sh
+++ b/scripts/m4-gatekeeper.sh
@@ -104,7 +104,7 @@ cleanup_stale_supabase_containers() {
 cleanup_stale_playwright_processes
 
 echo "💀 [Gatekeeper] Killing stale processes on port 3000..."
-PIDS="$(lsof -ti:3000 2>/dev/null || true)"
+PIDS="$(lsof -tiTCP:3000 -sTCP:LISTEN 2>/dev/null || true)"
 if [ -n "$PIDS" ]; then
   kill -9 $PIDS 2>/dev/null || true
 fi
@@ -201,7 +201,7 @@ echo "   - Data: Deterministic (Version: E2E-Golden)"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 echo "💀 Killing any stale processes on port 3000..."
-PIDS="$(lsof -ti:3000 2>/dev/null || true)"
+PIDS="$(lsof -tiTCP:3000 -sTCP:LISTEN 2>/dev/null || true)"
 if [ -n "$PIDS" ]; then
   kill -9 $PIDS 2>/dev/null || true
 fi

--- a/scripts/m4-gatekeeper.sh
+++ b/scripts/m4-gatekeeper.sh
@@ -4,23 +4,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 bash "${SCRIPT_DIR}/node-guard.sh"
 
-# ==============================================================================
-# M4 Gatekeeper: Deterministic Reset & Seed Contract
-# ==============================================================================
-# 1. Stops stale app processes
-# 2. Waits for Postgres readiness (strict contract)
-# 3. Resets DB via migration (not full nukes) for speed & stability
-# 4. Seeds deterministic verification data
-# 5. Ensures no dirty state leaks between runs
-# ==============================================================================
-
 echo "🚧 [Gatekeeper] Starting Deterministic Reset..."
 
 # 0. Load env (Gatekeeper must be runnable in a fresh shell/CI)
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
-# Preserve explicit shell-provided values before sourcing local env files.
 INHERITED_DATABASE_URL="${DATABASE_URL:-}"
 INHERITED_NEXT_PUBLIC_BILLING_TEST_MODE="${NEXT_PUBLIC_BILLING_TEST_MODE:-}"
 
@@ -35,14 +24,6 @@ if [ -n "${INHERITED_NEXT_PUBLIC_BILLING_TEST_MODE:-}" ]; then
   export NEXT_PUBLIC_BILLING_TEST_MODE="${INHERITED_NEXT_PUBLIC_BILLING_TEST_MODE}"
 fi
 
-# Deterministic DB resolution for gate runs:
-# 1) E2E_DATABASE_URL override
-# 2) Explicit caller-provided DATABASE_URL
-# 3) Local Supabase fallback
-#
-# NOTE: Keep this precedence aligned with scripts/e2e-webserver.sh.
-# If gatekeeper and Playwright web server resolve different DB URLs,
-# gate runs can hang waiting on /api/health while checking a different DB.
 if [ -n "${E2E_DATABASE_URL:-}" ]; then
   export DATABASE_URL="${E2E_DATABASE_URL}"
 elif [ -n "${INHERITED_DATABASE_URL:-}" ]; then
@@ -65,14 +46,11 @@ else
 fi
 
 if [ -z "${BETTER_AUTH_SECRET:-}" ]; then
-  # Any 32+ char secret works for local E2E; keep it deterministic within this run.
   export BETTER_AUTH_SECRET="$(node -e "process.stdout.write(require('crypto').randomBytes(32).toString('base64'))")"
   echo "⚠️  [Gatekeeper] BETTER_AUTH_SECRET not set; generated an ephemeral secret for this run"
 fi
 
 ensure_disk_space() {
-  # Next.js standalone output tracing can produce multiple GB of files.
-  # Avoid ENOSPC by cleaning stale build artifacts before we start.
   echo "🧹 [Gatekeeper] Cleaning stale build artifacts..."
   rm -rf apps/web/.next .turbo || true
 
@@ -82,14 +60,11 @@ ensure_disk_space() {
     return 0
   fi
 
-  # If we're still very low on disk, optionally prune the pnpm store.
-  # This is safe but can be slow, so we only do it under pressure.
   if [ "${AVAILABLE_KB}" -lt $((6 * 1024 * 1024)) ]; then
     echo "⚠️  [Gatekeeper] Low disk space detected (<6GiB). Pruning pnpm store..."
     pnpm store prune || true
   fi
 
-  # Re-check after cleanup
   AVAILABLE_KB="$(df -Pk . | awk 'NR==2 { print $4 }')"
   if [ "${AVAILABLE_KB}" -lt $((4 * 1024 * 1024)) ]; then
     echo "❌ [Gatekeeper] Not enough free disk space to build reliably (<4GiB)."
@@ -101,12 +76,6 @@ ensure_disk_space() {
 cleanup_stale_playwright_processes() {
   echo "🧽 [Gatekeeper] Cleaning stale Playwright helper processes..."
 
-  # Stale Playwright test-server instances can survive interrupted runs and
-  # block subsequent gate execution before tests even start.
-  #
-  # Keep patterns narrowly scoped to test-server processes. Broad patterns such
-  # as "playwright test e2e/gate" can match the currently running CI command
-  # line and terminate the active gate itself.
   local patterns=(
     '@playwright/test/cli.js test-server -c apps/web/playwright.config.ts'
     'playwright test-server -c apps/web/playwright.config.ts'

--- a/scripts/package-e2e-scripts.test.mjs
+++ b/scripts/package-e2e-scripts.test.mjs
@@ -72,7 +72,7 @@ test('web package exposes full and PR gate lanes separately', () => {
 });
 
 test('root package exposes the scripts/ci contract suite', () => {
-  assert.match(packageJson.scripts['test:ci:contracts'], /--test-concurrency=1/u);
+  assert.equal(packageJson.scripts['test:ci:contracts'].includes('--test-concurrency=1'), true);
 });
 
 test('pilot readiness commands keep local verification and production proof distinct', () => {

--- a/scripts/package-e2e-scripts.test.mjs
+++ b/scripts/package-e2e-scripts.test.mjs
@@ -72,7 +72,7 @@ test('web package exposes full and PR gate lanes separately', () => {
 });
 
 test('root package exposes the scripts/ci contract suite', () => {
-  assert.equal(packageJson.scripts['test:ci:contracts'], 'node --test scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs');
+  assert.match(packageJson.scripts['test:ci:contracts'], /--test-concurrency=1/u);
 });
 
 test('pilot readiness commands keep local verification and production proof distinct', () => {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35682210,
-  "maxTrackedFiles": 4187,
+  "maxTrackedBytes": 35690260,
+  "maxTrackedFiles": 4190,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
-    "source/scripts": 6666221,
+    "source/scripts": 6668517,
     "docs/text": 5100703,
-    "tests/e2e": 4509152,
-    "config/data/messages": 1549316,
+    "tests/e2e": 4515005,
+    "config/data/messages": 1549217,
     "other": 129165
   },
   "maxLargestFileBytes": 2872365,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35690904,
+  "maxTrackedBytes": 35690989,
   "maxTrackedFiles": 4190,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
     "source/scripts": 6668589,
     "docs/text": 5100703,
-    "tests/e2e": 4515460,
+    "tests/e2e": 4515545,
     "config/data/messages": 1549334,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35690260,
+  "maxTrackedBytes": 35690904,
   "maxTrackedFiles": 4190,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
-    "source/scripts": 6668517,
+    "source/scripts": 6668589,
     "docs/text": 5100703,
-    "tests/e2e": 4515005,
-    "config/data/messages": 1549217,
+    "tests/e2e": 4515460,
+    "config/data/messages": 1549334,
     "other": 129165
   },
   "maxLargestFileBytes": 2872365,

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -60,9 +60,7 @@ const projectLane = (project, env) => ({
   playwrightArgs: ['e2e/gate', project, ...strictArgs],
 });
 const laneDefinitions = {
-  state: {
-    playwrightArgs: [...setupArgs, ...strictWorkers],
-  },
+  state: { playwrightArgs: [...setupArgs, ...strictWorkers] },
   gate: gateLane([ksSq, mkMk], true),
   pr: gateLane([ksSq, mkContract], true),
   'gate-fast': gateLane([ksSq, mkMk]),
@@ -125,8 +123,16 @@ const baseEnv = {
 const laneEnv = lane.env ? { ...baseEnv, ...lane.env } : baseEnv;
 const stateEnv = { ...laneEnv, PW_FAST_GATES: '0' };
 const finalEnv = laneName === 'state' ? stateEnv : laneEnv;
+
+function stopProcessGroup(pid) {
+  try {
+    if (pid) process.kill(-pid, 'SIGTERM');
+  } catch {}
+}
+
 function run(command, args, env = baseEnv) {
-  const result = spawnSync(command, args, { cwd: rootDir, env, stdio: 'inherit' });
+  const result = spawnSync(command, args, { cwd: rootDir, detached: true, env, stdio: 'inherit' });
+  stopProcessGroup(result.pid);
 
   if (result.error) {
     console.error(result.error);
@@ -138,11 +144,6 @@ function run(command, args, env = baseEnv) {
   }
 }
 
-if (lane.gatekeeper) {
-  run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
-}
-
-if (lane.state) {
-  run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
-}
+if (lane.gatekeeper) run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
+if (lane.state) run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
 run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
-import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { runDetachedCommand } from './ci/run-detached-command.mjs';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const dbUrl = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
@@ -124,26 +124,15 @@ const laneEnv = lane.env ? { ...baseEnv, ...lane.env } : baseEnv;
 const stateEnv = { ...laneEnv, PW_FAST_GATES: '0' };
 const finalEnv = laneName === 'state' ? stateEnv : laneEnv;
 
-function stopProcessGroup(pid) {
+async function run(command, args, env = baseEnv) {
   try {
-    if (pid) process.kill(-pid, 'SIGTERM');
-  } catch {}
-}
-
-function run(command, args, env = baseEnv) {
-  const result = spawnSync(command, args, { cwd: rootDir, detached: true, env, stdio: 'inherit' });
-  stopProcessGroup(result.pid);
-
-  if (result.error) {
-    console.error(result.error);
-    process.exit(1);
-  }
-
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+    await runDetachedCommand(command, args, { cwd: rootDir, env });
+  } catch (error) {
+    console.error(error);
+    process.exit(error?.exitCode ?? 1);
   }
 }
 
-if (lane.gatekeeper) run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
-if (lane.state) run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
-run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);
+if (lane.gatekeeper) await run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
+if (lane.state) await run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
+await run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -3,7 +3,7 @@ import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runDetachedCommand } from './ci/run-detached-command.mjs';
+import { cleanupE2ePort, runDetachedCommand } from './ci/run-detached-command.mjs';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const dbUrl = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
@@ -125,14 +125,16 @@ const stateEnv = { ...laneEnv, PW_FAST_GATES: '0' };
 const finalEnv = laneName === 'state' ? stateEnv : laneEnv;
 
 async function run(command, args, env = baseEnv) {
-  try {
-    await runDetachedCommand(command, args, { cwd: rootDir, env });
-  } catch (error) {
-    console.error(error);
-    process.exit(error?.exitCode ?? 1);
-  }
+  await runDetachedCommand(command, args, { cwd: rootDir, env });
 }
 
-if (lane.gatekeeper) await run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
-if (lane.state) await run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
-await run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);
+try {
+  if (lane.gatekeeper) await run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
+  if (lane.state) await run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
+  await run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);
+} catch (error) {
+  console.error(error);
+  process.exitCode = error?.exitCode ?? 1;
+} finally {
+  cleanupE2ePort({ env: finalEnv });
+}


### PR DESCRIPTION
## Summary

- Clean the E2E lane web server in a `finally` path so failed/interrupted gate runs do not leave port `3000` occupied.
- Harden cleanup for listeners that are not process-group leaders by falling back from process-group signaling to direct PID signaling.
- Limit gatekeeper port cleanup to `3000` listeners only, so a connected client process is not killed just because its socket involves port `3000`.
- Add focused Node contracts for E2E lane cleanup and gatekeeper listener-only cleanup.
- Trim non-runtime gatekeeper comments to keep repo size budgets green.

## Scope note

This draft PR uses the existing `codex/autoresearch-ci-experiments` branch. It therefore includes six earlier CI/E2E commits already on that branch, plus today’s three validated commits:

- `43f9f7b3 fix: clean e2e server after lane failures`
- `c458b12e fix: harden e2e port cleanup fallback`
- `1c83e32a fix: limit gatekeeper port cleanup to listeners`

## Evidence

- Baseline before the first cleanup change: `pnpm e2e:gate:pr` failed after 256s at `admin-crm-routing-rules.spec.ts:123` and left a `next-server` listener on port `3000`.
- After the first cleanup change: `pnpm e2e:gate:pr` passed with 134 passed / 8 skipped in 380s and no leftover port/processes.
- Reproduced second cleanup gap before patch: `cleanupE2ePort` returned the listener PID for a non-group-leader child, but the listener remained active.
- After fallback patch: focused test starts a real `net` listener and verifies cleanup removes it.
- Reproduced gatekeeper broad-kill risk before the listener-only patch: with one server and one client, broad `lsof -ti:3000` returned both PIDs, while listener-only `lsof -tiTCP:3000 -sTCP:LISTEN` returned only the server PID.
- After listener-only patch: the same reproduction still showed listener-only selecting only the server PID, and `pnpm check:fast` passed.

## Validation

- `node --test --test-concurrency=1 scripts/ci/e2e-lane-runner-contracts.test.mjs` passed.
- `pnpm repo:size:check` passed.
- `pnpm security:guard` passed.
- `pnpm check:fast` passed with 134 passed / 8 skipped in 351s after the fallback patch.
- `pnpm check:fast` passed with 134 passed / 8 skipped in 354s after the listener-only gatekeeper patch.
- Final audit: no port `3000` listener and no stray pilot Next/Playwright processes.

## Current risk

- SonarQube Cloud previously reported 1 security hotspot on this PR. That report predates the latest push and still needs CI/Sonar re-evaluation before this draft can be considered green.
- Codex Senior Reviewer routing timed out after 15 minutes with no review output; local validation is green, but reviewer feedback was not obtained.

No changes to `apps/web/src/proxy.ts`, auth/routing/tenancy architecture, README, AGENTS.md, or architecture docs.