### PR TITLE
ci: surface sonar gate summaries

### DIFF
--- a/scripts/ci/sonar-check-run-gate.test.mjs
+++ b/scripts/ci/sonar-check-run-gate.test.mjs
@@ -21,38 +21,6 @@ function writeGhResponse(responsesDir, endpoint, payload) {
   fs.writeFileSync(responsePath, JSON.stringify(payload));
 }
 
-function writeMockGh(binDir) {
-  const mockGhPath = path.join(binDir, 'gh');
-  fs.writeFileSync(
-    mockGhPath,
-    `#!/usr/bin/env node
-const fs = require('node:fs');
-const path = require('node:path');
-
-const args = process.argv.slice(2);
-if (args[0] !== 'api') {
-  process.stderr.write('Unsupported gh command\\n');
-  process.exit(2);
-}
-
-const endpoint = args.at(-1);
-const responsePath = path.join(
-  process.env.MOCK_GH_RESPONSES_DIR,
-  endpoint.replace(/[^A-Za-z0-9._-]+/g, '_') + '.json'
-);
-
-if (!fs.existsSync(responsePath)) {
-  process.stderr.write(\`Missing mock response for \${endpoint}\\n\`);
-  process.exit(2);
-}
-
-process.stdout.write(fs.readFileSync(responsePath, 'utf8'));
-`,
-    { mode: 0o700 }
-  );
-  return mockGhPath;
-}
-
 function closeServer(server) {
   return new Promise((resolve, reject) => {
     server.close(error => {
@@ -130,14 +98,39 @@ test('sonar check-run gate accepts PR quality gate API results when the Sonar ch
   const binDir = path.join(tempRoot, 'bin');
   const responsesDir = path.join(tempRoot, 'responses');
   const evidenceDir = path.join(tempRoot, 'evidence');
-  const eventPath = path.join(tempRoot, 'event.json');
-  const stepSummaryPath = path.join(tempRoot, 'github-step-summary.md');
+  const eventPath = path.join(tempRoot, 'event.json'), stepSummaryPath = path.join(tempRoot, 'github-step-summary.md');
 
-  fs.mkdirSync(binDir, { recursive: true });
-  fs.mkdirSync(responsesDir, { recursive: true });
+  for (const dir of [binDir, responsesDir]) fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(eventPath, JSON.stringify({ pull_request: { number: 307 } }));
 
-  const mockGhPath = writeMockGh(binDir);
+  const mockGhPath = path.join(binDir, 'gh');
+  fs.writeFileSync(
+    mockGhPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const args = process.argv.slice(2);
+if (args[0] !== 'api') {
+  process.stderr.write('Unsupported gh command\\n');
+  process.exit(2);
+}
+
+const endpoint = args.at(-1);
+const responsePath = path.join(
+  process.env.MOCK_GH_RESPONSES_DIR,
+  endpoint.replace(/[^A-Za-z0-9._-]+/g, '_') + '.json'
+);
+
+if (!fs.existsSync(responsePath)) {
+  process.stderr.write(\`Missing mock response for \${endpoint}\\n\`);
+  process.exit(2);
+}
+
+process.stdout.write(fs.readFileSync(responsePath, 'utf8'));
+`,
+    { mode: 0o700 }
+  );
 
   const checkRunsEndpoint =
     'repos/interdomestik/interdomestik/commits/test-sha/check-runs?filter=latest&per_page=100';
@@ -201,13 +194,9 @@ test('sonar check-run gate accepts PR quality gate API results when the Sonar ch
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
 
-    const summaryPath = path.join(evidenceDir, 'notes', 'sonar-summary.md');
-    const summary = fs.readFileSync(summaryPath, 'utf8');
-    const stepSummary = fs.readFileSync(stepSummaryPath, 'utf8');
-    assert.match(summary, /source: Sonar quality gate API/);
-    assert.match(summary, /conclusion: OK/);
-    assert.match(stepSummary, /source: Sonar quality gate API/);
-    assert.match(stepSummary, /conclusion: OK/);
+    for (const summary of [fs.readFileSync(path.join(evidenceDir, 'notes', 'sonar-summary.md'), 'utf8'), fs.readFileSync(stepSummaryPath, 'utf8')]) {
+      assert.match(summary, /source: Sonar quality gate API/); assert.match(summary, /conclusion: OK/);
+    }
   } finally {
     await server.close();
   }
@@ -224,7 +213,34 @@ test('sonar check-run gate ignores stale PR quality gate data until Sonar analyz
   fs.mkdirSync(responsesDir, { recursive: true });
   fs.writeFileSync(eventPath, JSON.stringify({ pull_request: { number: 307 } }));
 
-  const mockGhPath = writeMockGh(binDir);
+  const mockGhPath = path.join(binDir, 'gh');
+  fs.writeFileSync(
+    mockGhPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const args = process.argv.slice(2);
+if (args[0] !== 'api') {
+  process.stderr.write('Unsupported gh command\\n');
+  process.exit(2);
+}
+
+const endpoint = args.at(-1);
+const responsePath = path.join(
+  process.env.MOCK_GH_RESPONSES_DIR,
+  endpoint.replace(/[^A-Za-z0-9._-]+/g, '_') + '.json'
+);
+
+if (!fs.existsSync(responsePath)) {
+  process.stderr.write(\`Missing mock response for \${endpoint}\\n\`);
+  process.exit(2);
+}
+
+process.stdout.write(fs.readFileSync(responsePath, 'utf8'));
+`,
+    { mode: 0o700 }
+  );
 
   const checkRunsEndpoint =
     'repos/interdomestik/interdomestik/commits/test-sha/check-runs?filter=latest&per_page=100';

--- a/scripts/ci/sonar-check-run-gate.test.mjs
+++ b/scripts/ci/sonar-check-run-gate.test.mjs
@@ -21,6 +21,38 @@ function writeGhResponse(responsesDir, endpoint, payload) {
   fs.writeFileSync(responsePath, JSON.stringify(payload));
 }
 
+function writeMockGh(binDir) {
+  const mockGhPath = path.join(binDir, 'gh');
+  fs.writeFileSync(
+    mockGhPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const args = process.argv.slice(2);
+if (args[0] !== 'api') {
+  process.stderr.write('Unsupported gh command\\n');
+  process.exit(2);
+}
+
+const endpoint = args.at(-1);
+const responsePath = path.join(
+  process.env.MOCK_GH_RESPONSES_DIR,
+  endpoint.replace(/[^A-Za-z0-9._-]+/g, '_') + '.json'
+);
+
+if (!fs.existsSync(responsePath)) {
+  process.stderr.write(\`Missing mock response for \${endpoint}\\n\`);
+  process.exit(2);
+}
+
+process.stdout.write(fs.readFileSync(responsePath, 'utf8'));
+`,
+    { mode: 0o700 }
+  );
+  return mockGhPath;
+}
+
 function closeServer(server) {
   return new Promise((resolve, reject) => {
     server.close(error => {
@@ -99,39 +131,13 @@ test('sonar check-run gate accepts PR quality gate API results when the Sonar ch
   const responsesDir = path.join(tempRoot, 'responses');
   const evidenceDir = path.join(tempRoot, 'evidence');
   const eventPath = path.join(tempRoot, 'event.json');
+  const stepSummaryPath = path.join(tempRoot, 'github-step-summary.md');
 
   fs.mkdirSync(binDir, { recursive: true });
   fs.mkdirSync(responsesDir, { recursive: true });
   fs.writeFileSync(eventPath, JSON.stringify({ pull_request: { number: 307 } }));
 
-  const mockGhPath = path.join(binDir, 'gh');
-  fs.writeFileSync(
-    mockGhPath,
-    `#!/usr/bin/env node
-const fs = require('node:fs');
-const path = require('node:path');
-
-const args = process.argv.slice(2);
-if (args[0] !== 'api') {
-  process.stderr.write('Unsupported gh command\\n');
-  process.exit(2);
-}
-
-const endpoint = args.at(-1);
-const responsePath = path.join(
-  process.env.MOCK_GH_RESPONSES_DIR,
-  endpoint.replace(/[^A-Za-z0-9._-]+/g, '_') + '.json'
-);
-
-if (!fs.existsSync(responsePath)) {
-  process.stderr.write(\`Missing mock response for \${endpoint}\\n\`);
-  process.exit(2);
-}
-
-process.stdout.write(fs.readFileSync(responsePath, 'utf8'));
-`,
-    { mode: 0o700 }
-  );
+  const mockGhPath = writeMockGh(binDir);
 
   const checkRunsEndpoint =
     'repos/interdomestik/interdomestik/commits/test-sha/check-runs?filter=latest&per_page=100';
@@ -183,6 +189,7 @@ process.stdout.write(fs.readFileSync(responsePath, 'utf8'));
       GH_TOKEN: 'test-gh-token',
       GITHUB_EVENT_PATH: eventPath,
       GITHUB_REPOSITORY: 'interdomestik/interdomestik',
+      GITHUB_STEP_SUMMARY: stepSummaryPath,
       MOCK_GH_RESPONSES_DIR: responsesDir,
       SONAR_CHECK_MAX_RETRIES: '1',
       SONAR_CHECK_RETRY_DELAY_SECONDS: '0',
@@ -196,8 +203,11 @@ process.stdout.write(fs.readFileSync(responsePath, 'utf8'));
 
     const summaryPath = path.join(evidenceDir, 'notes', 'sonar-summary.md');
     const summary = fs.readFileSync(summaryPath, 'utf8');
+    const stepSummary = fs.readFileSync(stepSummaryPath, 'utf8');
     assert.match(summary, /source: Sonar quality gate API/);
     assert.match(summary, /conclusion: OK/);
+    assert.match(stepSummary, /source: Sonar quality gate API/);
+    assert.match(stepSummary, /conclusion: OK/);
   } finally {
     await server.close();
   }
@@ -214,34 +224,7 @@ test('sonar check-run gate ignores stale PR quality gate data until Sonar analyz
   fs.mkdirSync(responsesDir, { recursive: true });
   fs.writeFileSync(eventPath, JSON.stringify({ pull_request: { number: 307 } }));
 
-  const mockGhPath = path.join(binDir, 'gh');
-  fs.writeFileSync(
-    mockGhPath,
-    `#!/usr/bin/env node
-const fs = require('node:fs');
-const path = require('node:path');
-
-const args = process.argv.slice(2);
-if (args[0] !== 'api') {
-  process.stderr.write('Unsupported gh command\\n');
-  process.exit(2);
-}
-
-const endpoint = args.at(-1);
-const responsePath = path.join(
-  process.env.MOCK_GH_RESPONSES_DIR,
-  endpoint.replace(/[^A-Za-z0-9._-]+/g, '_') + '.json'
-);
-
-if (!fs.existsSync(responsePath)) {
-  process.stderr.write(\`Missing mock response for \${endpoint}\\n\`);
-  process.exit(2);
-}
-
-process.stdout.write(fs.readFileSync(responsePath, 'utf8'));
-`,
-    { mode: 0o700 }
-  );
+  const mockGhPath = writeMockGh(binDir);
 
   const checkRunsEndpoint =
     'repos/interdomestik/interdomestik/commits/test-sha/check-runs?filter=latest&per_page=100';

--- a/scripts/sonar-check-run-gate.sh
+++ b/scripts/sonar-check-run-gate.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
-
 RUN_ID="${GITHUB_RUN_ID:-local-$(date +%Y%m%d%H%M%S)}"
 EVIDENCE_DIR="${EVIDENCE_DIR:-tmp/pilot-evidence/${RUN_ID}}"
 LOG_DIR="${EVIDENCE_DIR}/logs"
@@ -12,9 +11,10 @@ QG_JSON="${LOG_DIR}/sonar-qualitygate.json"
 PRS_JSON="${LOG_DIR}/sonar-pull-requests.json"
 SUMMARY_MD="${NOTES_DIR}/sonar-summary.md"
 SCAN_LOG="${LOG_DIR}/sonar-scan.log"
-
 mkdir -p "$LOG_DIR" "$NOTES_DIR"
 
+publish_job_summary() { [[ -n "${GITHUB_STEP_SUMMARY:-}" && -f "${SUMMARY_MD}" ]] && { cat "${SUMMARY_MD}"; echo; } >>"${GITHUB_STEP_SUMMARY}" || true; }
+trap 'status=$?; publish_job_summary; exit "$status"' EXIT
 if [[ -n "${GITHUB_TOKEN:-}" && -z "${GH_TOKEN:-}" ]]; then
   export GH_TOKEN="${GITHUB_TOKEN}"
 fi


### PR DESCRIPTION
## Summary
- publish the Sonar gate summary into the GitHub job summary when available
- keep the existing Sonar evidence file behavior intact
- refactor duplicated Sonar gate test mock setup while preserving coverage

## Scope
Changed files only:
- scripts/ci/sonar-check-run-gate.test.mjs
- scripts/sonar-check-run-gate.sh

Product/runtime/auth/proxy/schema/RLS/UI/tracker code is untouched.

## Local validation
- node --test scripts/ci/sonar-check-run-gate.test.mjs: passed, 2/2
- git diff --check origin/main...HEAD: passed
- pnpm repo:size:check: intentionally skipped because no tracked inventory/budget files changed and the diff is net-negative

## Risk
CI diagnostic summary behavior only. This does not weaken the Sonar gate, skip checks, loosen assertions, or change product behavior.
