### PR TITLE
Phase 5 API request guard pilot

### DIFF
--- a/apps/web/src/app/api/privacy/data-deletion/route.test.ts
+++ b/apps/web/src/app/api/privacy/data-deletion/route.test.ts
@@ -1,0 +1,109 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from './route';
+
+const hoisted = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  requestDataDeletionCore: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: hoisted.getSession,
+    },
+  },
+}));
+
+vi.mock('./_core', () => ({
+  requestDataDeletionCore: hoisted.requestDataDeletionCore,
+}));
+
+function request(body?: string, headers: HeadersInit = {}): NextRequest {
+  return new NextRequest('http://localhost:3000/api/privacy/data-deletion', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'user-agent': ' privacy-agent ',
+      'x-forwarded-for': ' 203.0.113.10, 198.51.100.7 ',
+      ...headers,
+    },
+    body,
+  });
+}
+
+describe('POST /api/privacy/data-deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSession.mockResolvedValue({
+      user: { id: 'user-1', role: 'member', tenantId: 'tenant-1' },
+    });
+    hoisted.requestDataDeletionCore.mockResolvedValue({
+      status: 202,
+      body: { success: true, requestId: 'req-1', alreadyPending: false },
+    });
+  });
+
+  it('returns 401 before body parsing when unauthenticated', async () => {
+    hoisted.getSession.mockResolvedValue(null);
+
+    const response = await POST(request('{'));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ success: false, error: 'Unauthorized' });
+    expect(hoisted.requestDataDeletionCore).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['authenticated malformed JSON', '{'],
+    ['explicitly empty body', ''],
+  ])('treats %s like an empty object', async (_label, body) => {
+    const response = await POST(request(body));
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      requestId: 'req-1',
+      alreadyPending: false,
+    });
+    expect(hoisted.requestDataDeletionCore).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: undefined })
+    );
+  });
+
+  it('passes normalized metadata and reason to the core', async () => {
+    const response = await POST(request('{"reason":" Delete me "}'));
+
+    expect(response.status).toBe(202);
+    expect(hoisted.requestDataDeletionCore).toHaveBeenCalledWith({
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      actorRole: 'member',
+      reason: ' Delete me ',
+      ipAddress: '203.0.113.10',
+      userAgent: 'privacy-agent',
+    });
+  });
+
+  it('preserves already-pending 202 semantics from the core', async () => {
+    hoisted.requestDataDeletionCore.mockResolvedValue({
+      status: 202,
+      body: {
+        success: true,
+        requestId: 'req-existing',
+        alreadyPending: true,
+        retryAfterDays: 12,
+      },
+    });
+
+    const response = await POST(request('{}'));
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      requestId: 'req-existing',
+      alreadyPending: true,
+      retryAfterDays: 12,
+    });
+  });
+});

--- a/apps/web/src/app/api/privacy/data-deletion/route.ts
+++ b/apps/web/src/app/api/privacy/data-deletion/route.ts
@@ -1,27 +1,18 @@
-import { auth } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getClientMetadata, safeJson } from '@/app/api/request-guard';
+import { auth } from '@/lib/auth';
+
 import { requestDataDeletionCore } from './_core';
 
-type RequestBody = {
-  reason?: string | null;
-};
-
-async function parseBody(request: NextRequest): Promise<RequestBody> {
-  try {
-    const parsed = (await request.json()) as RequestBody;
-    return parsed ?? {};
-  } catch {
-    return {};
-  }
-}
-
-function getClientIp(request: NextRequest): string | null {
-  return (
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-    request.headers.get('x-real-ip')?.trim() ||
-    null
-  );
-}
+const requestBodySchema = z.preprocess(
+  value => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+    return value;
+  },
+  z.object({ reason: z.string().nullable().optional() }).passthrough()
+);
 
 export async function POST(request: NextRequest) {
   const session = await auth.api.getSession({ headers: request.headers });
@@ -29,7 +20,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
   }
 
