### PR TITLE
fix(domain-claims): lock recovery prerequisite reads

### DIFF
--- a/packages/domain-claims/src/claims/lifecycle-state.test.ts
+++ b/packages/domain-claims/src/claims/lifecycle-state.test.ts
@@ -76,6 +76,7 @@ class FakeInsert {
 
 function makeTx(state: ClaimState): TransitionTx {
   return {
+    execute: async () => [authorizedRecoveryReadRow(state)],
     select: () => new FakeSelect(state),
     update: () => new FakeUpdate(state),
     insert: (table: unknown) => new FakeInsert(table),

--- a/packages/domain-claims/src/claims/recovery-invariant-evidence.test.ts
+++ b/packages/domain-claims/src/claims/recovery-invariant-evidence.test.ts
@@ -5,26 +5,38 @@ import { loadRecoveryInvariantReadRow } from './recovery-invariant-evidence';
 import type { TransitionTx } from './transition-side-effects';
 
 describe('loadRecoveryInvariantReadRow', () => {
-  it('loads current claim and evidence in one tenant-scoped query', async () => {
-    const calls: { joins: unknown[]; where?: unknown } = { joins: [] };
-    const row = {
-      claimId: 'claim-1',
-      lifecycleVersion: 4,
+  it('locks recovery prerequisite rows in order before loading the current claim', async () => {
+    const calls: { executedSql: string[]; where?: unknown } = { executedSql: [] };
+    const agreement = {
+      legalActionCapPercentage: 25,
+      paymentAuthorizationState: 'authorized',
+      signedAt: new Date('2026-03-11T09:00:00Z'),
+      successFeeAmount: '150.00',
+      successFeeCollectionMethod: 'payment_method_charge',
+      successFeeCurrencyCode: 'EUR',
+      successFeeHasStoredPaymentMethod: true,
+      successFeeResolvedAt: new Date('2026-03-13T09:00:00Z'),
+    };
+    const noFee = {
       noFeeDocumentedAt: new Date('2026-03-14T09:00:00Z'),
       noFeeDocumentedById: 'staff-1',
       noFeeReasonCode: 'no_recovery',
+    };
+    const current = {
+      lifecycleVersion: 4,
       status: 'negotiation',
     };
     const tx = {
+      execute: async (query: unknown) => {
+        const rendered = inspect(query, { depth: 20 });
+        calls.executedSql.push(rendered);
+        return rendered.includes('claim_escalation_agreements') ? [agreement] : [noFee];
+      },
       select: () => ({
         from: () => ({
-          leftJoin: (_table: unknown, condition: unknown) => {
-            calls.joins.push(condition);
-            return tx.select().from();
-          },
           where: (condition: unknown) => {
             calls.where = condition;
-            return { limit: async () => [row] };
+            return { limit: async () => [current] };
           },
         }),
       }),
@@ -32,19 +44,29 @@ describe('loadRecoveryInvariantReadRow', () => {
 
     await expect(
       loadRecoveryInvariantReadRow(tx as unknown as TransitionTx, {
+        claimId: 'claim-1',
         readWhere: { tenantId: 'tenant-1', claimId: 'claim-1' } as never,
         tenantId: 'tenant-1',
       })
     ).resolves.toEqual({
       current: { lifecycleVersion: 4, status: 'negotiation' },
-      evidence: row,
+      evidence: { claimId: 'claim-1', ...agreement, ...noFee },
     });
 
-    const joinedPredicates = inspect(calls.joins, { depth: 20 });
+    expect(calls.executedSql).toHaveLength(2);
+    expect(calls.executedSql[0]).toContain('claim_escalation_agreements');
+    expect(calls.executedSql[0].toLowerCase()).toContain('for update');
+    expect(calls.executedSql[0].toLowerCase()).toContain('order by');
+    expect(calls.executedSql[0]).toContain('updated_at');
+    expect(calls.executedSql[0]).toContain('tenant-1');
+    expect(calls.executedSql[0]).toContain('claim-1');
+    expect(calls.executedSql[1]).toContain('claim_recovery_no_fee_evidence');
+    expect(calls.executedSql[1].toLowerCase()).toContain('for update');
+    expect(calls.executedSql[1].toLowerCase()).toContain('order by');
+    expect(calls.executedSql[1]).toContain('updated_at');
+    expect(calls.executedSql[1]).toContain('tenant-1');
+    expect(calls.executedSql[1]).toContain('claim-1');
     const wherePredicate = inspect(calls.where, { depth: 20 });
-    expect(joinedPredicates).toContain('claim_escalation_agreements');
-    expect(joinedPredicates).toContain('claim_recovery_no_fee_evidence');
-    expect(joinedPredicates).toContain('tenant-1');
     expect(wherePredicate).toContain('tenant-1');
     expect(wherePredicate).toContain('claim-1');
   });

--- a/packages/domain-claims/src/claims/recovery-invariant-evidence.ts
+++ b/packages/domain-claims/src/claims/recovery-invariant-evidence.ts
@@ -1,10 +1,4 @@
-import {
-  and,
-  claimEscalationAgreements,
-  claimRecoveryNoFeeEvidence,
-  claims,
-  eq,
-} from '@interdomestik/database';
+import { claims, sql } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { SQL } from 'drizzle-orm';
 import type { TransitionTx } from './transition-side-effects';
@@ -20,56 +14,98 @@ export type RecoveryInvariantReadRow = {
   evidence: RecoveryInvariantEvidence | null;
 };
 
+type EscalationAgreementEvidence = Pick<
+  RecoveryInvariantEvidence,
+  | 'legalActionCapPercentage'
+  | 'paymentAuthorizationState'
+  | 'signedAt'
+  | 'successFeeAmount'
+  | 'successFeeCollectionMethod'
+  | 'successFeeCurrencyCode'
+  | 'successFeeDeductionAllowed'
+  | 'successFeeHasStoredPaymentMethod'
+  | 'successFeeInvoiceDueAt'
+  | 'successFeeRecoveredAmount'
+  | 'successFeeResolvedAt'
+  | 'successFeeSubscriptionId'
+>;
+type NoFeeEvidence = Pick<
+  RecoveryInvariantEvidence,
+  'noFeeDocumentedAt' | 'noFeeDocumentedById' | 'noFeeReasonCode'
+>;
+
+async function lockEscalationAgreementEvidence(
+  tx: TransitionTx,
+  params: { claimId: string; tenantId: string }
+): Promise<EscalationAgreementEvidence | undefined> {
+  const [row] = await tx.execute<EscalationAgreementEvidence>(sql`
+    select
+      "legal_action_cap_percentage" as "legalActionCapPercentage",
+      "payment_authorization_state" as "paymentAuthorizationState",
+      "signed_at" as "signedAt",
+      "success_fee_amount" as "successFeeAmount",
+      "success_fee_collection_method" as "successFeeCollectionMethod",
+      "success_fee_currency_code" as "successFeeCurrencyCode",
+      "success_fee_deduction_allowed" as "successFeeDeductionAllowed",
+      "success_fee_has_stored_payment_method" as "successFeeHasStoredPaymentMethod",
+      "success_fee_invoice_due_at" as "successFeeInvoiceDueAt",
+      "success_fee_recovered_amount" as "successFeeRecoveredAmount",
+      "success_fee_resolved_at" as "successFeeResolvedAt",
+      "success_fee_subscription_id" as "successFeeSubscriptionId"
+    from "claim_escalation_agreements"
+    where "tenant_id" = ${params.tenantId}
+      and "claim_id" = ${params.claimId}
+    order by "updated_at" desc, "id" desc
+    limit 1
+    for update
+  `);
+
+  return row;
+}
+
+async function lockNoFeeEvidence(
+  tx: TransitionTx,
+  params: { claimId: string; tenantId: string }
+): Promise<NoFeeEvidence | undefined> {
+  const [row] = await tx.execute<NoFeeEvidence>(sql`
+    select
+      "documented_at" as "noFeeDocumentedAt",
+      "documented_by_id" as "noFeeDocumentedById",
+      "reason_code" as "noFeeReasonCode"
+    from "claim_recovery_no_fee_evidence"
+    where "tenant_id" = ${params.tenantId}
+      and "claim_id" = ${params.claimId}
+    order by "updated_at" desc, "id" desc
+    limit 1
+    for update
+  `);
+
+  return row;
+}
+
 export async function loadRecoveryInvariantReadRow(
   tx: TransitionTx,
-  params: { readWhere: SQL; tenantId: string }
+  params: { claimId: string; readWhere: SQL; tenantId: string }
 ): Promise<RecoveryInvariantReadRow> {
-  const [row] = await tx
+  // Canonical recovery prerequisite lock order: agreement evidence, then no-fee evidence.
+  const agreement = await lockEscalationAgreementEvidence(tx, params);
+  const noFee = await lockNoFeeEvidence(tx, params);
+  const [current] = await tx
     .select({
-      claimId: claims.id,
       lifecycleVersion: claims.lifecycleVersion,
-      legalActionCapPercentage: claimEscalationAgreements.legalActionCapPercentage,
-      noFeeDocumentedAt: claimRecoveryNoFeeEvidence.documentedAt,
-      noFeeDocumentedById: claimRecoveryNoFeeEvidence.documentedById,
-      noFeeReasonCode: claimRecoveryNoFeeEvidence.reasonCode,
-      paymentAuthorizationState: claimEscalationAgreements.paymentAuthorizationState,
-      signedAt: claimEscalationAgreements.signedAt,
-      successFeeAmount: claimEscalationAgreements.successFeeAmount,
-      successFeeCollectionMethod: claimEscalationAgreements.successFeeCollectionMethod,
-      successFeeCurrencyCode: claimEscalationAgreements.successFeeCurrencyCode,
-      successFeeDeductionAllowed: claimEscalationAgreements.successFeeDeductionAllowed,
-      successFeeHasStoredPaymentMethod: claimEscalationAgreements.successFeeHasStoredPaymentMethod,
-      successFeeInvoiceDueAt: claimEscalationAgreements.successFeeInvoiceDueAt,
-      successFeeRecoveredAmount: claimEscalationAgreements.successFeeRecoveredAmount,
-      successFeeResolvedAt: claimEscalationAgreements.successFeeResolvedAt,
-      successFeeSubscriptionId: claimEscalationAgreements.successFeeSubscriptionId,
       status: claims.status,
     })
     .from(claims)
-    .leftJoin(
-      claimEscalationAgreements,
-      and(
-        eq(claimEscalationAgreements.tenantId, params.tenantId),
-        eq(claimEscalationAgreements.claimId, claims.id)
-      )
-    )
-    .leftJoin(
-      claimRecoveryNoFeeEvidence,
-      and(
-        eq(claimRecoveryNoFeeEvidence.tenantId, params.tenantId),
-        eq(claimRecoveryNoFeeEvidence.claimId, claims.id)
-      )
-    )
     .where(params.readWhere)
     .limit(1);
 
-  if (!row) return { current: undefined, evidence: null };
+  if (!current) return { current: undefined, evidence: null };
 
   return {
     current: {
-      lifecycleVersion: row.lifecycleVersion,
-      status: row.status,
+      lifecycleVersion: current.lifecycleVersion,
+      status: current.status,
     },
-    evidence: row,
+    evidence: { claimId: params.claimId, ...agreement, ...noFee },
   };
 }

--- a/packages/domain-claims/src/claims/transition-authorized-hook.test.ts
+++ b/packages/domain-claims/src/claims/transition-authorized-hook.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import {
+  type AuthorizedTransitionHookTx,
+  transitionClaimStatusInTransaction,
+  type TransitionClaimStatusParams,
+  type TransitionTx,
+} from './transition';
+import { authorizedRecoveryEvidence, makeTransitionTx } from './transition-test-support';
+
+type Params = TransitionClaimStatusParams;
+function makeParams(overrides: Partial<Params> = {}): Params {
+  return {
+    actor: { id: 'staff-1', role: 'staff' },
+    claimId: 'claim-1',
+    tenantId: 'tenant-1',
+    toStatus: 'negotiation',
+    ...overrides,
+  };
+}
+
+describe('transitionClaimStatusInTransaction authorized hook', () => {
+  it('types the pre-persist hook with transaction operations only', () => {
+    type HookHasTransaction = AuthorizedTransitionHookTx extends { transaction: unknown }
+      ? true
+      : false;
+
+    expectTypeOf<HookHasTransaction>().toEqualTypeOf<false>();
+    expectTypeOf<AuthorizedTransitionHookTx>().toMatchTypeOf<
+      Pick<TransitionTx, 'insert' | 'select' | 'update'>
+    >();
+  });
+
+  it('runs after recovery prerequisite locks and before the claim CAS using narrowed tx ops', async () => {
+    const { calls, tx } = makeTransitionTx({
+      current: { id: 'claim-1', lifecycleVersion: 6, status: 'evaluation' },
+      updated: [{ id: 'claim-1', lifecycleVersion: 7 }],
+    });
+
+    await transitionClaimStatusInTransaction(
+      tx,
+      makeParams({
+        beforePersistAuthorized: async hookTx => {
+          expect('execute' in hookTx).toBe(false);
+          expect('transaction' in hookTx).toBe(false);
+          calls.operations.push('hook:authorized');
+        },
+      })
+    );
+
+    expect(calls.operations.slice(0, 5)).toEqual([
+      'lock:agreement',
+      'lock:no-fee',
+      'select:current',
+      'hook:authorized',
+      'update:claim',
+    ]);
+    expect(calls.operations.indexOf('insert:history')).toBeGreaterThan(
+      calls.operations.indexOf('update:claim')
+    );
+  });
+
+  it('does not run when the transition guard rejects', async () => {
+    let hookRan = false;
+    const { calls, tx } = makeTransitionTx({
+      current: { id: 'claim-1', lifecycleVersion: 6, status: 'evaluation' },
+      evidence: { ...authorizedRecoveryEvidence, paymentAuthorizationState: 'pending' },
+      updated: [{ id: 'claim-1', lifecycleVersion: 7 }],
+    });
+
+    const result = await transitionClaimStatusInTransaction(
+      tx,
+      makeParams({
+        beforePersistAuthorized: async () => {
+          hookRan = true;
+        },
+      })
+    );
+
+    expect(result).toEqual({ success: false, error: 'transition_rejected' });
+    expect(hookRan).toBe(false);
+    expect(calls.updateValues).toBeUndefined();
+    expect(calls.historyValues).toBeUndefined();
+    expect(calls.eventValues).toBeUndefined();
+  });
+
+  it('does not persist status, history, or transition events when it fails', async () => {
+    const { calls, tx } = makeTransitionTx({
+      current: { id: 'claim-1', lifecycleVersion: 6, status: 'evaluation' },
+      updated: [{ id: 'claim-1', lifecycleVersion: 7 }],
+    });
+
+    const transition = transitionClaimStatusInTransaction(
+      tx,
+      makeParams({
+        beforePersistAuthorized: async () => {
+          throw new Error('recovery decision write failed');
+        },
+      })
+    );
+
+    await expect(transition).rejects.toThrow('recovery decision write failed');
+    expect(calls.updateValues).toBeUndefined();
+    expect(calls.historyValues).toBeUndefined();
+    expect(calls.eventValues).toBeUndefined();
+  });
+});

--- a/packages/domain-claims/src/claims/transition-events-test-support.ts
+++ b/packages/domain-claims/src/claims/transition-events-test-support.ts
@@ -93,6 +93,7 @@ function makeParams() {
 function makeTx(state: ClaimState, failOn?: FailOn) {
   const staged = { ...state, events: [...state.events], histories: [...state.histories] };
   const tx = {
+    execute: async () => [authorizedRecoveryReadRow(state)],
     select: () => new FakeSelect(state),
     update: () => new FakeUpdate(staged),
     insert: (table: unknown) => new FakeInsert(staged, table, failOn),

--- a/packages/domain-claims/src/claims/transition-read-context.ts
+++ b/packages/domain-claims/src/claims/transition-read-context.ts
@@ -36,6 +36,7 @@ export async function loadTransitionReadContext(
 
   if (needsRecoveryInvariantEvidence(params.toStatus)) {
     const row = await loadRecoveryInvariantReadRow(tx, {
+      claimId: params.claimId,
       readWhere,
       tenantId: params.tenantId,
     });

--- a/packages/domain-claims/src/claims/transition-rejection.test.ts
+++ b/packages/domain-claims/src/claims/transition-rejection.test.ts
@@ -8,6 +8,7 @@ import {
   transitionClaimStatusInTransaction,
   type TransitionTx,
 } from './transition';
+import { authorizedRecoveryReadRow } from './recovery-evidence-test-support';
 import { canTransition } from './transition-guard';
 
 type FakeTxCalls = {
@@ -47,6 +48,10 @@ class FakeInsertStep {
 
 class FakeTx {
   constructor(private readonly calls: FakeTxCalls) {}
+
+  async execute(): Promise<unknown[]> {
+    return [authorizedRecoveryReadRow({ lifecycleVersion: 1, status: 'draft' })];
+  }
 
   select() {
     return selectStep;

--- a/packages/domain-claims/src/claims/transition-side-effects.ts
+++ b/packages/domain-claims/src/claims/transition-side-effects.ts
@@ -7,6 +7,14 @@ import { recordTransitionDomainEvents } from './transition-domain-events';
 import type { CreateClaimValues } from '../validators/claims';
 
 export type TransitionTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+export type AuthorizedTransitionHookTx = Pick<TransitionTx, 'insert' | 'select' | 'update'>;
+export function authorizedTransitionHookTx(tx: TransitionTx): AuthorizedTransitionHookTx {
+  return {
+    insert: tx.insert.bind(tx),
+    select: tx.select.bind(tx),
+    update: tx.update.bind(tx),
+  };
+}
 export type TransitionSideEffectsArgs = {
   actor: ClaimTransitionActor;
   claimId: string;
@@ -42,6 +50,7 @@ export class ClaimTransitionAuthorizationError extends Error {
 }
 export type TransitionClaimStatusParams = {
   actor: ClaimTransitionActor;
+  beforePersistAuthorized?: (tx: AuthorizedTransitionHookTx) => Promise<void>;
   claimId: string;
   correlationId?: string;
   isPublic?: boolean;

--- a/packages/domain-claims/src/claims/transition-test-support.ts
+++ b/packages/domain-claims/src/claims/transition-test-support.ts
@@ -1,3 +1,5 @@
+import { inspect } from 'node:util';
+
 import { domainEvents } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { RecoveryInvariantEvidence } from './recovery-invariants';
@@ -10,8 +12,12 @@ type TransitionTxOptions = {
   updated?: UpdatedRows | (() => UpdatedRows);
 };
 type TransitionTxCalls = {
+  executedSql: string[];
+  eventWriteCount: number;
   eventValues?: unknown;
+  historyWriteCount: number;
   historyValues?: unknown;
+  operations: string[];
   updateValues?: Record<string, unknown>;
   whereConditions: unknown[];
 };
@@ -24,7 +30,6 @@ export const authorizedRecoveryEvidence: RecoveryInvariantEvidence = {
 };
 
 class FakeSelect {
-  private joined = false;
   constructor(
     private readonly options: TransitionTxOptions,
     private readonly calls: TransitionTxCalls
@@ -33,7 +38,6 @@ class FakeSelect {
     return this;
   }
   leftJoin(): this {
-    this.joined = true;
     return this;
   }
   where(condition: unknown): this {
@@ -41,20 +45,9 @@ class FakeSelect {
     return this;
   }
   async limit(): Promise<Record<string, unknown>[]> {
-    if (!this.joined) return this.options.current ? [this.options.current] : [];
     if (!this.options.current) return [];
-
-    const evidence =
-      this.options.evidence === null ? {} : (this.options.evidence ?? authorizedRecoveryEvidence);
-
-    return [
-      {
-        claimId: this.options.current.id,
-        lifecycleVersion: this.options.current.lifecycleVersion,
-        status: this.options.current.status,
-        ...evidence,
-      },
-    ];
+    this.calls.operations.push('select:current');
+    return [this.options.current];
   }
 }
 
@@ -67,6 +60,7 @@ class FakeUpdate {
   set(values: Record<string, unknown>): this {
     this.values = values;
     this.calls.updateValues = values;
+    this.calls.operations.push('update:claim');
     return this;
   }
   where(condition: unknown): this {
@@ -86,15 +80,43 @@ class FakeInsert {
     private readonly calls: TransitionTxCalls
   ) {}
   values(values: Record<string, unknown>) {
-    if (this.table === domainEvents) this.calls.eventValues = values;
-    else this.calls.historyValues = values;
+    if (this.table === domainEvents) {
+      this.calls.eventValues = values;
+      this.calls.eventWriteCount += 1;
+      this.calls.operations.push('insert:event');
+    } else {
+      this.calls.historyValues = values;
+      this.calls.historyWriteCount += 1;
+      this.calls.operations.push('insert:history');
+    }
     return { returning: async () => [{ id: values.id }] };
   }
 }
 
 export function makeTransitionTx(options: TransitionTxOptions) {
-  const calls: TransitionTxCalls = { whereConditions: [] };
+  const calls: TransitionTxCalls = {
+    eventWriteCount: 0,
+    executedSql: [],
+    historyWriteCount: 0,
+    operations: [],
+    whereConditions: [],
+  };
+  const evidence =
+    options.evidence === null ? null : (options.evidence ?? authorizedRecoveryEvidence);
   const tx = {
+    execute: async (query: unknown) => {
+      const rendered = String(inspect(query, { depth: 20 }));
+      calls.executedSql.push(rendered);
+      if (rendered.includes('claim_escalation_agreements')) {
+        calls.operations.push('lock:agreement');
+        return evidence ? [evidence] : [];
+      }
+      if (rendered.includes('claim_recovery_no_fee_evidence')) {
+        calls.operations.push('lock:no-fee');
+        return evidence?.noFeeReasonCode ? [evidence] : [];
+      }
+      return [];
+    },
     insert: (table: unknown) => new FakeInsert(table, calls),
     select: () => new FakeSelect(options, calls),
     update: () => new FakeUpdate(options, calls),

--- a/packages/domain-claims/src/claims/transition.test.ts
+++ b/packages/domain-claims/src/claims/transition.test.ts
@@ -66,7 +66,7 @@ describe('transitionClaimStatusInTransaction', () => {
   });
   it('lets exactly one same-version transition win', async () => {
     let claimed = false;
-    const { tx } = makeTransitionTx({
+    const { calls, tx } = makeTransitionTx({
       current: { id: 'claim-1', lifecycleVersion: 6, status: 'evaluation' },
       updated: () => {
         if (claimed) return [];
@@ -85,6 +85,8 @@ describe('transitionClaimStatusInTransaction', () => {
     expect(results.find(result => result.status === 'rejected')).toEqual(
       expect.objectContaining({ reason: expect.any(ClaimTransitionConflictError) })
     );
+    expect(calls.historyWriteCount).toBe(1);
+    expect(calls.eventWriteCount).toBe(3);
   });
 
   it('rejects payment-gated transitions without signed authorized evidence before updating', async () => {

--- a/packages/domain-claims/src/claims/transition.ts
+++ b/packages/domain-claims/src/claims/transition.ts
@@ -5,6 +5,7 @@ import { loadTransitionReadContext } from './transition-read-context';
 import {
   ClaimTransitionAuthorizationError,
   ClaimTransitionConflictError,
+  authorizedTransitionHookTx,
   recordTransitionSideEffects,
   type PersistAuthorizedTransitionArgs,
   type TransitionClaimStatusParams,
@@ -87,6 +88,7 @@ export async function transitionClaimStatusInTransaction(
 ): Promise<TransitionClaimStatusResult> {
   const {
     actor,
+    beforePersistAuthorized,
     claimId,
     correlationId,
     isPublic = true,
@@ -112,6 +114,12 @@ export async function transitionClaimStatusInTransaction(
     to: toStatus,
   });
   if (!decision.allowed) return { success: false, error: 'transition_rejected' };
+
+  if (beforePersistAuthorized) {
+    // Pre-CAS hooks are only for already-authorized prerequisite writes.
+    // They must respect the global order: agreement, no-fee evidence, claims CAS.
+    await beforePersistAuthorized(authorizedTransitionHookTx(tx));
+  }
 
   const { lifecycleVersion } = await persistAuthorizedTransition(tx, {
     actor,

--- a/packages/domain-claims/src/staff-claims/recovery-decision-record.test.ts
+++ b/packages/domain-claims/src/staff-claims/recovery-decision-record.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ClaimsSession } from '../claims/types';
 import { upsertRecoveryDecisionRecord } from './recovery-decision-record';
 
+type RecoveryDecisionTx = Parameters<typeof upsertRecoveryDecisionRecord>[0]['tx'];
+
+function recoveryDecisionTx(tx: unknown): RecoveryDecisionTx {
+  return tx as RecoveryDecisionTx;
+}
+
 const mocks = vi.hoisted(() => ({
   appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
   eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
@@ -60,7 +66,7 @@ describe('upsertRecoveryDecisionRecord', () => {
       explanation: 'Declined after review',
       session,
       tenantId: 'tenant-1',
-      tx: tx as unknown as Parameters<typeof upsertRecoveryDecisionRecord>[0]['tx'],
+      tx: recoveryDecisionTx(tx),
     });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -99,7 +105,7 @@ describe('upsertRecoveryDecisionRecord', () => {
       explanation: 'Accepted after review',
       session,
       tenantId: 'tenant-1',
-      tx: tx as unknown as Parameters<typeof upsertRecoveryDecisionRecord>[0]['tx'],
+      tx: recoveryDecisionTx(tx),
     });
 
     expect(tx.insert).not.toHaveBeenCalled();

--- a/packages/domain-claims/src/staff-claims/recovery-decision-record.test.ts
+++ b/packages/domain-claims/src/staff-claims/recovery-decision-record.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ClaimsSession } from '../claims/types';
+import { upsertRecoveryDecisionRecord } from './recovery-decision-record';
+
+const mocks = vi.hoisted(() => ({
+  appendEvent: vi.fn().mockResolvedValue({ id: 'event-1' }),
+  eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
+  withTenant: vi.fn((_tenantId, _column, condition) => ({ scoped: true, condition })),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  appendEvent: mocks.appendEvent,
+  claimEscalationAgreements: {
+    acceptedAt: 'claim_escalation_agreements.accepted_at',
+    acceptedById: 'claim_escalation_agreements.accepted_by_id',
+    claimId: 'claim_escalation_agreements.claim_id',
+    createdAt: 'claim_escalation_agreements.created_at',
+    decisionReason: 'claim_escalation_agreements.decision_reason',
+    decisionType: 'claim_escalation_agreements.decision_type',
+    declineReasonCode: 'claim_escalation_agreements.decline_reason_code',
+    id: 'claim_escalation_agreements.id',
+    tenantId: 'claim_escalation_agreements.tenant_id',
+    updatedAt: 'claim_escalation_agreements.updated_at',
+  },
+  db: {
+    insert: vi.fn(),
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+  eq: mocks.eq,
+}));
+vi.mock('@interdomestik/database/tenant-security', () => ({
+  withTenant: mocks.withTenant,
+}));
+
+const session = {
+  user: { id: 'staff-1', role: 'staff', tenantId: 'tenant-1' },
+} as unknown as ClaimsSession;
+
+describe('upsertRecoveryDecisionRecord', () => {
+  it('appends the recovery decision event through the passed transaction', async () => {
+    const insertValues = vi.fn();
+    const tx = {
+      insert: vi.fn(() => ({ values: insertValues })),
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [],
+          }),
+        }),
+      })),
+      update: vi.fn(),
+    };
+
+    await upsertRecoveryDecisionRecord({
+      claimId: 'claim-1',
+      decisionType: 'declined',
+      declineReasonCode: 'no_monetary_recovery_path',
+      explanation: 'Declined after review',
+      session,
+      tenantId: 'tenant-1',
+      tx: tx as unknown as Parameters<typeof upsertRecoveryDecisionRecord>[0]['tx'],
+    });
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        claimId: 'claim-1',
+        decisionType: 'declined',
+        tenantId: 'tenant-1',
+      })
+    );
+    expect(mocks.appendEvent).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        eventName: 'recovery.decision_recorded',
+        tenantId: 'tenant-1',
+      })
+    );
+  });
+
+  it('updates an existing recovery decision through the passed transaction', async () => {
+    const updateSet = vi.fn(() => ({ where: vi.fn() }));
+    const tx = {
+      insert: vi.fn(),
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [{ id: 'agreement-1' }],
+          }),
+        }),
+      })),
+      update: vi.fn(() => ({ set: updateSet })),
+    };
+
+    await upsertRecoveryDecisionRecord({
+      claimId: 'claim-1',
+      decisionType: 'accepted',
+      explanation: 'Accepted after review',
+      session,
+      tenantId: 'tenant-1',
+      tx: tx as unknown as Parameters<typeof upsertRecoveryDecisionRecord>[0]['tx'],
+    });
+
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decisionReason: 'Accepted after review',
+        decisionType: 'accepted',
+      })
+    );
+    expect(mocks.appendEvent).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ eventName: 'recovery.decision_recorded' })
+    );
+  });
+});

--- a/packages/domain-claims/src/staff-claims/update-status.test.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.test.ts
@@ -75,6 +75,22 @@ const mocks = vi.hoisted(() => {
   const serviceUsageExistsSelectChain = createSelectChain();
   const serviceUsageCountSelectChain = createSelectChain();
   const txSelectChain = createSelectChain();
+  const txExecute = vi.fn(async query => {
+    const rendered = JSON.stringify(query).toLowerCase();
+    if (rendered.includes('claim_escalation_agreements') && rendered.includes('for update')) {
+      return [
+        {
+          legalActionCapPercentage: 25,
+          paymentAuthorizationState: 'authorized',
+          signedAt: new Date('2026-03-11T09:00:00Z'),
+        },
+      ];
+    }
+    if (rendered.includes('claim_recovery_no_fee_evidence') && rendered.includes('for update')) {
+      return [];
+    }
+    throw new Error(`unexpected recovery lock query: ${rendered}`);
+  });
   const txInsertReturning = vi.fn();
   const txInsertOnConflictDoNothing = vi.fn(() => ({ returning: txInsertReturning }));
   const txInsertValues = vi.fn(() => ({
@@ -87,11 +103,7 @@ const mocks = vi.hoisted(() => {
   const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
   const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
   const transaction = vi.fn(async cb =>
-    cb({
-      insert: txInsert,
-      select: txSelect,
-      update: txUpdate,
-    })
+    cb({ execute: txExecute, insert: txInsert, select: txSelect, update: txUpdate })
   );
   return {
     db: {
@@ -192,6 +204,7 @@ const mocks = vi.hoisted(() => {
     serviceUsageExistsSelectChain,
     serviceUsageCountSelectChain,
     txInsert,
+    txExecute,
     txSelect,
     txSelectChain,
     txInsertOnConflictDoNothing,
@@ -340,27 +353,12 @@ describe('staff updateClaimStatusCore', () => {
     mocks.serviceUsageExistsSelectChain.where.mockReturnValue(mocks.serviceUsageExistsSelectChain);
     mocks.serviceUsageCountSelectChain.from.mockReturnValue(mocks.serviceUsageCountSelectChain);
     mocks.serviceUsageCountSelectChain.where.mockReturnValue(mocks.serviceUsageCountSelectChain);
-    let joinedTransitionEvidence = false;
-    mocks.txSelectChain.from.mockImplementation(() => {
-      joinedTransitionEvidence = false;
-      return mocks.txSelectChain;
-    });
-    mocks.txSelectChain.leftJoin.mockImplementation(() => {
-      joinedTransitionEvidence = true;
-      return mocks.txSelectChain;
-    });
+    mocks.txSelectChain.from.mockReturnValue(mocks.txSelectChain);
+    mocks.txSelectChain.leftJoin.mockReturnValue(mocks.txSelectChain);
     mocks.txSelectChain.where.mockReturnValue(mocks.txSelectChain);
-    mocks.txSelectChain.limit.mockImplementation(async () =>
-      joinedTransitionEvidence
-        ? [
-            {
-              ...READY_ACCEPTED_RECOVERY_RECORD,
-              lifecycleVersion: 1,
-              status: 'evaluation',
-            },
-          ]
-        : [{ id: 'claim-1', lifecycleVersion: 1, status: 'evaluation' }]
-    );
+    mocks.txSelectChain.limit.mockResolvedValue([
+      { id: 'claim-1', lifecycleVersion: 1, status: 'evaluation' },
+    ]);
     mocks.txInsertReturning.mockResolvedValue([{ id: 'usage-claim-1' }]);
     mocks.txUpdateReturning.mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 2 }]);
     mocks.projectClaimStatusAuditProjection.mockResolvedValue(undefined);

--- a/packages/domain-claims/src/staff-claims/update-status.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.ts
@@ -34,7 +34,10 @@ import {
   resolveScopedStaffClaimAccess,
   STAFF_SCOPE_ACCESS_DENIED_ERROR,
 } from './scope';
-import { transitionClaimStatusInTransaction } from '../claims/transition';
+import {
+  transitionClaimStatusInTransaction,
+  type AuthorizedTransitionHookTx,
+} from '../claims/transition';
 
 type StaffScopeWhere = ReturnType<typeof buildScopedStaffClaimWhere>;
 
@@ -229,11 +232,7 @@ async function handleStaffLedRecoveryStatusChange(
   }
 
   return finalizeClaimStatusChange({
-    auditMetadata: {
-      allowanceOverrideReason: trimmedAllowanceOverrideReason,
-      matterConsumptionServiceCode: matterServiceCode,
-    },
-    beforePersist: async tx => {
+    afterTransitionPersisted: async tx => {
       if (alreadyConsumedForClaim) {
         return;
       }
@@ -270,11 +269,7 @@ async function handleStaffLedRecoveryStatusChange(
   });
 }
 
-type ClaimsTransaction = {
-  insert: typeof db.insert;
-  select: typeof db.select;
-  update: typeof db.update;
-};
+type ClaimsTransaction = AuthorizedTransitionHookTx;
 
 async function assignClaimToActingStaffIfUnassigned(params: {
   currentStaffId: string | null;
@@ -345,8 +340,8 @@ function scheduleStatusChangeNotification(params: {
 }
 
 async function finalizeClaimStatusChange(params: {
-  auditMetadata?: Record<string, boolean | string | undefined>;
-  beforePersist?: (tx: ClaimsTransaction) => Promise<void>;
+  afterTransitionPersisted?: (tx: ClaimsTransaction) => Promise<void>;
+  beforePersistAuthorized?: (tx: AuthorizedTransitionHookTx) => Promise<void>;
   claimId: string;
   currentStatus: ClaimStatus | null;
   currentStaffId: string | null;
@@ -361,7 +356,7 @@ async function finalizeClaimStatusChange(params: {
   status: ClaimStatus;
   tenantId: string;
 }): Promise<ActionResult> {
-  const { beforePersist, ...rest } = params;
+  const { afterTransitionPersisted, beforePersistAuthorized, ...rest } = params;
 
   // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
   const transitionResult = await db.transaction(async tx => {
@@ -375,6 +370,7 @@ async function finalizeClaimStatusChange(params: {
         requiredWhereCondition: rest.staffScopeWhere,
         tenantId: rest.tenantId,
         toStatus: rest.status,
+        beforePersistAuthorized,
       }
     );
 
@@ -382,8 +378,8 @@ async function finalizeClaimStatusChange(params: {
       return result;
     }
 
-    if (beforePersist) {
-      await beforePersist(tx);
+    if (afterTransitionPersisted) {
+      await afterTransitionPersisted(tx);
     }
 
     await assignClaimToActingStaffIfUnassigned({
@@ -504,13 +500,7 @@ export async function updateClaimStatusCore(
         trimmedNote || getRecoveryDeclineMemberDescription(params.declineReasonCode);
 
       return finalizeClaimStatusChange({
-        auditMetadata: {
-          decisionNextStatus: 'rejected',
-          declineReasonCode: params.declineReasonCode,
-          decisionReason: trimmedDecisionExplanation,
-          decisionType: 'declined',
-        },
-        beforePersist: async tx => {
+        beforePersistAuthorized: async tx => {
           await upsertRecoveryDecisionRecord({
             claimId,
             decisionType: 'declined',

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36080302,
-  "maxTrackedFiles": 4280,
+  "maxTrackedBytes": 36109998,
+  "maxTrackedFiles": 4282,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17871719,
-    "source/scripts": 6749193,
-    "docs/text": 5153820,
-    "tests/e2e": 4636204,
+    "large support/generated-ish": 17885752,
+    "source/scripts": 6751445,
+    "docs/text": 5158344,
+    "tests/e2e": 4645091,
     "config/data/messages": 1540201,
     "other": 129165
   },
-  "maxLargestFileBytes": 2964765,
+  "maxLargestFileBytes": 2978798,
   "maxSourceOrTestLines": 3000
 }


### PR DESCRIPTION
## Summary
- Locks mutable recovery prerequisite evidence inside the claim transition transaction before the final claim lifecycle CAS.
- Adds the pre-CAS `beforePersistAuthorized` hook for the staff rejected-status recovery-decision path only, using the same transition transaction.
- Moves non-prerequisite post-persist staff side effects behind `afterTransitionPersisted` and keeps service usage post-CAS.

## Changed areas
- `packages/domain-claims/src/claims/**`: ordered recovery prerequisite lock/read helper, transition pre-CAS hook, focused transition/concurrency tests, shared test support updates.
- `packages/domain-claims/src/staff-claims/**`: staff rejected-status call site moved to direct same-tx `upsertRecoveryDecisionRecord`, focused recovery-decision event tests, existing update-status tests adjusted.
- `scripts/repo-size-budget.json`: refreshed for the added focused tests/support inventory.

## Lock-order and transaction evidence
- Recovery prerequisite reads use two separate ordered PostgreSQL `FOR UPDATE` statements: `claim_escalation_agreements` first, then `claim_recovery_no_fee_evidence`.
- The final `claims` lifecycle CAS remains the one-transition-wins guard after prerequisite locks and validation.
- `beforePersistAuthorized(tx)` runs after `canTransition(...)` allows and before `persistAuthorizedTransition(...)` updates `claims`.
- Staff rejected-status recovery-decision closure calls `upsertRecoveryDecisionRecord({ ..., tx })` directly with the same outer transition tx; it does not call `saveRecoveryDecisionCore(...)`.
- `upsertRecoveryDecisionRecord(...)` passes `params.tx` into `appendEvent(...)`; `appendEvent(...)` writes with `tx.insert(domainEvents)`, so the recovery-decision row/event, claim CAS, history, and transition event commit or roll back atomically.
- Concurrent same-claim proof covers one winner and no loser history/event.

## Verification
- Focused proof: `pnpm --filter @interdomestik/domain-claims type-check` passed.
- Focused proof: `pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/transition.test.ts src/claims/transition-authorized-hook.test.ts src/claims/recovery-invariant-evidence.test.ts src/staff-claims/recovery-decision-record.test.ts src/staff-claims/update-status.test.ts` passed, 5 files / 30 tests.
- `pnpm check:modularity-guard` passed.
- `git diff --check` passed.
- `node scripts/repo-size-budget-sync.mjs` and `pnpm repo:size:check` passed.
- `pnpm slice:verify` passed.
- `pnpm pr:verify` passed, including PR E2E lane `136 passed, 8 skipped` and smoke lane `13 passed, 9 skipped`.
- `pnpm security:guard` passed.
- `pnpm e2e:gate` passed, `136 passed, 8 skipped`.

## Reviewer disposition
- Sonnet post-diff route blocked by reviewer no-output timeout: `tmp/reviewer-routes/20260618T194824-sonnet.json/.md`, exit 143, elapsed 300571ms.
- Gemini fallback/second signal ran on the final stabilized diff: `tmp/reviewer-routes/20260618T212503-gemini.json/.md`, exit 0, elapsed 94662ms, no blockers.
- Gemini noted a non-blocking Drizzle `.for('update')` style option; this PR keeps explicit ordered raw SQL because the approved design requires two separate lock statements and tests assert the exact order.

## Local Docker parity blocker
- `pnpm ci:local:pr` was blocked before repo install/tests by local Docker/Corepack/undici tooling.
- Failure occurred during `pnpm install --frozen-lockfile --prefer-offline`; Node/undici threw `AssertionError [ERR_ASSERTION]: assert(!this.paused)` under Node v24.17.0.
- Classified as local tooling/resource blocker, not product logic. `ci:local:full` would hit the same pre-test Docker/Corepack path.

## Protected path audit
- No `apps/web/src/proxy.ts` changes.
- No route, clarity marker, README, AGENTS.md, `docs/plans`, slice-runner skill, or broad architecture-doc changes.
- No schema, billing provider, T-205/T-209/T-503/M3+ scope.

## Rollback / mitigation
- Roll back this commit to restore the prior transition flow and unlocked prerequisite reads.
- If production contention reveals unexpected lock waits, narrow mitigation is to temporarily revert the pre-CAS prerequisite lock helper and staff rejected-status hook move while preserving existing lifecycle CAS behavior.

## Residual risk
- Local Docker parity remains unproven due the Corepack/undici blocker, with host gates and focused domain coverage green.
- Locking is intentionally scoped to current positive-existence/value recovery invariants; absence-dependent phantom prevention remains out of scope unless a future invariant requires it.

## Scores
- Baseline maturity score: 8.6/10.
- CI discipline score: 8.8/10.

## Process lessons carried forward
- Durable acceptance evidence must be inventoried before coding.
- Current-head PR feedback and reviewer route state must be current for the final diff.
- Legacy oversized tests should shrink or move new coverage into focused files.
- Resource blockers must be classified with the exact failing command and pre-test/product boundary.