### PR TITLE
fix: harden access tenant isolation

### DIFF
--- a/apps/web/src/actions/admin-rbac.core.ts
+++ b/apps/web/src/actions/admin-rbac.core.ts
@@ -36,7 +36,7 @@ function resolveTenantForAdminAction(
   tenantId?: string,
   role?: string
 ): string | undefined {
-  const sessionTenantId = session.user?.accessTenantId ?? session.user?.tenantId ?? undefined;
+  const sessionTenantId = session.user?.accessTenantId?.trim() || session.user?.tenantId?.trim();
   if (role === 'super_admin') {
     return tenantId ?? sessionTenantId;
   }

--- a/apps/web/src/actions/admin-rbac.core.ts
+++ b/apps/web/src/actions/admin-rbac.core.ts
@@ -32,11 +32,11 @@ function revalidateAdminUserPage(locale: string | undefined, userId: string) {
 }
 
 function resolveTenantForAdminAction(
-  session: { user?: { tenantId?: string | null } | null },
+  session: { user?: { accessTenantId?: string | null; tenantId?: string | null } | null },
   tenantId?: string,
   role?: string
 ): string | undefined {
-  const sessionTenantId = session.user?.tenantId ?? undefined;
+  const sessionTenantId = session.user?.accessTenantId ?? session.user?.tenantId ?? undefined;
   if (role === 'super_admin') {
     return tenantId ?? sessionTenantId;
   }

--- a/apps/web/src/app/[locale]/admin/users/[id]/tenant-context.test.ts
+++ b/apps/web/src/app/[locale]/admin/users/[id]/tenant-context.test.ts
@@ -30,6 +30,18 @@ describe('resolveAdminTenantContext', () => {
     expect(mocks.findFirst).not.toHaveBeenCalled();
   });
 
+  it('falls back to tenantId when accessTenantId is blank', async () => {
+    const tenantId = await resolveAdminTenantContext({
+      session: {
+        user: { accessTenantId: ' ', role: 'tenant_admin', tenantId: 'tenant_ks' },
+      },
+      searchParams: { tenantId: 'tenant_mk' },
+    });
+
+    expect(tenantId).toBe('tenant_ks');
+    expect(mocks.findFirst).not.toHaveBeenCalled();
+  });
+
   it('allows super_admin tenant switch only for active tenants', async () => {
     mocks.findFirst.mockResolvedValue({ id: 'tenant_mk' });
 

--- a/apps/web/src/app/[locale]/admin/users/[id]/tenant-context.ts
+++ b/apps/web/src/app/[locale]/admin/users/[id]/tenant-context.ts
@@ -4,6 +4,7 @@ import { and, eq } from 'drizzle-orm';
 
 type SessionLike = {
   user?: {
+    accessTenantId?: string | null;
     role?: string | null;
     tenantId?: string | null;
   } | null;
@@ -18,7 +19,7 @@ export async function resolveAdminTenantContext(params: {
   searchParams: Record<string, string | string[] | undefined>;
 }): Promise<string | null> {
   const { session, searchParams } = params;
-  const sessionTenantId = session?.user?.tenantId ?? null;
+  const sessionTenantId = session?.user?.accessTenantId ?? session?.user?.tenantId ?? null;
   const role = session?.user?.role ?? null;
 
   if (role !== 'super_admin') {

--- a/apps/web/src/app/[locale]/admin/users/[id]/tenant-context.ts
+++ b/apps/web/src/app/[locale]/admin/users/[id]/tenant-context.ts
@@ -14,12 +14,16 @@ function getFirst(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
+function resolveSessionTenantId(session: SessionLike): string | null {
+  return session?.user?.accessTenantId?.trim() || session?.user?.tenantId?.trim() || null;
+}
+
 export async function resolveAdminTenantContext(params: {
   session: SessionLike;
   searchParams: Record<string, string | string[] | undefined>;
 }): Promise<string | null> {
   const { session, searchParams } = params;
-  const sessionTenantId = session?.user?.accessTenantId ?? session?.user?.tenantId ?? null;
+  const sessionTenantId = resolveSessionTenantId(session);
   const role = session?.user?.role ?? null;
 
   if (role !== 'super_admin') {

--- a/apps/web/src/app/api/documents/[id]/download/access-tenant.test.ts
+++ b/apps/web/src/app/api/documents/[id]/download/access-tenant.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  enforceRateLimit: vi.fn(),
+  logAuditEvent: vi.fn(),
+  storageDownload: vi.fn(),
+  dbSelect: vi.fn(),
+  setTag: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ auth: { api: { getSession: hoisted.getSession } } }));
+vi.mock('@/lib/rate-limit', () => ({ enforceRateLimit: hoisted.enforceRateLimit }));
+vi.mock('@/lib/audit', () => ({ logAuditEvent: hoisted.logAuditEvent }));
+vi.mock('@sentry/nextjs', () => ({ setTag: hoisted.setTag }));
+
+const mockSelectChain = {
+  from: vi.fn().mockReturnThis(),
+  leftJoin: vi.fn().mockReturnThis(),
+  where: vi.fn().mockResolvedValue([]),
+};
+
+vi.mock('@interdomestik/database', () => ({
+  db: { select: hoisted.dbSelect },
+  documents: { id: 'id', tenantId: 'tenant_id' },
+  claimDocuments: { tenantId: 'claim_documents.tenant_id' },
+  claims: { userId: 'user_id' },
+  createAdminClient: () => ({ storage: { from: () => ({ download: hoisted.storageDownload }) } }),
+}));
+
+vi.mock('drizzle-orm', async importOriginal => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, and: vi.fn(), eq: vi.fn(), relations: vi.fn() };
+});
+
+import { GET } from './route';
+
+describe('GET /api/documents/[id]/download access tenant audit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.enforceRateLimit.mockResolvedValue(null);
+    hoisted.dbSelect.mockReturnValue(mockSelectChain);
+    mockSelectChain.from.mockReturnThis();
+    mockSelectChain.leftJoin.mockReturnThis();
+    mockSelectChain.where.mockResolvedValue([]);
+    hoisted.storageDownload.mockResolvedValue({
+      data: new Blob(['hello'], { type: 'text/plain' }),
+      error: null,
+    });
+  });
+
+  it('uses access tenant for allowed download audit records', async () => {
+    hoisted.getSession.mockResolvedValue({
+      user: {
+        accessTenantId: 'tenant_access',
+        id: 'user-1',
+        role: 'user',
+        tenantId: 'tenant_legal_compat',
+      },
+    });
+    mockSelectChain.where.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        claimOwnerId: 'user-1',
+        doc: {
+          bucket: 'claim-evidence',
+          claimId: 'claim-1',
+          filePath: 'pii/tenants/tenant_access/claims/claim-1/file.pdf',
+          fileSize: 123,
+          fileType: 'application/pdf',
+          id: 'doc-1',
+          name: 'file.pdf',
+          uploadedBy: 'someone-else',
+        },
+      },
+    ]);
+
+    const request = new Request('http://localhost:3000/api/documents/doc-1/download');
+    const response = await GET(request, { params: Promise.resolve({ id: 'doc-1' }) });
+
+    expect(response.status).toBe(200);
+    expect(hoisted.logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'document.download', tenantId: 'tenant_access' })
+    );
+    expect(hoisted.logAuditEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'tenant_legal_compat' })
+    );
+  });
+});

