### PR TITLE
chore: retire golden loop from ci critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Run Audits
         run: |
           node scripts/check-env-ci.mjs
-          pnpm test:ci:contracts && node scripts/golden-loop/playbook-contracts.mjs
+          pnpm test:ci:contracts
           pnpm check:e2e-contracts:base
           pnpm lint:production-warnings
           pnpm track:audit

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -470,7 +470,7 @@ test('CI audit job runs the scripts/ci contract suite', () => {
   const quarantineBudgetStep = findStep(auditJob.steps, 'Check E2E quarantine budget');
 
   assert.ok(auditRunStep);
-  assert.match(auditRunStep.run, /test:ci:contracts.*playbook-contracts\.mjs/s);
+  assert.ok(/\bpnpm test:ci:contracts\b/.test(auditRunStep.run) && !/playbook-contracts\.mjs/.test(auditRunStep.run));
   assert.match(auditRunStep.run, /\bpnpm check:e2e-contracts:base\b/);
   assert.match(auditRunStep.run, /\bpnpm lint:production-warnings\b/);
   assert.ok(quarantineBudgetStep);

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -468,9 +468,9 @@ test('CI audit job runs the scripts/ci contract suite', () => {
   const auditJob = ciWorkflow.jobs.audit;
   const auditRunStep = findStep(auditJob.steps, 'Run Audits');
   const quarantineBudgetStep = findStep(auditJob.steps, 'Check E2E quarantine budget');
-
   assert.ok(auditRunStep);
-  assert.ok(/\bpnpm test:ci:contracts\b/.test(auditRunStep.run) && !/playbook-contracts\.mjs/.test(auditRunStep.run));
+  assert.match(auditRunStep.run, /\bpnpm test:ci:contracts\b/);
+  assert.doesNotMatch(auditRunStep.run, /playbook-contracts\.mjs/);
   assert.match(auditRunStep.run, /\bpnpm check:e2e-contracts:base\b/);
   assert.match(auditRunStep.run, /\bpnpm lint:production-warnings\b/);
   assert.ok(quarantineBudgetStep);

--- a/scripts/golden-loop/maturity-areas.mjs
+++ b/scripts/golden-loop/maturity-areas.mjs
@@ -66,7 +66,6 @@ export function buildMaturityAreas(repoRoot) {
   const reviewTests = readText(repoRoot, 'scripts/golden-loop/review-contract.test.mjs');
   const finalizerTests = readText(repoRoot, 'scripts/ci/pr-finalizer-workflow.test.mjs');
   const goldenLoopTests = readText(repoRoot, 'scripts/golden-loop/golden-loop.test.mjs');
-  const playbookContracts = readText(repoRoot, 'scripts/golden-loop/playbook-contracts.mjs');
   const changed = changedFiles(repoRoot);
   const protectedTouches = changed.files.filter(file =>
     PROTECTED_FORBIDDEN.some(item => file === item || file.startsWith(item))
@@ -118,10 +117,10 @@ export function buildMaturityAreas(repoRoot) {
       [
         { ok: hasEvery(gateNames, ['pr-verify', 'e2e-gate', 'ci-required-checks']), label: 'gate inventory' },
         { ok: JSON.stringify(adapter.gates).includes('skipWhenCoveredBy'), label: 'duplicate gate skip' },
-        { ok: ciWorkflow.includes('playbook-contracts.mjs'), label: 'CI contract gate' },
-        { ok: playbookContracts.includes('maturity scorecard'), label: 'score enforced by CI gate' },
+        { ok: ciWorkflow.includes('pnpm test:ci:contracts'), label: 'CI contract suite' },
+        { ok: !ciWorkflow.includes('playbook-contracts.mjs'), label: 'Golden Loop off critical path' },
       ],
-      'Gate inventory, duplicate-work policy, and maturity enforcement are wired into CI audit.'
+      'Gate inventory and duplicate-work policy stay wired into CI audit without Golden Loop on the critical path.'
     ),
     scoreArea(
       'Future-thread skill enforcement',

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35921788,
+  "maxTrackedBytes": 35921716,
   "maxTrackedFiles": 4237,
   "maxCategoryBytes": {
     "large support/generated-ish": 17798557,
-    "source/scripts": 6722630,
+    "source/scripts": 6722443,
     "docs/text": 5141509,
-    "tests/e2e": 4579549,
-    "config/data/messages": 1550493,
+    "tests/e2e": 4579600,
+    "config/data/messages": 1550442,
     "other": 129165
   },
   "maxLargestFileBytes": 2943303,


### PR DESCRIPTION
## Summary
- Retires Golden Loop playbook contracts from the default CI audit critical path.
- Keeps `pnpm test:ci:contracts` as the enforced CI contract suite and updates the governance contract test accordingly.
- Updates the maturity score signal to require Golden Loop to stay off the CI critical path.
- Synchronizes the repo-size budget metadata to the current tracked inventory.

## Validation
- `node --test --test-concurrency=1 scripts/ci/workflow-contracts.test.mjs scripts/golden-loop/maturity-scorecard.test.mjs`
- `pnpm test:ci:contracts`
- `pnpm security:guard`
- `pnpm repo:size:check`
- `git diff --check`
- `interdomestik_qa.scope_audit`: pass; no product/runtime/auth/schema/proxy paths changed

## Scope
No product/runtime behavior changed. No proxy, auth, tenant isolation, schema/RLS/migration, billing, canonical route, UI, app runtime, domain package, or Supabase files changed.