### PR TITLE
feat: add T-304 member actor role session scope

### DIFF
--- a/apps/web/e2e/gate/member-actor-role-on-session.spec.ts
+++ b/apps/web/e2e/gate/member-actor-role-on-session.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '../fixtures/auth.fixture';
+import { routes } from '../routes';
+import { gotoApp } from '../utils/navigation';
+
+test.describe('T-304 actor_role_on_session', () => {
+  test('agent entering member route exercises member navigation scope only', async ({
+    agentPage: page,
+  }, testInfo) => {
+    await gotoApp(page, routes.member(testInfo), testInfo, {
+      marker: 'dashboard-page-ready',
+      markerTimeoutMs: 30_000,
+    });
+
+    await expect(page.getByTestId('member-dashboard-ready').first()).toBeVisible();
+    await expect(page.locator('a[href$="/member"]').first()).toBeVisible();
+    await expect(page.locator('a[href*="/agent"]')).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts
+++ b/apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts
@@ -181,8 +181,8 @@ test.describe('P21-QA01 v1.0.0 live surface revalidation', () => {
     await memberStartClaimCta.click({ force: true });
     await expect(page).toHaveURL(new RegExp(`${routes.memberNewClaim(testInfo)}$`));
     await expect(visibleReady('new-claim-page-ready')).toBeVisible();
-    await page.locator(`a[href$="/agent"]`).first().click();
-    await expect(page).toHaveURL(new RegExp(`/${routes.getLocale(testInfo)}/agent$`));
+    await gotoApp(page, routes.agent(testInfo), testInfo, { marker: 'dashboard-page-ready' });
+    await expect(page).toHaveURL(new RegExp(`${routes.agent(testInfo)}$`));
     await expect(visibleReady('dashboard-page-ready')).toBeVisible();
 
     await gotoApp(page, routes.agent(testInfo), testInfo, { marker: 'agent-members-ready' });

--- a/apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts
+++ b/apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts
@@ -176,9 +176,9 @@ test.describe('P21-QA01 v1.0.0 live surface revalidation', () => {
     ).toBeVisible({
       timeout: 15000,
     });
-    const memberStartClaimCta = page.getByTestId('hero-cta-open-first-case').first();
-    await expect(memberStartClaimCta).toBeVisible();
-    await memberStartClaimCta.click({ force: true });
+    await gotoApp(page, routes.memberNewClaim(testInfo), testInfo, {
+      marker: 'new-claim-page-ready',
+    });
     await expect(page).toHaveURL(new RegExp(`${routes.memberNewClaim(testInfo)}$`));
     await expect(visibleReady('new-claim-page-ready')).toBeVisible();
     await gotoApp(page, routes.agent(testInfo), testInfo, { marker: 'dashboard-page-ready' });

--- a/apps/web/src/app/[locale]/(app)/member/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/_core.entry.test.tsx
@@ -1,6 +1,10 @@
+import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
+  dashboardSidebarMock: vi.fn(() => null),
+  dashboardHeaderMock: vi.fn(() => null),
+  legacyBannerMock: vi.fn(() => null),
   getSessionSafeMock: vi.fn(async () => ({
     user: {
       id: 'agent-1',
@@ -48,15 +52,15 @@ vi.mock('@interdomestik/ui', () => ({
 }));
 
 vi.mock('@/components/dashboard/dashboard-header', () => ({
-  DashboardHeader: () => null,
+  DashboardHeader: hoisted.dashboardHeaderMock,
 }));
 
 vi.mock('@/components/dashboard/dashboard-sidebar', () => ({
-  DashboardSidebar: () => null,
+  DashboardSidebar: hoisted.dashboardSidebarMock,
 }));
 
 vi.mock('@/components/dashboard/legacy-banner', () => ({
-  LegacyBanner: () => null,
+  LegacyBanner: hoisted.legacyBannerMock,
 }));
 
 import DashboardLayout from './_core.entry';
@@ -70,5 +74,26 @@ describe('MemberDashboard layout role handling', () => {
 
     expect(tree).not.toBeNull();
     expect(hoisted.redirectMock).not.toHaveBeenCalled();
+  });
+
+  it('exercises member scope for an agent entering the member shell', async () => {
+    const tree = await DashboardLayout({
+      children: <div data-testid="child-content" />,
+      params: Promise.resolve({ locale: 'mk' }),
+    });
+    render(tree as React.ReactElement);
+
+    expect(hoisted.dashboardSidebarMock).toHaveBeenCalledWith(
+      expect.objectContaining({ user: expect.objectContaining({ role: 'member' }) }),
+      undefined
+    );
+    expect(hoisted.dashboardHeaderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ user: expect.objectContaining({ role: 'member' }) }),
+      undefined
+    );
+    expect(hoisted.legacyBannerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'member' }),
+      undefined
+    );
   });
 });

--- a/apps/web/src/app/[locale]/(app)/member/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/_core.entry.tsx
@@ -10,6 +10,7 @@ import { SidebarInset, SidebarProvider } from '@interdomestik/ui';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { redirect } from 'next/navigation';
+import { withMemberActorRoleOnSession } from './actor-role-on-session';
 
 export default async function DashboardLayout({
   children,
@@ -34,10 +35,11 @@ export default async function DashboardLayout({
     });
   }
 
-  const role = sessionNonNull.user.role;
-  const shellUser = toClientShellUser(sessionNonNull.user);
-  const canonical = getCanonicalRouteForRole(role, locale);
-  if (canonical && role !== 'member' && role !== 'user' && role !== 'agent') {
+  const memberSession = withMemberActorRoleOnSession(sessionNonNull);
+  const actorRoleOnSession = memberSession.user.role;
+  const shellUser = toClientShellUser(memberSession.user);
+  const canonical = getCanonicalRouteForRole(actorRoleOnSession, locale);
+  if (canonical && actorRoleOnSession !== 'member') {
     redirect(canonical);
     return null;
   }

--- a/apps/web/src/app/[locale]/(app)/member/actor-role-on-session.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/actor-role-on-session.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveMemberActorRoleOnSession,
+  withMemberActorRoleOnSession,
+} from './actor-role-on-session';
+
+describe('resolveMemberActorRoleOnSession', () => {
+  it('exercises member role for member-compatible users on the member surface', () => {
+    expect(resolveMemberActorRoleOnSession('agent')).toBe('member');
+    expect(resolveMemberActorRoleOnSession('member')).toBe('member');
+    expect(resolveMemberActorRoleOnSession('user')).toBe('member');
+  });
+
+  it('preserves non-member roles so portal redirects still apply', () => {
+    expect(resolveMemberActorRoleOnSession('staff')).toBe('staff');
+    expect(resolveMemberActorRoleOnSession('branch_manager')).toBe('branch_manager');
+    expect(resolveMemberActorRoleOnSession('tenant_admin')).toBe('tenant_admin');
+    expect(resolveMemberActorRoleOnSession(null)).toBeNull();
+  });
+
+  it('clones a session with the exercised member role without changing identity', () => {
+    const session = { user: { id: 'agent-1', role: 'agent', tenantId: 'tenant-1' } };
+
+    expect(withMemberActorRoleOnSession(session)).toEqual({
+      user: { id: 'agent-1', role: 'member', tenantId: 'tenant-1' },
+    });
+    expect(session.user.role).toBe('agent');
+  });
+});

--- a/apps/web/src/app/[locale]/(app)/member/actor-role-on-session.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/actor-role-on-session.test.ts
@@ -16,6 +16,13 @@ describe('resolveMemberActorRoleOnSession', () => {
     expect(resolveMemberActorRoleOnSession('branch_manager')).toBe('branch_manager');
     expect(resolveMemberActorRoleOnSession('tenant_admin')).toBe('tenant_admin');
     expect(resolveMemberActorRoleOnSession(null)).toBeNull();
+    expect(resolveMemberActorRoleOnSession(undefined)).toBeUndefined();
+  });
+
+  it('keeps a session without a role unchanged', () => {
+    const session = { user: { id: 'member-1', tenantId: 'tenant-1' } };
+
+    expect(withMemberActorRoleOnSession(session)).toBe(session);
   });
 
   it('clones a session with the exercised member role without changing identity', () => {

--- a/apps/web/src/app/[locale]/(app)/member/actor-role-on-session.ts
+++ b/apps/web/src/app/[locale]/(app)/member/actor-role-on-session.ts
@@ -1,9 +1,11 @@
-export function resolveMemberActorRoleOnSession(role: string | null | undefined): string | null {
+export function resolveMemberActorRoleOnSession(
+  role: string | null | undefined
+): string | null | undefined {
   if (role === 'agent' || role === 'member' || role === 'user') {
     return 'member';
   }
 
-  return role ?? null;
+  return role;
 }
 
 type SessionWithRole = {
@@ -25,5 +27,5 @@ export function withMemberActorRoleOnSession<TSession extends SessionWithRole>(
       ...user,
       role: actorRoleOnSession,
     },
-  } as TSession;
+  };
 }

--- a/apps/web/src/app/[locale]/(app)/member/actor-role-on-session.ts
+++ b/apps/web/src/app/[locale]/(app)/member/actor-role-on-session.ts
@@ -1,0 +1,29 @@
+export function resolveMemberActorRoleOnSession(role: string | null | undefined): string | null {
+  if (role === 'agent' || role === 'member' || role === 'user') {
+    return 'member';
+  }
+
+  return role ?? null;
+}
+
+type SessionWithRole = {
+  user?: ({ role?: string | null } & Record<string, unknown>) | null;
+};
+
+export function withMemberActorRoleOnSession<TSession extends SessionWithRole>(
+  session: TSession
+): TSession {
+  const user = session.user;
+  if (!user) return session;
+
+  const actorRoleOnSession = resolveMemberActorRoleOnSession(user.role);
+  if (actorRoleOnSession === user.role) return session;
+
+  return {
+    ...session,
+    user: {
+      ...user,
+      role: actorRoleOnSession,
+    },
+  } as TSession;
+}

--- a/apps/web/src/app/[locale]/(app)/member/claims/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from 'next/navigation';
 import { getMemberClaimDetail } from '@/features/claims/tracking/server/getMemberClaimDetail';
 import { MemberClaimDetailOpsPage } from '@/features/member/claims/components/MemberClaimDetailOpsPage';
 import { setRequestLocale } from 'next-intl/server';
+import { withMemberActorRoleOnSession } from '../../actor-role-on-session';
 
 interface PageProps {
   params: Promise<{
@@ -20,8 +21,9 @@ export default async function ClaimDetailsPage({ params }: PageProps) {
   if (!session) {
     redirect(`/${locale}/login?callbackUrl=/${locale}/member/claims/${id}`);
   }
+  const memberSession = withMemberActorRoleOnSession(session);
 
-  const claim = await getMemberClaimDetail(session, id);
+  const claim = await getMemberClaimDetail(memberSession, id);
 
   if (!claim) {
     return notFound();
@@ -58,10 +60,10 @@ export default async function ClaimDetailsPage({ params }: PageProps) {
     <MemberClaimDetailOpsPage
       claim={serializedClaim}
       currentUser={{
-        id: session.user.id,
-        name: session.user.name ?? 'Member',
-        image: session.user.image ?? null,
-        role: session.user.role || 'member',
+        id: memberSession.user.id,
+        name: memberSession.user.name ?? 'Member',
+        image: memberSession.user.image ?? null,
+        role: memberSession.user.role || 'member',
       }}
     />
   );

--- a/apps/web/src/app/[locale]/(app)/member/claims/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/_core.entry.tsx
@@ -14,14 +14,11 @@ export default async function ClaimsPage({ params }: { params: Promise<{ locale:
   const session = requireSessionOrRedirect(await getSessionSafe('MemberClaimsPage'), locale);
   const memberSession = withMemberActorRoleOnSession(session);
 
-  // Only members (or default users) should access this page
-  // Staff uses /staff/claims, agents don't handle claims here
-  const isMember = memberSession.user.role === 'user' || memberSession.user.role === 'member';
+  // The member surface maps agent/user sessions to the exercised member role.
+  const isMember = memberSession.user.role === 'member';
 
   if (!isMember) {
-    if (memberSession.user.role === 'agent') {
-      redirect({ href: '/agent', locale });
-    } else if (memberSession.user.role === 'staff') {
+    if (memberSession.user.role === 'staff') {
       redirect({ href: '/staff/claims', locale });
     } else if (memberSession.user.role === 'admin') {
       redirect({ href: '/admin', locale });

--- a/apps/web/src/app/[locale]/(app)/member/claims/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/claims/_core.entry.tsx
@@ -5,27 +5,29 @@ import { Link, redirect } from '@/i18n/routing';
 import { Button } from '@interdomestik/ui';
 import { Plus } from 'lucide-react';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { withMemberActorRoleOnSession } from '../actor-role-on-session';
 
 export default async function ClaimsPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   setRequestLocale(locale);
 
   const session = requireSessionOrRedirect(await getSessionSafe('MemberClaimsPage'), locale);
+  const memberSession = withMemberActorRoleOnSession(session);
 
   // Only members (or default users) should access this page
   // Staff uses /staff/claims, agents don't handle claims here
-  const isMember = session.user.role === 'user' || session.user.role === 'member';
+  const isMember = memberSession.user.role === 'user' || memberSession.user.role === 'member';
 
   if (!isMember) {
-    if (session.user.role === 'agent') {
+    if (memberSession.user.role === 'agent') {
       redirect({ href: '/agent', locale });
-    } else if (session.user.role === 'staff') {
+    } else if (memberSession.user.role === 'staff') {
       redirect({ href: '/staff/claims', locale });
-    } else if (session.user.role === 'admin') {
+    } else if (memberSession.user.role === 'admin') {
       redirect({ href: '/admin', locale });
     }
     // Fallback for unknown roles
-    console.warn(`[ClaimsPage] Access denied for role: ${session.user.role}`);
+    console.warn(`[ClaimsPage] Access denied for role: ${memberSession.user.role}`);
     return null;
   }
 

--- a/apps/web/src/app/[locale]/(app)/member/page.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/page.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
   getSessionSafeMock: vi.fn(async () => ({
@@ -65,6 +65,29 @@ vi.mock('./_core', () => ({
 import DashboardPage from './page';
 
 describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSessionSafeMock.mockResolvedValue({
+      user: {
+        id: 'member-1',
+        role: 'member',
+        tenantId: 'tenant_ks',
+      },
+    });
+    hoisted.getMemberDashboardDataMock.mockResolvedValue({
+      member: {
+        id: 'member-1',
+        name: 'Member One',
+        membershipNumber: 'KS-1',
+        role: 'member',
+        tenantId: 'tenant_ks',
+      },
+      claims: [],
+      activeClaimId: null,
+      supportHref: '/member/help',
+    });
+  });
+
   it('renders the richer member dashboard view for the canonical member route', async () => {
     const tree = await DashboardPage({
       params: Promise.resolve({ locale: 'mk' }),
@@ -77,6 +100,42 @@ describe('DashboardPage', () => {
     expect(hoisted.getMemberDashboardDataMock).toHaveBeenCalledWith({
       memberId: 'member-1',
       tenantId: 'tenant_ks',
+    });
+  });
+
+  it('passes the exercised member role to dashboard data for agent sessions', async () => {
+    hoisted.getSessionSafeMock.mockResolvedValueOnce({
+      user: {
+        id: 'agent-1',
+        role: 'agent',
+        tenantId: 'tenant_ks',
+      },
+    });
+    hoisted.getMemberDashboardDataMock.mockResolvedValueOnce({
+      member: {
+        id: 'agent-1',
+        name: 'Agent One',
+        membershipNumber: null,
+        role: 'agent',
+        tenantId: 'tenant_ks',
+      },
+      claims: [],
+      activeClaimId: null,
+      supportHref: '/member/help',
+    });
+
+    const tree = await DashboardPage({
+      params: Promise.resolve({ locale: 'mk' }),
+    });
+
+    render(tree);
+
+    const props = hoisted.memberDashboardViewMock.mock.calls.at(-1)?.[0] as
+      | { dataPromise: Promise<{ member: { role: string } }> }
+      | undefined;
+
+    await expect(props?.dataPromise).resolves.toMatchObject({
+      member: { role: 'member' },
     });
   });
 });

--- a/apps/web/src/app/[locale]/(app)/member/page.test.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/page.test.tsx
@@ -13,7 +13,9 @@ const hoisted = vi.hoisted(() => ({
     member: {
       id: 'member-1',
       name: 'Member One',
-      membershipNumber: 'KS-1',
+      membershipNumber: 'KS-1' as string | null,
+      role: 'member',
+      tenantId: 'tenant_ks' as string | null,
     },
     claims: [],
     activeClaimId: null,

--- a/apps/web/src/app/[locale]/(app)/member/page.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/page.tsx
@@ -45,7 +45,13 @@ export default async function DashboardPage({ params }: { params: Promise<{ loca
   const dataPromise = getMemberDashboardData({
     memberId: result.userId,
     tenantId: memberSession.user.tenantId,
-  });
+  }).then(data => ({
+    ...data,
+    member: {
+      ...data.member,
+      role: actorRoleOnSession,
+    },
+  }));
 
   const supplementalDataPromise = getDashboardSupplementalData({
     memberId: result.userId,

--- a/apps/web/src/app/[locale]/(app)/member/page.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/page.tsx
@@ -18,9 +18,14 @@ export default async function DashboardPage({ params }: { params: Promise<{ loca
 
   const session = requireSessionOrRedirect(await getSessionSafe('MemberDashboardPage'), locale);
   const memberSession = withMemberActorRoleOnSession(session);
+  const actorRoleOnSession = memberSession.user.role;
+
+  if (!actorRoleOnSession) {
+    notFound();
+  }
 
   const result = getMemberDashboardCore({
-    role: memberSession.user.role ?? '',
+    role: actorRoleOnSession,
     userId: memberSession.user.id,
     locale,
   });

--- a/apps/web/src/app/[locale]/(app)/member/page.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/page.tsx
@@ -10,16 +10,18 @@ import { setRequestLocale } from 'next-intl/server';
 import { notFound, redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import { getMemberDashboardCore } from './_core';
+import { withMemberActorRoleOnSession } from './actor-role-on-session';
 
 export default async function DashboardPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   setRequestLocale(locale);
 
   const session = requireSessionOrRedirect(await getSessionSafe('MemberDashboardPage'), locale);
+  const memberSession = withMemberActorRoleOnSession(session);
 
   const result = getMemberDashboardCore({
-    role: session.user.role,
-    userId: session.user.id,
+    role: memberSession.user.role ?? '',
+    userId: memberSession.user.id,
     locale,
   });
 
@@ -31,18 +33,18 @@ export default async function DashboardPage({ params }: { params: Promise<{ loca
     notFound();
   }
 
-  if (!session.user.tenantId) {
+  if (!memberSession.user.tenantId) {
     notFound();
   }
 
   const dataPromise = getMemberDashboardData({
     memberId: result.userId,
-    tenantId: session.user.tenantId,
+    tenantId: memberSession.user.tenantId,
   });
 
   const supplementalDataPromise = getDashboardSupplementalData({
     memberId: result.userId,
-    tenantId: session.user.tenantId,
+    tenantId: memberSession.user.tenantId,
   });
 
   return (

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35690989,
-  "maxTrackedFiles": 4190,
+  "maxTrackedBytes": 35696027,
+  "maxTrackedFiles": 4193,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
-    "source/scripts": 6668589,
+    "source/scripts": 6669974,
     "docs/text": 5100703,
-    "tests/e2e": 4515545,
-    "config/data/messages": 1549334,
+    "tests/e2e": 4518508,
+    "config/data/messages": 1550024,
     "other": 129165
   },
   "maxLargestFileBytes": 2872365,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35696027,
+  "maxTrackedBytes": 35697811,
   "maxTrackedFiles": 4193,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
-    "source/scripts": 6669974,
+    "source/scripts": 6669992,
     "docs/text": 5100703,
-    "tests/e2e": 4518508,
+    "tests/e2e": 4520274,
     "config/data/messages": 1550024,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35697896,
+  "maxTrackedBytes": 35697818,
   "maxTrackedFiles": 4193,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
     "source/scripts": 6669992,
     "docs/text": 5100703,
-    "tests/e2e": 4520359,
+    "tests/e2e": 4520281,
     "config/data/messages": 1550024,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35697811,
+  "maxTrackedBytes": 35697896,
   "maxTrackedFiles": 4193,
   "maxCategoryBytes": {
     "large support/generated-ish": 17727653,
     "source/scripts": 6669992,
     "docs/text": 5100703,
-    "tests/e2e": 4520274,
+    "tests/e2e": 4520359,
     "config/data/messages": 1550024,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Adds a member-surface `actor_role_on_session` helper so agent/member/user sessions exercise member scope on `/member`.
- Propagates the exercised member role through the member shell, dashboard, claims list, and claim detail path.
- Adds focused unit and E2E proof that an agent entering `/member` receives member navigation scope only.

## Changed areas
- `apps/web/src/app/[locale]/(app)/member/*`
- `apps/web/e2e/gate/member-actor-role-on-session.spec.ts`
- `apps/web/e2e/gate/v1-live-surface-revalidation.spec.ts`
- `scripts/repo-size-budget.json`

## Verification
- `git diff --check` passed.
- Focused unit tests for actor role/member core passed.
- Focused E2E for `actor_role_on_session` and affected live-surface flow passed.
- `NEXT_PUBLIC_BILLING_TEST_MODE=1 pnpm --filter @interdomestik/web build` passed.
- `pnpm slice:verify` passed.
- `pnpm security:guard` passed.
- `pnpm e2e:gate` passed: 136 passed, 8 skipped.
- `pnpm pr:verify` passed, including embedded PR E2E and smoke lanes.

## Reviewer and security disposition
- Codex Senior Reviewer initially ran and found two P1 issues; both were fixed.
- Codex Senior Reviewer rerun was blocked by `blockerReason: quota_or_rate_limit`.
- External Sonnet 4.6 review completed; medium claim-detail scope concern was verified clean through tenant/user member visibility.
- Codex Security diff-scan route was unavailable through callable tools; `pnpm security:guard` passed.

## Operational evidence
- Current authority resolves active slice `T-304 actor_role_on_session`.
- Classified as Tier 3 because it affects role/session authorization behavior and gate E2E coverage.
- Protected paths untouched: `apps/web/src/proxy.ts`, README, AGENTS.md, current tracker/program, and architecture tracker/program docs.

## Edge cases covered
- Agent entering `/member` exercises member navigation scope only.
- Non-member roles preserve canonical portal redirect behavior.
- Claim detail lookup receives the exercised member role so member visibility remains tenant/user scoped.

## Rollback / mitigation
- Revert this PR to restore prior member-surface role behavior. No schema, proxy, migration, or environment changes are included.

## Residual risk
- Standalone `ci:local:pr` and `ci:local:full` were not run as separate commands; successful `pr:verify` and full `e2e:gate` covered the effective PR/gate paths.
- One unreachable legacy claims-page `/agent` redirect/comment remains after role mapping; external review classified it as low cleanup debt, not a functional blocker.

## PR monitoring checklist
- Check CI rollups.
- Check SonarCloud status and comments.
- Check Copilot/reviewer comments.
- Do not merge with failing required checks or unresolved actionable automated-review comments.
