### PR TITLE
feat: add tenant context resolver foundation

### DIFF
--- a/apps/web/e2e/smoke/ida-dashboard-smoke.spec.ts
+++ b/apps/web/e2e/smoke/ida-dashboard-smoke.spec.ts
@@ -54,6 +54,11 @@ test.describe('@smoke ida.localhost canonical dashboard smoke', () => {
 
       const origin = new URL(baseURL).origin;
       const forwardedHostHeader = ['x-forwarded', 'host'].join('-');
+      if (!new URL(origin).hostname.startsWith('ida.')) {
+        test.skip(true, 'ida dashboard smoke only runs in canonical ida projects');
+        return;
+      }
+
       expect(projectHeaders[forwardedHostHeader]).toBeUndefined();
       expect(projectHeaders['x-tenant-id']).toBe('tenant_ks');
 

--- a/apps/web/src/lib/tenant/tenant-context.test.ts
+++ b/apps/web/src/lib/tenant/tenant-context.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveTenantContext } from './tenant-context';
+import { resolveTenantContextFromSources } from './tenant-hosts';
+
+const SESSION_KS = { user: { tenantId: 'tenant_ks' } };
+const SESSION_MK = { user: { tenantId: 'tenant_mk' } };
+
+const request = (url: string, headers: HeadersInit): Request => new Request(url, { headers });
+
+describe('resolveTenantContext', () => {
+  const mutableEnv = process.env as Record<string, string | undefined>;
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalVercelEnv = process.env.VERCEL_ENV;
+  const originalDefaultPublicTenantId = process.env.DEFAULT_PUBLIC_TENANT_ID;
+  const restoreEnv = (key: string, value: string | undefined): void => {
+    if (value === undefined) {
+      delete mutableEnv[key];
+      return;
+    }
+    mutableEnv[key] = value;
+  };
+
+  afterEach(() => {
+    restoreEnv('NODE_ENV', originalNodeEnv);
+    restoreEnv('VERCEL_ENV', originalVercelEnv);
+    restoreEnv('DEFAULT_PUBLIC_TENANT_ID', originalDefaultPublicTenantId);
+  });
+
+  it('resolves the four tenant contexts from host and session tenant truth', () => {
+    expect(
+      resolveTenantContext(request('https://ida.localhost/member', { host: 'ks.localhost:3000' }), {
+        user: { tenantId: 'tenant_ks', legalTenantId: 'tenant_mk' },
+      })
+    ).toEqual({
+      status: 'resolved',
+      host_id: 'tenant_ks',
+      booking_tenant_id: 'tenant_ks',
+      access_tenant_id: 'tenant_ks',
+      legal_tenant_id: 'tenant_mk',
+      source: 'compatibility_alias',
+    });
+  });
+
+  it('preserves existing request-source precedence for booking tenant resolution', () => {
+    const req = request('https://ida.localhost/member?tenantId=tenant_mk', {
+      cookie: 'tenantId=tenant_ks',
+      host: 'localhost:3000',
+      'x-tenant-id': 'tenant_mk',
+    });
+
+    const result = resolveTenantContext(req, SESSION_KS);
+    const oldSwitch = resolveTenantContextFromSources({
+      host: 'localhost:3000',
+      cookieTenantId: 'tenant_ks',
+      headerTenantId: 'tenant_mk',
+      queryTenantId: 'tenant_mk',
+    });
+
+    expect(result.status).toBe('resolved');
+    expect(result.booking_tenant_id).toBe(oldSwitch.tenantId);
+    expect(result.source).toBe(oldSwitch.source);
+  });
+
+  it('ignores forwarded host by default and accepts it only as a trusted option', () => {
+    const req = request('https://ida.localhost/member', {
+      host: 'ida.localhost:3000',
+      'x-forwarded-host': 'ks.localhost:3000',
+    });
+
+    expect(resolveTenantContext(req, SESSION_KS)).toMatchObject({ host_id: null });
+    expect(resolveTenantContext(req, SESSION_KS, { trustForwardedHost: true })).toMatchObject({
+      host_id: 'tenant_ks',
+      status: 'resolved',
+    });
+  });
+
+  it('reuses host/session mismatch semantics for conflicting tenant hosts', () => {
+    const result = resolveTenantContext(
+      request('https://ida.localhost/member', { host: 'ks.localhost:3000' }),
+      SESSION_MK
+    );
+
+    expect(result).toMatchObject({
+      status: 'tenant_mismatch',
+      host_id: 'tenant_ks',
+      booking_tenant_id: 'tenant_ks',
+      access_tenant_id: 'tenant_mk',
+      legal_tenant_id: 'tenant_mk',
+    });
+  });
+
+  it('keeps neutral production hosts on the default public tenant and denies mismatched sessions', () => {
+    mutableEnv.NODE_ENV = 'production';
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
+
+    const result = resolveTenantContext(
+      request('https://ida.localhost/member?tenantId=tenant_mk', {
+        cookie: 'tenantId=tenant_mk',
+        host: 'localhost:3000',
+        'x-tenant-id': 'tenant_mk',
+      }),
+      SESSION_MK
+    );
+
+    expect(result).toMatchObject({
+      status: 'tenant_mismatch',
+      host_id: null,
+      booking_tenant_id: 'tenant_ks',
+      access_tenant_id: 'tenant_mk',
+      source: 'default_public',
+    });
+  });
+
+  it('denies neutral-host cookie context when it conflicts with the session tenant', () => {
+    const result = resolveTenantContext(
+      request('https://ida.localhost/member', {
+        cookie: 'tenantId=tenant_mk',
+        host: 'localhost:3000',
+      }),
+      SESSION_KS
+    );
+
+    expect(result).toMatchObject({
+      status: 'tenant_mismatch',
+      booking_tenant_id: 'tenant_mk',
+      access_tenant_id: 'tenant_ks',
+    });
+  });
+
+  it('reports missing session tenant without widening access on neutral hosts', () => {
+    delete mutableEnv.DEFAULT_PUBLIC_TENANT_ID;
+
+    const result = resolveTenantContext(
+      request('https://ida.localhost/member', { host: 'ida.localhost:3000' }),
+      null
+    );
+
+    expect(result).toEqual({
+      status: 'missing_session_tenant',
+      host_id: null,
+      booking_tenant_id: 'tenant_ks',
+      access_tenant_id: null,
+      legal_tenant_id: null,
+      source: 'default_public',
+    });
+  });
+});

--- a/apps/web/src/lib/tenant/tenant-context.ts
+++ b/apps/web/src/lib/tenant/tenant-context.ts
@@ -1,0 +1,132 @@
+import {
+  coerceTenantId,
+  hasHostSessionTenantMismatch,
+  resolveTenantContextFromSources,
+  TENANT_COOKIE_NAME,
+  TENANT_HEADER_NAME,
+  type TenantId,
+  type TenantResolutionOptions,
+  type TenantResolutionSource,
+} from './tenant-hosts';
+
+type RequestLike = {
+  headers: Headers;
+  url: string;
+};
+
+type SessionLike = {
+  user?: {
+    legalTenantId?: string | null;
+    tenantId?: string | null;
+  } | null;
+} | null;
+
+type TenantContextBase = {
+  host_id: TenantId | null;
+  booking_tenant_id: TenantId;
+  source: TenantResolutionSource;
+};
+
+export type TenantContextResolution =
+  | (TenantContextBase & {
+      status: 'resolved';
+      access_tenant_id: TenantId;
+      legal_tenant_id: TenantId;
+    })
+  | (TenantContextBase & {
+      status: 'missing_session_tenant';
+      access_tenant_id: null;
+      legal_tenant_id: null;
+    })
+  | (TenantContextBase & {
+      status: 'tenant_mismatch';
+      access_tenant_id: TenantId;
+      legal_tenant_id: TenantId;
+    });
+
+export type ResolveTenantContextOptions = TenantResolutionOptions & {
+  tenantIdFromQuery?: string | null;
+  /** Enable only after the caller verifies x-forwarded-host comes from a trusted proxy. */
+  trustForwardedHost?: boolean;
+};
+
+function parseCookieValue(cookieHeader: string | null, cookieName: string): string | null {
+  if (!cookieHeader) return null;
+  for (const entry of cookieHeader.split(';')) {
+    const [rawName, ...rest] = entry.trim().split('=');
+    if (rawName !== cookieName) continue;
+    const value = rest.join('=').trim();
+    if (!value) return null;
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+  return null;
+}
+
+function getRequestHost(headers: Headers, trustForwardedHost: boolean): string {
+  if (trustForwardedHost) return headers.get('x-forwarded-host') ?? headers.get('host') ?? '';
+  return headers.get('host') ?? '';
+}
+
+function getQueryTenantId(request: RequestLike, explicitTenantId?: string | null): string | null {
+  if (explicitTenantId !== undefined) return explicitTenantId;
+  try {
+    return new URL(request.url).searchParams.get('tenantId');
+  } catch {
+    return null;
+  }
+}
+
+export function resolveTenantContext(
+  request: RequestLike,
+  session: SessionLike,
+  options: ResolveTenantContextOptions = {}
+): TenantContextResolution {
+  const host = getRequestHost(request.headers, options.trustForwardedHost === true);
+  const requestContext = resolveTenantContextFromSources(
+    {
+      host,
+      cookieTenantId: parseCookieValue(request.headers.get('cookie'), TENANT_COOKIE_NAME),
+      headerTenantId: request.headers.get(TENANT_HEADER_NAME),
+      queryTenantId: getQueryTenantId(request, options.tenantIdFromQuery),
+    },
+    options
+  );
+  const hostId = requestContext.source === 'compatibility_alias' ? requestContext.tenantId : null;
+  const bookingTenantId = requestContext.defaultBookingTenantId ?? requestContext.tenantId;
+  const accessTenantId = coerceTenantId(session?.user?.tenantId);
+  const base = {
+    host_id: hostId,
+    booking_tenant_id: bookingTenantId,
+    source: requestContext.source,
+  };
+
+  if (!accessTenantId) {
+    return {
+      ...base,
+      status: 'missing_session_tenant',
+      access_tenant_id: null,
+      legal_tenant_id: null,
+    };
+  }
+
+  const legalTenantId = coerceTenantId(session?.user?.legalTenantId) ?? accessTenantId;
+  if (hasHostSessionTenantMismatch(hostId, accessTenantId) || accessTenantId !== bookingTenantId) {
+    return {
+      ...base,
+      status: 'tenant_mismatch',
+      access_tenant_id: accessTenantId,
+      legal_tenant_id: legalTenantId,
+    };
+  }
+
+  return {
+    ...base,
+    status: 'resolved',
+    access_tenant_id: accessTenantId,
+    legal_tenant_id: legalTenantId,
+  };
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35788506,
-  "maxTrackedFiles": 4207,
+  "maxTrackedBytes": 35797932,
+  "maxTrackedFiles": 4209,
   "maxCategoryBytes": {
     "large support/generated-ish": 17772041,
-    "source/scripts": 6675480,
+    "source/scripts": 6679216,
     "docs/text": 5126471,
-    "tests/e2e": 4535797,
-    "config/data/messages": 1549552,
+    "tests/e2e": 4540797,
+    "config/data/messages": 1550242,
     "other": 129165
   },
   "maxLargestFileBytes": 2916787,


### PR DESCRIPTION
## Summary
- Add the T-302 tenant-context resolver foundation in `apps/web/src/lib/tenant/tenant-context.ts`.
- Resolve request, access, booking, and legal tenant context without touching `apps/web/src/proxy.ts` or canonical routes.
- Add focused unit coverage for host/session parity, tenant mismatch, trusted forwarded host behavior, neutral host/default tenant behavior, cookie conflicts, and null-session failure.
- Keep the ida smoke assertion on canonical ida projects while skipping country-host projects that intentionally inject `x-forwarded-host`.

## Governance
- Active slice: T-302 tenant-context resolver foundation.
- Class: implementation.
- Manual risk tier: Tier 3, because tenant context affects tenancy/routing/access-boundary behavior.
- Protected paths: `apps/web/src/proxy.ts`, README, AGENTS.md, architecture/plan docs unchanged.
- Expected changed surfaces: tenant resolver foundation, focused resolver tests, e2e smoke harness skip, repo-size budget metadata.

## Reviewer Route
- Codex reviewer attempted through patched packet route.
- blockerReason: `quota_or_rate_limit` (exit 128, no actionable review output).
- Approved external reviewer fallback was used; real findings were addressed before final gates. Gemini fallback was blocked by CLI/auth configuration.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/lib/tenant/tenant-context.test.ts`
- `pnpm check:modularity-guard`
- `node scripts/repo-size-budget-sync.mjs --check`
- `pnpm repo:size:check`
- `pnpm slice:verify`
- `pnpm coverage:gate`
- `pnpm --filter @interdomestik/web e2e:smoke`
- `pnpm --filter @interdomestik/web e2e:smoke:ida`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate`

## Local Resource Note
- `pnpm ci:local:pr` reached the production build/E2E lane and exited 137 locally. After the mandatory Phase C gates completed green, this is classified as `local_resource_kill/exit_137`, not a code blocker.
