### PR TITLE
docs: add durable code review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Interdomestik AGENTS.md
 
-This file contains guidelines and commands for agentic coding agents working on the Interdomestik monorepo.
+This file contains agent guidelines and commands. For reviews, also follow `code_review.md`.
 
 ## ⚠️ V3 / Phase C Execution Rules (MANDATORY)
 

--- a/code_review.md
+++ b/code_review.md
@@ -24,7 +24,7 @@ Use this file for Codex review, external model review, and human PR review.
 
 - `apps/web/src/proxy.ts` is the routing/access-control authority and is read-only unless explicitly authorized.
 - Canonical routes `/member`, `/agent`, `/staff`, and `/admin` must not be renamed or bypassed.
-- `*-page-ready` clarity markers are contractual.
+- `page-ready` and `*-page-ready` clarity markers are contractual.
 - No broad auth, tenancy, routing, domain, schema, billing, UI, README, AGENTS, or architecture refactors unless explicitly authorized.
 - Paddle remains the only V3 pilot billing provider.
 

--- a/code_review.md
+++ b/code_review.md
@@ -1,0 +1,38 @@
+# Interdomestik Code Review Guidance
+
+Use this file for Codex review, external model review, and human PR review.
+
+## Review Posture
+
+- Review as an adversarial senior engineer.
+- Do not edit files during review.
+- Findings first, ordered by severity.
+- Include file and line references whenever possible.
+- Prefer concrete defects over style preferences.
+- Treat uncertainty as an open question, not approval.
+
+## Highest-Risk Areas
+
+- Auth, session, role, and permission regressions.
+- Tenant isolation, host resolution, routing, and canonical route behavior.
+- `apps/web/src/proxy.ts` drift or bypasses.
+- Schema, migration, RLS, event/outbox, audit, billing, and privacy changes.
+- Playwright lane, E2E gate, CI, reviewer, or security guard changes.
+- Missing focused tests for changed behavior.
+
+## Phase C Rules To Enforce
+
+- `apps/web/src/proxy.ts` is the routing/access-control authority and is read-only unless explicitly authorized.
+- Canonical routes `/member`, `/agent`, `/staff`, and `/admin` must not be renamed or bypassed.
+- `*-page-ready` clarity markers are contractual.
+- No broad auth, tenancy, routing, domain, schema, billing, UI, README, AGENTS, or architecture refactors unless explicitly authorized.
+- Paddle remains the only V3 pilot billing provider.
+
+## Finding Buckets
+
+- `blocker`: must fix before PR readiness or merge.
+- `hardening`: fix or explicitly defer with rationale before merge.
+- `optional`: non-blocking improvement.
+- `rejected`: false positive with repo evidence.
+
+Never count a blocked reviewer route as approval. If Codex is quota-blocked, record the blocker and use the approved external reviewer fallback instead of retrying in the same slice.

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35788489,
+  "maxTrackedBytes": 35788506,
   "maxTrackedFiles": 4207,
   "maxCategoryBytes": {
     "large support/generated-ish": 17772041,
     "source/scripts": 6675480,
-    "docs/text": 5126454,
+    "docs/text": 5126471,
     "tests/e2e": 4535797,
     "config/data/messages": 1549552,
     "other": 129165

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35787502,
-  "maxTrackedFiles": 4206,
+  "maxTrackedBytes": 35788489,
+  "maxTrackedFiles": 4207,
   "maxCategoryBytes": {
     "large support/generated-ish": 17772041,
     "source/scripts": 6675480,
-    "docs/text": 5124777,
+    "docs/text": 5126454,
     "tests/e2e": 4535797,
-    "config/data/messages": 1550242,
+    "config/data/messages": 1549552,
     "other": 129165
   },
   "maxLargestFileBytes": 2916787,


### PR DESCRIPTION
## Summary
- add root code_review.md for Codex, external model, and human PR review guidance
- reference code_review.md from AGENTS.md so Codex review can use durable repo guidance
- sync repo-size budget for the new markdown file

## Scope
- governance/docs-only review guidance
- no runtime code, proxy, routing, auth, tenancy, schema/RLS, billing, UI, CI workflow, tracker/program, or architecture-doc changes

## Validation
- git diff --check
- git diff --check HEAD~1 HEAD
- pnpm docs:verify
- node scripts/repo-size-budget-sync.mjs --check
- pnpm repo:size:check

## Reviewer Route Rationale
Codex quota blocks cannot be fixed by retrying the same route. This adds durable repo review guidance and keeps blocked Codex routes advisory, with external reviewer fallback still required when risk tier needs review evidence.