### PR TITLE
T-303: resolve neutral tenant context from session

### DIFF
--- a/apps/web/src/lib/tenant/tenant-context-session-precedence.test.ts
+++ b/apps/web/src/lib/tenant/tenant-context-session-precedence.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveTenantContext } from './tenant-context';
+
+const SESSION_KS = { user: { tenantId: 'tenant_ks' } };
+const SESSION_MK = { user: { tenantId: 'tenant_mk' } };
+
+const request = (url: string, headers: HeadersInit): Request => new Request(url, { headers });
+
+describe('resolveTenantContext session precedence', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('lets session tenant override stale cookie on neutral hosts', () => {
+    const result = resolveTenantContext(
+      request('https://ida.localhost/member', {
+        cookie: 'tenantId=tenant_mk',
+        host: 'ida.localhost:3000',
+      }),
+      SESSION_KS
+    );
+
+    expect(result).toMatchObject({
+      status: 'resolved',
+      host_id: null,
+      booking_tenant_id: 'tenant_ks',
+      access_tenant_id: 'tenant_ks',
+      source: 'session',
+    });
+  });
+
+  it('keeps tenant-host mismatch protection stronger than stale cookie precedence', () => {
+    const result = resolveTenantContext(
+      request('https://mk.localhost/member', {
+        cookie: 'tenantId=tenant_mk',
+        host: 'mk.localhost:3000',
+      }),
+      SESSION_KS
+    );
+
+    expect(result).toMatchObject({
+      status: 'tenant_mismatch',
+      host_id: 'tenant_mk',
+      booking_tenant_id: 'tenant_mk',
+      access_tenant_id: 'tenant_ks',
+      source: 'compatibility_alias',
+    });
+  });
+
+  it('keeps host-only context as an anonymous booking hint without access', () => {
+    const result = resolveTenantContext(
+      request('https://mk.localhost/member', { host: 'mk.localhost:3000' }),
+      null
+    );
+
+    expect(result).toMatchObject({
+      status: 'missing_session_tenant',
+      host_id: 'tenant_mk',
+      booking_tenant_id: 'tenant_mk',
+      access_tenant_id: null,
+      legal_tenant_id: null,
+    });
+  });
+
+  it('keeps neutral production hosts default-only while session tenant controls access', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('DEFAULT_PUBLIC_TENANT_ID', 'tenant_ks');
+
+    const result = resolveTenantContext(
+      request('https://ida.localhost/member?tenantId=tenant_mk', {
+        cookie: 'tenantId=tenant_mk',
+        host: 'localhost:3000',
+        'x-tenant-id': 'tenant_mk',
+      }),
+      SESSION_MK
+    );
+
+    expect(result).toMatchObject({
+      status: 'resolved',
+      host_id: null,
+      booking_tenant_id: 'tenant_mk',
+      access_tenant_id: 'tenant_mk',
+      source: 'session',
+    });
+  });
+
+  it('treats invalid session tenant as missing instead of widening access to hints', () => {
+    const result = resolveTenantContext(
+      request('https://ida.localhost/member', {
+        cookie: 'tenantId=tenant_mk',
+        host: 'localhost:3000',
+      }),
+      { user: { tenantId: 'tenant_unknown' } }
+    );
+
+    expect(result).toMatchObject({
+      status: 'missing_session_tenant',
+      booking_tenant_id: 'tenant_mk',
+      access_tenant_id: null,
+      legal_tenant_id: null,
+      source: 'cookie',
+    });
+  });
+});

--- a/apps/web/src/lib/tenant/tenant-context.test.ts
+++ b/apps/web/src/lib/tenant/tenant-context.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { resolveTenantContext } from './tenant-context';
-import { resolveTenantContextFromSources } from './tenant-hosts';
 
 const SESSION_KS = { user: { tenantId: 'tenant_ks' } };
 const SESSION_MK = { user: { tenantId: 'tenant_mk' } };
@@ -38,28 +37,24 @@ describe('resolveTenantContext', () => {
       booking_tenant_id: 'tenant_ks',
       access_tenant_id: 'tenant_ks',
       legal_tenant_id: 'tenant_mk',
-      source: 'compatibility_alias',
+      source: 'session',
     });
   });
 
