### PR TITLE
test: cover T-205 state machine transitions

### DIFF
--- a/packages/domain-claims/src/claims/case-state-machine.test.ts
+++ b/packages/domain-claims/src/claims/case-state-machine.test.ts
@@ -1,0 +1,88 @@
+import { CLAIM_STATUSES, type ClaimStatus } from '@interdomestik/database/constants';
+import { mapCaseStatusToLifecycleState } from '@interdomestik/domain-case';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALLOWED_CLAIM_STATUS_TRANSITIONS,
+  canTransition,
+  isClaimStatusTransitionInGraph,
+} from './transition-guard';
+
+const actor = { id: 'staff-1', role: 'staff' };
+
+const EXPECTED_CASE_STATES = {
+  draft: 'draft',
+  submitted: 'submitted',
+  verification: 'verification',
+  evaluation: 'evaluation',
+  negotiation: 'recovery',
+  court: 'recovery',
+  resolved: 'resolved',
+  rejected: 'rejected',
+} as const satisfies Record<ClaimStatus, ReturnType<typeof mapCaseStatusToLifecycleState>>;
+
+const EXPECTED_GRAPH = {
+  draft: ['submitted'],
+  submitted: ['verification', 'evaluation', 'rejected'],
+  verification: ['evaluation', 'submitted'],
+  evaluation: ['negotiation', 'verification', 'rejected', 'resolved'],
+  negotiation: ['court', 'resolved', 'evaluation', 'rejected'],
+  court: ['resolved', 'rejected', 'negotiation'],
+  resolved: ['evaluation', 'negotiation'],
+  rejected: ['evaluation', 'submitted'],
+} as const satisfies Record<ClaimStatus, readonly ClaimStatus[]>;
+
+function transitionIsAllowed(from: ClaimStatus, to: ClaimStatus): boolean {
+  return from === to || (EXPECTED_GRAPH[from] as readonly ClaimStatus[]).includes(to);
+}
+
+const allPairs = CLAIM_STATUSES.flatMap(from => CLAIM_STATUSES.map(to => [from, to] as const));
+const allowedPairs = allPairs.filter(([from, to]) => transitionIsAllowed(from, to));
+const rejectedPairs = allPairs.filter(([from, to]) => !transitionIsAllowed(from, to));
+
+describe('T-205 case state machine transitions', () => {
+  it('pins the explicit case transition graph', () => {
+    expect(ALLOWED_CLAIM_STATUS_TRANSITIONS).toEqual(EXPECTED_GRAPH);
+  });
+
+  it.each(CLAIM_STATUSES)('maps %s to the authoritative case lifecycle state', status => {
+    expect(mapCaseStatusToLifecycleState(status)).toBe(EXPECTED_CASE_STATES[status]);
+  });
+
+  it.each(allowedPairs)('allows case edge %s -> %s', (from, to) => {
+    const decision = canTransition({
+      actor,
+      context: { paymentAuthorizationState: 'authorized' },
+      from,
+      to,
+    });
+
+    expect(isClaimStatusTransitionInGraph(from, to)).toBe(true);
+    expect(mapCaseStatusToLifecycleState(to)).toBe(EXPECTED_CASE_STATES[to]);
+    expect(decision).toMatchObject({ allowed: true });
+    if (decision.allowed)
+      expect(decision.authorization).toMatchObject({ actorId: actor.id, from, to });
+  });
+
+  it.each(rejectedPairs)('rejects illegal case edge %s -> %s with a typed reason', (from, to) => {
+    expect(isClaimStatusTransitionInGraph(from, to)).toBe(false);
+    expect(
+      canTransition({
+        actor,
+        context: { paymentAuthorizationState: 'authorized' },
+        from,
+        to,
+      })
+    ).toEqual({ allowed: false, reason: 'illegal_transition' });
+  });
+
+  it('rejects invalid runtime statuses with a typed reason', () => {
+    expect(
+      canTransition({
+        actor,
+        from: 'not-a-status' as ClaimStatus,
+        to: 'submitted',
+      })
+    ).toEqual({ allowed: false, reason: 'invalid_status' });
+  });
+});

