### PR TITLE
T-302d: migrate RLS policies to access tenant context

### DIFF
--- a/packages/database/drizzle/0083_access_tenant_rls_policies.sql
+++ b/packages/database/drizzle/0083_access_tenant_rls_policies.sql
@@ -2,6 +2,12 @@ ALTER TABLE public."domain_events" ENABLE ROW LEVEL SECURITY;--> statement-break
 DO $$
 DECLARE
   access_tenant_setting constant text := 'app.current_access_tenant_id';
+  access_tenant_id_column constant text := 'access_tenant_id';
+  access_tenant_key_expr constant text := 'coalesce(access_tenant_id, tenant_id)';
+  domain_events_policy constant text := 'tenant_isolation_domain_events';
+  domain_events_table constant text := 'domain_events';
+  public_schema constant text := 'public';
+  tenant_id_column constant text := 'tenant_id';
   domain_events_key text;
   domain_events_expr text;
   target record;
@@ -12,11 +18,11 @@ BEGIN
     WHEN EXISTS (
       SELECT 1
       FROM information_schema.columns c
-      WHERE c.table_schema = 'public'
-        AND c.table_name = 'domain_events'
-        AND c.column_name = 'access_tenant_id'
-    ) THEN 'coalesce(access_tenant_id, tenant_id)'
-    ELSE 'tenant_id'
+      WHERE c.table_schema = public_schema
+        AND c.table_name = domain_events_table
+        AND c.column_name = access_tenant_id_column
+    ) THEN access_tenant_key_expr
+    ELSE tenant_id_column
   END;
   domain_events_expr := format(
     '%s = (select current_setting(%L, true))::text',
@@ -27,18 +33,20 @@ BEGIN
   IF NOT EXISTS (
     SELECT 1
     FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'domain_events'
-      AND policyname = 'tenant_isolation_domain_events'
+    WHERE schemaname = public_schema
+      AND tablename = domain_events_table
+      AND policyname = domain_events_policy
   ) THEN
     EXECUTE format(
-      'CREATE POLICY "tenant_isolation_domain_events" ON public."domain_events" USING (%s) WITH CHECK (%s)',
+      'CREATE POLICY %I ON public."domain_events" USING (%s) WITH CHECK (%s)',
+      domain_events_policy,
       domain_events_expr,
       domain_events_expr
     );
   END IF;
   EXECUTE format(
-    'ALTER POLICY "tenant_isolation_domain_events" ON public."domain_events" USING (%s) WITH CHECK (%s)',
+    'ALTER POLICY %I ON public."domain_events" USING (%s) WITH CHECK (%s)',
+    domain_events_policy,
     domain_events_expr,
     domain_events_expr
   );
@@ -53,21 +61,21 @@ BEGIN
         FROM information_schema.columns c
         WHERE c.table_schema = p.schemaname
           AND c.table_name = p.tablename
-          AND c.column_name = 'access_tenant_id'
+          AND c.column_name = access_tenant_id_column
       ) AS has_access_tenant_id
     FROM pg_policies p
     INNER JOIN information_schema.columns tenant_column
       ON tenant_column.table_schema = p.schemaname
      AND tenant_column.table_name = p.tablename
-     AND tenant_column.column_name = 'tenant_id'
-    WHERE p.schemaname = 'public'
+     AND tenant_column.column_name = tenant_id_column
+    WHERE p.schemaname = public_schema
       AND p.policyname = format('tenant_isolation_%s', p.tablename)
-      AND p.tablename <> 'domain_events'
+      AND p.tablename <> domain_events_table
     ORDER BY p.tablename
   LOOP
     target_key := CASE
