### PR TITLE
Phase 6: bound CRM forecast backfill work concurrency

### DIFF
--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_bounded-work-item-pool.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_bounded-work-item-pool.ts
@@ -1,0 +1,76 @@
+type BoundedWorkItemPoolFulfilled<TItem, TValue> = {
+  index: number;
+  item: TItem;
+  status: 'fulfilled';
+  value: TValue;
+};
+
+type BoundedWorkItemPoolRejected<TItem> = {
+  error: unknown;
+  index: number;
+  item: TItem;
+  status: 'rejected';
+};
+
+export type BoundedWorkItemPoolOutcome<TItem, TValue> =
+  | BoundedWorkItemPoolFulfilled<TItem, TValue>
+  | BoundedWorkItemPoolRejected<TItem>;
+
+export type BoundedWorkItemPoolResult<TItem, TValue> = {
+  outcomes: BoundedWorkItemPoolOutcome<TItem, TValue>[];
+  unscheduledCount: number;
+};
+
+export async function runBoundedWorkItemPool<TItem, TValue>(args: {
+  concurrency: number;
+  items: readonly TItem[];
+  onStopScheduling?: () => void;
+  run: (item: TItem, index: number) => Promise<TValue>;
+  shouldStart: (item: TItem, index: number) => boolean;
+  stopAfter?: (outcome: BoundedWorkItemPoolOutcome<TItem, TValue>) => boolean;
+}): Promise<BoundedWorkItemPoolResult<TItem, TValue>> {
+  const concurrency = Number.isFinite(args.concurrency) ? Math.floor(args.concurrency) : 1;
+  const workerCount = Math.min(Math.max(1, concurrency), args.items.length);
+  const outcomes: Array<BoundedWorkItemPoolOutcome<TItem, TValue> | undefined> = [];
+  let nextIndex = 0;
+  let scheduledCount = 0;
+  let stopScheduling = false;
+
+  async function worker(): Promise<void> {
+    while (!stopScheduling) {
+      const index = nextIndex;
+      const item = args.items[index];
+      if (item === undefined) return;
+      if (!args.shouldStart(item, index)) {
+        stopScheduling = true;
+        args.onStopScheduling?.();
+        return;
+      }
+
+      nextIndex += 1;
+      scheduledCount += 1;
+
+      let outcome: BoundedWorkItemPoolOutcome<TItem, TValue>;
+      try {
+        outcome = { index, item, status: 'fulfilled', value: await args.run(item, index) };
+      } catch (error) {
+        outcome = { error, index, item, status: 'rejected' };
+      }
+      outcomes[index] = outcome;
+
+      if (args.stopAfter?.(outcome)) {
+        stopScheduling = true;
+        args.onStopScheduling?.();
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return {
+    outcomes: outcomes.filter(
+      (outcome): outcome is BoundedWorkItemPoolOutcome<TItem, TValue> => outcome !== undefined
+    ),
+    unscheduledCount: args.items.length - scheduledCount,
+  };
+}

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_bounded-work-item-pool.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_bounded-work-item-pool.ts
@@ -36,14 +36,19 @@ export async function runBoundedWorkItemPool<TItem, TValue>(args: {
   let scheduledCount = 0;
   let stopScheduling = false;
 
+  function stopSchedulingOnce(): void {
+    if (stopScheduling) return;
+    stopScheduling = true;
+    args.onStopScheduling?.();
+  }
+
   async function worker(): Promise<void> {
     while (!stopScheduling) {
       const index = nextIndex;
       const item = args.items[index];
       if (item === undefined) return;
       if (!args.shouldStart(item, index)) {
-        stopScheduling = true;
-        args.onStopScheduling?.();
+        stopSchedulingOnce();
         return;
       }
 
@@ -59,8 +64,7 @@ export async function runBoundedWorkItemPool<TItem, TValue>(args: {
       outcomes[index] = outcome;
 
       if (args.stopAfter?.(outcome)) {
-        stopScheduling = true;
-        args.onStopScheduling?.();
+        stopSchedulingOnce();
       }
     }
   }

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.concurrency.test.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.concurrency.test.ts
@@ -58,6 +58,7 @@ describe('runCrmForecastSnapshotBackfillCore concurrency', () => {
     });
 
     expect(maxActive).toBeLessThanOrEqual(2);
+    expect(maxActive).toBeGreaterThan(1);
     expect(result).toMatchObject({
       failedWorkItems: 0,
       snapshotsInserted: 5,

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.concurrency.test.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.concurrency.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CrmForecastSnapshotWorkItem } from '@/adapters/crm/forecast-snapshot-work-items';
+
+import {
+  createCrmForecastSnapshotTestDeps,
+  createCrmForecastSnapshotWeightedRow,
+} from '../_core.test-helpers';
+import { runCrmForecastSnapshotBackfillCore } from './_core';
+
+const now = new Date('2026-05-15T10:30:00.000Z');
+
+function item(index: number): CrmForecastSnapshotWorkItem {
+  return {
+    branchId: `branch-${index}`,
+    currencyCode: 'EUR',
+    pipelineId: `pipeline-${index}`,
+    tenantId: `tenant-${index}`,
+  };
+}
+
+function rowsFor(items: readonly CrmForecastSnapshotWorkItem[]) {
+  return new Map(
+    items.map(workItem => [
+      workItem.tenantId,
+      createCrmForecastSnapshotWeightedRow({
+        branchId: workItem.branchId,
+        pipelineId: workItem.pipelineId,
+        tenantId: workItem.tenantId,
+      }),
+    ])
+  );
+}
+
+describe('runCrmForecastSnapshotBackfillCore concurrency', () => {
+  it('bounds per-date work-item concurrency while preserving aggregate rollups and idempotency', async () => {
+    const workItems = [item(1), item(2), item(3), item(4), item(5)];
+    const rowsByTenant = rowsFor(workItems);
+    const deps = createCrmForecastSnapshotTestDeps({ rows: [], workItems });
+    let active = 0;
+    let maxActive = 0;
+
+    deps.reportingRepository.listWeightedPipelineRows.mockImplementation(async input => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      active -= 1;
+      return [rowsByTenant.get(input.actor.tenantId)!];
+    });
+
+    const result = await runCrmForecastSnapshotBackfillCore({
+      ...deps,
+      fromDate: '2026-05-14',
+      now,
+      sourceRunId: 'run-1',
+      tenantId: 'tenant-1',
+      toDate: '2026-05-14',
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(result).toMatchObject({
+      failedWorkItems: 0,
+      snapshotsInserted: 5,
+      workItemsConsidered: 5,
+      workItemsDeferred: 0,
+      workItemsSucceeded: 5,
+    });
+    const insertCalls = deps.snapshotRepository.insertPipelineSnapshots.mock.calls as Array<
+      [{ snapshots: { idempotencyKey: string }[] }]
+    >;
+    const keys = insertCalls.flatMap(([params]) =>
+      params.snapshots.map(snapshot => snapshot.idempotencyKey)
+    );
+    expect(keys).toContain(
+      'crm-forecast-snapshot-backfill:tenant-3:pipeline-3:branch-3:EUR:2026-05-14:run-1'
+    );
+  });
+
+  it('rolls up failures without hiding completed concurrent work items', async () => {
+    const workItems = [item(1), item(2), item(3)];
+    const rowsByTenant = rowsFor(workItems);
+    const deps = createCrmForecastSnapshotTestDeps({ rows: [], workItems });
+    deps.reportingRepository.listWeightedPipelineRows.mockImplementation(async input => {
+      if (input.actor.tenantId === 'tenant-2') throw new Error('db down');
+      return [rowsByTenant.get(input.actor.tenantId)!];
+    });
+
+    const result = await runCrmForecastSnapshotBackfillCore({
+      ...deps,
+      fromDate: '2026-05-14',
+      logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+      now,
+      tenantId: 'tenant-1',
+      toDate: '2026-05-14',
+    });
+
+    expect(result.dateResults[0]).toMatchObject({
+      failedWorkItems: 1,
+      snapshotsInserted: 2,
+      status: 'partial',
+      workItemsSucceeded: 2,
+    });
+  });
+
+  it('keeps dates sequential while allowing bounded work-item concurrency within a date', async () => {
+    const deps = createCrmForecastSnapshotTestDeps({ workItems: [item(1)] });
+    let resolveFirstRows: (rows: ReturnType<typeof createCrmForecastSnapshotWeightedRow>[]) => void;
+    const firstRows = new Promise<ReturnType<typeof createCrmForecastSnapshotWeightedRow>[]>(
+      resolve => {
+        resolveFirstRows = resolve;
+      }
+    );
+    deps.reportingRepository.listWeightedPipelineRows
+      .mockReturnValueOnce(firstRows)
+      .mockResolvedValueOnce([createCrmForecastSnapshotWeightedRow(item(1))]);
+
+    const pending = runCrmForecastSnapshotBackfillCore({
+      ...deps,
+      fromDate: '2026-05-13',
+      now,
+      tenantId: 'tenant-1',
+      toDate: '2026-05-14',
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(deps.workItemRepository.listWorkItems).toHaveBeenCalledTimes(1);
+    resolveFirstRows!([createCrmForecastSnapshotWeightedRow(item(1))]);
+    await expect(pending).resolves.toMatchObject({ datesConsidered: 2 });
+    expect(deps.workItemRepository.listWorkItems).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.test.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.test.ts
@@ -277,11 +277,7 @@ describe('runCrmForecastSnapshotBackfillCore', () => {
   it('soft-times out individual work items and defers the rest of the date', async () => {
     const logger = { error: vi.fn(), info: vi.fn(), warn: vi.fn() };
     const deps = createDeps({
-      workItems: [
-        workItem,
-        { ...workItem, pipelineId: 'pipeline-2', tenantId: 'tenant-2' },
-        { ...workItem, pipelineId: 'pipeline-3', tenantId: 'tenant-3' },
-      ],
+      workItems: [workItem, { ...workItem, pipelineId: 'pipeline-2', tenantId: 'tenant-2' }],
     });
     deps.reportingRepository.listWeightedPipelineRows.mockReturnValue(new Promise(() => {}));
 
@@ -296,11 +292,13 @@ describe('runCrmForecastSnapshotBackfillCore', () => {
     });
 
     expect(result.dateResults[0]).toMatchObject({
-      failedWorkItems: 2,
+      failedWorkItems: 1,
       status: 'partial',
       workItemsDeferred: 1,
       workItemsSucceeded: 0,
     });
+    expect(result.datesFailed).toBe(0);
+    expect(getCrmForecastSnapshotBackfillStatus(result)).toBe(200);
     expect(logger.warn).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.test.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.test.ts
@@ -242,15 +242,18 @@ describe('runCrmForecastSnapshotBackfillCore', () => {
 
   it('stops starting more work items within a date after the global duration budget is reached', async () => {
     const deps = createDeps({
-      workItems: [workItem, { ...workItem, pipelineId: 'pipeline-2' }],
+      rows: [weightedRow(), weightedRow({ pipelineId: 'pipeline-2', tenantId: 'tenant-2' })],
+      workItems: [
+        workItem,
+        { ...workItem, pipelineId: 'pipeline-2', tenantId: 'tenant-2' },
+        { ...workItem, pipelineId: 'pipeline-3', tenantId: 'tenant-3' },
+      ],
     });
-    const nowMs = vi
-      .fn()
-      .mockReturnValueOnce(1_000)
-      .mockReturnValueOnce(1_000)
-      .mockReturnValueOnce(1_000)
-      .mockReturnValueOnce(1_500)
-      .mockReturnValue(61_001);
+    let nowCalls = 0;
+    const nowMs = vi.fn(() => {
+      nowCalls += 1;
+      return nowCalls <= 6 ? 1_000 : 61_001;
+    });
 
     const result = await runCrmForecastSnapshotBackfillCore({
       ...deps,
@@ -264,17 +267,21 @@ describe('runCrmForecastSnapshotBackfillCore', () => {
 
     expect(result.dateResults[0]).toMatchObject({
       status: 'partial',
-      workItemsConsidered: 2,
+      snapshotsInserted: 2,
+      workItemsConsidered: 3,
       workItemsDeferred: 1,
-      workItemsSucceeded: 1,
+      workItemsSucceeded: 2,
     });
-    expect(deps.snapshotRepository.insertPipelineSnapshots).toHaveBeenCalledTimes(1);
   });
 
   it('soft-times out individual work items and defers the rest of the date', async () => {
     const logger = { error: vi.fn(), info: vi.fn(), warn: vi.fn() };
     const deps = createDeps({
-      workItems: [workItem, { ...workItem, pipelineId: 'pipeline-2', tenantId: 'tenant-2' }],
+      workItems: [
+        workItem,
+        { ...workItem, pipelineId: 'pipeline-2', tenantId: 'tenant-2' },
+        { ...workItem, pipelineId: 'pipeline-3', tenantId: 'tenant-3' },
+      ],
     });
     deps.reportingRepository.listWeightedPipelineRows.mockReturnValue(new Promise(() => {}));
 
@@ -289,19 +296,12 @@ describe('runCrmForecastSnapshotBackfillCore', () => {
     });
 
     expect(result.dateResults[0]).toMatchObject({
-      failedWorkItems: 1,
+      failedWorkItems: 2,
       status: 'partial',
       workItemsDeferred: 1,
       workItemsSucceeded: 0,
     });
-    expect(logger.warn).toHaveBeenCalledWith(
-      '[CRM Forecast Snapshot Backfill] work item timed out',
-      expect.objectContaining({
-        errorMessage: 'CRM forecast snapshot backfill timed out',
-        snapshotDate: '2026-05-14',
-        tenantId: 'tenant-1',
-      })
-    );
+    expect(logger.warn).toHaveBeenCalledTimes(2);
   });
 
   it('returns 500 only when every considered date fails', async () => {

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.ts
@@ -25,6 +25,7 @@ import {
   withCrmForecastSnapshotTimeout,
   type CrmForecastSnapshotTenantWeightedRows,
 } from '../_shared';
+import { runBoundedWorkItemPool } from './_bounded-work-item-pool';
 
 export const CRM_FORECAST_SNAPSHOT_BACKFILL_MAX_DAYS = 7;
 export const CRM_FORECAST_SNAPSHOT_BACKFILL_MAX_LOOKBACK_DAYS = 366;
@@ -36,6 +37,7 @@ export const CRM_FORECAST_SNAPSHOT_BACKFILL_SYSTEM_ACTOR_ID =
 export const CRM_FORECAST_SNAPSHOT_BACKFILL_TARGET_DURATION_MS = 60_000;
 export const CRM_FORECAST_SNAPSHOT_BACKFILL_SOURCE_RUN_PREFIX = 'crm-forecast-snapshot-backfill';
 export const CRM_FORECAST_SNAPSHOT_BACKFILL_WORK_ITEM_SOFT_TIMEOUT_MS = 5_000;
+export const CRM_FORECAST_SNAPSHOT_BACKFILL_WORK_ITEM_CONCURRENCY = 2;
 export const CRM_FORECAST_SNAPSHOT_BACKFILL_NO_BRANCH_SENTINEL = '_no_branch';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -252,14 +254,11 @@ async function processDate(args: {
   result.workItemsDeferred = listed.workItemsDeferred;
 
   const tenantRows: CrmForecastSnapshotTenantWeightedRows = new Map();
-  for (const [index, workItem] of listed.workItems.entries()) {
-    if (args.nowMs() - args.startedMs >= args.targetDurationMs) {
-      result.workItemsDeferred += listed.workItems.length - index;
-      break;
-    }
-
-    try {
-      const inserted = await withTimeout(
+  const workItemResults = await runBoundedWorkItemPool({
+    concurrency: CRM_FORECAST_SNAPSHOT_BACKFILL_WORK_ITEM_CONCURRENCY,
+    items: listed.workItems,
+    run: workItem =>
+      withCrmForecastSnapshotTimeout(
         signal =>
           processWorkItem({
             dryRun: args.dryRun,
@@ -274,21 +273,27 @@ async function processDate(args: {
             tenantRows,
             workItem,
           }),
-        args.workItemSoftTimeoutMs
-      );
-      if (inserted === 'version_conflict') {
-        result.versionConflicts += 1;
-      } else {
-        result.workItemsSucceeded += 1;
-        if (!args.dryRun) result.snapshotsInserted += inserted;
-      }
-    } catch (error) {
+        args.workItemSoftTimeoutMs,
+        SOFT_TIMEOUT_MESSAGE
+      ),
+    shouldStart: () => args.nowMs() - args.startedMs < args.targetDurationMs,
+    stopAfter: outcome =>
+      outcome.status === 'rejected' && isCrmForecastSnapshotSoftTimeoutError(outcome.error),
+  });
+
+  result.workItemsDeferred += workItemResults.unscheduledCount;
+  for (const outcome of workItemResults.outcomes) {
+    if (outcome.status === 'rejected') {
       result.failedWorkItems += 1;
-      logWorkItemFailure(args.logger, args.snapshotDate, workItem, error);
-      if (isCrmForecastSnapshotSoftTimeoutError(error)) {
-        result.workItemsDeferred += listed.workItems.length - index - 1;
-        break;
-      }
+      logWorkItemFailure(args.logger, args.snapshotDate, outcome.item, outcome.error);
+      continue;
+    }
+
+    if (outcome.value === 'version_conflict') {
+      result.versionConflicts += 1;
+    } else {
+      result.workItemsSucceeded += 1;
+      if (!args.dryRun) result.snapshotsInserted += outcome.value;
     }
   }
 
@@ -549,11 +554,4 @@ function endExclusiveForSnapshotDate(snapshotDate: string): Date {
 
 function startInclusiveForSnapshotDate(snapshotDateEndExclusive: Date): Date {
   return new Date(snapshotDateEndExclusive.getTime() - CRM_REPORTING_MAX_WINDOW_DAYS * MS_PER_DAY);
-}
-
-function withTimeout<T>(
-  startWork: (signal: AbortSignal) => Promise<T>,
-  timeoutMs: number
-): Promise<T> {
-  return withCrmForecastSnapshotTimeout(startWork, timeoutMs, SOFT_TIMEOUT_MESSAGE);
 }

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.ts
@@ -26,6 +26,8 @@ import {
   type CrmForecastSnapshotTenantWeightedRows,
 } from '../_shared';
 import { runBoundedWorkItemPool } from './_bounded-work-item-pool';
+import { getCrmForecastSnapshotBackfillDateStatus } from './_date-status';
+import { rollUpCrmForecastSnapshotBackfillWorkItemOutcomes } from './_work-item-rollup';
 
 export const CRM_FORECAST_SNAPSHOT_BACKFILL_MAX_DAYS = 7;
 export const CRM_FORECAST_SNAPSHOT_BACKFILL_MAX_LOOKBACK_DAYS = 366;
@@ -282,32 +284,15 @@ async function processDate(args: {
   });
 
   result.workItemsDeferred += workItemResults.unscheduledCount;
-  let softTimeoutFailures = 0;
-  for (const outcome of workItemResults.outcomes) {
-    if (outcome.status === 'rejected') {
-      if (isCrmForecastSnapshotSoftTimeoutError(outcome.error) && softTimeoutFailures > 0) {
-        result.workItemsDeferred += 1;
-        logWorkItemFailure(args.logger, args.snapshotDate, outcome.item, outcome.error);
-        continue;
-      }
+  rollUpCrmForecastSnapshotBackfillWorkItemOutcomes({
+    dryRun: args.dryRun,
+    logFailure: (workItem, error) =>
+      logWorkItemFailure(args.logger, args.snapshotDate, workItem, error),
+    outcomes: workItemResults.outcomes,
+    result,
+  });
 
-      if (isCrmForecastSnapshotSoftTimeoutError(outcome.error)) {
-        softTimeoutFailures += 1;
-      }
-      result.failedWorkItems += 1;
-      logWorkItemFailure(args.logger, args.snapshotDate, outcome.item, outcome.error);
-      continue;
-    }
-
-    if (outcome.value === 'version_conflict') {
-      result.versionConflicts += 1;
-    } else {
-      result.workItemsSucceeded += 1;
-      if (!args.dryRun) result.snapshotsInserted += outcome.value;
-    }
-  }
-
-  result.status = dateStatus(result, args.dryRun);
+  result.status = getCrmForecastSnapshotBackfillDateStatus(result, args.dryRun);
   return result;
 }
 
@@ -360,18 +345,6 @@ function reportingInputFor(tenantId: string, from: Date, to: Date): CrmReporting
     },
     window: { from: from.toISOString(), to: to.toISOString() },
   };
-}
-
-function dateStatus(
-  result: CrmForecastSnapshotBackfillDateResult,
-  dryRun: boolean
-): CrmForecastSnapshotBackfillDateStatus {
-  if (result.workItemsConsidered > 0 && result.failedWorkItems === result.workItemsConsidered) {
-    return 'failed';
-  }
-  if (result.failedWorkItems > 0 || result.workItemsDeferred > 0) return 'partial';
-  if (dryRun) return 'dry_run';
-  return 'completed';
 }
 
 function rollUpDateResults(result: CrmForecastSnapshotBackfillResult): void {

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_core.ts
@@ -282,8 +282,18 @@ async function processDate(args: {
   });
 
   result.workItemsDeferred += workItemResults.unscheduledCount;
+  let softTimeoutFailures = 0;
   for (const outcome of workItemResults.outcomes) {
     if (outcome.status === 'rejected') {
+      if (isCrmForecastSnapshotSoftTimeoutError(outcome.error) && softTimeoutFailures > 0) {
+        result.workItemsDeferred += 1;
+        logWorkItemFailure(args.logger, args.snapshotDate, outcome.item, outcome.error);
+        continue;
+      }
+
+      if (isCrmForecastSnapshotSoftTimeoutError(outcome.error)) {
+        softTimeoutFailures += 1;
+      }
       result.failedWorkItems += 1;
       logWorkItemFailure(args.logger, args.snapshotDate, outcome.item, outcome.error);
       continue;

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_date-status.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_date-status.ts
@@ -1,0 +1,16 @@
+import type {
+  CrmForecastSnapshotBackfillDateResult,
+  CrmForecastSnapshotBackfillDateStatus,
+} from './_core';
+
+export function getCrmForecastSnapshotBackfillDateStatus(
+  result: CrmForecastSnapshotBackfillDateResult,
+  dryRun: boolean
+): CrmForecastSnapshotBackfillDateStatus {
+  if (result.workItemsConsidered > 0 && result.failedWorkItems === result.workItemsConsidered) {
+    return 'failed';
+  }
+  if (result.failedWorkItems > 0 || result.workItemsDeferred > 0) return 'partial';
+  if (dryRun) return 'dry_run';
+  return 'completed';
+}

--- a/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_work-item-rollup.ts
+++ b/apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/_work-item-rollup.ts
@@ -1,0 +1,50 @@
+import type { CrmForecastSnapshotWorkItem } from '@/adapters/crm/forecast-snapshot-work-items';
+
+import { isCrmForecastSnapshotSoftTimeoutError } from '../_shared';
+import type { BoundedWorkItemPoolOutcome } from './_bounded-work-item-pool';
+import type { CrmForecastSnapshotBackfillDateResult } from './_core';
+
+type WorkItemOutcome = BoundedWorkItemPoolOutcome<
+  CrmForecastSnapshotWorkItem,
+  number | 'version_conflict'
+>;
+
+export function rollUpCrmForecastSnapshotBackfillWorkItemOutcomes(args: {
+  dryRun: boolean;
+  logFailure: (workItem: CrmForecastSnapshotWorkItem, error: unknown) => void;
+  outcomes: readonly WorkItemOutcome[];
+  result: CrmForecastSnapshotBackfillDateResult;
+}): void {
+  let softTimeoutFailures = 0;
+  for (const outcome of args.outcomes) {
+    if (outcome.status === 'fulfilled') {
+      rollUpFulfilledOutcome(args.result, outcome.value, args.dryRun);
+      continue;
+    }
+
+    const softTimeout = isCrmForecastSnapshotSoftTimeoutError(outcome.error);
+    const deferTimedOutWorkItem = softTimeout && softTimeoutFailures > 0;
+    if (softTimeout) softTimeoutFailures += 1;
+
+    args.logFailure(outcome.item, outcome.error);
+    if (deferTimedOutWorkItem) {
+      args.result.workItemsDeferred += 1;
+    } else {
+      args.result.failedWorkItems += 1;
+    }
+  }
+}
+
+function rollUpFulfilledOutcome(
+  result: CrmForecastSnapshotBackfillDateResult,
+  value: number | 'version_conflict',
+  dryRun: boolean
+): void {
+  if (value === 'version_conflict') {
+    result.versionConflicts += 1;
+    return;
+  }
+
+  result.workItemsSucceeded += 1;
+  if (!dryRun) result.snapshotsInserted += value;
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36019897,
-  "maxTrackedFiles": 4272,
+  "maxTrackedBytes": 36028359,
+  "maxTrackedFiles": 4274,
   "maxCategoryBytes": {
     "large support/generated-ish": 17798557,
-    "source/scripts": 6759366,
+    "source/scripts": 6763667,
     "docs/text": 5157944,
-    "tests/e2e": 4624339,
+    "tests/e2e": 4628500,
     "config/data/messages": 1550526,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -6,7 +6,7 @@
     "large support/generated-ish": 17798557,
     "source/scripts": 6763667,
     "docs/text": 5157944,
-    "tests/e2e": 4628824,
+    "tests/e2e": 4628866,
     "config/data/messages": 1550526,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -6,7 +6,7 @@
     "large support/generated-ish": 17798557,
     "source/scripts": 6763667,
     "docs/text": 5157944,
-    "tests/e2e": 4628500,
+    "tests/e2e": 4628824,
     "config/data/messages": 1550526,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36028359,
-  "maxTrackedFiles": 4274,
+  "maxTrackedBytes": 36028724,
+  "maxTrackedFiles": 4276,
   "maxCategoryBytes": {
     "large support/generated-ish": 17798557,
-    "source/scripts": 6763667,
+    "source/scripts": 6763656,
     "docs/text": 5157944,
-    "tests/e2e": 4628901,
+    "tests/e2e": 4628876,
     "config/data/messages": 1550526,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -6,7 +6,7 @@
     "large support/generated-ish": 17798557,
     "source/scripts": 6763667,
     "docs/text": 5157944,
-    "tests/e2e": 4628866,
+    "tests/e2e": 4628901,
     "config/data/messages": 1550526,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36028724,
+  "maxTrackedBytes": 36028730,
   "maxTrackedFiles": 4276,
   "maxCategoryBytes": {
     "large support/generated-ish": 17798557,
-    "source/scripts": 6763656,
+    "source/scripts": 6763662,
     "docs/text": 5157944,
     "tests/e2e": 4628876,
     "config/data/messages": 1550526,


### PR DESCRIPTION
## Summary
- add a local bounded work-item pool for CRM forecast backfill processing
- run work items per date with conservative concurrency while preserving sequential date processing
- preserve result rollups, idempotency keys, soft-timeout/deferred behavior, tenant/pipeline scoping, and PII guards

## Scope
Changed only backfill implementation/tests and repo-size budget:
- apps/web/src/app/api/cron/crm/forecast-snapshots/backfill/*
- scripts/repo-size-budget.json

No proxy/auth/tenancy/schema/RLS/migrations/billing/UI/Golden Loop/release-gate/AI routing/docs changes.

## Validation
- focused CRM backfill unit tests passed: 4 files, 26 tests
- pnpm check:modularity-guard
- pnpm check:db-access
- pnpm slice:verify
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate
- git diff --check

## Reviewers
- Codex Senior Reviewer initial pass found shared-abort risk; fixed
- Codex Senior Reviewer rerun blocked by quota/rate-limit receipt
- Claude Sonnet external route blocked by no-output timeout receipt
- Gemini 3.1 Pro external route completed; cache finding rejected as false positive, logger assertion accepted and added

## Worktree note
Implementation and gates ran in /Users/arbenlila/development/interdomestik-crystal-home on codex/phase6-crm-forecast-backfill-concurrency. Detached worktree /Users/arbenlila/.codex/worktrees/886f/interdomestik-crystal-home was left untouched after the deviation was identified.