--- a/packages/domain-claims/src/claims/recovery-state-machine.test.ts
+++ b/packages/domain-claims/src/claims/recovery-state-machine.test.ts
@@ -1,0 +1,135 @@
+import { CLAIM_STATUSES, type ClaimStatus } from '@interdomestik/database/constants';
+import { mapRecoveryStatusToLifecycleState } from '@interdomestik/domain-recovery';
+import { describe, expect, it } from 'vitest';
+
+import { evaluateRecoveryInvariants, type RecoveryInvariantEvidence } from './recovery-invariants';
+import { transitionClaimStatusInTransaction } from './transition';
+import { authorizedRecoveryEvidence, makeTransitionTx } from './transition-test-support';
+import { canTransition } from './transition-guard';
+
+const actor = { id: 'staff-1', role: 'staff' };
+
+const EXPECTED_RECOVERY_STATES = {
+  draft: 'not_started',
+  submitted: 'not_started',
+  verification: 'not_started',
+  evaluation: 'not_started',
+  negotiation: 'negotiation',
+  court: 'court',
+  resolved: 'resolved',
+  rejected: 'closed',
+} as const satisfies Record<ClaimStatus, ReturnType<typeof mapRecoveryStatusToLifecycleState>>;
+
+const successFeeEvidence: RecoveryInvariantEvidence = {
+  ...authorizedRecoveryEvidence,
+  successFeeAmount: '150.00',
+  successFeeCollectionMethod: 'payment_method_charge',
+  successFeeCurrencyCode: 'EUR',
+  successFeeDeductionAllowed: false,
+  successFeeHasStoredPaymentMethod: true,
+  successFeeRecoveredAmount: '1000.00',
+  successFeeResolvedAt: new Date('2026-03-13T09:00:00Z'),
+  successFeeSubscriptionId: 'sub-1',
+};
+
+const noFeeEvidence: RecoveryInvariantEvidence = {
+  ...authorizedRecoveryEvidence,
+  noFeeDocumentedAt: new Date('2026-03-14T09:00:00Z'),
+  noFeeDocumentedById: 'staff-1',
+  noFeeReasonCode: 'no_recovery',
+};
+
+describe('T-205 recovery state machine transitions', () => {
+  it.each(CLAIM_STATUSES)('maps %s to the authoritative recovery lifecycle state', status => {
+    expect(mapRecoveryStatusToLifecycleState(status)).toBe(EXPECTED_RECOVERY_STATES[status]);
+  });
+
+  it.each([
+    ['evaluation', 'negotiation', 'negotiation'],
+    ['negotiation', 'court', 'court'],
+    ['negotiation', 'resolved', 'resolved'],
+    ['court', 'resolved', 'resolved'],
+    ['court', 'rejected', 'closed'],
+    ['negotiation', 'rejected', 'closed'],
+  ] satisfies Array<[ClaimStatus, ClaimStatus, string]>)(
+    'allows recovery edge %s -> %s and lands in %s',
+    (from, to, lifecycleState) => {
+      expect(
+        canTransition({
+          actor,
+          context: { paymentAuthorizationState: 'authorized' },
+          from,
+          to,
+        })
+      ).toMatchObject({ allowed: true });
+      expect(mapRecoveryStatusToLifecycleState(to)).toBe(lifecycleState);
+    }
+  );
+
+  it.each([
+    ['negotiation', {}, 'signed_agreement_authorization_required'],
+    [
+      'court',
+      { ...authorizedRecoveryEvidence, legalActionCapPercentage: null },
+      'legal_action_cap_required',
+    ],
+    ['resolved', authorizedRecoveryEvidence, 'success_fee_or_no_fee_required'],
+  ] satisfies Array<[ClaimStatus, RecoveryInvariantEvidence | Record<string, never>, string]>)(
+    'asserts typed recovery invariant rejection for %s',
+    (toStatus, evidence, reason) => {
+      const rejection = evaluateRecoveryInvariants({
+        evidence: { claimId: 'claim-1', ...evidence },
+        toStatus,
+      });
+
+      expect(rejection).toBe(reason);
+      expect(
+        canTransition({
+          actor,
+          context: {
+            paymentAuthorizationState: 'authorized',
+            recoveryInvariantRejection: rejection,
+          },
+          from: toStatus === 'negotiation' ? 'evaluation' : 'negotiation',
+          to: toStatus,
+        })
+      ).toEqual({ allowed: false, reason });
+    }
+  );
+
+  it.each([
+    ['resolved', successFeeEvidence],
+    ['resolved', noFeeEvidence],
+  ] satisfies Array<[ClaimStatus, RecoveryInvariantEvidence]>)(
+    'allows %s when required recovery evidence exists',
+    (toStatus, evidence) => {
+      expect(evaluateRecoveryInvariants({ evidence, toStatus })).toBeNull();
+    }
+  );
+
+  it.each([
+    ['resolved', null],
+    ['negotiation', { ...authorizedRecoveryEvidence, paymentAuthorizationState: 'pending' }],
+  ] satisfies Array<[ClaimStatus, RecoveryInvariantEvidence | null]>)(
+    'keeps command rejection generic and side-effect free for %s',
+    async (toStatus, evidence) => {
+      const { calls, tx } = makeTransitionTx({
+        current: { id: 'claim-1', lifecycleVersion: 1, status: 'evaluation' },
+        evidence,
+        updated: [{ id: 'claim-1', lifecycleVersion: 2 }],
+      });
+
+      await expect(
+        transitionClaimStatusInTransaction(tx, {
+          actor,
+          claimId: 'claim-1',
+          tenantId: 'tenant-1',
+          toStatus,
+        })
+      ).resolves.toEqual({ success: false, error: 'transition_rejected' });
+      expect(calls.updateValues).toBeUndefined();
+      expect(calls.historyValues).toBeUndefined();
+      expect(calls.eventValues).toBeUndefined();
+    }
+  );
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36109998,
-  "maxTrackedFiles": 4282,
+  "maxTrackedBytes": 36132252,
+  "maxTrackedFiles": 4284,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17885752,
+    "large support/generated-ish": 17894707,
     "source/scripts": 6751445,
-    "docs/text": 5158344,
-    "tests/e2e": 4645091,
+    "docs/text": 5163641,
+    "tests/e2e": 4653093,
     "config/data/messages": 1540201,
     "other": 129165
   },
-  "maxLargestFileBytes": 2978798,
+  "maxLargestFileBytes": 2987753,
   "maxSourceOrTestLines": 3000
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36132252,
+  "maxTrackedBytes": 36132306,
   "maxTrackedFiles": 4284,
   "maxCategoryBytes": {
     "large support/generated-ish": 17894707,
     "source/scripts": 6751445,
     "docs/text": 5163641,
-    "tests/e2e": 4653093,
+    "tests/e2e": 4653147,
     "config/data/messages": 1540201,
     "other": 129165
   },


### PR DESCRIPTION
## Summary

Implements the approved test-only T-205 slice: state-machine transition test suites for the current case and recovery lifecycle behavior.

Current-authority note: `next-slice.mjs` / `workflow-scorecard.mjs` still report `blocked_requires_current_authority` because they see umbrella `ARCH-FINAL`; this branch proceeds under the explicit post-T-203b handoff approval for `T-205`.

## Changed Files

| File | Lines | Purpose |
| --- | ---: | --- |
| `packages/domain-claims/src/claims/case-state-machine.test.ts` | 88 | Pins the current allowed claim transition graph, every allowed/illegal pair, case lifecycle mapping, and typed guard rejection reasons. |
| `packages/domain-claims/src/claims/recovery-state-machine.test.ts` | 135 | Pins recovery lifecycle mapping, recovery edges/invariants, typed recovery rejection reasons, and current command-level generic rejection/no-side-effect behavior. |
| `scripts/repo-size-budget.json` | 15 | Generated repo-size budget hygiene after adding tracked test files. `repo-size-budget-sync.mjs` refreshed multiple category ceilings; no product scope is implied. |

## Edge / Invariant Coverage

Case machine:
- Covers every allowed status pair, including same-status transitions.
- Covers every illegal status pair as `illegal_transition`.
- Asserts invalid runtime status returns `invalid_status` at `canTransition`.
- Asserts target case lifecycle mapping for all statuses.

Recovery machine:
- Asserts recovery lifecycle mapping for all statuses.
- Covers recovery edges into `negotiation`, `court`, `resolved`, and `closed`.
- Asserts typed invariant reasons at `evaluateRecoveryInvariants` / `canTransition`:
  - `signed_agreement_authorization_required`
  - `legal_action_cap_required`
  - `success_fee_or_no_fee_required`
- Asserts current `transitionClaimStatusInTransaction` contract remains generic `transition_rejected` with no update/history/event side effects.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/case-state-machine.test.ts` | Pass: 74 tests |
| `pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/recovery-state-machine.test.ts` | Pass: 21 tests |
| `pnpm --filter @interdomestik/domain-claims type-check` | Pass |
| `pnpm exec prettier --check ...changed files...` | Pass |
| `pnpm check:modularity-guard` | Pass |
| `node scripts/repo-size-budget-sync.mjs` | Ran; updated budget |
| `pnpm repo:size:check` | Pass |
| `pnpm security:guard` | Pass |
| `pnpm slice:verify` | Pass |

`pnpm slice:verify` covered repo size, `git diff --check`, lint, type-check, entrypoints, DB access, architecture boundaries, `security:guard`, web unit tests, and domain unit tests. DB-backed unit subchecks without `DATABASE_URL` remained skipped/no-op as existing local behavior while the aggregate gate exited green.

## Reviewer / Security Disposition

Pre-PR senior review:
- Sonnet design route: blocked with `reviewer_no_output_timeout` after 300538ms.
- Gemini design route: ran; recommended command-level typed rejection reasons. Classified as future production-source addendum, not this test-only T-205 scope.
- Sonnet implementation route: blocked with `reviewer_no_output_timeout` after 180526ms.
- Gemini implementation route: ran. Findings about terminal-state semantics and command-level typed reasons are classified as non-actionable for this approved test-only scope because this PR preserves and pins current production behavior. The request explicitly forbids production source changes for those addenda.

Security/scope:
- Full Codex Security app diff scan not used as a top-level workspace scan in this pre-PR flow because it requires a user-started scan setup. Fallback evidence: `pnpm security:guard` passed and changed-file scope is limited to approved paths.
- Scope guard: no proxy, auth, routing, tenancy, schema, RLS, billing, UI, tracker/program, README, or AGENTS changes.

Post-PR monitoring placeholders:
- SonarCloud: pending
- Copilot/reviewer comments: pending
- CodeQL/security alerts: pending
- CI/checks: pending

## Residual Risks

- The audit §9 source is derived from program/tracker/source evidence rather than a single standalone audit document.
- Command-level typed rejection reasons remain a future production-source addendum unless separately approved.
- Current production graph permits reopen/backtrack edges out of `resolved` / `rejected`; this PR tests existing behavior only and does not redefine lifecycle semantics.