### PR TITLE
feat: type membership hierarchy

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts
@@ -14,7 +14,10 @@ vi.mock('@/lib/entity-disclosure.core', () => ({
   getSubscriptionEntityDisclosureCore: hoisted.getSubscriptionEntityDisclosureCore,
 }));
 
-import { attachMembershipEntityDisclosures } from './_entity-disclosure';
+import {
+  attachMembershipEntityDisclosure,
+  attachMembershipEntityDisclosures,
+} from './_entity-disclosure';
 
 describe('membership entity disclosure attachment', () => {
   it('reuses disclosure reads for subscription rows with the same legal entity snapshot', async () => {
@@ -25,20 +28,50 @@ describe('membership entity disclosure attachment', () => {
       subscriptionRecord('sub-2', 'legal-ks', 'XK'),
     ];
 
-    await expect(attachMembershipEntityDisclosures(records)).resolves.toEqual([
+    await expect(attachMembershipEntityDisclosures(records as never)).resolves.toEqual([
       expect.objectContaining({ id: 'sub-1', entityDisclosure: hoisted.disclosure }),
       expect.objectContaining({ id: 'sub-2', entityDisclosure: hoisted.disclosure }),
     ]);
     expect(hoisted.getSubscriptionEntityDisclosureCore).toHaveBeenCalledTimes(1);
   });
+
+  it('strips price-bearing offer fields from the membership workspace plan', async () => {
+    hoisted.getSubscriptionEntityDisclosureCore.mockResolvedValue(hoisted.disclosure);
+
+    const record = await attachMembershipEntityDisclosure({
+      ...subscriptionRecord('sub-1', 'legal-ks', 'XK'),
+      plan: {
+        id: 'standard-year',
+        name: 'Standard',
+        price: '20.00',
+        interval: 'year',
+        tier: 'standard',
+        paddlePriceId: 'pri_standard',
+      },
+    } as never);
+
+    expect(record.plan).toEqual({
+      kind: 'membership_workspace_plan',
+      id: 'standard-year',
+      name: 'Standard',
+    });
+    expect(record.plan).not.toHaveProperty('price');
+    expect(record.plan).not.toHaveProperty('interval');
+    expect(record.plan).not.toHaveProperty('tier');
+    expect(record.plan).not.toHaveProperty('paddlePriceId');
+  });
 });
 
-function subscriptionRecord(id: string, legalTenantId: string, governingLawSnapshot: string) {
+function subscriptionRecord(
+  id: string,
+  legalTenantId: string,
+  governingLawSnapshot: string
+): Record<string, unknown> {
   return {
     id,
     tenantId: 'tenant-ks',
     legalTenantId,
     governingLawSnapshot,
     plan: null,
-  } as never;
+  };
 }

--- a/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+
+import type { MembershipWorkspacePlan } from '@interdomestik/domain-membership-billing/membership-hierarchy';
 
 const hoisted = vi.hoisted(() => ({
   disclosure: {
@@ -32,8 +34,8 @@ describe('membership entity disclosure attachment', () => {
     ];
 
     await expect(attachMembershipEntityDisclosures(records)).resolves.toEqual([
-      expect.objectContaining({ id: 'sub-1', entityDisclosure: hoisted.disclosure }),
-      expect.objectContaining({ id: 'sub-2', entityDisclosure: hoisted.disclosure }),
+      expect.objectContaining({ id: 'sub-1', plan: null, entityDisclosure: hoisted.disclosure }),
+      expect.objectContaining({ id: 'sub-2', plan: null, entityDisclosure: hoisted.disclosure }),
     ]);
     expect(hoisted.getSubscriptionEntityDisclosureCore).toHaveBeenCalledTimes(1);
   });
@@ -62,6 +64,7 @@ describe('membership entity disclosure attachment', () => {
     expect(record.plan).not.toHaveProperty('interval');
     expect(record.plan).not.toHaveProperty('tier');
     expect(record.plan).not.toHaveProperty('paddlePriceId');
+    expectTypeOf(record.plan).toMatchTypeOf<MembershipWorkspacePlan | null>();
   });
 });
 

--- a/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts
@@ -19,6 +19,9 @@ import {
   attachMembershipEntityDisclosures,
 } from './_entity-disclosure';
 
+type SubscriptionInput = Parameters<typeof attachMembershipEntityDisclosure>[0];
+type PlanInput = NonNullable<SubscriptionInput['plan']>;
+
 describe('membership entity disclosure attachment', () => {
   it('reuses disclosure reads for subscription rows with the same legal entity snapshot', async () => {
     hoisted.getSubscriptionEntityDisclosureCore.mockResolvedValue(hoisted.disclosure);
@@ -28,7 +31,7 @@ describe('membership entity disclosure attachment', () => {
       subscriptionRecord('sub-2', 'legal-ks', 'XK'),
     ];
 
-    await expect(attachMembershipEntityDisclosures(records as never)).resolves.toEqual([
+    await expect(attachMembershipEntityDisclosures(records)).resolves.toEqual([
       expect.objectContaining({ id: 'sub-1', entityDisclosure: hoisted.disclosure }),
       expect.objectContaining({ id: 'sub-2', entityDisclosure: hoisted.disclosure }),
     ]);
@@ -40,15 +43,15 @@ describe('membership entity disclosure attachment', () => {
 
     const record = await attachMembershipEntityDisclosure({
       ...subscriptionRecord('sub-1', 'legal-ks', 'XK'),
-      plan: {
+      plan: membershipPlan({
         id: 'standard-year',
         name: 'Standard',
         price: '20.00',
         interval: 'year',
         tier: 'standard',
         paddlePriceId: 'pri_standard',
-      },
-    } as never);
+      }),
+    });
 
     expect(record.plan).toEqual({
       kind: 'membership_workspace_plan',
@@ -66,12 +69,65 @@ function subscriptionRecord(
   id: string,
   legalTenantId: string,
   governingLawSnapshot: string
-): Record<string, unknown> {
+): SubscriptionInput {
   return {
     id,
     tenantId: 'tenant-ks',
+    userId: 'member-1',
+    status: 'active',
+    planId: 'standard',
+    planKey: 'standard-year',
+    provider: 'paddle',
+    providerSubscriptionId: 'sub_paddle_1',
+    providerCustomerId: 'ctm_1',
+    currentPeriodStart: new Date('2026-01-01T00:00:00.000Z'),
+    currentPeriodEnd: new Date('2027-01-01T00:00:00.000Z'),
+    cancelAtPeriodEnd: false,
+    canceledAt: null,
+    pastDueAt: null,
+    gracePeriodEndsAt: null,
+    dunningAttemptCount: 0,
+    lastDunningAt: null,
+    referredByAgentId: null,
+    referredByMemberId: null,
+    referralCode: null,
+    acquisitionSource: null,
+    utmSource: null,
+    utmMedium: null,
+    utmCampaign: null,
+    utmContent: null,
+    branchId: null,
+    agentId: null,
     legalTenantId,
+    billingEntity: null,
     governingLawSnapshot,
+    termsVersionAccepted: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: null,
     plan: null,
+  };
+}
+
+function membershipPlan(overrides: Partial<PlanInput> = {}): PlanInput {
+  return {
+    id: 'standard-year',
+    tenantId: 'tenant-ks',
+    name: 'Standard',
+    description: null,
+    tier: 'standard',
+    interval: 'year',
+    price: '20.00',
+    currency: 'EUR',
+    membersIncluded: 1,
+    legalConsultationsPerYear: 1,
+    mediationDiscountPercent: 0,
+    successFeePercent: 15,
+    paddlePriceId: 'pri_standard',
+    paddleProductId: 'pro_standard',
+    features: [],
+    isActive: true,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
   };
 }

--- a/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.ts
@@ -1,4 +1,8 @@
 import { membershipPlans, subscriptions } from '@interdomestik/database';
+import {
+  toMembershipWorkspacePlan,
+  type MembershipWorkspacePlan,
+} from '@interdomestik/domain-membership-billing/membership-hierarchy';
 import type { InferSelectModel } from 'drizzle-orm';
 
 import {
@@ -10,15 +14,19 @@ type SubscriptionWithPlan = InferSelectModel<typeof subscriptions> & {
   plan: InferSelectModel<typeof membershipPlans> | null;
 };
 
-export type SubscriptionRecord = SubscriptionWithPlan & {
+export type SubscriptionRecord = Omit<SubscriptionWithPlan, 'plan'> & {
+  plan: MembershipWorkspacePlan | null;
   entityDisclosure: EntityDisclosureModel;
 };
 
 export async function attachMembershipEntityDisclosure(
   subscription: SubscriptionWithPlan
 ): Promise<SubscriptionRecord> {
+  const { plan, ...subscriptionFields } = subscription;
+
   return {
-    ...subscription,
+    ...subscriptionFields,
+    plan: toMembershipWorkspacePlan(plan),
     entityDisclosure: await getSubscriptionEntityDisclosureCore(subscription),
   };
 }
@@ -29,10 +37,15 @@ export async function attachMembershipEntityDisclosures(
   const disclosureCache = new Map<string, Promise<EntityDisclosureModel>>();
 
   return Promise.all(
-    records.map(async record => ({
-      ...record,
-      entityDisclosure: await getCachedEntityDisclosure(record, disclosureCache),
-    }))
+    records.map(async record => {
+      const { plan, ...subscriptionFields } = record;
+
+      return {
+        ...subscriptionFields,
+        plan: toMembershipWorkspacePlan(plan),
+        entityDisclosure: await getCachedEntityDisclosure(record, disclosureCache),
+      };
+    })
   );
 }
 

--- a/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.ts
@@ -22,13 +22,10 @@ export type SubscriptionRecord = Omit<SubscriptionWithPlan, 'plan'> & {
 export async function attachMembershipEntityDisclosure(
   subscription: SubscriptionWithPlan
 ): Promise<SubscriptionRecord> {
-  const { plan, ...subscriptionFields } = subscription;
-
-  return {
-    ...subscriptionFields,
-    plan: toMembershipWorkspacePlan(plan),
-    entityDisclosure: await getSubscriptionEntityDisclosureCore(subscription),
-  };
+  return toSubscriptionRecord(
+    subscription,
+    await getSubscriptionEntityDisclosureCore(subscription)
+  );
 }
 
 export async function attachMembershipEntityDisclosures(
@@ -37,16 +34,23 @@ export async function attachMembershipEntityDisclosures(
   const disclosureCache = new Map<string, Promise<EntityDisclosureModel>>();
 
   return Promise.all(
-    records.map(async record => {
-      const { plan, ...subscriptionFields } = record;
-
-      return {
-        ...subscriptionFields,
-        plan: toMembershipWorkspacePlan(plan),
-        entityDisclosure: await getCachedEntityDisclosure(record, disclosureCache),
-      };
-    })
+    records.map(async record =>
+      toSubscriptionRecord(record, await getCachedEntityDisclosure(record, disclosureCache))
+    )
   );
+}
+
+function toSubscriptionRecord(
+  subscription: SubscriptionWithPlan,
+  entityDisclosure: EntityDisclosureModel
+): SubscriptionRecord {
+  const { plan, ...subscriptionFields } = subscription;
+
+  return {
+    ...subscriptionFields,
+    plan: toMembershipWorkspacePlan(plan),
+    entityDisclosure,
+  };
 }
 
 function getCachedEntityDisclosure(

--- a/apps/web/src/app/[locale]/(app)/member/membership/card/membership-card-subscription.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/card/membership-card-subscription.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { toMemberCardSubscription } from './membership-card-subscription';
+
+describe('toMemberCardSubscription', () => {
+  const now = new Date('2026-06-20T12:00:00.000Z');
+  const currentPeriodEnd = new Date('2026-07-20T12:00:00.000Z');
+
+  it('projects an active subscription as membership proof', () => {
+    expect(
+      toMemberCardSubscription(
+        {
+          status: 'active',
+          planId: 'standard-year',
+          currentPeriodEnd,
+          gracePeriodEndsAt: null,
+        },
+        now
+      )
+    ).toEqual({
+      kind: 'membership_proof',
+      status: 'active',
+      planId: 'standard-year',
+      currentPeriodEnd,
+      gracePeriodEndsAt: null,
+    });
+  });
+
+  it('projects a past due subscription that is still in grace as membership proof', () => {
+    const gracePeriodEndsAt = new Date('2026-06-27T12:00:00.000Z');
+
+    expect(
+      toMemberCardSubscription(
+        {
+          status: 'past_due',
+          planId: 'standard-year',
+          currentPeriodEnd,
+          gracePeriodEndsAt,
+        },
+        now
+      )
+    ).toEqual({
+      kind: 'membership_proof',
+      status: 'past_due',
+      planId: 'standard-year',
+      currentPeriodEnd,
+      gracePeriodEndsAt,
+    });
+  });
+
+  it('returns null without a subscription', () => {
+    expect(toMemberCardSubscription(null, now)).toBeNull();
+  });
+
+  it('strips offer price fields from raw subscription input', () => {
+    const rawSubscription = {
+      status: 'active',
+      planId: 'standard-year',
+      currentPeriodEnd,
+      gracePeriodEndsAt: null,
+      price: '20.00',
+      tier: 'standard',
+      interval: 'year',
+      currency: 'EUR',
+      paddlePriceId: 'pri_standard',
+    };
+
+    const proof = toMemberCardSubscription(rawSubscription, now);
+
+    expect(proof).toEqual({
+      kind: 'membership_proof',
+      status: 'active',
+      planId: 'standard-year',
+      currentPeriodEnd,
+      gracePeriodEndsAt: null,
+    });
+    expect(proof).not.toHaveProperty('price');
+    expect(proof).not.toHaveProperty('tier');
+    expect(proof).not.toHaveProperty('interval');
+    expect(proof).not.toHaveProperty('currency');
+    expect(proof).not.toHaveProperty('paddlePriceId');
+  });
+});

--- a/apps/web/src/app/[locale]/(app)/member/membership/card/membership-card-subscription.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/card/membership-card-subscription.ts
@@ -1,9 +1,6 @@
-export interface MemberCardSubscription {
-  readonly status: 'active' | 'past_due';
-  readonly planId: string;
-  readonly currentPeriodEnd: Date | null;
-  readonly gracePeriodEndsAt: Date | null;
-}
+import type { MembershipProof } from '@interdomestik/domain-membership-billing/membership-hierarchy';
+
+export type MemberCardSubscription = MembershipProof;
 
 export type MemberCardSubscriptionInput =
   | {
@@ -23,6 +20,7 @@ export function toMemberCardSubscription(
 
   if (subscription.status === 'active') {
     return {
+      kind: 'membership_proof',
       status: 'active',
       planId: subscription.planId,
       currentPeriodEnd: subscription.currentPeriodEnd ?? null,
@@ -36,6 +34,7 @@ export function toMemberCardSubscription(
   if (!gracePeriodEndsAt || gracePeriodEndsAt.getTime() < now.getTime()) return null;
 
   return {
+    kind: 'membership_proof',
     status: 'past_due',
     planId: subscription.planId,
     currentPeriodEnd: subscription.currentPeriodEnd ?? null,

--- a/packages/domain-membership-billing/package.json
+++ b/packages/domain-membership-billing/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./annual-membership": "./src/annual-membership.ts",
     "./billing-snapshot": "./src/billing-snapshot.ts",
+    "./membership-hierarchy": "./src/membership-hierarchy.ts",
     "./paddle": "./src/paddle.ts",
     "./paddle-server": "./src/paddle-server.ts",
     "./subscription": "./src/subscription.ts",

--- a/packages/domain-membership-billing/src/index.ts
+++ b/packages/domain-membership-billing/src/index.ts
@@ -12,6 +12,7 @@ export * from './ownership-attribution';
 export * from './commissions/summary';
 export * from './commissions/types';
 export * from './enterprise-controls';
+export * from './membership-hierarchy';
 export * from './paddle';
 export * from './paddle-server';
 export * from './paddle-webhooks';

--- a/packages/domain-membership-billing/src/membership-hierarchy.test.ts
+++ b/packages/domain-membership-billing/src/membership-hierarchy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import {
+  createMembershipOffer,
+  toMembershipWorkspacePlan,
+  type MembershipOffer,
+  type MembershipProof,
+  type MembershipWorkspacePlan,
+} from './membership-hierarchy';
+
+describe('membership hierarchy', () => {
+  it('keeps price-bearing data on membership offers', () => {
+    const offer = createMembershipOffer({
+      id: 'standard-year',
+      name: 'Standard',
+      currency: 'EUR',
+      interval: 'year',
+      price: '20.00',
+      tier: 'standard',
+      paddlePriceId: 'pri_standard',
+    });
+
+    expect(offer).toEqual({
+      kind: 'membership_offer',
+      id: 'standard-year',
+      name: 'Standard',
+      currency: 'EUR',
+      interval: 'year',
+      price: '20.00',
+      tier: 'standard',
+      paddlePriceId: 'pri_standard',
+    });
+    expectTypeOf(offer).toMatchTypeOf<MembershipOffer>();
+  });
+
+  it('projects workspace plan identity without price-bearing offer fields', () => {
+    const dbPlan = {
+      id: 'standard-year',
+      name: 'Standard',
+      currency: 'EUR',
+      interval: 'year',
+      price: '20.00',
+      tier: 'standard',
+      paddlePriceId: 'pri_standard',
+    };
+
+    const workspacePlan = toMembershipWorkspacePlan(dbPlan);
+
+    expect(workspacePlan).toEqual({
+      kind: 'membership_workspace_plan',
+      id: 'standard-year',
+      name: 'Standard',
+    });
+    expect(workspacePlan).not.toHaveProperty('price');
+    expect(workspacePlan).not.toHaveProperty('interval');
+    expect(workspacePlan).not.toHaveProperty('tier');
+  });
+});
+
+const proofWithPrice = {
+  kind: 'membership_proof',
+  status: 'active',
+  planId: 'standard',
+  currentPeriodEnd: null,
+  gracePeriodEndsAt: null,
+  price: '20.00',
+} as const;
+
+// @ts-expect-error T-402: membership_proof cannot carry offer price data.
+const proofMustRejectPrice: MembershipProof = proofWithPrice;
+
+const workspacePlanWithTier = {
+  kind: 'membership_workspace_plan',
+  id: 'standard-year',
+  name: 'Standard',
+  tier: 'standard',
+} as const;
+
+// @ts-expect-error T-402: membership_workspace_plan cannot carry offer tier data.
+const workspacePlanMustRejectTier: MembershipWorkspacePlan = workspacePlanWithTier;
+
+void proofMustRejectPrice;
+void workspacePlanMustRejectTier;

--- a/packages/domain-membership-billing/src/membership-hierarchy.test.ts
+++ b/packages/domain-membership-billing/src/membership-hierarchy.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import {
-  createMembershipOffer,
   toMembershipWorkspacePlan,
   type MembershipOffer,
   type MembershipProof,
@@ -10,7 +9,8 @@ import {
 
 describe('membership hierarchy', () => {
   it('keeps price-bearing data on membership offers', () => {
-    const offer = createMembershipOffer({
+    const offer = {
+      kind: 'membership_offer',
       id: 'standard-year',
       name: 'Standard',
       currency: 'EUR',
@@ -18,7 +18,7 @@ describe('membership hierarchy', () => {
       price: '20.00',
       tier: 'standard',
       paddlePriceId: 'pri_standard',
-    });
+    } satisfies MembershipOffer;
 
     expect(offer).toEqual({
       kind: 'membership_offer',

--- a/packages/domain-membership-billing/src/membership-hierarchy.test.ts
+++ b/packages/domain-membership-billing/src/membership-hierarchy.test.ts
@@ -67,7 +67,7 @@ const proofWithPrice = {
 } as const;
 
 // @ts-expect-error T-402: membership_proof cannot carry offer price data.
-const proofMustRejectPrice: MembershipProof = proofWithPrice;
+export const proofMustRejectPrice: MembershipProof = proofWithPrice;
 
 const workspacePlanWithTier = {
   kind: 'membership_workspace_plan',
@@ -77,7 +77,4 @@ const workspacePlanWithTier = {
 } as const;
 
 // @ts-expect-error T-402: membership_workspace_plan cannot carry offer tier data.
-const workspacePlanMustRejectTier: MembershipWorkspacePlan = workspacePlanWithTier;
-
-void proofMustRejectPrice;
-void workspacePlanMustRejectTier;
+export const workspacePlanMustRejectTier: MembershipWorkspacePlan = workspacePlanWithTier;

--- a/packages/domain-membership-billing/src/membership-hierarchy.ts
+++ b/packages/domain-membership-billing/src/membership-hierarchy.ts
@@ -1,13 +1,11 @@
 export type MembershipPriceInterval = 'month' | 'year';
 export type MembershipTier = 'standard' | 'family' | 'business' | (string & {});
 
-type PriceBearingMembershipFields = {
+type OfferPricingFieldsExcluded = {
   readonly currency?: never;
   readonly interval?: never;
   readonly paddlePriceId?: never;
   readonly price?: never;
-  readonly priceCents?: never;
-  readonly priceId?: never;
   readonly tier?: never;
 };
 
@@ -22,7 +20,7 @@ export type MembershipOffer = {
   readonly paddlePriceId: string | null;
 };
 
-export type MembershipProof = PriceBearingMembershipFields & {
+export type MembershipProof = OfferPricingFieldsExcluded & {
   readonly kind: 'membership_proof';
   readonly status: 'active' | 'past_due';
   readonly planId: string;
@@ -30,20 +28,10 @@ export type MembershipProof = PriceBearingMembershipFields & {
   readonly gracePeriodEndsAt: Date | null;
 };
 
-export type MembershipWorkspacePlan = PriceBearingMembershipFields & {
+export type MembershipWorkspacePlan = OfferPricingFieldsExcluded & {
   readonly kind: 'membership_workspace_plan';
   readonly id: string;
   readonly name: string;
-};
-
-export type MembershipWorkspace = PriceBearingMembershipFields & {
-  readonly kind: 'membership_workspace';
-  readonly id: string;
-  readonly status: string;
-  readonly planId: string;
-  readonly plan: MembershipWorkspacePlan | null;
-  readonly currentPeriodEnd: Date | null;
-  readonly gracePeriodEndsAt: Date | null;
 };
 
 export type MembershipWorkspacePlanSource =

--- a/packages/domain-membership-billing/src/membership-hierarchy.ts
+++ b/packages/domain-membership-billing/src/membership-hierarchy.ts
@@ -1,0 +1,74 @@
+export type MembershipPriceInterval = 'month' | 'year';
+export type MembershipTier = 'standard' | 'family' | 'business' | (string & {});
+
+type PriceBearingMembershipFields = {
+  readonly currency?: never;
+  readonly interval?: never;
+  readonly paddlePriceId?: never;
+  readonly price?: never;
+  readonly priceCents?: never;
+  readonly priceId?: never;
+  readonly tier?: never;
+};
+
+export type MembershipOffer = {
+  readonly kind: 'membership_offer';
+  readonly id: string;
+  readonly name: string;
+  readonly currency: string;
+  readonly interval: MembershipPriceInterval | (string & {});
+  readonly price: string;
+  readonly tier: MembershipTier;
+  readonly paddlePriceId: string | null;
+};
+
+export type MembershipProof = PriceBearingMembershipFields & {
+  readonly kind: 'membership_proof';
+  readonly status: 'active' | 'past_due';
+  readonly planId: string;
+  readonly currentPeriodEnd: Date | null;
+  readonly gracePeriodEndsAt: Date | null;
+};
+
+export type MembershipWorkspacePlan = PriceBearingMembershipFields & {
+  readonly kind: 'membership_workspace_plan';
+  readonly id: string;
+  readonly name: string;
+};
+
+export type MembershipWorkspace = PriceBearingMembershipFields & {
+  readonly kind: 'membership_workspace';
+  readonly id: string;
+  readonly status: string;
+  readonly planId: string;
+  readonly plan: MembershipWorkspacePlan | null;
+  readonly currentPeriodEnd: Date | null;
+  readonly gracePeriodEndsAt: Date | null;
+};
+
+export type MembershipWorkspacePlanSource =
+  | {
+      readonly id: string;
+      readonly name: string;
+    }
+  | null
+  | undefined;
+
+export function createMembershipOffer(offer: Omit<MembershipOffer, 'kind'>): MembershipOffer {
+  return {
+    kind: 'membership_offer',
+    ...offer,
+  };
+}
+
+export function toMembershipWorkspacePlan(
+  plan: MembershipWorkspacePlanSource
+): MembershipWorkspacePlan | null {
+  if (!plan) return null;
+
+  return {
+    kind: 'membership_workspace_plan',
+    id: plan.id,
+    name: plan.name,
+  };
+}

--- a/packages/domain-membership-billing/src/membership-hierarchy.ts
+++ b/packages/domain-membership-billing/src/membership-hierarchy.ts
@@ -14,7 +14,7 @@ export type MembershipOffer = {
   readonly id: string;
   readonly name: string;
   readonly currency: string;
-  readonly interval: MembershipPriceInterval | (string & {});
+  readonly interval: MembershipPriceInterval;
   readonly price: string;
   readonly tier: MembershipTier;
   readonly paddlePriceId: string | null;
@@ -41,13 +41,6 @@ export type MembershipWorkspacePlanSource =
     }
   | null
   | undefined;
-
-export function createMembershipOffer(offer: Omit<MembershipOffer, 'kind'>): MembershipOffer {
-  return {
-    kind: 'membership_offer',
-    ...offer,
-  };
-}
 
 export function toMembershipWorkspacePlan(
   plan: MembershipWorkspacePlanSource

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36371553,
-  "maxTrackedFiles": 4341,
+  "maxTrackedBytes": 36373863,
+  "maxTrackedFiles": 4342,
   "maxCategoryBytes": {
     "large support/generated-ish": 17964557,
-    "source/scripts": 6814417,
+    "source/scripts": 6814243,
     "docs/text": 5205686,
-    "tests/e2e": 4717008,
+    "tests/e2e": 4719492,
     "config/data/messages": 1540720,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36370341,
+  "maxTrackedBytes": 36371553,
   "maxTrackedFiles": 4341,
   "maxCategoryBytes": {
     "large support/generated-ish": 17964557,
-    "source/scripts": 6814761,
+    "source/scripts": 6814417,
     "docs/text": 5205686,
-    "tests/e2e": 4715452,
+    "tests/e2e": 4717008,
     "config/data/messages": 1540720,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36339723,
-  "maxTrackedFiles": 4338,
+  "maxTrackedBytes": 36370341,
+  "maxTrackedFiles": 4341,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17949364,
-    "source/scripts": 6812280,
-    "docs/text": 5195995,
-    "tests/e2e": 4712262,
-    "config/data/messages": 1540657,
+    "large support/generated-ish": 17964557,
+    "source/scripts": 6814761,
+    "docs/text": 5205686,
+    "tests/e2e": 4715452,
+    "config/data/messages": 1540720,
     "other": 129165
   },
-  "maxLargestFileBytes": 3034390,
+  "maxLargestFileBytes": 3049583,
   "maxSourceOrTestLines": 3000
 }


### PR DESCRIPTION
Summary
- Adds a typed membership hierarchy: `membership_offer` owns price/interval/tier data, while `membership_proof` and `membership_workspace_plan` reject price-bearing offer fields at type level.
- Projects member workspace plan data down to presentation-safe id/name before rendering surfaces consume it.
- Updates membership card subscription output to the `membership_proof` shape.

Changed Areas
- `packages/domain-membership-billing/src/membership-hierarchy.ts`
- `packages/domain-membership-billing/src/membership-hierarchy.test.ts`
- `apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.ts`
- `apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts`
- `apps/web/src/app/[locale]/(app)/member/membership/card/membership-card-subscription.ts`
- package export wiring and repo-size budget sync

Verification
- `pnpm --filter @interdomestik/domain-membership-billing test:unit --run src/membership-hierarchy.test.ts`: pass
- `pnpm --filter @interdomestik/web test:unit --run src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts`: pass
- `pnpm --filter @interdomestik/domain-membership-billing type-check`: pass
- `pnpm --filter @interdomestik/web type-check`: pass
- `pnpm check:modularity-guard`: pass
- `pnpm repo:size:check`: pass after required `scripts/repo-size-budget.json` sync
- `pnpm slice:verify`: pass
- `pnpm slice:e2e:pr`: blocked locally before browser execution by low disk space (`<4GiB`) after gatekeeper pruned pnpm store; classified as local resource/setup friction, not a product defect

Operational Evidence
- No schema, RLS, auth/session, tenancy, proxy, Paddle provider, invoice/tax, route, or clarity-marker changes.
- Protected-path audit reported no changes to `apps/web/src/proxy.ts`, README, AGENTS, current tracker/program docs, or architecture docs.

Edge Cases
- Verified offer data retains price-bearing fields.
- Verified workspace plan projection strips `price`, `interval`, `tier`, and `paddlePriceId`.
- Compile-time proof uses `@ts-expect-error` for forbidden price/tier fields on proof/workspace-plan types.

Review/Security
- Senior reviewer: pending.
- Copilot review: pending.
- Codex Security: pending.
- Sonar/reviewer findings: pending PR checks.

Rollback/Mitigation
- Revert the single commit to restore prior subscription plan relation exposure.

Residual Risk
- Local E2E and final Phase C gates still need completion on an environment with enough disk or CI proof. This draft PR is not merge-ready.
