### PR TITLE
fix: redact performance advisory stdout

### DIFF
--- a/scripts/ci/performance-upload-advisory.test.mjs
+++ b/scripts/ci/performance-upload-advisory.test.mjs
@@ -46,10 +46,9 @@ async function withServer(handler, testBody) {
 test('upload advisory runner reports blocked when prerequisites are missing', () => {
   const result = run([]);
   assert.equal(result.status, 2);
-  const report = JSON.parse(result.stdout);
-  assert.equal(report.status, 'blocked');
-  assert.match(report.reasonCodes.join('\n'), /missing target URL/u);
-  assert.match(report.reasonCodes.join('\n'), /missing fixture session env/u);
+  assert.match(result.stdout, /status=blocked/u);
+  assert.match(result.stdout, /reasonCount=5/u);
+  assert.doesNotMatch(result.stdout, /missing target URL|missing fixture session env/u);
   assert.doesNotMatch(result.stdout + result.stderr, /session=/u);
 });
 
@@ -61,10 +60,10 @@ test('upload advisory runner requires a safe tmp performance output path', () =>
     ENT_PERF_UPLOAD_ACTOR_ID: 'user_fixture',
   });
   assert.equal(result.status, 2);
-  assert.match(result.stdout, /missing safe output path/u);
+  assert.match(result.stdout, /status=blocked/u);
   assert.doesNotMatch(
     result.stdout + result.stderr,
-    /secret|127\.0\.0\.1:3000|tenant_fixture|user_fixture/u
+    /secret|127\.0\.0\.1:3000|tenant_fixture|user_fixture|missing safe output path/u
   );
 });
 
@@ -117,6 +116,8 @@ test('upload advisory runner writes aggregate-only metrics', async () => {
       assert.equal(report.metrics.errorCount, 0);
       assert.equal(typeof report.metrics.p95Ms, 'number');
       assert.equal(requests.length, 3);
+      assert.match(result.stdout, /status=advisory_passed/u);
+      assert.match(result.stdout, /samples=2/u);
       assert.ok(
         requests.every(
           request =>
@@ -127,6 +128,10 @@ test('upload advisory runner writes aggregate-only metrics', async () => {
         )
       );
       assert.doesNotMatch(output + result.stdout + result.stderr, /secret-token|session=secret/u);
+      assert.doesNotMatch(
+        result.stdout + result.stderr,
+        /127\.0\.0\.1|tenant_fixture|user_fixture/u
+      );
     }
   );
 

--- a/scripts/ci/performance-upload-advisory.test.mjs
+++ b/scripts/ci/performance-upload-advisory.test.mjs
@@ -48,8 +48,8 @@ test('upload advisory runner reports blocked when prerequisites are missing', ()
   assert.equal(result.status, 2);
   const report = JSON.parse(result.stdout);
   assert.equal(report.status, 'blocked');
-  assert.match(report.reasons.join('\n'), /missing target URL/u);
-  assert.match(report.reasons.join('\n'), /missing fixture session env/u);
+  assert.match(report.reasonCodes.join('\n'), /missing target URL/u);
+  assert.match(report.reasonCodes.join('\n'), /missing fixture session env/u);
   assert.doesNotMatch(result.stdout + result.stderr, /session=/u);
 });
 
@@ -62,7 +62,10 @@ test('upload advisory runner requires a safe tmp performance output path', () =>
   });
   assert.equal(result.status, 2);
   assert.match(result.stdout, /missing safe output path/u);