-      WHEN target.has_access_tenant_id THEN 'coalesce(access_tenant_id, tenant_id)'
-      ELSE 'tenant_id'
+      WHEN target.has_access_tenant_id THEN access_tenant_key_expr
+      ELSE tenant_id_column
     END;
     target_expr := format(
       '%s = (select current_setting(%L, true))::text',

--- a/packages/database/drizzle/0083_access_tenant_rls_policies.sql
+++ b/packages/database/drizzle/0083_access_tenant_rls_policies.sql
@@ -1,0 +1,103 @@
+ALTER TABLE public."domain_events" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DO $$
+DECLARE
+  access_tenant_setting constant text := 'app.current_access_tenant_id';
+  domain_events_key text;
+  domain_events_expr text;
+  target record;
+  target_key text;
+  target_expr text;
+BEGIN
+  domain_events_key := CASE
+    WHEN EXISTS (
+      SELECT 1
+      FROM information_schema.columns c
+      WHERE c.table_schema = 'public'
+        AND c.table_name = 'domain_events'
+        AND c.column_name = 'access_tenant_id'
+    ) THEN 'coalesce(access_tenant_id, tenant_id)'
+    ELSE 'tenant_id'
+  END;
+  domain_events_expr := format(
+    '%s = (select current_setting(%L, true))::text',
+    domain_events_key,
+    access_tenant_setting
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'domain_events'
+      AND policyname = 'tenant_isolation_domain_events'
+  ) THEN
+    EXECUTE format(
+      'CREATE POLICY "tenant_isolation_domain_events" ON public."domain_events" USING (%s) WITH CHECK (%s)',
+      domain_events_expr,
+      domain_events_expr
+    );
+  END IF;
+  EXECUTE format(
+    'ALTER POLICY "tenant_isolation_domain_events" ON public."domain_events" USING (%s) WITH CHECK (%s)',
+    domain_events_expr,
+    domain_events_expr
+  );
+
+  FOR target IN
+    SELECT
+      p.tablename,
+      p.policyname,
+      p.cmd,
+      EXISTS (
+        SELECT 1
+        FROM information_schema.columns c
+        WHERE c.table_schema = p.schemaname
+          AND c.table_name = p.tablename
+          AND c.column_name = 'access_tenant_id'
+      ) AS has_access_tenant_id
+    FROM pg_policies p
+    INNER JOIN information_schema.columns tenant_column
+      ON tenant_column.table_schema = p.schemaname
+     AND tenant_column.table_name = p.tablename
+     AND tenant_column.column_name = 'tenant_id'
+    WHERE p.schemaname = 'public'
+      AND p.policyname = format('tenant_isolation_%s', p.tablename)
+      AND p.tablename <> 'domain_events'
+    ORDER BY p.tablename
+  LOOP
+    target_key := CASE
+      WHEN target.has_access_tenant_id THEN 'coalesce(access_tenant_id, tenant_id)'
+      ELSE 'tenant_id'
+    END;
+    target_expr := format(
+      '%s = (select current_setting(%L, true))::text',
+      target_key,
+      access_tenant_setting
+    );
+
+    IF target.cmd = 'INSERT' THEN
+      EXECUTE format(
+        'ALTER POLICY %I ON public.%I WITH CHECK (%s)',
+        target.policyname,
+        target.tablename,
+        target_expr
+      );
+    ELSIF target.cmd IN ('SELECT', 'DELETE') THEN
+      EXECUTE format(
+        'ALTER POLICY %I ON public.%I USING (%s)',
+        target.policyname,
+        target.tablename,
+        target_expr
+      );
+    ELSE
+      EXECUTE format(
+        'ALTER POLICY %I ON public.%I USING (%s) WITH CHECK (%s)',
+        target.policyname,
+        target.tablename,
+        target_expr,
+        target_expr
+      );
+    END IF;
+  END LOOP;
+END;
+$$;

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -582,6 +582,13 @@
       "when": 1781306185466,
       "tag": "0082_claim_recovery_law",
       "breakpoints": true
+    },
+    {
+      "idx": 83,
+      "version": "7",
+      "when": 1781753406721,
+      "tag": "0083_access_tenant_rls_policies",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/test/access-tenant-rls-migration.test.ts
+++ b/packages/database/test/access-tenant-rls-migration.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const MIGRATION_PATH = fileURLToPath(
+  new URL('../drizzle/0083_access_tenant_rls_policies.sql', import.meta.url)
+);
+
+function migrationSql(): string {
+  return readFileSync(MIGRATION_PATH, 'utf8');
+}
+
+test('T-302d migration uses access-tenant GUC for tenant-isolation policies', () => {
+  const sql = migrationSql();
+
+  assert.match(sql, /access_tenant_setting constant text := 'app\.current_access_tenant_id'/u);
+  assert.match(sql, /current_setting\(%L, true\)/u);
+  assert.match(sql, /coalesce\(access_tenant_id, tenant_id\)/u);
+  assert.match(sql, /c\.table_name = 'domain_events'/u);
+  assert.doesNotMatch(sql, /app\.current_tenant_id/u);
+});
+
+test('T-302d migration preserves policy names and initPlan predicate shape', () => {
+  const sql = migrationSql();
+
+  assert.match(sql, /p\.policyname = format\('tenant_isolation_%s', p\.tablename\)/u);
+  assert.match(sql, /p\.tablename <> 'domain_events'/u);
+  assert.match(sql, /ALTER POLICY "tenant_isolation_domain_events"/u);
+  assert.match(sql, /target\.cmd = 'INSERT'/u);
+  assert.match(sql, /ALTER POLICY %I ON public\.%I USING \(%s\)'/u);
+  assert.match(sql, /ALTER POLICY %I ON public\.%I USING \(%s\) WITH CHECK \(%s\)'/u);
+  assert.match(sql, /target\.cmd IN \('SELECT', 'DELETE'\)/u);
+  assert.match(sql, /information_schema\.columns c/u);
+});
+
+test('T-302d migration keeps domain_events RLS enabled and access-scoped', () => {
+  const sql = migrationSql();
+
+  assert.match(sql, /ALTER TABLE public\."domain_events" ENABLE ROW LEVEL SECURITY/u);
+  assert.match(sql, /policyname = 'tenant_isolation_domain_events'/u);
+  assert.match(sql, /CREATE POLICY "tenant_isolation_domain_events"/u);
+  assert.match(sql, /domain_events_expr/u);
+});

--- a/packages/database/test/access-tenant-rls-migration.test.ts
+++ b/packages/database/test/access-tenant-rls-migration.test.ts
@@ -15,9 +15,10 @@ test('T-302d migration uses access-tenant GUC for tenant-isolation policies', ()
   const sql = migrationSql();
 
   assert.match(sql, /access_tenant_setting constant text := 'app\.current_access_tenant_id'/u);
+  assert.match(sql, /domain_events_table constant text := 'domain_events'/u);
   assert.match(sql, /current_setting\(%L, true\)/u);
   assert.match(sql, /coalesce\(access_tenant_id, tenant_id\)/u);
-  assert.match(sql, /c\.table_name = 'domain_events'/u);
+  assert.match(sql, /c\.table_name = domain_events_table/u);
   assert.doesNotMatch(sql, /app\.current_tenant_id/u);
 });
 
@@ -25,8 +26,8 @@ test('T-302d migration preserves policy names and initPlan predicate shape', () 
   const sql = migrationSql();
 
   assert.match(sql, /p\.policyname = format\('tenant_isolation_%s', p\.tablename\)/u);
-  assert.match(sql, /p\.tablename <> 'domain_events'/u);
-  assert.match(sql, /ALTER POLICY "tenant_isolation_domain_events"/u);
+  assert.match(sql, /p\.tablename <> domain_events_table/u);
+  assert.match(sql, /ALTER POLICY %I ON public\."domain_events"/u);
   assert.match(sql, /target\.cmd = 'INSERT'/u);
   assert.match(sql, /ALTER POLICY %I ON public\.%I USING \(%s\)'/u);
   assert.match(sql, /ALTER POLICY %I ON public\.%I USING \(%s\) WITH CHECK \(%s\)'/u);
@@ -38,7 +39,8 @@ test('T-302d migration keeps domain_events RLS enabled and access-scoped', () =>
   const sql = migrationSql();
 
   assert.match(sql, /ALTER TABLE public\."domain_events" ENABLE ROW LEVEL SECURITY/u);
-  assert.match(sql, /policyname = 'tenant_isolation_domain_events'/u);
-  assert.match(sql, /CREATE POLICY "tenant_isolation_domain_events"/u);
+  assert.match(sql, /domain_events_policy constant text := 'tenant_isolation_domain_events'/u);
+  assert.match(sql, /policyname = domain_events_policy/u);
+  assert.match(sql, /CREATE POLICY %I ON public\."domain_events"/u);
   assert.match(sql, /domain_events_expr/u);
 });

--- a/packages/database/test/rls-engaged.test.ts
+++ b/packages/database/test/rls-engaged.test.ts
@@ -11,6 +11,7 @@ import {
   applyRlsTestConnectionEnv,
   grantRlsTestRole,
   quoteIdentifier,
+  quoteSqlLiteral,
   requireRlsPreconditions,
   resolveRlsTestConnectionConfig,
   TEST_DB_PASSWORD,
@@ -85,10 +86,10 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
     sql.raw(`
       do $$
       begin
-        create role "${TEST_DB_ROLE}" login password '${TEST_DB_PASSWORD}';
+        create role ${quoteIdentifier(TEST_DB_ROLE)} login password ${quoteSqlLiteral(TEST_DB_PASSWORD)};
       exception
         when duplicate_object then
-          alter role "${TEST_DB_ROLE}" with login password '${TEST_DB_PASSWORD}';
+          alter role ${quoteIdentifier(TEST_DB_ROLE)} with login password ${quoteSqlLiteral(TEST_DB_PASSWORD)};
       end
       $$;
     `)

--- a/packages/database/test/rls-engaged.test.ts
+++ b/packages/database/test/rls-engaged.test.ts
@@ -50,10 +50,14 @@ test('resolveRlsTestConnectionConfig uses a dedicated low-privilege connection f
     'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
   );
 
-  assert.equal(
-    config.databaseUrlRls,
-    'postgresql://interdomestik_rls_test:interdomestik_rls_test_password@127.0.0.1:54322/postgres'
-  );
+  assert.ok(config.databaseUrlRls);
+  const rlsUrl = new URL(config.databaseUrlRls);
+  assert.equal(rlsUrl.protocol, 'postgresql:');
+  assert.equal(rlsUrl.username, TEST_DB_ROLE);
+  assert.equal(rlsUrl.password, TEST_DB_PASSWORD);
+  assert.equal(rlsUrl.hostname, '127.0.0.1');
+  assert.equal(rlsUrl.port, '54322');
+  assert.equal(rlsUrl.pathname, '/postgres');
   assert.equal(config.dbRlsRole, null);
 });
 

--- a/packages/database/test/rls-engaged.test.ts
+++ b/packages/database/test/rls-engaged.test.ts
@@ -1,23 +1,26 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
-import type { TestContext } from 'node:test';
 
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 
-import { claims, crmTaskHistory, crmTasks, user } from '../src/schema';
+import { claims, crmTaskHistory, crmTasks, domainEvents, user } from '../src/schema';
+import {
+  applyRlsTestConnectionEnv,
+  grantRlsTestRole,
+  quoteIdentifier,
+  requireRlsPreconditions,
+  resolveRlsTestConnectionConfig,
+  TEST_DB_PASSWORD,
+  TEST_DB_ROLE,
+} from './rls-test-connection';
+import { assertRlsWriteBoundaries } from './rls-write-boundary-proof';
 
 const KS_TENANT_ID = 'tenant_ks';
 const MK_TENANT_ID = 'tenant_mk';
-const TEST_DB_ROLE = 'interdomestik_rls_test';
-const TEST_DB_PASSWORD = 'interdomestik_rls_test_password';
-
-type RlsTestConnectionConfig = {
-  databaseUrlRls: string | null;
-  dbRlsRole: string | null;
-};
+const REQUIRED_RLS_TABLES = ['claim', 'crm_tasks', 'crm_task_history', 'domain_events'] as const;
 
 type RlsRuntimeReceipt = {
   currentUser: string;
@@ -31,141 +34,6 @@ type TenantModule = typeof import('../src/tenant');
 
 function uniqueId(prefix: string): string {
   return `${prefix}_${Date.now()}_${randomUUID().slice(0, 8)}`;
-}
-
-function quoteIdentifier(identifier: string): string {
-  return `"${identifier.replaceAll('"', '""')}"`;
-}
-
-function isPoolerConnection(databaseUrl: string): boolean {
-  return /\.pooler\.supabase\.com$/iu.test(new URL(databaseUrl).hostname);
-}
-
-function buildRlsDatabaseUrl(databaseUrl: string): string {
-  const url = new URL(databaseUrl);
-  url.username = TEST_DB_ROLE;
-  url.password = TEST_DB_PASSWORD;
-  return url.toString();
-}
-
-function resolveRlsTestConnectionConfig(databaseUrl: string): RlsTestConnectionConfig {
-  if (isPoolerConnection(databaseUrl)) {
-    return {
-      databaseUrlRls: null,
-      dbRlsRole: TEST_DB_ROLE,
-    };
-  }
-
-  return {
-    databaseUrlRls: buildRlsDatabaseUrl(databaseUrl),
-    dbRlsRole: null,
-  };
-}
-
-async function requireRlsPreconditions(
-  adminDb: ReturnType<typeof drizzle>,
-  adminSql: postgres.Sql,
-  requireIntegration: boolean,
-  t: TestContext
-): Promise<void> {
-  const requiredTables = ['claim', 'crm_tasks', 'crm_task_history'] as const;
-  const [rlsEnabled] = await adminDb.execute<{ enabled: boolean }>(
-    sql`select relrowsecurity as enabled from pg_class where relname = 'claim'`
-  );
-  if (!rlsEnabled?.enabled) {
-    await adminSql.end({ timeout: 5 });
-    if (requireIntegration) {
-      assert.fail(
-        'RLS test requires claim table RLS enabled when REQUIRE_RLS_INTEGRATION=1 (migrations must be applied).'
-      );
-    }
-    t.skip('claim table RLS is not enabled in current database');
-    return;
-  }
-
-  const tableRows = await adminDb.execute<{ relname: string; relrowsecurity: boolean }>(sql`
-    select c.relname, c.relrowsecurity
-    from pg_class c
-    join pg_namespace n
-      on n.oid = c.relnamespace
-    where n.nspname = 'public'
-      and c.relkind = 'r'
-      and c.relname in ('claim', 'crm_tasks', 'crm_task_history')
-  `);
-  const enabledTables = new Map(tableRows.map(row => [row.relname, row.relrowsecurity]));
-  const missingOrDisabled = requiredTables.filter(table => enabledTables.get(table) !== true);
-  if (missingOrDisabled.length > 0) {
-    await adminSql.end({ timeout: 5 });
-    if (requireIntegration) {
-      assert.fail(
-        `RLS test requires CRM task tables with RLS enabled when REQUIRE_RLS_INTEGRATION=1: ${missingOrDisabled.join(', ')}`
-      );
-    }
-    t.skip(`CRM task RLS tables are not ready: ${missingOrDisabled.join(', ')}`);
-    return;
-  }
-
-  const policies = await adminDb.execute<{ policyname: string }>(
-    sql`
-      select policyname
-      from pg_policies
-      where schemaname = 'public'
-        and (
-          (tablename = 'claim' and policyname = 'tenant_isolation_claim')
-          or (tablename = 'crm_tasks' and policyname = 'tenant_isolation_crm_tasks')
-          or (tablename = 'crm_task_history' and policyname = 'tenant_isolation_crm_task_history')
-        )
-    `
-  );
-  if (policies.length !== requiredTables.length) {
-    await adminSql.end({ timeout: 5 });
-    if (requireIntegration) {
-      assert.fail(
-        'RLS test requires tenant-isolation policies for claim, crm_tasks, and crm_task_history when REQUIRE_RLS_INTEGRATION=1.'
-      );
-    }
-    t.skip('tenant-isolation policy set for claim/crm task tables is not present');
-    return;
-  }
-}
-
-function applyRlsTestConnectionEnv(databaseUrl: string): {
-  restore(): void;
-} {
-  const previousDatabaseUrlRls = process.env.DATABASE_URL_RLS;
-  const previousDbRlsRole = process.env.DB_RLS_ROLE;
-  const connectionConfig = resolveRlsTestConnectionConfig(databaseUrl);
-
-  if (connectionConfig.databaseUrlRls) {
-    process.env.DATABASE_URL_RLS = connectionConfig.databaseUrlRls;
-  } else {
-    delete process.env.DATABASE_URL_RLS;
-  }
-
-  if (connectionConfig.dbRlsRole) {
-    process.env.DB_RLS_ROLE = connectionConfig.dbRlsRole;
-  } else {
-    delete process.env.DB_RLS_ROLE;
-  }
-
-  delete (globalThis as { queryClientAdmin?: unknown; queryClientRls?: unknown }).queryClientAdmin;
-  delete (globalThis as { queryClientAdmin?: unknown; queryClientRls?: unknown }).queryClientRls;
-
-  return {
-    restore() {
-      if (previousDatabaseUrlRls) {
-        process.env.DATABASE_URL_RLS = previousDatabaseUrlRls;
-      } else {
-        delete process.env.DATABASE_URL_RLS;
-      }
-
-      if (previousDbRlsRole) {
-        process.env.DB_RLS_ROLE = previousDbRlsRole;
-      } else {
-        delete process.env.DB_RLS_ROLE;
-      }
-    },
-  };
 }
 
 test('resolveRlsTestConnectionConfig keeps pooler URLs on the admin connection and uses SET ROLE', () => {
@@ -203,7 +71,7 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
   const adminSql = postgres(process.env.DATABASE_URL);
   const adminDb = drizzle(adminSql);
 
-  await requireRlsPreconditions(adminDb, adminSql, requireIntegration, t);
+  await requireRlsPreconditions(adminDb, adminSql, requireIntegration, t, REQUIRED_RLS_TABLES);
   if (t.signal.aborted) {
     return;
   }
@@ -221,20 +89,24 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
       $$;
     `)
   );
-  await adminDb.execute(sql.raw(`grant usage on schema public to "${TEST_DB_ROLE}"`));
-  await adminDb.execute(sql.raw(`grant select on table "claim" to "${TEST_DB_ROLE}"`));
-  await adminDb.execute(sql.raw(`grant select on table "crm_tasks" to "${TEST_DB_ROLE}"`));
-  await adminDb.execute(sql.raw(`grant select on table "crm_task_history" to "${TEST_DB_ROLE}"`));
-  const [{ currentUser }] = await adminDb.execute<{ currentUser: string }>(
-    sql`select current_user as "currentUser"`
+  await grantRlsTestRole(adminDb, REQUIRED_RLS_TABLES);
+  await adminDb.execute(
+    sql.raw(`grant insert on table "claim" to ${quoteIdentifier(TEST_DB_ROLE)}`)
   );
-  await adminDb.execute(sql.raw(`grant "${TEST_DB_ROLE}" to ${quoteIdentifier(currentUser)}`));
+  await adminDb.execute(
+    sql.raw(`grant insert on table "domain_events" to ${quoteIdentifier(TEST_DB_ROLE)}`)
+  );
 
   const ksUserId = uniqueId('rls_user_ks');
   const mkUserId = uniqueId('rls_user_mk');
   const claimId = uniqueId('rls_claim_ks');
   const taskId = uniqueId('rls_task_ks');
   const historyId = uniqueId('rls_task_history_ks');
+  const eventId = uniqueId('rls_event_ks');
+  const mkEventId = uniqueId('rls_event_mk');
+  const rlsEventId = uniqueId('rls_event_insert_ks');
+  const rejectedClaimId = uniqueId('rls_claim_rejected_mk');
+  const rejectedEventId = uniqueId('rls_event_rejected_mk');
   const now = new Date();
   let rlsTestEnv: ReturnType<typeof applyRlsTestConnectionEnv> | null = null;
   let dbAdmin: DbModule['dbAdmin'] | null = null;
@@ -320,6 +192,34 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
       toStatus: 'pending',
     });
 
+    await dbAdmin.insert(domainEvents).values({
+      actorId: ksUserId,
+      actorRole: 'admin',
+      aggregateVersion: 1,
+      correlationId: uniqueId('rls_correlation'),
+      entityId: claimId,
+      entityType: 'claim',
+      eventName: 'claim.rls_tested',
+      eventVersion: 1,
+      id: eventId,
+      payload: {},
+      tenantId: KS_TENANT_ID,
+    });
+
+    await dbAdmin.insert(domainEvents).values({
+      actorId: mkUserId,
+      actorRole: 'admin',
+      aggregateVersion: 1,
+      correlationId: uniqueId('rls_correlation'),
+      entityId: mkUserId,
+      entityType: 'user',
+      eventName: 'user.rls_tested',
+      eventVersion: 1,
+      id: mkEventId,
+      payload: {},
+      tenantId: MK_TENANT_ID,
+    });
+
     const [mkRlsReceipt] = await withTenantContext(
       { tenantId: MK_TENANT_ID, accessTenantId: '  ' },
       async tx => {
@@ -357,6 +257,94 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
 
     assert.equal(mkRows.length, 0, 'tenant_mk must not see tenant_ks claim row');
 
+    const blankAccessEventRows = await withTenantContext(
+      { tenantId: MK_TENANT_ID, accessTenantId: '  ' },
+      async tx => {
+        return tx
+          .select({ id: domainEvents.id })
+          .from(domainEvents)
+          .where(and(eq(domainEvents.id, eventId), eq(domainEvents.tenantId, KS_TENANT_ID)));
+      }
+    );
+    assert.equal(
+      blankAccessEventRows.length,
+      0,
+      'blank access_tenant fallback to tenant_mk must not see tenant_ks domain event'
+    );
+
+    const blankAccessOwnEventRows = await withTenantContext(
+      { tenantId: MK_TENANT_ID, accessTenantId: '  ' },
+      async tx => {
+        return tx
+          .select({ id: domainEvents.id })
+          .from(domainEvents)
+          .where(and(eq(domainEvents.id, mkEventId), eq(domainEvents.tenantId, MK_TENANT_ID)));
+      }
+    );
+    assert.equal(
+      blankAccessOwnEventRows.length,
+      1,
+      'blank access_tenant fallback to tenant_mk must see tenant_mk domain event'
+    );
+
+    const accessKsClaimRows = await withTenantContext(
+      { tenantId: MK_TENANT_ID, accessTenantId: KS_TENANT_ID },
+      async tx => {
+        return tx
+          .select({ id: claims.id })
+          .from(claims)
+          .where(and(eq(claims.id, claimId), eq(claims.tenantId, KS_TENANT_ID)));
+      }
+    );
+    assert.equal(
+      accessKsClaimRows.length,
+      1,
+      'access_tenant tenant_ks must see tenant_ks claim even when current_tenant is tenant_mk'
+    );
+
+    const accessKsEventRows = await withTenantContext(
+      { tenantId: MK_TENANT_ID, accessTenantId: KS_TENANT_ID },
+      async tx => {
+        return tx
+          .select({ id: domainEvents.id })
+          .from(domainEvents)
+          .where(and(eq(domainEvents.id, eventId), eq(domainEvents.tenantId, KS_TENANT_ID)));
+      }
+    );
+    assert.equal(
+      accessKsEventRows.length,
+      1,
+      'access_tenant tenant_ks must see tenant_ks domain event under access-GUC RLS'
+    );
+
+    const tenantKsAccessMkRows = await withTenantContext(
+      { tenantId: KS_TENANT_ID, accessTenantId: MK_TENANT_ID },
+      async tx => {
+        return tx
+          .select({ id: domainEvents.id })
+          .from(domainEvents)
+          .where(and(eq(domainEvents.id, eventId), eq(domainEvents.tenantId, KS_TENANT_ID)));
+      }
+    );
+    assert.equal(
+      tenantKsAccessMkRows.length,
+      0,
+      'access_tenant tenant_mk must not see tenant_ks domain event even when current_tenant is tenant_ks'
+    );
+
+    await assertRlsWriteBoundaries({
+      claimId,
+      ksTenantId: KS_TENANT_ID,
+      ksUserId,
+      mkTenantId: MK_TENANT_ID,
+      mkUserId,
+      rejectedClaimId,
+      rejectedEventId,
+      rlsEventId,
+      uniqueId,
+      withTenantContext,
+    });
+
     const unsetTaskRows = await dbRls
       .select({ id: crmTasks.id })
       .from(crmTasks)
@@ -392,6 +380,9 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
     assert.equal(ksTaskRows.length, 1, 'tenant_ks must see its own CRM task row');
   } finally {
     if (dbAdmin) {
+      await dbAdmin
+        .delete(domainEvents)
+        .where(inArray(domainEvents.id, [eventId, mkEventId, rlsEventId]));
       await dbAdmin.delete(crmTaskHistory).where(eq(crmTaskHistory.id, historyId));
       await dbAdmin.delete(crmTasks).where(eq(crmTasks.id, taskId));
       await dbAdmin.delete(claims).where(eq(claims.id, claimId));

--- a/packages/database/test/rls-test-connection.ts
+++ b/packages/database/test/rls-test-connection.ts
@@ -14,6 +14,8 @@ export function quoteIdentifier(identifier: string): string {
   return `"${identifier.replaceAll('"', '""')}"`;
 }
 
+export const quoteSqlLiteral = (value: string): string => `'${value.replaceAll("'", "''")}'`;
+
 function isPoolerConnection(databaseUrl: string): boolean {
   return /\.pooler\.supabase\.com$/iu.test(new URL(databaseUrl).hostname);
 }
@@ -39,9 +41,7 @@ export function resolveRlsTestConnectionConfig(databaseUrl: string): RlsTestConn
   };
 }
 
-export function applyRlsTestConnectionEnv(databaseUrl: string): {
-  restore(): void;
-} {
+export function applyRlsTestConnectionEnv(databaseUrl: string): { restore(): void } {
   const previousDatabaseUrlRls = process.env.DATABASE_URL_RLS;
   const previousDbRlsRole = process.env.DB_RLS_ROLE;
   const connectionConfig = resolveRlsTestConnectionConfig(databaseUrl);

--- a/packages/database/test/rls-test-connection.ts
+++ b/packages/database/test/rls-test-connection.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import type { TestContext } from 'node:test';
 
 import { sql } from 'drizzle-orm';
@@ -6,8 +7,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import type postgres from 'postgres';
 
 export const TEST_DB_ROLE = 'interdomestik_rls_test';
-export const TEST_DB_PASSWORD =
-  process.env.RLS_TEST_DB_PASSWORD ?? 'interdomestik_rls_test_password';
+export const TEST_DB_PASSWORD = process.env.RLS_TEST_DB_PASSWORD ?? randomUUID();
 export type RlsTestConnectionConfig = { databaseUrlRls: string | null; dbRlsRole: string | null };
 
 export function quoteIdentifier(identifier: string): string {
@@ -129,7 +129,6 @@ export async function requireRlsPreconditions(
       );
     }
     t.skip(`tenant-isolation policies are not present: ${missingPolicyTables.join(', ')}`);
-    return;
   }
 }
 

--- a/packages/database/test/rls-test-connection.ts
+++ b/packages/database/test/rls-test-connection.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import type { TestContext } from 'node:test';
+
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type postgres from 'postgres';
+
+export const TEST_DB_ROLE = 'interdomestik_rls_test';
+export const TEST_DB_PASSWORD =
+  process.env.RLS_TEST_DB_PASSWORD ?? 'interdomestik_rls_test_password';
+export type RlsTestConnectionConfig = { databaseUrlRls: string | null; dbRlsRole: string | null };
+
+export function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function isPoolerConnection(databaseUrl: string): boolean {
+  return /\.pooler\.supabase\.com$/iu.test(new URL(databaseUrl).hostname);
+}
+
+function buildRlsDatabaseUrl(databaseUrl: string): string {
+  const url = new URL(databaseUrl);
+  url.username = TEST_DB_ROLE;
+  url.password = TEST_DB_PASSWORD;
+  return url.toString();
+}
+
+export function resolveRlsTestConnectionConfig(databaseUrl: string): RlsTestConnectionConfig {
+  if (isPoolerConnection(databaseUrl)) {
+    return {
+      databaseUrlRls: null,
+      dbRlsRole: TEST_DB_ROLE,
+    };
+  }
+
+  return {
+    databaseUrlRls: buildRlsDatabaseUrl(databaseUrl),
+    dbRlsRole: null,
+  };
+}
+
+export function applyRlsTestConnectionEnv(databaseUrl: string): {
+  restore(): void;
+} {
+  const previousDatabaseUrlRls = process.env.DATABASE_URL_RLS;
+  const previousDbRlsRole = process.env.DB_RLS_ROLE;
+  const connectionConfig = resolveRlsTestConnectionConfig(databaseUrl);
+
+  if (connectionConfig.databaseUrlRls) {
+    process.env.DATABASE_URL_RLS = connectionConfig.databaseUrlRls;
+  } else {
+    delete process.env.DATABASE_URL_RLS;
+  }
+
+  if (connectionConfig.dbRlsRole) {
+    process.env.DB_RLS_ROLE = connectionConfig.dbRlsRole;
+  } else {
+    delete process.env.DB_RLS_ROLE;
+  }
+
+  delete (globalThis as { queryClientAdmin?: unknown; queryClientRls?: unknown }).queryClientAdmin;
+  delete (globalThis as { queryClientAdmin?: unknown; queryClientRls?: unknown }).queryClientRls;
+
+  return {
+    restore() {
+      if (previousDatabaseUrlRls) {
+        process.env.DATABASE_URL_RLS = previousDatabaseUrlRls;
+      } else {
+        delete process.env.DATABASE_URL_RLS;
+      }
+
+      if (previousDbRlsRole) {
+        process.env.DB_RLS_ROLE = previousDbRlsRole;
+      } else {
+        delete process.env.DB_RLS_ROLE;
+      }
+    },
+  };
+}
+
+export async function requireRlsPreconditions(
+  adminDb: ReturnType<typeof drizzle>,
+  adminSql: postgres.Sql,
+  requireIntegration: boolean,
+  t: TestContext,
+  requiredTables: readonly string[]
+): Promise<void> {
+  const tableList = sql.join(
+    requiredTables.map(tableName => sql`${tableName}`),
+    sql`, `
+  );
+  const tableRows = await adminDb.execute<{ relname: string; relrowsecurity: boolean }>(sql`
+    select c.relname, c.relrowsecurity
+    from pg_class c
+    join pg_namespace n
+      on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relkind = 'r'
+      and c.relname in (${tableList})
+  `);
+  const enabledTables = new Map(tableRows.map(row => [row.relname, row.relrowsecurity]));
+  const missingOrDisabled = requiredTables.filter(table => enabledTables.get(table) !== true);
+  if (missingOrDisabled.length > 0) {
+    await adminSql.end({ timeout: 5 });
+    if (requireIntegration) {
+      assert.fail(
+        `RLS test requires tables with RLS enabled when REQUIRE_RLS_INTEGRATION=1: ${missingOrDisabled.join(', ')}`
+      );
+    }
+    t.skip(`RLS tables are not ready: ${missingOrDisabled.join(', ')}`);
+    return;
+  }
+
+  const policies = await adminDb.execute<{ tablename: string; policyname: string }>(sql`
+    select tablename, policyname
+    from pg_policies
+    where schemaname = 'public'
+      and policyname = ('tenant_isolation_' || tablename)
+      and tablename in (${tableList})
+  `);
+  const policyTables = new Set(policies.map(row => row.tablename));
+  const missingPolicyTables = requiredTables.filter(table => !policyTables.has(table));
+
+  if (missingPolicyTables.length > 0) {
+    await adminSql.end({ timeout: 5 });
+    if (requireIntegration) {
+      assert.fail(
+        `RLS test requires tenant-isolation policies when REQUIRE_RLS_INTEGRATION=1: ${missingPolicyTables.join(', ')}`
+      );
+    }
+    t.skip(`tenant-isolation policies are not present: ${missingPolicyTables.join(', ')}`);
+    return;
+  }
+}
+
+export async function grantRlsTestRole(
+  adminDb: ReturnType<typeof drizzle>,
+  tableNames: readonly string[]
+): Promise<void> {
+  await adminDb.execute(sql.raw(`grant usage on schema public to "${TEST_DB_ROLE}"`));
+  for (const tableName of tableNames) {
+    await adminDb.execute(
+      sql.raw(`grant select on table ${quoteIdentifier(tableName)} to "${TEST_DB_ROLE}"`)
+    );
+  }
+  const [{ currentUser }] = await adminDb.execute<{ currentUser: string }>(
+    sql`select current_user as "currentUser"`
+  );
+  await adminDb.execute(sql.raw(`grant "${TEST_DB_ROLE}" to ${quoteIdentifier(currentUser)}`));
+}

--- a/packages/database/test/rls-write-boundary-proof.ts
+++ b/packages/database/test/rls-write-boundary-proof.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+
+import { claims, domainEvents } from '../src/schema';
+
+type WithTenantContext = (typeof import('../src/tenant'))['withTenantContext'];
+
+type WriteBoundaryProofParams = {
+  claimId: string;
+  ksTenantId: string;
+  ksUserId: string;
+  mkTenantId: string;
+  mkUserId: string;
+  rejectedClaimId: string;
+  rejectedEventId: string;
+  rlsEventId: string;
+  uniqueId(prefix: string): string;
+  withTenantContext: WithTenantContext;
+};
+
+function isRlsRejection(error: unknown): boolean {
+  const cause = (error as { cause?: { message?: string } }).cause;
+  return /violates row-level security policy/iu.test(cause?.message ?? String(error));
+}
+
+export async function assertRlsWriteBoundaries(params: WriteBoundaryProofParams): Promise<void> {
+  const {
+    claimId,
+    ksTenantId,
+    ksUserId,
+    mkTenantId,
+    mkUserId,
+    rejectedClaimId,
+    rejectedEventId,
+    rlsEventId,
+    uniqueId,
+    withTenantContext,
+  } = params;
+
+  await withTenantContext({ tenantId: ksTenantId }, async tx => {
+    await tx.insert(domainEvents).values({
+      actorId: ksUserId,
+      actorRole: 'admin',
+      aggregateVersion: 1,
+      correlationId: uniqueId('rls_correlation'),
+      entityId: claimId,
+      entityType: 'claim',
+      eventName: 'claim.rls_insert_tested',
+      eventVersion: 1,
+      id: rlsEventId,
+      payload: {},
+      tenantId: ksTenantId,
+    });
+  });
+
+  await assert.rejects(
+    () =>
+      withTenantContext({ tenantId: mkTenantId, accessTenantId: ksTenantId }, async tx => {
+        await tx.insert(claims).values({
+          category: 'retail',
+          companyName: 'RLS Test Co',
+          description: 'home-tenant write must fail under mismatched access tenant',
+          id: rejectedClaimId,
+          origin: 'portal',
+          tenantId: mkTenantId,
+          title: 'RLS rejected write proof',
+          userId: mkUserId,
+        });
+      }),
+    isRlsRejection
+  );
+
+  await assert.rejects(
+    () =>
+      withTenantContext({ tenantId: mkTenantId, accessTenantId: ksTenantId }, async tx => {
+        await tx.insert(domainEvents).values({
+          actorId: mkUserId,
+          actorRole: 'admin',
+          aggregateVersion: 1,
+          correlationId: uniqueId('rls_correlation'),
+          entityId: rejectedClaimId,
+          entityType: 'claim',
+          eventName: 'claim.rls_rejected',
+          eventVersion: 1,
+          id: rejectedEventId,
+          payload: {},
+          tenantId: mkTenantId,
+        });
+      }),
+    isRlsRejection
+  );
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35946410,
-  "maxTrackedFiles": 4253,
+  "maxTrackedBytes": 35957512,
+  "maxTrackedFiles": 4257,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17805713,
-    "source/scripts": 6709538,
+    "large support/generated-ish": 17808793,
+    "source/scripts": 6717023,
     "docs/text": 5144534,
-    "tests/e2e": 4616537,
-    "config/data/messages": 1540923,
+    "tests/e2e": 4617764,
+    "config/data/messages": 1540233,
     "other": 129165
   },
   "maxLargestFileBytes": 2950459,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35957512,
+  "maxTrackedBytes": 35958265,
   "maxTrackedFiles": 4257,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17808793,
-    "source/scripts": 6717023,
+    "large support/generated-ish": 17809161,
+    "source/scripts": 6717030,
     "docs/text": 5144534,
-    "tests/e2e": 4617764,
+    "tests/e2e": 4618142,
     "config/data/messages": 1540233,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35958265,
+  "maxTrackedBytes": 35958436,
   "maxTrackedFiles": 4257,
   "maxCategoryBytes": {
     "large support/generated-ish": 17809161,
-    "source/scripts": 6717030,
+    "source/scripts": 6717122,
     "docs/text": 5144534,
-    "tests/e2e": 4618142,
+    "tests/e2e": 4618221,
     "config/data/messages": 1540233,
     "other": 129165
   },


### PR DESCRIPTION
## Scope

T-302d Tier 3 implementation: migrate tenant RLS policy predicates toward `app.current_access_tenant_id`, keep transitional compatibility through `coalesce(access_tenant_id, tenant_id)`, add RLS coverage for `domain_events`, and extend required RLS proof for access-tenant isolation.

## Files

- `packages/database/drizzle/0083_access_tenant_rls_policies.sql` - new migration enabling/replacing access-tenant RLS policies, including `domain_events`.
- `packages/database/drizzle/meta/_journal.json` - journal entry for migration 0083.
- `packages/database/test/access-tenant-rls-migration.test.ts` - static migration shape checks.
- `packages/database/test/rls-engaged.test.ts` - required live RLS proof extended for access-tenant isolation; touched legacy file reduced from 403 to 394 lines.
- `packages/database/test/rls-test-connection.ts` - extracted RLS test connection/grant helper, 150 lines.
- `packages/database/test/rls-write-boundary-proof.ts` - write-boundary RLS proof for claims/domain events.
- `scripts/repo-size-budget.json` - repo-size inventory sync from added files, not product scope creep.

## Reviewer Disposition

- Initial Sonnet 4.6 senior review: ran; findings fixed/dispositioned.
- Gemini 3.1 Pro Preview: blocked by CLI/auth/environment setup; not counted as approval.
- Opus escalation: ran as usable fallback; findings fixed/dispositioned.
- Post-remediation Sonnet: blocked/no-output timeout; not counted as approval.
- Final usable post-remediation reviewer signal: Opus fallback.

## Focused Proof

- `git diff --cached --check` - passed.
- `pnpm check:modularity-guard` - passed.
- `pnpm db:migrations:check-journal` - passed.
- `node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/database exec tsx --test test/access-tenant-rls-migration.test.ts` - passed.
- `pnpm db:rls:test:required` - passed, 25 tests, `RLS_COVERAGE total=72 enabled=72 missing=0 pct=100.00`, `RLS_INTEGRATION_RAN=1`.

## Broad Gates

- `pnpm slice:verify` - initial run failed in `security:guard` because claim-status writer inventory flagged explicit `status: 'draft'` in the new write-boundary proof; fixed by removing the explicit status and relying on the schema default; rerun passed.
- `pnpm ci:local:pr` - blocked by local resource kill, `exit_137`, during Docker `e2e:gate:pr` web build TypeScript validation after prior lanes passed. Classified as `local_resource_kill/exit_137`.
- `pnpm ci:local:full` - blocked at the same Docker web build TypeScript validation point, `exit_137`. Classified as `local_resource_kill/exit_137`.
- `pnpm pr:verify` - passed end to end, including PR E2E lane and smoke lane.
- `pnpm security:guard` - passed.
- `pnpm e2e:gate` - passed, 136 passed / 8 skipped.

## Protected Paths

Confirmed untouched in the staged/committed diff:

- `apps/web/src/proxy.ts`
- `README.md`
- `AGENTS.md`
- `docs/**`

## Ops / Rollback Notes

Migration is forward-only and idempotent in shape: it enables RLS on `domain_events`, drops/replaces old `tenant_isolation_*` policies where needed, and uses transitional `coalesce(access_tenant_id, tenant_id)` for tables carrying both columns. Rollback would require reverting this migration and redeploying the prior policy set; no data rewrite is introduced by this slice.

During the dual-write transition, application context must continue setting both `app.current_tenant_id` and `app.current_access_tenant_id` so unmigrated policies do not fail closed. Future cleanup should remove the transitional `tenant_id` fallback only after the access-tenant migration is complete.

## Residual Risks

- Event writers must run with correct RLS GUC context or a governed privileged owner path; the tests cover the required low-privilege isolation boundary.
- `coalesce(access_tenant_id, tenant_id)` is intentionally transitional and should be revisited in the follow-up access-tenancy cleanup.
- Docker local-CI wrappers remained resource-constrained on this workstation; host mandatory gates and focused RLS proof passed.

## Tier 3 Approval

This is Tier 3 RLS/tenant-isolation work. Human approval or an explicit written waiver is required before merge.
