### PR TITLE
fix: harden verification agent port cleanup

### DIFF
--- a/scripts/ci/verification-agent-contracts.test.mjs
+++ b/scripts/ci/verification-agent-contracts.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const verificationAgent = readFileSync(
+  new URL('../multi-agent/verification-agent.sh', import.meta.url),
+  'utf8'
+);
+
+test('verification agent clears only port 3000 listeners', () => {
+  assert.match(verificationAgent, /remediation=clear-port-3000/);
+  assert.match(verificationAgent, /lsof -tiTCP:3000 -sTCP:LISTEN/);
+  assert.match(verificationAgent, /remaining="\$\(lsof -tiTCP:3000 -sTCP:LISTEN/);
+  assert.match(verificationAgent, /xargs kill -9/);
+  assert.match(verificationAgent, /fi; true'/);
+  assert.doesNotMatch(verificationAgent, /lsof -ti\s+:3000/);
+});

--- a/scripts/multi-agent/verification-agent.sh
+++ b/scripts/multi-agent/verification-agent.sh
@@ -140,7 +140,7 @@ if match_pattern 'EADDRINUSE|address already in use|Port 3000|port 3000' "$log_e
   if already_attempted_fix "clear-port-3000"; then
     printf '[verification-agent] remediation=clear-port-3000 status=skipped reason=already-attempted\n'
   else
-    run_fix "clear-port-3000" bash -lc 'pids="$(lsof -ti :3000 2>/dev/null || true)"; if [[ -n "$pids" ]]; then printf "%s\n" "$pids" | xargs kill || printf "%s\n" "$pids" | xargs kill -9; fi'
+    run_fix "clear-port-3000" bash -lc 'pids="$(lsof -tiTCP:3000 -sTCP:LISTEN 2>/dev/null || true)"; if [[ -n "$pids" ]]; then printf "%s\n" "$pids" | xargs kill || true; sleep 1; remaining="$(lsof -tiTCP:3000 -sTCP:LISTEN 2>/dev/null || true)"; if [[ -n "$remaining" ]]; then printf "%s\n" "$remaining" | xargs kill -9; fi; fi; true'
     exit $?
   fi
 fi

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35706921,
-  "maxTrackedFiles": 4193,
+  "maxTrackedBytes": 35707746,
+  "maxTrackedFiles": 4194,
   "maxCategoryBytes": {
     "large support/generated-ish": 17734885,
-    "source/scripts": 6669992,
+    "source/scripts": 6670134,
     "docs/text": 5102574,
-    "tests/e2e": 4520281,
+    "tests/e2e": 4520964,
     "config/data/messages": 1550024,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Harden verification-agent port 3000 remediation to target only LISTEN pids
- Send SIGTERM first, wait briefly, then SIGKILL only remaining listener pids
- Add executable CI contract coverage for listener-only cleanup behavior
- Sync repo-size budget for the new contract test

## Scope
CI/tooling only. This is not T-306/product slice work and does not modify tracker/program authority. Protected paths untouched: apps/web/src/proxy.ts, README, AGENTS.md, docs/plans, architecture docs, product code.

## Validation
- Focused contract: `node --test scripts/ci/verification-agent-contracts.test.mjs` passed
- Focused live repro: SIGTERM-resistant localhost:3000 listener was cleared by verification-agent SIGKILL fallback; listener absent after remediation
- `pnpm test:ci:contracts` passed: 215 tests
- `pnpm repo:size:check` passed after budget sync
- `pnpm security:guard` passed
- `pnpm check:fast` passed: 136 passed, 8 skipped
- Final cleanup audit: no port 3000 listener and no leftover Next/Playwright gate processes
- MCP scope audit passed with changes limited to the approved three files

## Reviewer Note
Attempted local Codex reviewer route before commit, but it produced no output for several minutes and was interrupted to avoid blocking on an unavailable reviewer path.

## Residual Risk
Low. The changed shell still performs process termination, so CI/Sonar may flag it for review, but it is now narrower than the previous broad `lsof :3000` behavior.

## Rollback
Revert this PR to restore the previous verification-agent port cleanup behavior.