-  assert.doesNotMatch(result.stdout + result.stderr, /secret/u);
+  assert.doesNotMatch(
+    result.stdout + result.stderr,
+    /secret|127\.0\.0\.1:3000|tenant_fixture|user_fixture/u
+  );
 });
 
 test('upload advisory runner writes aggregate-only metrics', async () => {

--- a/scripts/ci/performance-upload-advisory.test.mjs
+++ b/scripts/ci/performance-upload-advisory.test.mjs
@@ -44,12 +44,20 @@ async function withServer(handler, testBody) {
 }
 
 test('upload advisory runner reports blocked when prerequisites are missing', () => {
-  const result = run([]);
+  const tempRoot = mkdtempSync(path.join(tmpdir(), 'ent-perf03-blocked-'));
+  const outputPath = path.join('tmp/performance', path.basename(tempRoot), 'blocked.json');
+  const absoluteOutputPath = path.join(repoRoot, outputPath);
+  const result = run([`--out=${outputPath}`]);
   assert.equal(result.status, 2);
+  const report = JSON.parse(readFileSync(absoluteOutputPath, 'utf8'));
+  assert.match(report.reasons.join('\n'), /missing target URL/u);
+  assert.match(report.reasons.join('\n'), /missing fixture session env/u);
   assert.match(result.stdout, /status=blocked/u);
-  assert.match(result.stdout, /reasonCount=5/u);
+  assert.match(result.stdout, /reasonCount=4/u);
   assert.doesNotMatch(result.stdout, /missing target URL|missing fixture session env/u);
   assert.doesNotMatch(result.stdout + result.stderr, /session=/u);
+  rmSync(path.dirname(absoluteOutputPath), { recursive: true, force: true });
+  rmSync(tempRoot, { recursive: true, force: true });
 });
 
 test('upload advisory runner requires a safe tmp performance output path', () => {

--- a/scripts/performance-upload-advisory.mjs
+++ b/scripts/performance-upload-advisory.mjs
@@ -41,7 +41,7 @@ function writeReport(report, outputPath, publicSummary) {
 
 function blocked(reasons, outputPath) {
   writeReport(
-    { status: 'blocked', surface, reasonCodes: reasons },
+    { status: 'blocked', surface, reasons },
     outputPath,
     `performance_upload_advisory status=blocked surface=upload reasonCount=${reasons.length}`
   );

--- a/scripts/performance-upload-advisory.mjs
+++ b/scripts/performance-upload-advisory.mjs
@@ -7,7 +7,6 @@ const repoRoot = process.cwd();
 const sessionEnvName = 'ENT_PERF_UPLOAD_SESSION_COOKIE';
 const surface = 'POST /api/uploads';
 const uploadBody = { fileName: 'ent-perf03-synthetic.txt', fileType: 'text/plain', fileSize: 128 };
-
 function arg(name, fallback) {
   const prefix = `--${name}=`;
   const value = process.argv.slice(2).find(item => item.startsWith(prefix));
@@ -32,24 +31,20 @@ function percentile(values, pct) {
   return sorted[Math.max(0, Math.min(sorted.length - 1, index))];
 }
 
-function writeReport(report, outputPath) {
-  const body = `${JSON.stringify(report, null, 2)}\n`;
+function writeReport(report, outputPath, publicSummary) {
   if (outputPath) {
     mkdirSync(path.dirname(outputPath), { recursive: true });
-    writeFileSync(outputPath, body);
+    writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
   }
-
-  const publicBody =
-    report.status === 'blocked'
-      ? report
-      : (({ status, surface, samples, metrics }) => ({ status, surface, samples, metrics }))(
-          report
-        );
-  console.log(JSON.stringify(publicBody, null, 2));
+  console.log(publicSummary);
 }
 
 function blocked(reasons, outputPath) {
-  writeReport({ status: 'blocked', surface, reasonCodes: reasons }, outputPath);
+  writeReport(
+    { status: 'blocked', surface, reasonCodes: reasons },
+    outputPath,
+    `performance_upload_advisory status=blocked surface=upload reasonCount=${reasons.length}`
+  );
   process.exitCode = 2;
 }
 
@@ -120,9 +115,21 @@ async function main() {
   for (let i = 0; i < config.samples; i += 1) attempts.push(await timedUploadAttempt(config));
 
   const durations = attempts.map(attempt => attempt.durationMs);
+  const status = attempts.some(attempt => !attempt.ok) ? 'advisory_failed' : 'advisory_passed';
+  const errorCount = attempts.filter(attempt => !attempt.ok).length;
+  const timeoutCount = attempts.filter(attempt => attempt.timeout).length;
+  const metrics = {
+    minMs: Math.min(...durations),
+    maxMs: Math.max(...durations),
+    p50Ms: percentile(durations, 50),
+    p95Ms: percentile(durations, 95),
+    p99Ms: percentile(durations, 99),
+    errorCount,
+    timeoutCount,
+  };
   writeReport(
     {
-      status: attempts.some(attempt => !attempt.ok) ? 'advisory_failed' : 'advisory_passed',
+      status,
       surface,
       generatedAt: new Date().toISOString(),
       targetKind: new URL(config.targetUrl).hostname,
@@ -134,17 +141,10 @@ async function main() {
       warmup: config.warmup,
       concurrency: 1,
       timeoutMs: config.timeoutMs,
-      metrics: {
-        minMs: Math.min(...durations),
-        maxMs: Math.max(...durations),
-        p50Ms: percentile(durations, 50),
-        p95Ms: percentile(durations, 95),
-        p99Ms: percentile(durations, 99),
-        errorCount: attempts.filter(attempt => !attempt.ok).length,
-        timeoutCount: attempts.filter(attempt => attempt.timeout).length,
-      },
+      metrics,
     },
-    config.outputPath
+    config.outputPath,
+    `performance_upload_advisory status=${status} surface=upload samples=${attempts.length} errorCount=${errorCount} timeoutCount=${timeoutCount}`
   );
 }
 await main();

--- a/scripts/performance-upload-advisory.mjs
+++ b/scripts/performance-upload-advisory.mjs
@@ -5,6 +5,7 @@ import { performance } from 'node:perf_hooks';
 
 const repoRoot = process.cwd();
 const sessionEnvName = 'ENT_PERF_UPLOAD_SESSION_COOKIE';
+const surface = 'POST /api/uploads';
 const uploadBody = { fileName: 'ent-perf03-synthetic.txt', fileType: 'text/plain', fileSize: 128 };
 
 function arg(name, fallback) {
@@ -37,11 +38,18 @@ function writeReport(report, outputPath) {
     mkdirSync(path.dirname(outputPath), { recursive: true });
     writeFileSync(outputPath, body);
   }
-  console.log(body.trimEnd());
+
+  const publicBody =
+    report.status === 'blocked'
+      ? report
+      : (({ status, surface, samples, metrics }) => ({ status, surface, samples, metrics }))(
+          report
+        );
+  console.log(JSON.stringify(publicBody, null, 2));
 }
 
 function blocked(reasons, outputPath) {
-  writeReport({ status: 'blocked', surface: 'POST /api/uploads', reasons }, outputPath);
+  writeReport({ status: 'blocked', surface, reasonCodes: reasons }, outputPath);
   process.exitCode = 2;
 }
 
@@ -115,7 +123,7 @@ async function main() {
   writeReport(
     {
       status: attempts.some(attempt => !attempt.ok) ? 'advisory_failed' : 'advisory_passed',
-      surface: 'POST /api/uploads',
+      surface,
       generatedAt: new Date().toISOString(),
       targetKind: new URL(config.targetUrl).hostname,
       fixture: {
@@ -139,5 +147,4 @@ async function main() {
     config.outputPath
   );
 }
-
 await main();

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36303370,
+  "maxTrackedBytes": 36303952,
   "maxTrackedFiles": 4330,
   "maxCategoryBytes": {
     "large support/generated-ish": 17938302,
-    "source/scripts": 6809805,
+    "source/scripts": 6809792,
     "docs/text": 5187032,
-    "tests/e2e": 4698409,
+    "tests/e2e": 4699004,
     "config/data/messages": 1540657,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36303082,
+  "maxTrackedBytes": 36303370,
   "maxTrackedFiles": 4330,
   "maxCategoryBytes": {
     "large support/generated-ish": 17938302,
-    "source/scripts": 6809723,
+    "source/scripts": 6809805,
     "docs/text": 5187032,
-    "tests/e2e": 4698203,
+    "tests/e2e": 4698409,
     "config/data/messages": 1540657,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36302437,
+  "maxTrackedBytes": 36303082,
   "maxTrackedFiles": 4330,
   "maxCategoryBytes": {
     "large support/generated-ish": 17938302,
-    "source/scripts": 6809379,
+    "source/scripts": 6809723,
     "docs/text": 5187032,
-    "tests/e2e": 4697902,
+    "tests/e2e": 4698203,
     "config/data/messages": 1540657,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- redact `performance-upload-advisory` stdout so CI logs only public status/surface/sample/metric fields
- keep full advisory details in the safe tmp performance artifact path
- add focused assertions that blocked output does not expose raw target URL, session, tenant, or actor fixture values
- sync repo-size budget after the scoped script/test byte changes

## Sonar disposition
- Addresses post-merge main Sonar blocker on `8778a63eaf3e70a98ad2aa144f408406a5092ef2`
- New-code vulnerability: `scripts/performance-upload-advisory.mjs:40`, key `AZ7R8oDD1nN34RRwzSa5`, rule `jssecurity:S8689`, message `Change this code to prevent confidential data from leaking in logs.`
- Fix removes the full report `console.log(body.trimEnd())` sink and logs only a public projection.

## Verification
- `node --test scripts/ci/performance-upload-advisory.test.mjs`
- `pnpm exec prettier --check scripts/performance-upload-advisory.mjs scripts/ci/performance-upload-advisory.test.mjs`
- `git diff --check`
- `pnpm check:modularity-guard`
- `pnpm repo:size:check`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`

## Phase C boundaries
- No product runtime, routing, auth, tenancy, billing, docs, README, AGENTS, architecture, or `apps/web/src/proxy.ts` changes.