--- a/apps/web/src/app/api/documents/_core.access-tenant.test.ts
+++ b/apps/web/src/app/api/documents/_core.access-tenant.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sqlMocks = vi.hoisted(() => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+}));
+
+vi.mock('drizzle-orm', async importOriginal => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, and: sqlMocks.and, eq: sqlMocks.eq };
+});
+
+import { getDocumentAccessCore, type DocumentAccessDeps } from './_core';
+
+const mockDb = { select: vi.fn() };
+const mockDeps: DocumentAccessDeps = {
+  db: mockDb as unknown as DocumentAccessDeps['db'],
+  storage: {
+    createSignedUrl: vi.fn(),
+    download: vi.fn(),
+  },
+};
+
+function selectResult(rows: unknown[]) {
+  const chain = { where: vi.fn().mockResolvedValue(rows) };
+  return { from: vi.fn().mockReturnValue(chain) };
+}
+
+describe('getDocumentAccessCore access tenant isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.select.mockReturnValue(
+      selectResult([
+        {
+          id: 'doc-1',
+          entityType: 'claim',
+          entityId: 'claim-1',
+          fileName: 'legal.pdf',
+          mimeType: 'application/pdf',
+          fileSize: 10,
+          storagePath: 'pii/tenants/tenant_access/claims/claim-1/legal.pdf',
+          uploadedBy: 'member-1',
+        },
+      ])
+    );
+  });
+
+  it('uses accessTenantId instead of legal, recovery, booking, host, or ambient tenant values', async () => {
+    const session = {
+      user: {
+        id: 'support-1',
+        role: 'global_support',
+        tenantId: 'tenant_legal_compat',
+        accessTenantId: 'tenant_access',
+        legalTenantId: 'tenant_legal',
+        recoveryLegalTenantId: 'tenant_recovery',
+        bookingTenantId: 'tenant_booking',
+        hostTenantId: 'tenant_host',
+      },
+    };
+
+    const result = await getDocumentAccessCore({
+      deps: mockDeps,
+      documentId: 'doc-1',
+      mode: 'download',
+      session,
+    });
+
+    expect(result).toEqual(expect.objectContaining({ ok: true, tenantId: 'tenant_access' }));
+    expect(sqlMocks.eq).toHaveBeenCalledWith(expect.anything(), 'tenant_access');
+    expect(sqlMocks.eq).not.toHaveBeenCalledWith(expect.anything(), 'tenant_legal_compat');
+    expect(sqlMocks.eq).not.toHaveBeenCalledWith(expect.anything(), 'tenant_legal');
+    expect(sqlMocks.eq).not.toHaveBeenCalledWith(expect.anything(), 'tenant_recovery');
+  });
+});

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -237,7 +237,7 @@ export async function logDeniedDocumentAccess(args: {
   await args.logAuditEvent({
     actorId: args.session.user.id,
     actorRole: args.session.user.role || null,
-    tenantId: args.tenantId ?? undefined,
+    tenantId: ensureAccessTenantId(args.session),
     action: 'document.forbidden',
     entityType: 'claim_document',
     entityId: args.documentId,
@@ -256,7 +256,7 @@ export async function logAllowedDocumentAccess(args: {
   await args.logAuditEvent({
     actorId: args.session.user.id,
     actorRole: args.access.audit.actorRole,
-    tenantId: args.tenantId ?? undefined,
+    tenantId: args.access.tenantId,
     action: args.access.audit.action,
     entityType: args.access.audit.entityType,
     entityId: args.access.audit.entityId,

--- a/apps/web/src/app/api/documents/_core.ts
+++ b/apps/web/src/app/api/documents/_core.ts
@@ -3,8 +3,15 @@ import type { AuditEvent } from '@/lib/audit';
 import type { TenantStorageFamily } from '@/lib/storage/tenant-prefix';
 import type * as DatabaseModule from '@interdomestik/database';
 import { claimDocuments, claims, documents, policies } from '@interdomestik/database/schema';
-import { ensureTenantId } from '@interdomestik/shared-auth';
+import { ensureAccessTenantId, type CaseScopedAccessGrant } from '@interdomestik/shared-auth';
 import { and, eq } from 'drizzle-orm';
+
+import {
+  hasCaseScopedDocumentGrant,
+  hasScopedClaimReadAccess,
+  isFullTenantClaimsRole,
+  isScopedClaimReaderRole,
+} from './access-policy';
 
 type DatabaseClient = typeof DatabaseModule.db;
 
@@ -28,6 +35,8 @@ export interface DocumentAccessDeps {
 type SessionDTO = {
   user: {
     id: string;
+    accessTenantId?: string | null;
+    caseScopedAccessGrants?: readonly CaseScopedAccessGrant[] | null;
     branchId?: string | null;
     role?: string | null;
     tenantId?: string | null;
@@ -37,6 +46,7 @@ type SessionDTO = {
 type DocumentRow = {
   id: string;
   claimId: string | null;
+  category?: GrantDocumentClass | null;
   bucket: string;
   filePath: string;
   uploadedBy: string | null;
@@ -44,15 +54,15 @@ type DocumentRow = {
   fileType: string | null;
   fileSize: number | null;
 };
-
 type DocumentAccessMode = 'signed_url' | 'download';
 type PolymorphicDocumentRow = {
   id: string;
   entityId: string;
   entityType: string;
+  category?: GrantDocumentClass | null;
   uploadedBy: string | null;
 };
-
+type GrantDocumentClass = Parameters<typeof hasCaseScopedDocumentGrant>[0]['documentClass'];
 export type DocumentAccessResult =
   | {
       ok: true;
@@ -85,41 +95,6 @@ type AuditContext = {
   actorRole: string | null;
   metadata: Record<string, unknown>;
 };
-
-function isFullTenantClaimsRole(role: string | null | undefined): boolean {
-  return role === 'admin' || role === 'tenant_admin' || role === 'super_admin';
-}
-
-function isScopedClaimReaderRole(role: string | null | undefined): boolean {
-  return role === 'staff' || role === 'branch_manager' || role === 'agent';
-}
-
-function hasScopedClaimReadAccess(args: {
-  branchId?: string | null;
-  claim: {
-    branchId?: string | null;
-    staffId?: string | null;
-    userId: string | null;
-    agentId?: string | null;
-  };
-  role: string | null | undefined;
-  userId: string;
-}): boolean {
-  if (args.role === 'agent') {
-    return args.claim.agentId === args.userId;
-  }
-  const branchId = args.branchId ?? null;
-
-  if (args.role === 'branch_manager') {
-    return branchId !== null && args.claim.branchId === branchId;
-  }
-
-  if (branchId !== null) {
-    return args.claim.branchId === branchId;
-  }
-
-  return args.claim.staffId === args.userId || args.claim.staffId == null;
-}
 
 export function safeFilename(value: string) {
   const ascii = value
@@ -362,6 +337,17 @@ async function canReadPolymorphicClaimDocument(args: {
 
   if (!claimRow) return false;
 
+  if (
+    hasCaseScopedDocumentGrant({
+      accessTenantId: tenantId,
+      caseId: polyDoc.entityId,
+      documentClass: polyDoc.category ?? 'other',
+      session,
+    })
+  ) {
+    return true;
+  }
+
   // Member can read any document attached to their own claim.
   if (userRole !== 'agent' && claimRow.claimOwnerId === session.user.id) {
     return true;
@@ -392,12 +378,25 @@ function canReadLegacyClaimDocument(args: {
     agentId: string | null;
   };
   document: DocumentRow;
+  tenantId: string;
   session: SessionDTO;
   userRole: string | undefined;
 }): boolean {
-  const { claim, document, session, userRole } = args;
+  const { claim, document, session, tenantId, userRole } = args;
 
   if (isFullTenantClaimsRole(userRole)) {
+    return true;
+  }
+
+  if (
+    document.claimId &&
+    hasCaseScopedDocumentGrant({
+      accessTenantId: tenantId,
+      caseId: document.claimId,
+      documentClass: document.category ?? 'other',
+      session,
+    })
+  ) {
     return true;
   }
 
@@ -433,7 +432,7 @@ export async function getDocumentAccessCore(args: {
   deps: DocumentAccessDeps;
 }): Promise<DocumentAccessResult> {
   const { session, documentId, mode, disposition, deps } = args;
-  const tenantId = ensureTenantId(session);
+  const tenantId = ensureAccessTenantId(session);
   const { db } = deps;
   const userRole = (session.user.role as string | undefined) ?? undefined;
   const finalDisposition = getFinalDisposition(disposition);
@@ -501,6 +500,7 @@ export async function getDocumentAccessCore(args: {
       agentId: row.claimAgentId ?? null,
     },
     document: doc,
+    tenantId,
     session,
     userRole,
   });

--- a/apps/web/src/app/api/documents/access-policy.test.ts
+++ b/apps/web/src/app/api/documents/access-policy.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasCaseScopedDocumentGrant,
+  hasScopedClaimReadAccess,
+  isFullTenantClaimsRole,
+} from './access-policy';
+
+describe('document access policy', () => {
+  it('treats global support as selected-tenant read, not legal-entity mutation', () => {
+    expect(isFullTenantClaimsRole('global_support')).toBe(true);
+    expect(isFullTenantClaimsRole('auditor')).toBe(false);
+  });
+
+  it('allows grants only for the named case and document class inside the access tenant', () => {
+    const session = {
+      user: {
+        id: 'local-legal-1',
+        caseScopedAccessGrants: [
+          {
+            accessTenantId: 'tenant_access',
+            actorId: 'local-legal-1',
+            caseId: 'claim-1',
+            documentClasses: ['legal' as const],
+          },
+        ],
+      },
+    };
+
+    expect(
+      hasCaseScopedDocumentGrant({
+        accessTenantId: 'tenant_access',
+        caseId: 'claim-1',
+        documentClass: 'legal',
+        session,
+      })
+    ).toBe(true);
+    expect(
+      hasCaseScopedDocumentGrant({
+        accessTenantId: 'tenant_legal',
+        caseId: 'claim-1',
+        documentClass: 'legal',
+        session,
+      })
+    ).toBe(false);
+    expect(
+      hasCaseScopedDocumentGrant({
+        accessTenantId: 'tenant_access',
+        caseId: 'claim-1',
+        documentClass: 'medical',
+        session,
+      })
+    ).toBe(false);
+  });
+
+  it('does not elevate branch staff to branch-manager document access', () => {
+    expect(
+      hasScopedClaimReadAccess({
+        branchId: 'branch-1',
+        claim: { branchId: 'branch-1', staffId: 'staff-2', userId: 'member-1' },
+        role: 'staff',
+        userId: 'staff-1',
+      })
+    ).toBe(false);
+    expect(
+      hasScopedClaimReadAccess({
+        branchId: 'branch-1',
+        claim: { branchId: 'branch-1', staffId: 'staff-1', userId: 'member-1' },
+        role: 'staff',
+        userId: 'staff-1',
+      })
+    ).toBe(true);
+  });
+
+  it('does not grant branchless staff access to every unassigned claim document', () => {
+    expect(
+      hasScopedClaimReadAccess({
+        branchId: null,
+        claim: { branchId: null, staffId: null, userId: 'member-1' },
+        role: 'staff',
+        userId: 'staff-1',
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/app/api/documents/access-policy.test.ts
+++ b/apps/web/src/app/api/documents/access-policy.test.ts
@@ -72,6 +72,17 @@ describe('document access policy', () => {
     ).toBe(true);
   });
 
+  it('preserves assigned staff document access across branch boundaries', () => {
+    expect(
+      hasScopedClaimReadAccess({
+        branchId: 'branch-1',
+        claim: { branchId: 'branch-2', staffId: 'staff-1', userId: 'member-1' },
+        role: 'staff',
+        userId: 'staff-1',
+      })
+    ).toBe(true);
+  });
+
   it('does not grant branchless staff access to every unassigned claim document', () => {
     expect(
       hasScopedClaimReadAccess({

--- a/apps/web/src/app/api/documents/access-policy.ts
+++ b/apps/web/src/app/api/documents/access-policy.ts
@@ -40,12 +40,9 @@ export function hasScopedClaimReadAccess(args: {
 }): boolean {
   if (args.role === 'agent') return args.claim.agentId === args.userId;
 
-  const branchId = args.branchId ?? null;
   if (args.role === 'branch_manager') {
+    const branchId = args.branchId ?? null;
     return branchId !== null && args.claim.branchId === branchId;
-  }
-  if (args.role === 'staff' && branchId !== null) {
-    return args.claim.branchId === branchId && args.claim.staffId === args.userId;
   }
 
   return args.role === 'staff' && args.claim.staffId === args.userId;

--- a/apps/web/src/app/api/documents/access-policy.ts
+++ b/apps/web/src/app/api/documents/access-policy.ts
@@ -1,0 +1,67 @@
+import {
+  canUseCaseScopedDocumentGrant,
+  type CaseScopedAccessGrant,
+  type CaseScopedDocumentClass,
+} from '@interdomestik/shared-auth';
+
+export type DocumentAccessSession = {
+  user: {
+    id: string;
+    branchId?: string | null;
+    caseScopedAccessGrants?: readonly CaseScopedAccessGrant[] | null;
+  };
+};
+
+export type ScopedClaim = {
+  branchId?: string | null;
+  staffId?: string | null;
+  userId: string | null;
+  agentId?: string | null;
+};
+
+export function isFullTenantClaimsRole(role: string | null | undefined): boolean {
+  return (
+    role === 'admin' ||
+    role === 'tenant_admin' ||
+    role === 'super_admin' ||
+    role === 'global_support'
+  );
+}
+
+export function isScopedClaimReaderRole(role: string | null | undefined): boolean {
+  return role === 'staff' || role === 'branch_manager' || role === 'agent';
+}
+
+export function hasScopedClaimReadAccess(args: {
+  branchId?: string | null;
+  claim: ScopedClaim;
+  role: string | null | undefined;
+  userId: string;
+}): boolean {
+  if (args.role === 'agent') return args.claim.agentId === args.userId;
+
+  const branchId = args.branchId ?? null;
+  if (args.role === 'branch_manager') {
+    return branchId !== null && args.claim.branchId === branchId;
+  }
+  if (args.role === 'staff' && branchId !== null) {
+    return args.claim.branchId === branchId && args.claim.staffId === args.userId;
+  }
+
+  return args.role === 'staff' && args.claim.staffId === args.userId;
+}
+
+export function hasCaseScopedDocumentGrant(args: {
+  accessTenantId: string;
+  caseId: string;
+  documentClass: CaseScopedDocumentClass;
+  session: DocumentAccessSession;
+}): boolean {
+  return canUseCaseScopedDocumentGrant({
+    accessTenantId: args.accessTenantId,
+    actorId: args.session.user.id,
+    caseId: args.caseId,
+    documentClass: args.documentClass,
+    grants: args.session.user.caseScopedAccessGrants,
+  });
+}

--- a/apps/web/src/app/api/uploads/_core.access-tenant.test.ts
+++ b/apps/web/src/app/api/uploads/_core.access-tenant.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  and: vi.fn(),
+  createTenantSignedUploadUrl: vi.fn(),
+  eq: vi.fn(),
+  findClaimFirst: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  and: hoisted.and,
+  claims: { id: 'id', tenantId: 'tenant_id' },
+  db: { query: { claims: { findFirst: hoisted.findClaimFirst } } },
+  eq: hoisted.eq,
+}));
+
+vi.mock('@/lib/storage/service-role', () => ({
+  createTenantSignedUploadUrl: hoisted.createTenantSignedUploadUrl,
+}));
+
+vi.mock('nanoid', () => ({ nanoid: () => 'evidence-123' }));
+
+import { createSignedUploadCore } from './_core';
+
+describe('createSignedUploadCore access tenant isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('CLAIM_UPLOAD_INTENT_SECRET', 'test-upload-intent-secret-value-123456');
+    hoisted.findClaimFirst.mockResolvedValue({ id: 'claim-1', userId: 'member-1' });
+    hoisted.createTenantSignedUploadUrl.mockResolvedValue({
+      data: { token: 'tok', signedUrl: 'https://signed.example/upload' },
+      error: null,
+    });
+  });
+
+  it('uses accessTenantId for claim lookup, storage path, and signed upload URL', async () => {
+    const result = await createSignedUploadCore({
+      bucket: 'claim-evidence',
+      input: {
+        claimId: 'claim-1',
+        fileName: 'legal.pdf',
+        fileSize: 10,
+        fileType: 'application/pdf',
+      },
+      session: {
+        user: {
+          id: 'member-1',
+          role: 'member',
+          tenantId: 'tenant_legal_compat',
+          accessTenantId: 'tenant_access',
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(hoisted.eq).toHaveBeenCalledWith('tenant_id', 'tenant_access');
+    expect(hoisted.eq).not.toHaveBeenCalledWith('tenant_id', 'tenant_legal_compat');
+    if (result.ok) {
+      expect(result.body.upload.path).toBe(
+        'pii/tenants/tenant_access/claims/claim-1/evidence-123.pdf'
+      );
+    }
+    expect(hoisted.createTenantSignedUploadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'tenant_access' })
+    );
+  });
+});

--- a/apps/web/src/app/api/uploads/_core.ts
+++ b/apps/web/src/app/api/uploads/_core.ts
@@ -1,5 +1,5 @@
 import { and, claims, db, eq } from '@interdomestik/database';
-import { ensureTenantId } from '@interdomestik/shared-auth';
+import { ensureAccessTenantId } from '@interdomestik/shared-auth';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 import { DEFAULT_EVIDENCE_BUCKET } from '@/lib/storage/evidence-bucket';
@@ -9,13 +9,13 @@ import {
   buildEvidenceStoragePath,
 } from '@/features/claims/upload/server/storage-path';
 
-type Session = {
-  user: {
-    id: string;
-    role?: string | null;
-    tenantId?: string | null;
-  };
+type SessionUser = {
+  id: string;
+  accessTenantId?: string | null;
+  role?: string | null;
+  tenantId?: string | null;
 };
+type Session = { user: SessionUser };
 
 export const ALLOWED_MIME_TYPES = [
   'image/jpeg',
@@ -92,7 +92,7 @@ export async function createSignedUploadCore(args: {
     return { ok: false, status: 413, error: 'File too large' };
   }
 
-  const tenantId = ensureTenantId(session);
+  const tenantId = ensureAccessTenantId(session);
 
   if (claimId) {
     const claim = await db.query.claims.findFirst({

--- a/apps/web/src/server/auth/effective-portal-access.test.ts
+++ b/apps/web/src/server/auth/effective-portal-access.test.ts
@@ -114,4 +114,30 @@ describe('hasEffectivePortalAccess', () => {
     expect(mocks.eq).toHaveBeenCalledWith(expect.anything(), 'tenant_access');
     expect(mocks.eq).not.toHaveBeenCalledWith(expect.anything(), 'tenant_legal_compat');
   });
+
+  it('falls back to tenantId when accessTenantId is blank before role lookup', async () => {
+    mocks.findUserRoles.mockImplementationOnce(async query => {
+      query.where(
+        { userId: 'user_id', tenantId: 'tenant_id' },
+        { and: (...conditions: unknown[]) => conditions }
+      );
+      return [{ role: 'admin' }];
+    });
+
+    await expect(
+      hasEffectivePortalAccess(
+        {
+          user: {
+            id: 'admin-1',
+            role: 'member',
+            tenantId: 'tenant_ks',
+            accessTenantId: '   ',
+          },
+        },
+        ['admin']
+      )
+    ).resolves.toBe(true);
+
+    expect(mocks.eq).toHaveBeenCalledWith(expect.anything(), 'tenant_ks');
+  });
 });

--- a/apps/web/src/server/auth/effective-portal-access.test.ts
+++ b/apps/web/src/server/auth/effective-portal-access.test.ts
@@ -26,6 +26,22 @@ vi.mock('drizzle-orm', async importOriginal => {
 
 import { hasEffectivePortalAccess } from './effective-portal-access';
 
+const adminRoles = ['admin', 'tenant_admin', 'super_admin'];
+
+function session(role: string, tenantId = 'tenant_ks', accessTenantId?: string) {
+  return { user: { id: 'u1', role, tenantId, accessTenantId } };
+}
+
+function mockTenantRole(role = 'admin') {
+  mocks.findUserRoles.mockImplementationOnce(async query => {
+    query.where(
+      { userId: 'user_id', tenantId: 'tenant_id' },
+      { and: (...parts: unknown[]) => parts }
+    );
+    return [{ role }];
+  });
+}
+
 describe('hasEffectivePortalAccess', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -33,81 +49,40 @@ describe('hasEffectivePortalAccess', () => {
     mocks.findTenant.mockResolvedValue(undefined);
   });
 
-  it('denies cross-tenant access for non-super-admin even with elevated legacy role', async () => {
-    const allowed = await hasEffectivePortalAccess(
-      { user: { id: 'u1', tenantId: 'tenant_ks', role: 'admin' } },
-      ['admin', 'tenant_admin', 'super_admin'],
-      { requestedTenantId: 'tenant_mk' }
-    );
+  it.each([
+    ['admin', undefined, false],
+    ['super_admin', { id: 'tenant_mk' }, true],
+    ['super_admin', undefined, false],
+  ])(
+    'resolves cross-tenant legacy %s access with active tenant %s',
+    async (role, tenant, expected) => {
+      if (tenant) mocks.findTenant.mockResolvedValueOnce(tenant);
 
-    expect(allowed).toBe(false);
-  });
-
-  it('allows cross-tenant access only for legacy super_admin to active target tenant', async () => {
-    mocks.findTenant.mockResolvedValueOnce({ id: 'tenant_mk' });
-
-    const allowed = await hasEffectivePortalAccess(
-      { user: { id: 'u1', tenantId: 'tenant_ks', role: 'super_admin' } },
-      ['admin', 'tenant_admin', 'super_admin'],
-      { requestedTenantId: 'tenant_mk' }
-    );
-
-    expect(allowed).toBe(true);
-  });
-
-  it('denies cross-tenant super_admin when requested tenant is not active/valid', async () => {
-    const allowed = await hasEffectivePortalAccess(
-      { user: { id: 'u1', tenantId: 'tenant_ks', role: 'super_admin' } },
-      ['admin', 'tenant_admin', 'super_admin'],
-      { requestedTenantId: 'tenant_mk' }
-    );
-
-    expect(allowed).toBe(false);
-  });
+      await expect(
+        hasEffectivePortalAccess(session(role), adminRoles, { requestedTenantId: 'tenant_mk' })
+      ).resolves.toBe(expected);
+    }
+  );
 
   it('allows same-tenant legacy fallback when no tenant user_roles rows exist', async () => {
-    const allowed = await hasEffectivePortalAccess(
-      { user: { id: 'u1', tenantId: 'tenant_ks', role: 'admin' } },
-      ['admin', 'tenant_admin', 'super_admin'],
-      { requestedTenantId: 'tenant_ks' }
-    );
-
-    expect(allowed).toBe(true);
+    await expect(
+      hasEffectivePortalAccess(session('admin'), adminRoles, { requestedTenantId: 'tenant_ks' })
+    ).resolves.toBe(true);
   });
 
   it('treats user_roles as authoritative when rows exist for requested tenant', async () => {
     mocks.findUserRoles.mockResolvedValueOnce([{ role: 'member' }]);
 
-    const deniedByAuthoritativeRoles = await hasEffectivePortalAccess(
-      { user: { id: 'u1', tenantId: 'tenant_ks', role: 'admin' } },
-      ['admin', 'tenant_admin', 'super_admin'],
-      { requestedTenantId: 'tenant_mk' }
-    );
-
-    expect(deniedByAuthoritativeRoles).toBe(false);
+    await expect(
+      hasEffectivePortalAccess(session('admin'), adminRoles, { requestedTenantId: 'tenant_mk' })
+    ).resolves.toBe(false);
   });
 
   it('uses accessTenantId instead of legal-compatible tenantId for access checks', async () => {
-    mocks.findUserRoles.mockImplementationOnce(async query => {
-      query.where(
-        { userId: 'user_id', tenantId: 'tenant_id' },
-        { and: (...conditions: unknown[]) => conditions }
-      );
-      return [{ role: 'admin' }];
-    });
+    mockTenantRole();
 
     await expect(
-      hasEffectivePortalAccess(
-        {
-          user: {
-            id: 'admin-1',
-            role: 'member',
-            tenantId: 'tenant_legal_compat',
-            accessTenantId: 'tenant_access',
-          },
-        },
-        ['admin']
-      )
+      hasEffectivePortalAccess(session('member', 'tenant_legal_compat', 'tenant_access'), ['admin'])
     ).resolves.toBe(true);
 
     expect(mocks.findUserRoles).toHaveBeenCalledTimes(1);
@@ -116,26 +91,10 @@ describe('hasEffectivePortalAccess', () => {
   });
 
   it('falls back to tenantId when accessTenantId is blank before role lookup', async () => {
-    mocks.findUserRoles.mockImplementationOnce(async query => {
-      query.where(
-        { userId: 'user_id', tenantId: 'tenant_id' },
-        { and: (...conditions: unknown[]) => conditions }
-      );
-      return [{ role: 'admin' }];
-    });
+    mockTenantRole();
 
     await expect(
-      hasEffectivePortalAccess(
-        {
-          user: {
-            id: 'admin-1',
-            role: 'member',
-            tenantId: 'tenant_ks',
-            accessTenantId: '   ',
-          },
-        },
-        ['admin']
-      )
+      hasEffectivePortalAccess(session('member', 'tenant_ks', '   '), ['admin'])
     ).resolves.toBe(true);
 
     expect(mocks.eq).toHaveBeenCalledWith(expect.anything(), 'tenant_ks');

--- a/apps/web/src/server/auth/effective-portal-access.test.ts
+++ b/apps/web/src/server/auth/effective-portal-access.test.ts
@@ -1,28 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { hasEffectivePortalAccess } from './effective-portal-access';
 
 const mocks = vi.hoisted(() => ({
-  findUserRoles: vi.fn(),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
   findTenant: vi.fn(),
+  findUserRoles: vi.fn(),
 }));
 
 vi.mock('@interdomestik/database/db', () => ({
   db: {
     query: {
-      userRoles: {
-        findMany: (...args: unknown[]) => mocks.findUserRoles(...args),
-      },
       tenants: {
         findFirst: (...args: unknown[]) => mocks.findTenant(...args),
+      },
+      userRoles: {
+        findMany: (...args: unknown[]) => mocks.findUserRoles(...args),
       },
     },
   },
 }));
 
+vi.mock('drizzle-orm', async importOriginal => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, eq: mocks.eq };
+});
+
+import { hasEffectivePortalAccess } from './effective-portal-access';
+
 describe('hasEffectivePortalAccess', () => {
   beforeEach(() => {
-    mocks.findUserRoles.mockReset();
-    mocks.findTenant.mockReset();
+    vi.clearAllMocks();
     mocks.findUserRoles.mockResolvedValue([]);
     mocks.findTenant.mockResolvedValue(undefined);
   });
@@ -50,8 +56,6 @@ describe('hasEffectivePortalAccess', () => {
   });
 
   it('denies cross-tenant super_admin when requested tenant is not active/valid', async () => {
-    mocks.findTenant.mockResolvedValueOnce(undefined);
-
     const allowed = await hasEffectivePortalAccess(
       { user: { id: 'u1', tenantId: 'tenant_ks', role: 'super_admin' } },
       ['admin', 'tenant_admin', 'super_admin'],
@@ -81,5 +85,33 @@ describe('hasEffectivePortalAccess', () => {
     );
 
     expect(deniedByAuthoritativeRoles).toBe(false);
+  });
+
+  it('uses accessTenantId instead of legal-compatible tenantId for access checks', async () => {
+    mocks.findUserRoles.mockImplementationOnce(async query => {
+      query.where(
+        { userId: 'user_id', tenantId: 'tenant_id' },
+        { and: (...conditions: unknown[]) => conditions }
+      );
+      return [{ role: 'admin' }];
+    });
+
+    await expect(
+      hasEffectivePortalAccess(
+        {
+          user: {
+            id: 'admin-1',
+            role: 'member',
+            tenantId: 'tenant_legal_compat',
+            accessTenantId: 'tenant_access',
+          },
+        },
+        ['admin']
+      )
+    ).resolves.toBe(true);
+
+    expect(mocks.findUserRoles).toHaveBeenCalledTimes(1);
+    expect(mocks.eq).toHaveBeenCalledWith(expect.anything(), 'tenant_access');
+    expect(mocks.eq).not.toHaveBeenCalledWith(expect.anything(), 'tenant_legal_compat');
   });
 });

--- a/apps/web/src/server/auth/effective-portal-access.ts
+++ b/apps/web/src/server/auth/effective-portal-access.ts
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 
 type SessionLike = {
   user?: {
+    accessTenantId?: string | null;
     id?: string | null;
     role?: string | null;
     tenantId?: string | null;
@@ -40,7 +41,7 @@ export async function hasEffectivePortalAccess(
   allowedRoles: readonly string[],
   options: PortalAccessOptions = {}
 ): Promise<boolean> {
-  const sessionTenantId = session?.user?.tenantId ?? null;
+  const sessionTenantId = session?.user?.accessTenantId ?? session?.user?.tenantId ?? null;
   const requestedTenantId = options.requestedTenantId ?? sessionTenantId ?? null;
   const userId = session?.user?.id ?? null;
   const legacyRole = session?.user?.role ?? null;

--- a/apps/web/src/server/auth/effective-portal-access.ts
+++ b/apps/web/src/server/auth/effective-portal-access.ts
@@ -36,12 +36,16 @@ type PortalAccessOptions = {
   requestedTenantId?: string | null;
 };
 
+function resolveSessionTenantId(session: SessionLike): string | null {
+  return session?.user?.accessTenantId?.trim() || session?.user?.tenantId?.trim() || null;
+}
+
 export async function hasEffectivePortalAccess(
   session: SessionLike,
   allowedRoles: readonly string[],
   options: PortalAccessOptions = {}
 ): Promise<boolean> {
-  const sessionTenantId = session?.user?.accessTenantId ?? session?.user?.tenantId ?? null;
+  const sessionTenantId = resolveSessionTenantId(session);
   const requestedTenantId = options.requestedTenantId ?? sessionTenantId ?? null;
   const userId = session?.user?.id ?? null;
   const legacyRole = session?.user?.role ?? null;

--- a/packages/domain-users/src/admin/resolve-tenant-classification.test.ts
+++ b/packages/domain-users/src/admin/resolve-tenant-classification.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 type QueryTable = {
   findFirst: ReturnType<typeof vi.fn>;
 };
-
 const mocks = vi.hoisted(() => {
   const makeQueryTable = (): QueryTable => ({
     findFirst: vi.fn(),
@@ -31,7 +30,6 @@ const mocks = vi.hoisted(() => {
   const where = vi.fn();
   const set = vi.fn(() => ({ where }));
   const update = vi.fn(() => ({ set }));
-
   return {
     db: {
       transaction: vi.fn(),
@@ -118,7 +116,8 @@ const mocks = vi.hoisted(() => {
       tenantColumn,
       filter,
     })),
-    ensureTenantId: vi.fn((session: { user: { tenantId: string } }) => session.user.tenantId),
+    ensureAccessTenantId: vi.fn(session => session.user.accessTenantId ?? session.user.tenantId),
+    ensureTenantId: vi.fn(session => session.user.accessTenantId ?? session.user.tenantId),
   };
 });
 
@@ -145,6 +144,7 @@ vi.mock('@interdomestik/database', () => ({
 }));
 
 vi.mock('@interdomestik/shared-auth', () => ({
+  ensureAccessTenantId: mocks.ensureAccessTenantId,
   ensureTenantId: mocks.ensureTenantId,
 }));
 

--- a/packages/domain-users/src/admin/resolve-tenant-classification.test.ts
+++ b/packages/domain-users/src/admin/resolve-tenant-classification.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-type QueryTable = {
-  findFirst: ReturnType<typeof vi.fn>;
-};
+type QueryTable = { findFirst: ReturnType<typeof vi.fn> };
+type MockTenantSession = { user: { accessTenantId?: string | null; tenantId?: string | null } };
 const mocks = vi.hoisted(() => {
   const makeQueryTable = (): QueryTable => ({
     findFirst: vi.fn(),
@@ -27,7 +26,8 @@ const mocks = vi.hoisted(() => {
     user: makeQueryTable(),
   };
   const where = vi.fn();
-  const resolveTenantId = ({ user }) => user.accessTenantId?.trim() || user.tenantId?.trim();
+  const resolveTenantId = ({ user }: MockTenantSession) =>
+    user.accessTenantId?.trim() || user.tenantId?.trim();
   const set = vi.fn(() => ({ where }));
   const update = vi.fn(() => ({ set }));
   return {
@@ -120,7 +120,6 @@ const mocks = vi.hoisted(() => {
     ensureTenantId: vi.fn(resolveTenantId),
   };
 });
-
 vi.mock('@interdomestik/database', () => ({
   db: mocks.db,
   user: mocks.user,

--- a/packages/domain-users/src/admin/resolve-tenant-classification.test.ts
+++ b/packages/domain-users/src/admin/resolve-tenant-classification.test.ts
@@ -26,8 +26,8 @@ const mocks = vi.hoisted(() => {
     tenants: makeQueryTable(),
     user: makeQueryTable(),
   };
-
   const where = vi.fn();
+  const resolveTenantId = ({ user }) => user.accessTenantId?.trim() || user.tenantId?.trim();
   const set = vi.fn(() => ({ where }));
   const update = vi.fn(() => ({ set }));
   return {
@@ -116,8 +116,8 @@ const mocks = vi.hoisted(() => {
       tenantColumn,
       filter,
     })),
-    ensureAccessTenantId: vi.fn(session => session.user.accessTenantId ?? session.user.tenantId),
-    ensureTenantId: vi.fn(session => session.user.accessTenantId ?? session.user.tenantId),
+    ensureAccessTenantId: vi.fn(resolveTenantId),
+    ensureTenantId: vi.fn(resolveTenantId),
   };
 });
 

--- a/packages/domain-users/src/admin/roles.list.test.ts
+++ b/packages/domain-users/src/admin/roles.list.test.ts
@@ -41,6 +41,7 @@ vi.mock('@interdomestik/database/tenant-security', () => ({
 }));
 
 vi.mock('@interdomestik/shared-auth', () => ({
+  ensureAccessTenantId: vi.fn(session => session.user.accessTenantId ?? session.user.tenantId),
   hasPermission: vi.fn(() => true),
   PERMISSIONS: {
     'roles.manage': 'roles.manage',

--- a/packages/domain-users/src/admin/roles.list.test.ts
+++ b/packages/domain-users/src/admin/roles.list.test.ts
@@ -41,7 +41,9 @@ vi.mock('@interdomestik/database/tenant-security', () => ({
 }));
 
 vi.mock('@interdomestik/shared-auth', () => ({
-  ensureAccessTenantId: vi.fn(session => session.user.accessTenantId ?? session.user.tenantId),
+  ensureAccessTenantId: vi.fn(
+    session => session.user.accessTenantId?.trim() || session.user.tenantId?.trim()
+  ),
   hasPermission: vi.fn(() => true),
   PERMISSIONS: {
     'roles.manage': 'roles.manage',

--- a/packages/domain-users/src/admin/roles.revoke.test.ts
+++ b/packages/domain-users/src/admin/roles.revoke.test.ts
@@ -36,6 +36,7 @@ vi.mock('@interdomestik/database/tenant-security', () => ({
 }));
 
 vi.mock('@interdomestik/shared-auth', () => ({
+  ensureAccessTenantId: vi.fn(session => session.user.accessTenantId ?? session.user.tenantId),
   hasPermission: vi.fn(() => true),
   PERMISSIONS: {
     'roles.manage': 'roles.manage',

--- a/packages/domain-users/src/admin/roles.revoke.test.ts
+++ b/packages/domain-users/src/admin/roles.revoke.test.ts
@@ -36,7 +36,9 @@ vi.mock('@interdomestik/database/tenant-security', () => ({
 }));
 
 vi.mock('@interdomestik/shared-auth', () => ({
-  ensureAccessTenantId: vi.fn(session => session.user.accessTenantId ?? session.user.tenantId),
+  ensureAccessTenantId: vi.fn(
+    session => session.user.accessTenantId?.trim() || session.user.tenantId?.trim()
+  ),
   hasPermission: vi.fn(() => true),
   PERMISSIONS: {
     'roles.manage': 'roles.manage',

--- a/packages/domain-users/src/admin/utils.test.ts
+++ b/packages/domain-users/src/admin/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTenantId } from './utils';
+import type { UserSession } from '../types';
+
+const session = {
+  user: {
+    id: 'admin-1',
+    role: 'admin',
+    tenantId: 'tenant_legal_compat',
+    accessTenantId: 'tenant_access',
+  },
+} satisfies UserSession;
+
+describe('resolveTenantId', () => {
+  it('uses accessTenantId for non-super-admin access scope', () => {
+    expect(resolveTenantId(session, 'tenant_access')).toBe('tenant_access');
+    expect(() => resolveTenantId(session, 'tenant_legal_compat')).toThrow('Unauthorized');
+    expect(resolveTenantId(session)).toBe('tenant_access');
+  });
+
+  it('preserves explicit super-admin tenant selection', () => {
+    expect(
+      resolveTenantId(
+        { user: { id: 'root', role: 'super_admin', tenantId: 'tenant_legal_compat' } },
+        'tenant_any'
+      )
+    ).toBe('tenant_any');
+  });
+});

--- a/packages/domain-users/src/admin/utils.ts
+++ b/packages/domain-users/src/admin/utils.ts
@@ -1,4 +1,4 @@
-import { ensureTenantId } from '@interdomestik/shared-auth';
+import { ensureAccessTenantId } from '@interdomestik/shared-auth';
 import type { UserSession } from '../types';
 
 export function resolveTenantId(session: UserSession, requestedTenantId?: string | null): string {
@@ -6,12 +6,12 @@ export function resolveTenantId(session: UserSession, requestedTenantId?: string
     if (session.user.role === 'super_admin') return requestedTenantId;
 
     // Non-super-admin users may only operate within their current tenant.
-    if (session.user.tenantId && session.user.tenantId === requestedTenantId) {
+    if (ensureAccessTenantId(session) === requestedTenantId) {
       return requestedTenantId;
     }
 
     throw new Error('Unauthorized');
   }
 
-  return ensureTenantId(session);
+  return ensureAccessTenantId(session);
 }

--- a/packages/domain-users/src/types.ts
+++ b/packages/domain-users/src/types.ts
@@ -2,6 +2,7 @@ export type UserSession = {
   user: {
     id: string;
     role: string;
+    accessTenantId?: string | null;
     tenantId?: string | null;
     name?: string | null;
     email?: string | null;

--- a/packages/shared-auth/src/access-grants.test.ts
+++ b/packages/shared-auth/src/access-grants.test.ts
@@ -54,6 +54,19 @@ describe('canUseCaseScopedDocumentGrant', () => {
     ).toBe(false);
   });
 
+  it('normalizes identifier whitespace before matching grants', () => {
+    expect(
+      canUseCaseScopedDocumentGrant({
+        accessTenantId: ' tenant_access ',
+        actorId: ' actor-local-legal ',
+        caseId: ' claim-1 ',
+        documentClass: 'legal',
+        grants: [{ ...grant, accessTenantId: ' tenant_access ', caseId: ' claim-1 ' }],
+        now,
+      })
+    ).toBe(true);
+  });
+
   it('rejects revoked or expired grants', () => {
     expect(
       canUseCaseScopedDocumentGrant({

--- a/packages/shared-auth/src/access-grants.test.ts
+++ b/packages/shared-auth/src/access-grants.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { canUseCaseScopedDocumentGrant, type CaseScopedAccessGrant } from './access-grants';
+
+const grant: CaseScopedAccessGrant = {
+  accessTenantId: 'tenant_access',
+  actorId: 'actor-local-legal',
+  caseId: 'claim-1',
+  documentClasses: ['evidence', 'legal'],
+  expiresAt: '2026-07-01T00:00:00.000Z',
+};
+
+const now = new Date('2026-06-16T00:00:00.000Z');
+
+describe('canUseCaseScopedDocumentGrant', () => {
+  it('allows only named case and approved document classes inside the access tenant', () => {
+    expect(
+      canUseCaseScopedDocumentGrant({
+        accessTenantId: 'tenant_access',
+        actorId: 'actor-local-legal',
+        caseId: 'claim-1',
+        documentClass: 'legal',
+        grants: [grant],
+        now,
+      })
+    ).toBe(true);
+
+    for (const denied of [
+      { caseId: 'claim-2', documentClass: 'legal' as const },
+      { caseId: 'claim-1', documentClass: 'medical' as const },
+    ]) {
+      expect(
+        canUseCaseScopedDocumentGrant({
+          accessTenantId: 'tenant_access',
+          actorId: 'actor-local-legal',
+          grants: [grant],
+          now,
+          ...denied,
+        })
+      ).toBe(false);
+    }
+  });
+
+  it('does not derive access from legal, recovery, host, booking, or ambient tenant values', () => {
+    expect(
+      canUseCaseScopedDocumentGrant({
+        accessTenantId: 'tenant_legal',
+        actorId: 'actor-local-legal',
+        caseId: 'claim-1',
+        documentClass: 'legal',
+        grants: [grant],
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('rejects revoked or expired grants', () => {
+    expect(
+      canUseCaseScopedDocumentGrant({
+        accessTenantId: 'tenant_access',
+        actorId: 'actor-local-legal',
+        caseId: 'claim-1',
+        documentClass: 'legal',
+        grants: [
+          { ...grant, revokedAt: now },
+          { ...grant, expiresAt: '2026-01-01T00:00:00Z' },
+        ],
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('rejects blank access, actor, or case identifiers', () => {
+    for (const denied of [
+      { accessTenantId: '', actorId: 'actor-local-legal', caseId: 'claim-1' },
+      { accessTenantId: 'tenant_access', actorId: '', caseId: 'claim-1' },
+      { accessTenantId: 'tenant_access', actorId: 'actor-local-legal', caseId: '' },
+    ]) {
+      expect(
+        canUseCaseScopedDocumentGrant({
+          documentClass: 'legal',
+          grants: [{ ...grant, ...denied }],
+          now,
+          ...denied,
+        })
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/shared-auth/src/access-grants.ts
+++ b/packages/shared-auth/src/access-grants.ts
@@ -1,0 +1,49 @@
+export type CaseScopedDocumentClass =
+  | 'correspondence'
+  | 'contract'
+  | 'evidence'
+  | 'export'
+  | 'identity'
+  | 'legal'
+  | 'medical'
+  | 'other'
+  | 'receipt';
+
+export type CaseScopedAccessGrant = {
+  accessTenantId: string;
+  actorId: string;
+  caseId: string;
+  documentClasses: readonly CaseScopedDocumentClass[];
+  expiresAt?: Date | string | null;
+  revokedAt?: Date | string | null;
+};
+
+function isActiveGrant(grant: CaseScopedAccessGrant, now: Date): boolean {
+  if (grant.revokedAt) return false;
+  if (!grant.expiresAt) return true;
+  return new Date(grant.expiresAt).getTime() > now.getTime();
+}
+
+export function canUseCaseScopedDocumentGrant(args: {
+  accessTenantId: string;
+  actorId: string;
+  caseId: string;
+  documentClass: CaseScopedDocumentClass;
+  grants?: readonly CaseScopedAccessGrant[] | null;
+  now?: Date;
+}): boolean {
+  if (!args.accessTenantId.trim() || !args.actorId.trim() || !args.caseId.trim()) {
+    return false;
+  }
+
+  const now = args.now ?? new Date();
+
+  return (args.grants ?? []).some(
+    grant =>
+      grant.accessTenantId === args.accessTenantId &&
+      grant.actorId === args.actorId &&
+      grant.caseId === args.caseId &&
+      grant.documentClasses.includes(args.documentClass) &&
+      isActiveGrant(grant, now)
+  );
+}

--- a/packages/shared-auth/src/access-grants.ts
+++ b/packages/shared-auth/src/access-grants.ts
@@ -32,7 +32,11 @@ export function canUseCaseScopedDocumentGrant(args: {
   grants?: readonly CaseScopedAccessGrant[] | null;
   now?: Date;
 }): boolean {
-  if (!args.accessTenantId.trim() || !args.actorId.trim() || !args.caseId.trim()) {
+  const accessTenantId = args.accessTenantId.trim();
+  const actorId = args.actorId.trim();
+  const caseId = args.caseId.trim();
+
+  if (!accessTenantId || !actorId || !caseId) {
     return false;
   }
 
@@ -40,9 +44,9 @@ export function canUseCaseScopedDocumentGrant(args: {
 
   return (args.grants ?? []).some(
     grant =>
-      grant.accessTenantId === args.accessTenantId &&
-      grant.actorId === args.actorId &&
-      grant.caseId === args.caseId &&
+      grant.accessTenantId.trim() === accessTenantId &&
+      grant.actorId.trim() === actorId &&
+      grant.caseId.trim() === caseId &&
       grant.documentClasses.includes(args.documentClass) &&
       isActiveGrant(grant, now)
   );

--- a/packages/shared-auth/src/index.ts
+++ b/packages/shared-auth/src/index.ts
@@ -7,9 +7,10 @@
 export { AuthError, MissingTenantError, UnauthorizedError } from './errors';
 
 // Session types and utilities
-export { ensureTenantId, type SessionWithTenant } from './session';
+export { ensureAccessTenantId, ensureTenantId, type SessionWithTenant } from './session';
 
 // RBAC and Scoping
+export * from './access-grants';
 export * from './permissions';
 export * from './scope';
 export * from './governance';

--- a/packages/shared-auth/src/scope.test.ts
+++ b/packages/shared-auth/src/scope.test.ts
@@ -2,16 +2,17 @@ import { describe, expect, it } from 'vitest';
 
 import { MissingTenantError } from './errors';
 import { ROLES } from './permissions';
+import { ensureAccessTenantId, type SessionWithTenant } from './session';
 import { scopeFilter } from './scope';
-import type { SessionWithTenant } from './session';
 
-function session(role: string, tenantId?: string): SessionWithTenant {
+function session(role: string, tenantId?: string, accessTenantId?: string): SessionWithTenant {
   return {
     user: {
       id: 'user-1',
       email: 'user@example.com',
       role,
       ...(tenantId ? { tenantId } : {}),
+      ...(accessTenantId ? { accessTenantId } : {}),
     },
   } as SessionWithTenant;
 }
@@ -20,6 +21,7 @@ describe('scopeFilter', () => {
   it('allows global support to read an explicitly selected tenant', () => {
     expect(scopeFilter(session(ROLES.global_support, 'tenant-1'))).toEqual({
       tenantId: 'tenant-1',
+      accessTenantId: 'tenant-1',
       isFullTenantScope: true,
       isCrossTenantScope: false,
     });
@@ -28,9 +30,67 @@ describe('scopeFilter', () => {
   it('allows auditor to read an explicitly selected tenant', () => {
     expect(scopeFilter(session(ROLES.auditor, 'tenant-1'))).toEqual({
       tenantId: 'tenant-1',
+      accessTenantId: 'tenant-1',
       isFullTenantScope: true,
       isCrossTenantScope: false,
     });
+  });
+
+  it('uses accessTenantId instead of generic or legal tenant concepts for isolation', () => {
+    const scopedSession = {
+      user: {
+        id: 'user-1',
+        role: ROLES.staff,
+        tenantId: 'tenant_legal_compat',
+        accessTenantId: 'tenant_access',
+        bookingTenantId: 'tenant_booking',
+        legalTenantId: 'tenant_legal',
+        recoveryLegalTenantId: 'tenant_recovery',
+        hostTenantId: 'tenant_host',
+      },
+    } satisfies SessionWithTenant;
+
+    expect(ensureAccessTenantId(scopedSession)).toBe('tenant_access');
+    expect(scopeFilter(scopedSession)).toEqual({
+      tenantId: 'tenant_access',
+      accessTenantId: 'tenant_access',
+      isFullTenantScope: true,
+      isCrossTenantScope: false,
+    });
+  });
+
+  it('keeps global support scoped to access tenant without changing legal entity', () => {
+    const scopedSession = {
+      user: {
+        id: 'support-1',
+        role: ROLES.global_support,
+        tenantId: 'tenant_legal_compat',
+        accessTenantId: 'tenant_access',
+        legalTenantId: 'tenant_legal',
+      },
+    } satisfies SessionWithTenant;
+
+    expect(scopeFilter(scopedSession)).toEqual({
+      tenantId: 'tenant_access',
+      accessTenantId: 'tenant_access',
+      isFullTenantScope: true,
+      isCrossTenantScope: false,
+    });
+    expect(scopedSession.user.legalTenantId).toBe('tenant_legal');
+  });
+
+  it('falls back to tenantId when accessTenantId is blank', () => {
+    const scopedSession = {
+      user: {
+        id: 'user-1',
+        role: ROLES.staff,
+        tenantId: 'tenant_access',
+        accessTenantId: '',
+      },
+    } satisfies SessionWithTenant;
+
+    expect(ensureAccessTenantId(scopedSession)).toBe('tenant_access');
+    expect(scopeFilter(scopedSession).accessTenantId).toBe('tenant_access');
   });
 
   it('requires tenant context for non-super-admin roles', () => {

--- a/packages/shared-auth/src/scope.ts
+++ b/packages/shared-auth/src/scope.ts
@@ -5,10 +5,11 @@
 
 import { MissingTenantError, UnauthorizedError } from './errors';
 import { isSuperAdmin, isTenantAdmin, ROLES, type Permission } from './permissions';
-import type { SessionWithTenant } from './session';
+import { ensureAccessTenantId, type SessionWithTenant } from './session';
 
 export type ScopeFilter = {
   tenantId: string;
+  accessTenantId: string;
   branchId?: string | null;
   agentId?: string | null;
   userId?: string | null;
@@ -31,25 +32,30 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
     throw new UnauthorizedError();
   }
 
-  const { id: userId, role, tenantId, branchId } = session.user;
+  const { id: userId, role, branchId } = session.user;
+  const accessTenantId =
+    session.user.accessTenantId?.trim() || session.user.tenantId?.trim() || null;
 
   // Super admin: cross-tenant access
   if (isSuperAdmin(role)) {
     return {
-      tenantId: tenantId ?? '*',
+      tenantId: accessTenantId ?? '*',
+      accessTenantId: accessTenantId ?? '*',
       isFullTenantScope: true,
       isCrossTenantScope: true,
     };
   }
 
-  if (!tenantId) {
+  if (!accessTenantId) {
     throw new MissingTenantError();
   }
+  const tenantId = ensureAccessTenantId(session);
 
   // Tenant admin: full tenant scope
   if (isTenantAdmin(role)) {
     return {
       tenantId,
+      accessTenantId: tenantId,
       isFullTenantScope: true,
       isCrossTenantScope: false,
     };
@@ -59,6 +65,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   if (role === ROLES.global_support || role === ROLES.auditor) {
     return {
       tenantId,
+      accessTenantId: tenantId,
       isFullTenantScope: true,
       isCrossTenantScope: false,
     };
@@ -68,6 +75,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   if (role === ROLES.staff) {
     return {
       tenantId,
+      accessTenantId: tenantId,
       isFullTenantScope: true,
       isCrossTenantScope: false,
     };
@@ -77,6 +85,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   if (role === ROLES.branch_manager) {
     return {
       tenantId,
+      accessTenantId: tenantId,
       branchId: branchId ?? null,
       isFullTenantScope: false,
       isCrossTenantScope: false,
@@ -87,6 +96,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   if (role === ROLES.agent) {
     return {
       tenantId,
+      accessTenantId: tenantId,
       agentId: userId ?? null,
       isFullTenantScope: false,
       isCrossTenantScope: false,
@@ -96,6 +106,7 @@ export function scopeFilter(session: SessionWithTenant): ScopeFilter {
   // Member: self only
   return {
     tenantId,
+    accessTenantId: tenantId,
     userId: userId ?? null,
     isFullTenantScope: false,
     isCrossTenantScope: false,

--- a/packages/shared-auth/src/session.ts
+++ b/packages/shared-auth/src/session.ts
@@ -11,6 +11,11 @@ import { MissingTenantError, UnauthorizedError } from './errors';
 export type SessionWithTenant = {
   user?: {
     id?: string;
+    accessTenantId?: string | null;
+    bookingTenantId?: string | null;
+    legalTenantId?: string | null;
+    recoveryLegalTenantId?: string | null;
+    hostTenantId?: string | null;
     tenantId?: string | null;
     role?: string | null;
     branchId?: string | null;
@@ -26,15 +31,25 @@ export type SessionWithTenant = {
  * @returns The validated tenant ID
  */
 export function ensureTenantId(session: SessionWithTenant): string {
+  return ensureAccessTenantId(session);
+}
+
+/**
+ * Extracts and validates the access tenant from a session.
+ *
+ * `tenantId` remains a compatibility fallback while callers migrate to the
+ * explicit `accessTenantId` session concept.
+ */
+export function ensureAccessTenantId(session: SessionWithTenant): string {
   if (!session) {
     throw new UnauthorizedError();
   }
   if (!session.user) {
     throw new UnauthorizedError('Unauthorized: No user in session');
   }
-  const tenantId = session.user.tenantId;
-  if (!tenantId) {
+  const accessTenantId = session.user.accessTenantId?.trim() || session.user.tenantId?.trim();
+  if (!accessTenantId) {
     throw new MissingTenantError();
   }
-  return tenantId;
+  return accessTenantId;
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35881417,
-  "maxTrackedFiles": 4227,
+  "maxTrackedBytes": 35901447,
+  "maxTrackedFiles": 4234,
   "maxCategoryBytes": {
     "large support/generated-ish": 17790632,
-    "source/scripts": 6716120,
+    "source/scripts": 6720576,
     "docs/text": 5139170,
-    "tests/e2e": 4556603,
-    "config/data/messages": 1549727,
+    "tests/e2e": 4571487,
+    "config/data/messages": 1550417,
     "other": 129165
   },
   "maxLargestFileBytes": 2935378,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35901447,
-  "maxTrackedFiles": 4234,
+  "maxTrackedBytes": 35905526,
+  "maxTrackedFiles": 4235,
   "maxCategoryBytes": {
     "large support/generated-ish": 17790632,
-    "source/scripts": 6720576,
+    "source/scripts": 6720586,
     "docs/text": 5139170,
-    "tests/e2e": 4571487,
+    "tests/e2e": 4575556,
     "config/data/messages": 1550417,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Harden access-tenant resolution across shared auth scope/session helpers and portal access checks.
- Add focused access grant helpers and tests for access-tenant fallback behavior.
- Tighten document/upload access checks so branch staff are not elevated to branch-manager document visibility and branchless staff must be assigned to the claim.
- Keep scope limited to T-302b product/access-tenant files plus focused tests and repo-size budget sync.

## Scope discipline
- Did not edit `apps/web/src/proxy.ts`.
- Did not edit `package.json`, docs, `code_review.md`, Golden Loop/reviewer tooling, migrations, RLS policies, billing, canonical routes, or workflow scripts.
- Only `scripts/` change is `scripts/repo-size-budget.json`, expected for added tracked proof files.

## Reviewer disposition
Codex, Sonnet, Gemini, and Opus reviewer routes were attempted through repo-owned receipt wrappers. Codex blocked on quota/rate limit. Sonnet and Opus returned invalid/non-review evidence. Gemini produced actionable findings in an earlier run; document-access findings were fixed, and the later rerun blocked on quota/rate limit.

No blocked or invalid route is counted as approval. External model approval is explicitly waived by the user/owner for this PR based on complete local proof, fixed actionable reviewer findings, and passing required gates: `pnpm slice:verify`, `pnpm pr:verify`, `pnpm security:guard`, and `pnpm e2e:gate`.

## Validation
- `pnpm --filter @interdomestik/shared-auth test:unit --run src/scope.test.ts src/access-grants.test.ts` passed.
- `pnpm --filter @interdomestik/web test:unit --run src/app/api/documents/access-policy.test.ts src/app/api/documents/_core.access-tenant.test.ts src/app/api/uploads/_core.access-tenant.test.ts` passed.
- `pnpm --filter @interdomestik/domain-users test:unit --run src/admin/resolve-tenant-classification.test.ts src/admin/roles.list.test.ts src/admin/roles.revoke.test.ts src/admin/utils.test.ts` passed.
- `pnpm --filter @interdomestik/web test:unit --run src/server/auth/effective-portal-access.test.ts` passed.
- `pnpm slice:verify` passed.
- `pnpm pr:verify` passed.
- `pnpm security:guard` passed.
- `pnpm e2e:gate` passed: 136 passed, 8 skipped.
- `git diff --check` passed.
- MCP scope audit passed.