-  const body = await parseBody(request);
+  const parsed = await safeJson(request, requestBodySchema, {
+    allowEmptyBody: true,
+    emptyBody: {},
+    invalidJsonData: {},
+  });
+  if (!parsed.ok) return parsed.response;
+
+  const clientMetadata = getClientMetadata(request.headers);
   const user = session.user as {
     id?: string;
     role?: string | null;
@@ -40,9 +38,9 @@ export async function POST(request: NextRequest) {
     userId: user.id || '',
     tenantId: user.tenantId,
     actorRole: user.role ?? null,
-    reason: body.reason,
-    ipAddress: getClientIp(request),
-    userAgent: request.headers.get('user-agent'),
+    reason: parsed.data.reason,
+    ipAddress: clientMetadata.ipAddress,
+    userAgent: clientMetadata.userAgent,
   });
 
   return NextResponse.json(result.body, { status: result.status });

--- a/apps/web/src/app/api/request-guard.test.ts
+++ b/apps/web/src/app/api/request-guard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { apiResultResponse, getClientMetadata, safeJson } from './request-guard';
+
+const schema = z.object({ name: z.string() }).strict();
+
+function jsonRequest(body: string): Request {
+  return new Request('http://localhost.test/api/test', {
+    method: 'POST',
+    body,
+  });
+}
+
+async function expectJson(response: Response, status: number, body: Record<string, unknown>) {
+  expect(response.status).toBe(status);
+  await expect(response.json()).resolves.toEqual(body);
+}
+
+describe('safeJson', () => {
+  it('returns parsed schema data for valid JSON', async () => {
+    const result = await safeJson(jsonRequest('{"name":"Ada"}'), schema);
+
+    expect(result).toEqual({ ok: true, data: { name: 'Ada' } });
+  });
+
+  it('returns standard invalid_json without exposing parser details', async () => {
+    const result = await safeJson(jsonRequest('{'), schema);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected invalid_json response');
+    await expectJson(result.response, 400, {
+      success: false,
+      error: 'Invalid JSON',
+      code: 'invalid_json',
+    });
+  });
+
+  it('returns standard invalid_request without exposing Zod issues', async () => {
+    const result = await safeJson(jsonRequest('{"name":7}'), schema);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected invalid_request response');
+    await expectJson(result.response, 400, {
+      success: false,
+      error: 'Invalid request',
+      code: 'invalid_request',
+    });
+  });
+
+  it('allows empty bodies only with explicit opt-in', async () => {
+    const result = await safeJson(jsonRequest(''), schema, {
+      allowEmptyBody: true,
+      emptyBody: { name: 'empty-default' },
+    });
+
+    expect(result).toEqual({ ok: true, data: { name: 'empty-default' } });
+  });
+});
+
+describe('getClientMetadata', () => {
+  it('normalizes first forwarded IP hop and bounds user agent', () => {
+    const headers = new Headers({
+      'x-forwarded-for': ' 203.0.113.10, 198.51.100.7 ',
+      'x-real-ip': '198.51.100.20',
+      'user-agent': ` ${'a'.repeat(520)} `,
+    });
+
+    expect(getClientMetadata(headers)).toEqual({
+      ipAddress: '203.0.113.10',
+      userAgent: 'a'.repeat(512),
+    });
+  });
+});
+
+describe('apiResultResponse', () => {
+  it('maps shared ApiResult codes to standard HTTP statuses', async () => {
+    const response = apiResultResponse({ ok: false, code: 'FORBIDDEN', message: 'Nope' });
+
+    await expectJson(response, 403, {
+      success: false,
+      error: 'Nope',
+      code: 'FORBIDDEN',
+    });
+  });
+});

