### PR TITLE
feat: classify country hosts as compatibility aliases

### DIFF
--- a/apps/web/src/lib/proxy-front-door.test.ts
+++ b/apps/web/src/lib/proxy-front-door.test.ts
@@ -91,4 +91,32 @@ describe('proxy ida front-door context', () => {
     expect(response.headers.get('x-e2e-tenant-context')).toBe('public');
     expect(response.headers.get('set-cookie')).toBeNull();
   });
+
+  it('keeps unknown hosts outside tenant and public cookie handling', async () => {
+    const response = await proxy(makeRequest('/sq', undefined, 'example.test'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-e2e-tenant')).toBe('none');
+    expect(response.headers.get('x-e2e-tenant-context')).toBe('unknown');
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('keeps country hosts resolving as compatibility aliases', async () => {
+    const response = await proxy(makeRequest('/sq', undefined, 'ks.localhost:3000'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-e2e-tenant')).toBe('tenant_ks');
+    expect(response.headers.get('x-e2e-tenant-context')).toBe('compatibility_alias');
+    expect(response.headers.get('set-cookie')).toContain('tenantId=tenant_ks');
+  });
+
+  it('overwrites stale tenant cookies on country-host aliases', async () => {
+    const response = await proxy(makeRequest('/sq', 'tenantId=tenant_mk', 'ks.localhost:3000'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-e2e-tenant')).toBe('tenant_ks');
+    expect(response.headers.get('x-e2e-tenant-context')).toBe('compatibility_alias');
+    expect(response.headers.get('set-cookie')).toContain('tenantId=tenant_ks');
+    expect(response.headers.get('set-cookie')).not.toContain('tenantId=tenant_mk');
+  });
 });

--- a/apps/web/src/lib/proxy-front-door.test.ts
+++ b/apps/web/src/lib/proxy-front-door.test.ts
@@ -46,6 +46,23 @@ function makeRequest(pathname: string, cookieHeader?: string, host = 'ida.localh
   return new NextRequest(`http://${host}${pathname}`, { headers });
 }
 
+function expectProxyContext(
+  response: Response,
+  expected: { tenant: string; context: string; setCookie?: string | null }
+): void {
+  expect(response.status).toBe(200);
+  expect(response.headers.get('x-e2e-tenant')).toBe(expected.tenant);
+  expect(response.headers.get('x-e2e-tenant-context')).toBe(expected.context);
+
+  const setCookie = response.headers.get('set-cookie');
+  if (expected.setCookie === undefined) return;
+  if (expected.setCookie === null) {
+    expect(setCookie).toBeNull();
+    return;
+  }
+  expect(setCookie).toContain(expected.setCookie);
+}
+
 describe('proxy ida front-door context', () => {
   beforeEach(() => {
     originalE2eEnv = Object.fromEntries(E2E_ENV_KEYS.map(key => [key, process.env[key]]));
@@ -64,10 +81,7 @@ describe('proxy ida front-door context', () => {
   it('resolves ida.localhost as public no-tenant context without setting a tenant cookie', async () => {
     const response = await proxy(makeRequest('/sq'));
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('x-e2e-tenant')).toBe('none');
-    expect(response.headers.get('x-e2e-tenant-context')).toBe('public');
-    expect(response.headers.get('set-cookie')).toBeNull();
+    expectProxyContext(response, { tenant: 'none', context: 'public', setCookie: null });
   });
 
   it('does not refresh stale tenant cookies on ida public requests', async () => {
@@ -75,10 +89,7 @@ describe('proxy ida front-door context', () => {
       makeRequest('/sq/pricing', 'tenantId=tenant_mk', 'ida.127.0.0.1.nip.io:3000')
     );
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('x-e2e-tenant')).toBe('none');
-    expect(response.headers.get('x-e2e-tenant-context')).toBe('public');
-    expect(response.headers.get('set-cookie')).toBeNull();
+    expectProxyContext(response, { tenant: 'none', context: 'public', setCookie: null });
   });
 
   it('supports configured IDA_HOST as public no-tenant context', async () => {
@@ -86,37 +97,33 @@ describe('proxy ida front-door context', () => {
 
     const response = await proxy(makeRequest('/sq', undefined, 'front-door.localhost:3000'));
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('x-e2e-tenant')).toBe('none');
-    expect(response.headers.get('x-e2e-tenant-context')).toBe('public');
-    expect(response.headers.get('set-cookie')).toBeNull();
+    expectProxyContext(response, { tenant: 'none', context: 'public', setCookie: null });
   });
 
   it('keeps unknown hosts outside tenant and public cookie handling', async () => {
     const response = await proxy(makeRequest('/sq', undefined, 'example.test'));
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('x-e2e-tenant')).toBe('none');
-    expect(response.headers.get('x-e2e-tenant-context')).toBe('unknown');
-    expect(response.headers.get('set-cookie')).toBeNull();
+    expectProxyContext(response, { tenant: 'none', context: 'unknown', setCookie: null });
   });
 
   it('keeps country hosts resolving as compatibility aliases', async () => {
     const response = await proxy(makeRequest('/sq', undefined, 'ks.localhost:3000'));
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('x-e2e-tenant')).toBe('tenant_ks');
-    expect(response.headers.get('x-e2e-tenant-context')).toBe('compatibility_alias');
-    expect(response.headers.get('set-cookie')).toContain('tenantId=tenant_ks');
+    expectProxyContext(response, {
+      tenant: 'tenant_ks',
+      context: 'compatibility_alias',
+      setCookie: 'tenantId=tenant_ks',
+    });
   });
 
   it('overwrites stale tenant cookies on country-host aliases', async () => {
     const response = await proxy(makeRequest('/sq', 'tenantId=tenant_mk', 'ks.localhost:3000'));
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('x-e2e-tenant')).toBe('tenant_ks');
-    expect(response.headers.get('x-e2e-tenant-context')).toBe('compatibility_alias');
-    expect(response.headers.get('set-cookie')).toContain('tenantId=tenant_ks');
+    expectProxyContext(response, {
+      tenant: 'tenant_ks',
+      context: 'compatibility_alias',
+      setCookie: 'tenantId=tenant_ks',
+    });
     expect(response.headers.get('set-cookie')).not.toContain('tenantId=tenant_mk');
   });
 });

--- a/apps/web/src/lib/tenant/tenant-front-door.test.ts
+++ b/apps/web/src/lib/tenant/tenant-front-door.test.ts
@@ -40,16 +40,28 @@ describe('tenant-front-door', () => {
     });
   });
 
-  it('keeps country and pilot hosts as tenant contexts', () => {
+  it('keeps unknown hosts outside tenant and public contexts', () => {
+    expect(resolveTenantHostContext('example.test')).toEqual({
+      kind: 'unknown',
+      tenantId: null,
+      source: 'unknown_host',
+    });
+  });
+
+  it('keeps country and pilot hosts as compatibility alias contexts', () => {
     expect(resolveTenantHostContext('ks.localhost:3000')).toEqual({
-      kind: 'tenant',
+      kind: 'compatibility_alias',
       tenantId: 'tenant_ks',
-      source: 'host',
+      source: 'country_host_alias',
+      defaultBookingTenantId: 'tenant_ks',
+      hostAlias: 'ks',
     });
     expect(resolveTenantHostContext('pilot.127.0.0.1.nip.io:3000')).toEqual({
-      kind: 'tenant',
+      kind: 'compatibility_alias',
       tenantId: 'pilot-mk',
-      source: 'host',
+      source: 'country_host_alias',
+      defaultBookingTenantId: 'pilot-mk',
+      hostAlias: 'pilot',
     });
   });
 });

--- a/apps/web/src/lib/tenant/tenant-front-door.ts
+++ b/apps/web/src/lib/tenant/tenant-front-door.ts
@@ -1,4 +1,8 @@
-import { resolveTenantFromHost, type TenantId } from './tenant-hosts';
+import {
+  resolveCountryHostCompatibilityAlias,
+  type CountryHostAliasLabel,
+  type TenantId,
+} from './tenant-host-aliases';
 
 const DEFAULT_IDA_FRONT_DOOR_HOSTS = new Set([
   'ida.interdomestik.com',
@@ -7,7 +11,13 @@ const DEFAULT_IDA_FRONT_DOOR_HOSTS = new Set([
 ]);
 
 export type TenantHostContext =
-  | { kind: 'tenant'; tenantId: TenantId; source: 'host' }
+  | {
+      kind: 'compatibility_alias';
+      tenantId: TenantId;
+      source: 'country_host_alias';
+      defaultBookingTenantId: TenantId;
+      hostAlias: CountryHostAliasLabel;
+    }
   | { kind: 'public'; tenantId: null; source: 'ida_front_door' }
   | { kind: 'unknown'; tenantId: null; source: 'unknown_host' };
 
@@ -46,9 +56,15 @@ export function isKnownIdaFrontDoorHost(host: string | null | undefined): boolea
 }
 
 export function resolveTenantHostContext(host: string): TenantHostContext {
-  const tenantId = resolveTenantFromHost(host);
-  if (tenantId) {
-    return { kind: 'tenant', tenantId, source: 'host' };
+  const alias = resolveCountryHostCompatibilityAlias(host);
+  if (alias) {
+    return {
+      kind: 'compatibility_alias',
+      tenantId: alias.tenantId,
+      source: 'country_host_alias',
+      defaultBookingTenantId: alias.defaultBookingTenantId,
+      hostAlias: alias.label,
+    };
   }
 
   if (isKnownIdaFrontDoorHost(host)) {

--- a/apps/web/src/lib/tenant/tenant-host-aliases.test.ts
+++ b/apps/web/src/lib/tenant/tenant-host-aliases.test.ts
@@ -13,6 +13,10 @@ describe('tenant host compatibility aliases', () => {
   const originalKsHost = process.env.KS_HOST;
 
   afterEach(() => {
+    if (originalKsHost === undefined) {
+      delete mutableEnv.KS_HOST;
+      return;
+    }
     mutableEnv.KS_HOST = originalKsHost;
   });
 

--- a/apps/web/src/lib/tenant/tenant-host-aliases.test.ts
+++ b/apps/web/src/lib/tenant/tenant-host-aliases.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  canonicalHostForTenant,
+  envHostForTenant,
+  localHostForTenant,
+  resolveCountryHostCompatibilityAlias,
+} from './tenant-host-aliases';
+import { resolveTenantContextFromSources } from './tenant-hosts';
+
+describe('tenant host compatibility aliases', () => {
+  const mutableEnv = process.env as Record<string, string | undefined>;
+  const originalKsHost = process.env.KS_HOST;
+
+  afterEach(() => {
+    mutableEnv.KS_HOST = originalKsHost;
+  });
+
+  it.each([
+    ['ks.localhost:3000', 'tenant_ks', 'ks'],
+    ['mk.localhost:3000', 'tenant_mk', 'mk'],
+    ['al.localhost:3000', 'tenant_al', 'al'],
+    ['ks.interdomestik.com', 'tenant_ks', 'ks'],
+    ['mk.interdomestik.com', 'tenant_mk', 'mk'],
+    ['al.interdomestik.com', 'tenant_al', 'al'],
+    ['pilot.interdomestik.com', 'pilot-mk', 'pilot'],
+    ['ks.10.0.2.15.nip.io', 'tenant_ks', 'ks'],
+    ['pilot.127.0.0.1.nip.io', 'pilot-mk', 'pilot'],
+  ] as const)(
+    'classifies %s as a compatibility alias with default booking hint',
+    (host, tenantId, label) => {
+      expect(resolveCountryHostCompatibilityAlias(host)).toEqual({
+        kind: 'country_host_compatibility_alias',
+        label,
+        tenantId,
+        defaultBookingTenantId: tenantId,
+      });
+    }
+  );
+
+  it('rejects unconfigured lookalike hosts', () => {
+    expect(resolveCountryHostCompatibilityAlias('ks.attacker.test')).toBeNull();
+    expect(resolveCountryHostCompatibilityAlias('mk-evil.localhost')).toBeNull();
+    expect(resolveCountryHostCompatibilityAlias('ks.999.0.0.1.nip.io')).toBeNull();
+    expect(resolveCountryHostCompatibilityAlias('example.test')).toBeNull();
+  });
+
+  it('exposes preferred hosts without cross-tenant fallback', () => {
+    mutableEnv.KS_HOST = 'ks.dev.example:1234';
+
+    expect(canonicalHostForTenant('tenant_ks')).toBe('ks.interdomestik.com');
+    expect(localHostForTenant('tenant_mk')).toBe('mk.localhost');
+    expect(envHostForTenant('tenant_ks')).toBe('ks.dev.example:1234');
+  });
+
+  it('keeps alias compatibility while marking host context as non-authoritative', () => {
+    expect(
+      resolveTenantContextFromSources({
+        host: 'ks.localhost:3000',
+        cookieTenantId: 'tenant_mk',
+        headerTenantId: 'tenant_mk',
+        queryTenantId: 'tenant_mk',
+      })
+    ).toEqual({
+      tenantId: 'tenant_ks',
+      source: 'compatibility_alias',
+      defaultBookingTenantId: 'tenant_ks',
+      hostAlias: 'ks',
+    });
+  });
+});

--- a/apps/web/src/lib/tenant/tenant-host-aliases.ts
+++ b/apps/web/src/lib/tenant/tenant-host-aliases.ts
@@ -1,0 +1,121 @@
+export type TenantId = 'tenant_mk' | 'tenant_ks' | 'tenant_al' | 'pilot-mk';
+export type CountryHostAliasLabel = 'mk' | 'ks' | 'al' | 'pilot';
+
+type AliasConfig = {
+  label: CountryHostAliasLabel;
+  tenantId: TenantId;
+  envKey: 'MK_HOST' | 'KS_HOST' | 'AL_HOST' | 'PILOT_HOST';
+  canonicalHost: string;
+  localHost: string;
+};
+
+export type CountryHostCompatibilityAlias = {
+  kind: 'country_host_compatibility_alias';
+  label: CountryHostAliasLabel;
+  tenantId: TenantId;
+  defaultBookingTenantId: TenantId;
+};
+
+const ALIASES: readonly AliasConfig[] = [
+  {
+    label: 'mk',
+    tenantId: 'tenant_mk',
+    envKey: 'MK_HOST',
+    canonicalHost: 'mk.interdomestik.com',
+    localHost: 'mk.localhost',
+  },
+  {
+    label: 'ks',
+    tenantId: 'tenant_ks',
+    envKey: 'KS_HOST',
+    canonicalHost: 'ks.interdomestik.com',
+    localHost: 'ks.localhost',
+  },
+  {
+    label: 'al',
+    tenantId: 'tenant_al',
+    envKey: 'AL_HOST',
+    canonicalHost: 'al.interdomestik.com',
+    localHost: 'al.localhost',
+  },
+  {
+    label: 'pilot',
+    tenantId: 'pilot-mk',
+    envKey: 'PILOT_HOST',
+    canonicalHost: 'pilot.interdomestik.com',
+    localHost: 'pilot.localhost',
+  },
+];
+
+function normalizeHost(host: string): string {
+  const raw = host.split(',')[0]?.trim() ?? '';
+  const withoutPort = raw.replace(/:\d+$/, '');
+  return withoutPort.toLowerCase().replace(/\.$/, '');
+}
+
+function normalizeHostWithPort(host: string): string {
+  const raw = host.split(',')[0]?.trim() ?? '';
+  return raw.toLowerCase().replace(/\.$/, '');
+}
+
+function envHost(config: AliasConfig): string | null {
+  return process.env[config.envKey] ?? null;
+}
+
+function hostsForAlias(config: AliasConfig): string[] {
+  return [config.canonicalHost, config.localHost, envHost(config)].filter((host): host is string =>
+    Boolean(host)
+  );
+}
+
+function aliasForTenant(tenantId: TenantId): AliasConfig {
+  const config = ALIASES.find(alias => alias.tenantId === tenantId);
+  if (!config) throw new Error(`Missing country host alias for tenant ${tenantId}`);
+  return config;
+}
+
+function toCompatibilityAlias(config: AliasConfig): CountryHostCompatibilityAlias {
+  return {
+    kind: 'country_host_compatibility_alias',
+    label: config.label,
+    tenantId: config.tenantId,
+    defaultBookingTenantId: config.tenantId,
+  };
+}
+
+function isLocalNipIoAlias(host: string, label: CountryHostAliasLabel): boolean {
+  const octet = '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)';
+  return new RegExp(`^${label}\\.${octet}\\.${octet}\\.${octet}\\.${octet}\\.nip\\.io$`).test(host);
+}
+
+export function resolveCountryHostCompatibilityAlias(
+  host: string
+): CountryHostCompatibilityAlias | null {
+  const normalized = normalizeHost(host);
+  const normalizedWithPort = normalizeHostWithPort(host);
+
+  for (const config of ALIASES) {
+    for (const candidate of hostsForAlias(config)) {
+      if (normalized === normalizeHost(candidate)) return toCompatibilityAlias(config);
+      if (normalizedWithPort === normalizeHostWithPort(candidate)) {
+        return toCompatibilityAlias(config);
+      }
+    }
+
+    if (isLocalNipIoAlias(normalized, config.label)) return toCompatibilityAlias(config);
+  }
+
+  return null;
+}
+
+export function canonicalHostForTenant(tenantId: TenantId): string {
+  return aliasForTenant(tenantId).canonicalHost;
+}
+
+export function localHostForTenant(tenantId: TenantId): string {
+  return aliasForTenant(tenantId).localHost;
+}
+
+export function envHostForTenant(tenantId: TenantId): string | null {
+  return envHost(aliasForTenant(tenantId));
+}

--- a/apps/web/src/lib/tenant/tenant-host-aliases.ts
+++ b/apps/web/src/lib/tenant/tenant-host-aliases.ts
@@ -84,8 +84,10 @@ function toCompatibilityAlias(config: AliasConfig): CountryHostCompatibilityAlia
 }
 
 function isLocalNipIoAlias(host: string, label: CountryHostAliasLabel): boolean {
-  const octet = '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)';
-  return new RegExp(`^${label}\\.${octet}\\.${octet}\\.${octet}\\.${octet}\\.nip\\.io$`).test(host);
+  const octet = String.raw`(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)`;
+  return new RegExp(String.raw`^${label}\.${octet}\.${octet}\.${octet}\.${octet}\.nip\.io$`).test(
+    host
+  );
 }
 
 export function resolveCountryHostCompatibilityAlias(

--- a/apps/web/src/lib/tenant/tenant-host-security.test.ts
+++ b/apps/web/src/lib/tenant/tenant-host-security.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTenantFromHost } from './tenant-hosts';
+
+describe('tenant host security boundaries', () => {
+  it('does not treat country-label lookalike hosts as tenant hosts', () => {
+    expect(resolveTenantFromHost('ks.attacker.test')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/tenant/tenant-hosts.test.ts
+++ b/apps/web/src/lib/tenant/tenant-hosts.test.ts
@@ -129,7 +129,7 @@ describe('tenant-hosts', () => {
     expect(preferredLocaleForTenant('pilot-mk')).toBe('en');
   });
 
-  it('uses host as canonical source when other tenant hints conflict', () => {
+  it('keeps host alias compatibility when other tenant hints conflict', () => {
     expect(
       resolveTenantIdFromSources({
         host: 'ks.localhost:3000',

--- a/apps/web/src/lib/tenant/tenant-hosts.ts
+++ b/apps/web/src/lib/tenant/tenant-hosts.ts
@@ -1,4 +1,13 @@
-export type TenantId = 'tenant_mk' | 'tenant_ks' | 'tenant_al' | 'pilot-mk';
+import {
+  canonicalHostForTenant,
+  envHostForTenant,
+  localHostForTenant,
+  resolveCountryHostCompatibilityAlias,
+  type CountryHostAliasLabel,
+  type TenantId,
+} from './tenant-host-aliases';
+
+export type { TenantId } from './tenant-host-aliases';
 export type TenantLocale = 'sq' | 'en' | 'sr' | 'mk';
 
 export const TENANT_COOKIE_NAME = 'tenantId';
@@ -16,11 +25,18 @@ export type TenantResolutionOptions = {
   allowLoopbackFallback?: boolean;
 };
 
-export type TenantResolutionSource = 'host' | 'cookie' | 'header' | 'query' | 'default_public';
+export type TenantResolutionSource =
+  | 'compatibility_alias'
+  | 'cookie'
+  | 'header'
+  | 'query'
+  | 'default_public';
 
 export type TenantResolutionResult = {
   tenantId: TenantId;
   source: TenantResolutionSource;
+  defaultBookingTenantId?: TenantId;
+  hostAlias?: CountryHostAliasLabel;
 };
 
 export function resolveDefaultPublicTenantId(): TenantId {
@@ -34,99 +50,14 @@ function normalizeHost(host: string): string {
   return withoutPort.toLowerCase().replace(/\.$/, '');
 }
 
-function normalizeHostWithPort(host: string): string {
-  const raw = host.split(',')[0]?.trim() ?? '';
-  return raw.toLowerCase().replace(/\.$/, '');
-}
-
 function isTenantId(value: string | null | undefined): value is TenantId {
   return (
     value === 'tenant_mk' || value === 'tenant_ks' || value === 'tenant_al' || value === 'pilot-mk'
   );
 }
 
-function hostsForTenant(tenantId: TenantId): string[] {
-  const envHosts: string[] = [];
-
-  if (tenantId === 'tenant_mk' && process.env.MK_HOST) envHosts.push(process.env.MK_HOST);
-  if (tenantId === 'tenant_ks' && process.env.KS_HOST) envHosts.push(process.env.KS_HOST);
-  if (tenantId === 'tenant_al' && process.env.AL_HOST) envHosts.push(process.env.AL_HOST);
-  if (tenantId === 'pilot-mk' && process.env.PILOT_HOST) envHosts.push(process.env.PILOT_HOST);
-
-  // Canonical production hosts
-  const canonical =
-    tenantId === 'tenant_mk'
-      ? ['mk.interdomestik.com']
-      : tenantId === 'tenant_ks'
-        ? ['ks.interdomestik.com']
-        : tenantId === 'tenant_al'
-          ? ['al.interdomestik.com']
-          : ['pilot.interdomestik.com'];
-
-  // Local development convenience (documented in docs/tenant-domains.md)
-  const local =
-    tenantId === 'tenant_mk'
-      ? ['mk.localhost']
-      : tenantId === 'tenant_ks'
-        ? ['ks.localhost']
-        : tenantId === 'tenant_al'
-          ? ['al.localhost']
-          : ['pilot.localhost'];
-
-  // Include both host-only and host:port variants from env.
-  // We match against both because `Host` may include a port in dev.
-  return [...canonical, ...local, ...envHosts].filter(Boolean);
-}
-
-function canonicalHostForTenant(tenantId: TenantId): string {
-  return tenantId === 'tenant_mk'
-    ? 'mk.interdomestik.com'
-    : tenantId === 'tenant_ks'
-      ? 'ks.interdomestik.com'
-      : tenantId === 'tenant_al'
-        ? 'al.interdomestik.com'
-        : 'pilot.interdomestik.com';
-}
-
-function localHostForTenant(tenantId: TenantId): string {
-  return tenantId === 'tenant_mk'
-    ? 'mk.localhost'
-    : tenantId === 'tenant_ks'
-      ? 'ks.localhost'
-      : tenantId === 'tenant_al'
-        ? 'al.localhost'
-        : 'pilot.localhost';
-}
-
-function envHostForTenant(tenantId: TenantId): string | null {
-  if (tenantId === 'tenant_mk') return process.env.MK_HOST ?? null;
-  if (tenantId === 'tenant_ks') return process.env.KS_HOST ?? null;
-  if (tenantId === 'tenant_al') return process.env.AL_HOST ?? null;
-  return process.env.PILOT_HOST ?? null;
-}
-
 export function resolveTenantFromHost(host: string): TenantId | null {
-  const normalized = normalizeHost(host);
-  const normalizedWithPort = normalizeHostWithPort(host);
-
-  for (const tenantId of ['tenant_mk', 'tenant_ks', 'tenant_al', 'pilot-mk'] as const) {
-    for (const candidate of hostsForTenant(tenantId)) {
-      const candidateNormalized = normalizeHost(candidate);
-      const candidateWithPort = normalizeHostWithPort(candidate);
-
-      if (normalized === candidateNormalized) return tenantId;
-      if (normalizedWithPort === candidateWithPort) return tenantId;
-    }
-  }
-
-  // Robust CI/Local fallback using nip.io (wildcard-like)
-  // Matches: ks.127.0.0.1.nip.io, mk.127.0.0.1.nip.io, etc.
-  if (/^mk\./i.test(normalized)) return 'tenant_mk';
-  if (/^ks\./i.test(normalized)) return 'tenant_ks';
-  if (/^al\./i.test(normalized)) return 'tenant_al';
-  if (/^pilot\./i.test(normalized)) return 'pilot-mk';
-
-  return null;
+  return resolveCountryHostCompatibilityAlias(host)?.tenantId ?? null;
 }
 
 export function isTenantHost(host: string): boolean {
@@ -179,8 +110,15 @@ export function resolveTenantContextFromSources(
   sources: TenantResolutionSources,
   options: TenantResolutionOptions = {}
 ): TenantResolutionResult {
-  const hostTenant = resolveTenantFromHost(sources.host ?? '');
-  if (hostTenant) return { tenantId: hostTenant, source: 'host' };
+  const hostAlias = resolveCountryHostCompatibilityAlias(sources.host ?? '');
+  if (hostAlias) {
+    return {
+      tenantId: hostAlias.tenantId,
+      source: 'compatibility_alias',
+      defaultBookingTenantId: hostAlias.defaultBookingTenantId,
+      hostAlias: hostAlias.label,
+    };
+  }
 
   const productionSensitive = options.productionSensitive ?? true;
   const isLocalLoopbackFallbackAllowed =

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "mod:autopilot:apply": "node scripts/modularize-autopilot.mjs --apply",
     "check:entrypoints": "node scripts/check-entrypoints-no-db.mjs",
     "check:db-access": "node scripts/check-db-access-guard.mjs",
-    "check:architecture-boundaries": "node scripts/check-architecture-boundaries.mjs && node scripts/check-case-recovery-boundaries.mjs",
+    "check:architecture-boundaries": "node scripts/check-architecture-boundaries.mjs && node scripts/check-case-recovery-boundaries.mjs && node scripts/check-country-host-alias-guard.mjs",
     "check:evidence-storage-paths": "node scripts/check-evidence-storage-paths.mjs",
     "check:raw-role-arrays": "node scripts/check-raw-role-arrays.mjs",
     "check:modularity-guard": "node scripts/check-modularity-guard.mjs",

--- a/scripts/check-country-host-alias-guard.mjs
+++ b/scripts/check-country-host-alias-guard.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const sourceRoots = ['apps/web/src', 'packages'];
+const sourceExtensions = new Set(['.ts', '.tsx']);
+const excluded = new Set(['.git', '.next', '.turbo', 'build', 'coverage', 'dist', 'node_modules']);
+const allowedResolveTenantFromHostImports = new Set([
+  'apps/web/src/lib/tenant/tenant-hosts.test.ts',
+  'apps/web/src/lib/tenant/tenant-host-security.test.ts',
+  'apps/web/src/app/api/claims/evidence-upload/_core.ts',
+  'apps/web/src/app/api/register/route.ts',
+  'apps/web/src/app/[locale]/components/home/home-page-runtime.tsx',
+  'apps/web/src/features/admin/claims/actions/evidence-upload.ts',
+  'apps/web/src/features/admin/claims/server/getOpsClaimDetail.ts',
+]);
+const allowedCountryHostAliasImports = new Set([
+  'apps/web/src/lib/tenant/tenant-hosts.ts',
+  'apps/web/src/lib/tenant/tenant-front-door.ts',
+  'apps/web/src/lib/tenant/tenant-host-aliases.test.ts',
+]);
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+function walk(root, results = []) {
+  if (!fs.existsSync(root)) return results;
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (excluded.has(entry.name)) continue;
+    const fullPath = path.join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      walk(fullPath, results);
+      continue;
+    }
+
+    if (sourceExtensions.has(path.extname(entry.name))) results.push(fullPath);
+  }
+
+  return results;
+}
+
+function importsResolveTenantFromHost(source) {
+  const namedImport =
+    /import\s*\{[^}]*\bresolveTenantFromHost\b[^}]*\}\s*from\s*['"][^'"]*tenant-hosts['"]/su;
+  const namespaceImport =
+    /import\s+\*\s+as\s+\w+\s+from\s*['"][^'"]*tenant-hosts['"]/su;
+  const namespaceUse = /(?:\.resolveTenantFromHost\b|\[['"]resolveTenantFromHost['"]\])/u;
+  return namedImport.test(source) || (namespaceImport.test(source) && namespaceUse.test(source));
+}
+
+function importsCountryHostAliasResolver(source) {
+  const namedImport =
+    /import\s*\{[^}]*\bresolveCountryHostCompatibilityAlias\b[^}]*\}\s*from\s*['"][^'"]*tenant-host-aliases['"]/su;
+  const namespaceImport =
+    /import\s+\*\s+as\s+\w+\s+from\s*['"][^'"]*tenant-host-aliases['"]/su;
+  const namespaceUse =
+    /(?:\.resolveCountryHostCompatibilityAlias\b|\[['"]resolveCountryHostCompatibilityAlias['"]\])/u;
+  return (
+    namedImport.test(source) ||
+    (namespaceImport.test(source) && namespaceUse.test(source))
+  );
+}
+
+const failures = [];
+const files = sourceRoots.flatMap(root => walk(path.join(repoRoot, root)));
+
+for (const file of files) {
+  const relativePath = toPosix(path.relative(repoRoot, file));
+  const source = fs.readFileSync(file, 'utf8');
+
+  if (
+    importsResolveTenantFromHost(source) &&
+    !allowedResolveTenantFromHostImports.has(relativePath)
+  ) {
+    failures.push(
+      `${relativePath} imports resolveTenantFromHost; use explicit session/app tenant context and keep country hosts as compatibility aliases/default-booking hints.`
+    );
+  }
+
+  if (
+    importsCountryHostAliasResolver(source) &&
+    !allowedCountryHostAliasImports.has(relativePath)
+  ) {
+    failures.push(
+      `${relativePath} imports resolveCountryHostCompatibilityAlias; use the tenant context boundary instead of adding direct host-as-tenant branches.`
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Country host alias guard failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Country host alias guard passed.');

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35752232,
-  "maxTrackedFiles": 4198,
+  "maxTrackedBytes": 35761686,
+  "maxTrackedFiles": 4202,
   "maxCategoryBytes": {
     "large support/generated-ish": 17756270,
-    "source/scripts": 6670454,
+    "source/scripts": 6675240,
     "docs/text": 5120580,
-    "tests/e2e": 4525739,
-    "config/data/messages": 1550024,
+    "tests/e2e": 4530356,
+    "config/data/messages": 1550075,
     "other": 129165
   },
   "maxLargestFileBytes": 2901016,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35761686,
+  "maxTrackedBytes": 35761536,
   "maxTrackedFiles": 4202,
   "maxCategoryBytes": {
     "large support/generated-ish": 17756270,
-    "source/scripts": 6675240,
+    "source/scripts": 6675257,
     "docs/text": 5120580,
-    "tests/e2e": 4530356,
+    "tests/e2e": 4530189,
     "config/data/messages": 1550075,
     "other": 129165
   },


### PR DESCRIPTION
Implements T-109.

Country hosts ks, mk, al, and pilot now resolve through explicit compatibility-alias metadata. ida.* remains neutral/public. Unknown and hostile lookalike hosts fail closed. Added an architecture guard to prevent new host-as-tenant branching outside the allowed compatibility boundary.

Validation:
- focused unit proof: 5 files, 50 tests
- pnpm check:architecture-boundaries
- pnpm check:modularity-guard
- pnpm repo:size:check
- pnpm check:e2e-contracts
- git diff --check
- pnpm slice:verify
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate: 136 passed, 8 skipped

Reviewer:
- Codex blocked: blockerReason=quota_or_rate_limit
- external review completed; valid findings fixed

Known local parity note:
- pnpm ci:local:pr exited 137 after earlier lanes passed, classified as local_resource_kill/exit_137.