-  it('preserves existing request-source precedence for booking tenant resolution', () => {
-    const req = request('https://ida.localhost/member?tenantId=tenant_mk', {
-      cookie: 'tenantId=tenant_ks',
-      host: 'localhost:3000',
-      'x-tenant-id': 'tenant_mk',
-    });
-
-    const result = resolveTenantContext(req, SESSION_KS);
-    const oldSwitch = resolveTenantContextFromSources({
-      host: 'localhost:3000',
-      cookieTenantId: 'tenant_ks',
-      headerTenantId: 'tenant_mk',
-      queryTenantId: 'tenant_mk',
-    });
+  it('lets the session tenant override cookie, header, and query booking hints', () => {
+    const result = resolveTenantContext(
+      request('https://ida.localhost/member?tenantId=tenant_mk', {
+        cookie: 'tenantId=tenant_mk',
+        host: 'localhost:3000',
+        'x-tenant-id': 'tenant_mk',
+      }),
+      SESSION_KS
+    );
 
     expect(result.status).toBe('resolved');
-    expect(result.booking_tenant_id).toBe(oldSwitch.tenantId);
-    expect(result.source).toBe(oldSwitch.source);
+    expect(result.booking_tenant_id).toBe('tenant_ks');
+    expect(result.access_tenant_id).toBe('tenant_ks');
+    expect(result.source).toBe('session');
   });
 
   it('ignores forwarded host by default and accepts it only as a trusted option', () => {
@@ -75,7 +70,7 @@ describe('resolveTenantContext', () => {
     });
   });
 
-  it('reuses host/session mismatch semantics for conflicting tenant hosts', () => {
+  it('preserves tenant-host/session mismatch protection', () => {
     const result = resolveTenantContext(
       request('https://ida.localhost/member', { host: 'ks.localhost:3000' }),
       SESSION_MK
@@ -87,44 +82,7 @@ describe('resolveTenantContext', () => {
       booking_tenant_id: 'tenant_ks',
       access_tenant_id: 'tenant_mk',
       legal_tenant_id: 'tenant_mk',
-    });
-  });
-
-  it('keeps neutral production hosts on the default public tenant and denies mismatched sessions', () => {
-    mutableEnv.NODE_ENV = 'production';
-    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
-
-    const result = resolveTenantContext(
-      request('https://ida.localhost/member?tenantId=tenant_mk', {
-        cookie: 'tenantId=tenant_mk',
-        host: 'localhost:3000',
-        'x-tenant-id': 'tenant_mk',
-      }),
-      SESSION_MK
-    );
-
-    expect(result).toMatchObject({
-      status: 'tenant_mismatch',
-      host_id: null,
-      booking_tenant_id: 'tenant_ks',
-      access_tenant_id: 'tenant_mk',
-      source: 'default_public',
-    });
-  });
-
-  it('denies neutral-host cookie context when it conflicts with the session tenant', () => {
-    const result = resolveTenantContext(
-      request('https://ida.localhost/member', {
-        cookie: 'tenantId=tenant_mk',
-        host: 'localhost:3000',
-      }),
-      SESSION_KS
-    );
-
-    expect(result).toMatchObject({
-      status: 'tenant_mismatch',
-      booking_tenant_id: 'tenant_mk',
-      access_tenant_id: 'tenant_ks',
+      source: 'compatibility_alias',
     });
   });
 

--- a/apps/web/src/lib/tenant/tenant-context.ts
+++ b/apps/web/src/lib/tenant/tenant-context.ts
@@ -28,10 +28,11 @@ type TenantContextBase = {
 };
 
 export type TenantContextResolution =
-  | (TenantContextBase & {
+  | (Omit<TenantContextBase, 'source'> & {
       status: 'resolved';
       access_tenant_id: TenantId;
       legal_tenant_id: TenantId;
+      source: TenantResolutionSource | 'session';
     })
   | (TenantContextBase & {
       status: 'missing_session_tenant';
@@ -96,17 +97,17 @@ export function resolveTenantContext(
     options
   );
   const hostId = requestContext.source === 'compatibility_alias' ? requestContext.tenantId : null;
-  const bookingTenantId = requestContext.defaultBookingTenantId ?? requestContext.tenantId;
   const accessTenantId = coerceTenantId(session?.user?.tenantId);
-  const base = {
+  const requestBookingTenantId = requestContext.defaultBookingTenantId ?? requestContext.tenantId;
+  const requestBase = {
     host_id: hostId,
-    booking_tenant_id: bookingTenantId,
+    booking_tenant_id: requestBookingTenantId,
     source: requestContext.source,
   };
 
   if (!accessTenantId) {
     return {
-      ...base,
+      ...requestBase,
       status: 'missing_session_tenant',
       access_tenant_id: null,
       legal_tenant_id: null,
@@ -114,9 +115,9 @@ export function resolveTenantContext(
   }
 
   const legalTenantId = coerceTenantId(session?.user?.legalTenantId) ?? accessTenantId;
-  if (hasHostSessionTenantMismatch(hostId, accessTenantId) || accessTenantId !== bookingTenantId) {
+  if (hasHostSessionTenantMismatch(hostId, accessTenantId)) {
     return {
-      ...base,
+      ...requestBase,
       status: 'tenant_mismatch',
       access_tenant_id: accessTenantId,
       legal_tenant_id: legalTenantId,
@@ -124,9 +125,11 @@ export function resolveTenantContext(
   }
 
   return {
-    ...base,
     status: 'resolved',
+    host_id: hostId,
+    booking_tenant_id: accessTenantId,
     access_tenant_id: accessTenantId,
     legal_tenant_id: legalTenantId,
+    source: 'session',
   };
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35821504,
-  "maxTrackedFiles": 4215,
+  "maxTrackedBytes": 35824612,
+  "maxTrackedFiles": 4216,
   "maxCategoryBytes": {
     "large support/generated-ish": 17772670,
-    "source/scripts": 6695143,
+    "source/scripts": 6695275,
     "docs/text": 5129680,
-    "tests/e2e": 4545549,
-    "config/data/messages": 1549297,
+    "tests/e2e": 4547835,
+    "config/data/messages": 1549987,
     "other": 129165
   },
   "maxLargestFileBytes": 2917416,


### PR DESCRIPTION
## Summary
- Implements T-303 host=default-only/session-tenant-wins resolver behavior for neutral/default hosts.
- Preserves explicit tenant-host/session mismatch protection and existing canonical route boundaries.
- Adds focused tenant resolver tests for stale cookie/query/header precedence, neutral/default host behavior, host-only anonymous booking hints, and invalid session tenants.

## Authority and risk
- Active slice: T-303.
- Class: implementation.
- Manual risk tier: Tier 3, because tenant resolution touches tenancy/routing/access-boundary behavior.
- Protected paths: clean; no apps/web/src/proxy.ts, README, AGENTS.md, or architecture docs changed.
- Changed surfaces: apps/web/src/lib/tenant/tenant-context.ts, focused tenant-context tests, repo-size budget.

## Maturity / scorecard
- Slice-runner workflow scorecard after commit: ok=true for active-slice-continuation; worktree clean; protected paths untouched; active slice T-303; gate plan inferred as Tier 3.
- Repo pnpm workflow-scorecard script does not exist. Used: node /Users/arbenlila/.codex/skills/interdomestik-slice-runner/scripts/workflow-scorecard.mjs /Users/arbenlila/development/interdomestik-crystal-home.
- Golden-loop maturity commands are not present in this worktree yet: scripts/golden-loop/maturity-scorecard.mjs and scripts/golden-loop/playbook-contracts.mjs returned MODULE_NOT_FOUND, so that signal is blocked until PR #1077 changes are synced into this branch/main.

## Reviewer routing
- Codex reviewer was routed through the patched packet route and blocked with blockerReason=quota_or_rate_limit.
- Used approved external reviewer fallback; actionable findings were addressed before final local gates.

## Local verification
- pnpm --filter @interdomestik/web test:unit --run src/lib/tenant/tenant-context.test.ts src/lib/tenant/tenant-context-session-precedence.test.ts
- pnpm check:modularity-guard
- pnpm repo:size:check
- pnpm review:preflight
- pnpm slice:verify
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate

Notes:
- First pnpm pr:verify attempt hit a non-repeatable support-handoff E2E failure outside the touched resolver surface; rerun passed.
- Final pnpm e2e:gate passed: 136 passed, 8 skipped.