--- a/apps/web/src/app/api/request-guard.ts
+++ b/apps/web/src/app/api/request-guard.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server';
+import type { z } from 'zod';
+
+import type { ApiErrorCode, ApiResult } from '@/core-contracts';
+
+type SafeJsonOptions = {
+  allowEmptyBody?: boolean;
+  emptyBody?: unknown;
+  invalidJsonData?: unknown;
+  invalidJsonResponse?: () => Response;
+  invalidRequestResponse?: () => Response;
+};
+
+type SafeJsonResult<T> = { ok: true; data: T } | { ok: false; response: Response };
+
+export type ClientMetadata = {
+  ipAddress: string | null;
+  userAgent: string | null;
+};
+
+const USER_AGENT_MAX_LENGTH = 512;
+
+function guardedErrorResponse(error: string, code: 'invalid_json' | 'invalid_request'): Response {
+  return NextResponse.json({ success: false, error, code }, { status: 400 });
+}
+
+export async function safeJson<T extends z.ZodTypeAny>(
+  request: Request,
+  schema: T,
+  options: SafeJsonOptions = {}
+): Promise<SafeJsonResult<z.infer<T>>> {
+  const invalidJson =
+    options.invalidJsonResponse ?? (() => guardedErrorResponse('Invalid JSON', 'invalid_json'));
+  const invalidRequest =
+    options.invalidRequestResponse ??
+    (() => guardedErrorResponse('Invalid request', 'invalid_request'));
+
+  let body: unknown;
+  try {
+    const text = await request.text();
+    if (text.trim().length === 0) {
+      if (!options.allowEmptyBody) return { ok: false, response: invalidJson() };
+      body = options.emptyBody ?? {};
+    } else {
+      body = JSON.parse(text);
+    }
+  } catch {
+    if (!('invalidJsonData' in options)) return { ok: false, response: invalidJson() };
+    body = options.invalidJsonData;
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return { ok: false, response: invalidRequest() };
+
+  return { ok: true, data: parsed.data };
+}
+
+export function getClientMetadata(headers: Headers): ClientMetadata {
+  const forwardedIp = headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  const realIp = headers.get('x-real-ip')?.trim();
+  const userAgent = headers.get('user-agent')?.trim();
+
+  return {
+    ipAddress: forwardedIp || realIp || null,
+    userAgent: userAgent ? userAgent.slice(0, USER_AGENT_MAX_LENGTH) : null,
+  };
+}
+
+export function apiResultStatus(code: ApiErrorCode): number {
+  switch (code) {
+    case 'UNAUTHORIZED':
+      return 401;
+    case 'FORBIDDEN':
+      return 403;
+    case 'NOT_FOUND':
+      return 404;
+    case 'CONFLICT':
+      return 409;
+    case 'RATE_LIMIT':
+      return 429;
+    case 'PAYLOAD_TOO_LARGE':
+      return 413;
+    case 'UNPROCESSABLE_ENTITY':
+      return 422;
+    case 'TIMEOUT':
+      return 504;
+    case 'INTERNAL_ERROR':
+      return 500;
+    case 'BAD_REQUEST':
+    default:
+      return 400;
+  }
+}
+
+export function apiResultResponse<T>(
+  result: ApiResult<T>,
+  options: { message?: (code: ApiErrorCode) => string } = {}
+): Response {
+  if (result.ok) return NextResponse.json(result.data);
+
+  return NextResponse.json(
+    {
+      success: false,
+      error: options.message?.(result.code) ?? result.message ?? 'Request failed',
+      code: result.code,
+    },
+    { status: apiResultStatus(result.code) }
+  );
+}

--- a/apps/web/src/app/api/share-pack/route.request-guard.test.ts
+++ b/apps/web/src/app/api/share-pack/route.request-guard.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from './route';
+
+const routeDoubles = vi.hoisted(() => ({
+  createPack: vi.fn(),
+  readPack: vi.fn(),
+  readSession: vi.fn(),
+  readHeaders: vi.fn(),
+  writeAudit: vi.fn(),
+}));
+
+vi.mock('@/features/share-pack/share-pack.service', () => ({
+  createSharePack: routeDoubles.createPack,
+  getSharePack: routeDoubles.readPack,
+  logAuditEvent: routeDoubles.writeAudit,
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      getSession: routeDoubles.readSession,
+    },
+  },
+}));
+
+vi.mock('next/headers', () => ({
+  headers: routeDoubles.readHeaders,
+}));
+
+type SharePackPostRequest = Parameters<typeof POST>[0];
+
+function request(body: string): SharePackPostRequest {
+  const headers = new Headers();
+  headers.set('content-type', 'application/json');
+  headers.set('user-agent', ' vitest-agent ');
+  headers.set('x-forwarded-for', ' 203.0.113.10, 198.51.100.7 ');
+
+  return new Request('http://localhost:3000/api/share-pack', {
+    method: 'POST',
+    headers,
+    body,
+  }) as SharePackPostRequest;
+}
+
+describe('POST /api/share-pack request guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeDoubles.readHeaders.mockResolvedValue(new Headers());
+    routeDoubles.readSession.mockResolvedValue({ user: { id: 'user-1', tenantId: 'tenant-1' } });
+    routeDoubles.createPack.mockResolvedValue({
+      packId: 'pack-1',
+      token: 'share-token',
+      expiresAt: new Date('2026-04-25T12:00:00.000Z'),
+    });
+    routeDoubles.writeAudit.mockResolvedValue(undefined);
+  });
+
+  it('returns invalid_json after auth for malformed JSON', async () => {
+    const response = await POST(request('{'));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: 'Invalid JSON',
+      code: 'invalid_json',
+    });
+    expect(routeDoubles.createPack).not.toHaveBeenCalled();
+  });
+
+  it('keeps auth before body parsing', async () => {
+    routeDoubles.readSession.mockResolvedValue(null);
+
+    const response = await POST(request('{'));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(routeDoubles.createPack).not.toHaveBeenCalled();
+  });
+
+  it('keeps the legacy invalid-shape response text', async () => {
+    const response = await POST(request('{"documentIds":[7]}'));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'IDs required' });
+    expect(routeDoubles.createPack).not.toHaveBeenCalled();
+  });
+
+  it('passes normalized client metadata to audit logging', async () => {
+    const response = await POST(request('{"documentIds":["doc-1"]}'));
+
+    expect(response.status).toBe(200);
+    expect(routeDoubles.writeAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: '203.0.113.10',
+        userAgent: 'vitest-agent',
+      })
+    );
+  });
+});

--- a/apps/web/src/app/api/share-pack/route.ts
+++ b/apps/web/src/app/api/share-pack/route.ts
@@ -1,3 +1,8 @@
+import { headers } from 'next/headers';
+import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getClientMetadata, safeJson } from '@/app/api/request-guard';
 import { resolveTenantBoundary } from '@/app/api/tenant-boundary';
 import {
   createSharePack,
@@ -5,8 +10,7 @@ import {
   logAuditEvent,
 } from '@/features/share-pack/share-pack.service';
 import { auth } from '@/lib/auth';
-import { headers } from 'next/headers';
-import { type NextRequest, NextResponse } from 'next/server';
+
 import { createSharePackCore, getSharePackCore } from './_core';
 
 const services = {
@@ -15,20 +19,9 @@ const services = {
   logAuditEvent,
 };
 
-const idsKey = 'documentIds' as const;
-
-function getDocumentIds(body: unknown): string[] | null {
-  if (!body || typeof body !== 'object' || !(idsKey in body)) {
-    return null;
-  }
-
-  const ids = body[idsKey];
-  if (!Array.isArray(ids) || !ids.every(id => typeof id === 'string')) {
-    return null;
-  }
-
-  return ids;
-}
+const DOCUMENT_IDS_FIELD = 'documentIds';
+const createSharePackRequestShape = { [DOCUMENT_IDS_FIELD]: z.array(z.string()) };
+const createSharePackRequestSchema = z.object(createSharePackRequestShape).passthrough();
 
 /**
  * POST /api/share-pack - Create a share pack link
@@ -48,19 +41,23 @@ export async function POST(request: NextRequest) {
       return tenant.response;
     }
 
-    const ids = getDocumentIds(await request.json());
-    if (!ids) {
-      return NextResponse.json({ error: 'IDs required' }, { status: 400 });
-    }
+    const parsed = await safeJson(request, createSharePackRequestSchema, {
+      invalidRequestResponse: () => NextResponse.json({ error: 'IDs required' }, { status: 400 }),
+    });
+    if (!parsed.ok) return parsed.response;
 
-    const result = await createSharePackCore({
+    const clientMetadata = getClientMetadata(request.headers);
+    const requestedDocumentIds = parsed.data[DOCUMENT_IDS_FIELD];
+
+    const coreInput = {
       tenantId: tenant.tenantId,
       userId: session.user.id,
-      [idsKey]: ids,
-      ipAddress: request.headers.get('x-forwarded-for') ?? undefined,
-      userAgent: request.headers.get('user-agent') ?? undefined,
+      ipAddress: clientMetadata.ipAddress ?? undefined,
+      userAgent: clientMetadata.userAgent ?? undefined,
       services,
-    });
+    };
+    const sharePackInput = Object.assign(coreInput, { [DOCUMENT_IDS_FIELD]: requestedDocumentIds });
+    const result = await createSharePackCore(sharePackInput);
 
     if (!result.ok) {
       const status = result.error === 'Invalid IDs' ? 403 : 400;

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36007081,
-  "maxTrackedFiles": 4268,
+  "maxTrackedBytes": 36019897,
+  "maxTrackedFiles": 4272,
   "maxCategoryBytes": {
     "large support/generated-ish": 17798557,
-    "source/scripts": 6755940,
+    "source/scripts": 6759366,
     "docs/text": 5157944,
-    "tests/e2e": 4615639,
-    "config/data/messages": 1549836,
+    "tests/e2e": 4624339,
+    "config/data/messages": 1550526,
     "other": 129165
   },
   "maxLargestFileBytes": 2943303,


### PR DESCRIPTION
## Summary
- Add a narrow API request guard helper for safe JSON parsing, default guarded 400 responses, client metadata normalization, and shared ApiResult response mapping.
- Migrate exactly `POST /api/share-pack` and `POST /api/privacy/data-deletion` to the helper.
- Preserve privacy deletion legacy malformed-body tolerance: unauthenticated malformed bodies still return 401 before parsing; authenticated malformed JSON and empty body are treated as `{}` with `reason: undefined`; `202 alreadyPending` passthrough remains covered.

## Scope
Changed files only:
- `apps/web/src/app/api/request-guard.ts`
- `apps/web/src/app/api/request-guard.test.ts`
- `apps/web/src/app/api/share-pack/route.ts`
- `apps/web/src/app/api/share-pack/route.request-guard.test.ts`
- `apps/web/src/app/api/privacy/data-deletion/route.ts`
- `apps/web/src/app/api/privacy/data-deletion/route.test.ts`
- `scripts/repo-size-budget.json` (repo-size budget accounting for the new helper/tests)

Untouched: product behavior beyond this pilot, `apps/web/src/proxy.ts`, auth/tenancy architecture, schema/RLS/migrations, billing, canonical routes, UI, README, AGENTS, Golden Loop, CRM forecast backfill, and release-gate parallelization.

## Validation
- `pnpm --filter @interdomestik/web test:unit --run src/app/api/request-guard.test.ts src/app/api/share-pack/route.test.ts src/app/api/share-pack/route.request-guard.test.ts src/app/api/privacy/data-deletion/route.test.ts src/app/api/privacy/data-deletion/_core.test.ts` passed: 5 files, 28 tests.
- `pnpm check:modularity-guard` passed.
- `pnpm check:db-access` passed.
- `node scripts/repo-size-budget-sync.mjs && pnpm repo:size:check` passed.
- `pnpm slice:verify` passed.
- `pnpm pr:verify` passed. Duplicate gate recovery: MCP `pr_verify` timed out after 120s and left PID 9875/PGID 42191 running without capturable output; authoritative shell lane PID 17768/PGID 17768 completed successfully, older PGID was terminated. MCP blocker recorded as `tool_timeout_after_120s`, not a product/test failure.
- `pnpm security:guard` passed.
- `pnpm e2e:gate` passed: 136 passed, 8 skipped.

## Reviewers
- Codex Senior Reviewer: blocked, `quota_or_rate_limit`, exitCode 128, receipt `tmp/reviewer-routes/20260617T144843-codex-senior-reviewer.*`; not counted as approval.
- Sonnet: ran, receipt `tmp/reviewer-routes/20260617T144900-sonnet.*`; findings referenced a nonexistent shared-secret guard and broader route-coverage scope, treated as not applicable to this diff.
- Gemini: blocked, `quota_or_rate_limit`, receipt `tmp/reviewer-routes/20260617T145116-gemini.*`; not counted as approval.
- Opus escalation: ran, receipt `tmp/reviewer-routes/20260617T145750-opus.*`; findings referenced a different implementation shape (`maxBodyBytes`, `sharedBy`, etc.) and were verified not to exist in this diff.

## Notes
- Risk tier: Tier 3, conservatively, because this touches a reusable API helper and privacy/PII route surface.
- Worktree deviation: implementation was reconciled to the primary checkout on `codex/phase5-request-guard` after the detached thread worktree was cleaned. This PR should not be treated as having been implemented entirely in the originally requested fresh worktree.
- Residual risk: this is a two-route pilot. The helper default is strict on malformed JSON; privacy deletion has an explicit malformed-body compatibility opt-in to preserve its old contract.
