### PR TITLE
T-309 tenant cache guard

### DIFF
--- a/apps/web/src/server/domains/tenant-cache-revalidation-failure.test.ts
+++ b/apps/web/src/server/domains/tenant-cache-revalidation-failure.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  resetTenantCacheRelayMocks,
+  tenantCacheRelayMocks,
+} from './tenant-cache-revalidation.test-mocks';
+import {
+  relayTenantCacheRevalidationEvents,
+  TENANT_CACHE_REVALIDATION_CONSUMER,
+} from './tenant-cache-revalidation';
+import {
+  relayDelivery,
+  relayEvent,
+  relayParams,
+  relayTx,
+} from './tenant-cache-revalidation.test-support';
+
+const databaseMocks = tenantCacheRelayMocks();
+
+describe('relayTenantCacheRevalidationEvents failures', () => {
+  beforeEach(() => resetTenantCacheRelayMocks());
+
+  it('continues the batch when one event fails before delivery recording', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    databaseMocks.selectDomainEventsForRelay.mockResolvedValue([
+      relayEvent({ id: 'event-fail' }),
+      relayEvent({ id: 'event-ok', entityId: 'claim-ok' }),
+    ]);
+
+    const result = await relayTenantCacheRevalidationEvents(
+      relayTx,
+      relayParams(vi.fn(), {
+        resolveMemberId: async row =>
+          row.id === 'event-fail' ? Promise.reject(new Error('resolver')) : 'member-1',
+      })
+    );
+
+    expect(databaseMocks.recordDomainEventDelivery).toHaveBeenCalledTimes(1);
+    expect(databaseMocks.recordDomainEventDelivery).toHaveBeenCalledWith(relayTx, {
+      ...relayDelivery(TENANT_CACHE_REVALIDATION_CONSUMER, 'event-ok'),
+    });
+    expect(errorSpy).toHaveBeenCalledWith('tenant cache revalidation event failed', {
+      entityType: 'case',
+      eventId: 'event-fail',
+      eventName: 'case.lifecycle_changed',
+    });
+    expect(result).toEqual({ delivered: 1, failed: 1, selected: 2, tagsRevalidated: 2 });
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/web/src/server/domains/tenant-cache-revalidation.test-mocks.ts
+++ b/apps/web/src/server/domains/tenant-cache-revalidation.test-mocks.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest';
+
+const databaseMocks = vi.hoisted(() => ({
+  recordDomainEventDelivery: vi.fn(),
+  selectDomainEventsForRelay: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => databaseMocks);
+
+export function tenantCacheRelayMocks() {
+  return databaseMocks;
+}
+
+export function resetTenantCacheRelayMocks(): void {
+  vi.resetAllMocks();
+  databaseMocks.recordDomainEventDelivery.mockResolvedValue({ status: 'delivered' });
+}

--- a/apps/web/src/server/domains/tenant-cache-revalidation.test-support.ts
+++ b/apps/web/src/server/domains/tenant-cache-revalidation.test-support.ts
@@ -1,0 +1,48 @@
+import type { DomainEventRelayEvent } from '@interdomestik/database';
+import type { relayTenantCacheRevalidationEvents } from './tenant-cache-revalidation';
+
+type RelayTx = Parameters<typeof relayTenantCacheRevalidationEvents>[0];
+type RevalidateTenantCacheTag = (tag: string, profile: 'max') => void;
+type ResolveMemberId = (event: DomainEventRelayEvent) => Promise<string | null>;
+
+export const relayTx = Symbol('tenant-cache-relay-test-tx') as unknown as RelayTx;
+
+export function relayEvent(overrides: Partial<DomainEventRelayEvent> = {}): DomainEventRelayEvent {
+  return {
+    actorId: 'staff-1',
+    actorRole: 'staff',
+    aggregateVersion: 1,
+    correlationId: 'corr-1',
+    createdAt: new Date('2026-06-20T12:00:00.000Z'),
+    entityId: 'shared-claim-id',
+    entityType: 'case',
+    eventName: 'case.lifecycle_changed',
+    eventVersion: 1,
+    id: 'event-1',
+    payload: {},
+    tenantId: 'tenant-a',
+    ...overrides,
+  };
+}
+
+export function relayParams(
+  revalidate: RevalidateTenantCacheTag,
+  overrides: { resolveMemberId?: ResolveMemberId; tenantId?: string } = {}
+) {
+  return {
+    deps: {
+      revalidate,
+      resolveMemberId: overrides.resolveMemberId ?? (async () => 'member-1'),
+    },
+    limit: 10,
+    tenantId: overrides.tenantId ?? 'tenant-a',
+  };
+}
+
+export function relaySelection(consumerName: string, tenantId = 'tenant-a') {
+  return { consumerName, limit: 10, mode: undefined, tenantId };
+}
+
+export function relayDelivery(consumerName: string, eventId: string, tenantId = 'tenant-a') {
+  return { consumerName, eventId, tenantId };
+}

--- a/apps/web/src/server/domains/tenant-cache-revalidation.test.ts
+++ b/apps/web/src/server/domains/tenant-cache-revalidation.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  resetTenantCacheRelayMocks,
+  tenantCacheRelayMocks,
+} from './tenant-cache-revalidation.test-mocks';
+import {
+  relayTenantCacheRevalidationEvents,
+  TENANT_CACHE_REVALIDATION_CONSUMER,
+} from './tenant-cache-revalidation';
+import {
+  relayDelivery,
+  relayEvent,
+  relayParams,
+  relaySelection,
+  relayTx,
+} from './tenant-cache-revalidation.test-support';
+
+const databaseMocks = tenantCacheRelayMocks();
+
+describe('relayTenantCacheRevalidationEvents', () => {
+  beforeEach(() => resetTenantCacheRelayMocks());
+
+  it('revalidates tenant-qualified case and member tags from outbox events', async () => {
+    const revalidate = vi.fn();
+    databaseMocks.selectDomainEventsForRelay.mockResolvedValue([relayEvent()]);
+
+    const result = await relayTenantCacheRevalidationEvents(relayTx, relayParams(revalidate));
+
+    expect(databaseMocks.selectDomainEventsForRelay).toHaveBeenCalledWith(relayTx, {
+      ...relaySelection(TENANT_CACHE_REVALIDATION_CONSUMER),
+    });
+    expect(revalidate).toHaveBeenCalledWith(
+      'case:access_tenant_id:tenant-a:shared-claim-id',
+      'max'
+    );
+    expect(revalidate).toHaveBeenCalledWith('member:access_tenant_id:tenant-a:member-1', 'max');
+    expect(databaseMocks.recordDomainEventDelivery).toHaveBeenCalledWith(relayTx, {
+      ...relayDelivery(TENANT_CACHE_REVALIDATION_CONSUMER, 'event-1'),
+    });
+    expect(result).toEqual({ delivered: 1, failed: 0, selected: 1, tagsRevalidated: 2 });
+  });
+
+  it('records non-case events without revalidating tags', async () => {
+    const revalidate = vi.fn();
+    databaseMocks.selectDomainEventsForRelay.mockResolvedValue([
+      relayEvent({ entityType: 'subscription', eventName: 'subscription.updated' }),
+    ]);
+
+    const result = await relayTenantCacheRevalidationEvents(relayTx, relayParams(revalidate));
+
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(databaseMocks.recordDomainEventDelivery).toHaveBeenCalledWith(relayTx, {
+      ...relayDelivery(TENANT_CACHE_REVALIDATION_CONSUMER, 'event-1'),
+    });
+    expect(result).toEqual({ delivered: 1, failed: 0, selected: 1, tagsRevalidated: 0 });
+  });
+
+  it('keeps overlapping ids isolated by event tenant', async () => {
+    const revalidate = vi.fn();
+    databaseMocks.selectDomainEventsForRelay
+      .mockResolvedValueOnce([relayEvent({ id: 'event-a', tenantId: 'tenant-a' })])
+      .mockResolvedValueOnce([relayEvent({ id: 'event-b', tenantId: 'tenant-b' })]);
+
+    await relayTenantCacheRevalidationEvents(relayTx, relayParams(revalidate));
+    await relayTenantCacheRevalidationEvents(
+      relayTx,
+      relayParams(revalidate, { tenantId: 'tenant-b' })
+    );
+
+    expect(databaseMocks.selectDomainEventsForRelay).toHaveBeenNthCalledWith(1, relayTx, {
+      ...relaySelection(TENANT_CACHE_REVALIDATION_CONSUMER),
+    });
+    expect(databaseMocks.selectDomainEventsForRelay).toHaveBeenNthCalledWith(2, relayTx, {
+      ...relaySelection(TENANT_CACHE_REVALIDATION_CONSUMER, 'tenant-b'),
+    });
+    expect(revalidate.mock.calls).toEqual([
+      ['case:access_tenant_id:tenant-a:shared-claim-id', 'max'],
+      ['member:access_tenant_id:tenant-a:member-1', 'max'],
+      ['case:access_tenant_id:tenant-b:shared-claim-id', 'max'],
+      ['member:access_tenant_id:tenant-b:member-1', 'max'],
+    ]);
+  });
+});

--- a/apps/web/src/server/domains/tenant-cache-revalidation.ts
+++ b/apps/web/src/server/domains/tenant-cache-revalidation.ts
@@ -1,0 +1,86 @@
+import 'server-only';
+
+import {
+  recordDomainEventDelivery,
+  selectDomainEventsForRelay,
+  type DomainEventRelayEvent,
+  type DomainEventTx,
+  type RelayMode,
+} from '@interdomestik/database';
+import { revalidateTag } from 'next/cache';
+
+import { tenantCacheTag } from './tenant-cache';
+
+export const TENANT_CACHE_REVALIDATION_CONSUMER = 'tenant_cache_revalidation';
+
+type RelayTx = DomainEventTx & { execute<T>(query: unknown): Promise<T[]> };
+type RevalidateTenantCacheTag = (tag: string, profile: 'max') => void;
+
+type RevalidationDeps = {
+  revalidate?: RevalidateTenantCacheTag;
+  resolveMemberId(event: DomainEventRelayEvent): Promise<string | null>;
+};
+
+function isCaseCacheEvent(event: DomainEventRelayEvent): boolean {
+  return (
+    event.entityType === 'case' ||
+    event.entityType === 'claim' ||
+    event.eventName.startsWith('case.') ||
+    event.eventName.startsWith('claim.')
+  );
+}
+
+async function revalidateEventTags(
+  event: DomainEventRelayEvent,
+  deps: RevalidationDeps
+): Promise<number> {
+  if (!isCaseCacheEvent(event)) return 0;
+
+  const revalidate = deps.revalidate ?? revalidateTag;
+  revalidate(tenantCacheTag('case', event.tenantId, event.entityId), 'max');
+
+  const memberId = await deps.resolveMemberId(event);
+  if (memberId) {
+    revalidate(tenantCacheTag('member', event.tenantId, memberId), 'max');
+    return 2;
+  }
+
+  return 1;
+}
+
+export async function relayTenantCacheRevalidationEvents(
+  tx: RelayTx,
+  params: { deps: RevalidationDeps; limit: number; mode?: RelayMode; tenantId: string }
+): Promise<{ delivered: number; failed: number; selected: number; tagsRevalidated: number }> {
+  // Specialized relay mirrors billing relays: revalidate tags before recording delivery.
+  const events = await selectDomainEventsForRelay(tx, {
+    consumerName: TENANT_CACHE_REVALIDATION_CONSUMER,
+    limit: params.limit,
+    mode: params.mode,
+    tenantId: params.tenantId,
+  });
+  let delivered = 0;
+  let failed = 0;
+  let tagsRevalidated = 0;
+
+  for (const event of events) {
+    try {
+      tagsRevalidated += await revalidateEventTags(event, params.deps);
+      const delivery = await recordDomainEventDelivery(tx, {
+        consumerName: TENANT_CACHE_REVALIDATION_CONSUMER,
+        eventId: event.id,
+        tenantId: event.tenantId,
+      });
+      if (delivery.status === 'delivered') delivered += 1;
+    } catch {
+      failed += 1;
+      console.error('tenant cache revalidation event failed', {
+        entityType: event.entityType,
+        eventId: event.id,
+        eventName: event.eventName,
+      });
+    }
+  }
+
+  return { delivered, failed, selected: events.length, tagsRevalidated };
+}

--- a/apps/web/src/server/domains/tenant-cache.test.ts
+++ b/apps/web/src/server/domains/tenant-cache.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { tenantCacheKey, tenantCacheTag } from './tenant-cache';
+
+describe('tenantCacheKey', () => {
+  it('separates overlapping ids by access tenant', () => {
+    const route = '/member/claims/shared-id';
+    const sharedValues = ['claim_id', 'shared-id'];
+
+    const tenantA = tenantCacheKey({
+      accessTenantId: 'tenant-a',
+      memberId: 'member-1',
+      route,
+      scope: 'member-claim',
+      values: sharedValues,
+    });
+    const tenantB = tenantCacheKey({
+      accessTenantId: 'tenant-b',
+      memberId: 'member-1',
+      route,
+      scope: 'member-claim',
+      values: sharedValues,
+    });
+
+    expect(tenantA).toContain('access_tenant_id');
+    expect(tenantA).toContain('member_id');
+    expect(tenantA.join('\0')).not.toEqual(tenantB.join('\0'));
+  });
+
+  it('rejects blank tenant or member key components', () => {
+    expect(() =>
+      tenantCacheKey({ accessTenantId: ' ', route: '/member', scope: 'claims' })
+    ).toThrow('tenant cache key requires accessTenantId');
+    expect(() =>
+      tenantCacheKey({
+        accessTenantId: 'tenant-a',
+        memberId: '',
+        route: '/member',
+        scope: 'claims',
+      })
+    ).toThrow('tenant cache key requires memberId');
+  });
+});
+
+describe('tenantCacheTag', () => {
+  it('builds tenant-qualified case and member invalidation tags', () => {
+    expect(tenantCacheTag('case', 'tenant-a', 'claim-1')).toBe(
+      'case:access_tenant_id:tenant-a:claim-1'
+    );
+    expect(tenantCacheTag('member', 'tenant-a', 'member-1')).toBe(
+      'member:access_tenant_id:tenant-a:member-1'
+    );
+  });
+});

--- a/apps/web/src/server/domains/tenant-cache.ts
+++ b/apps/web/src/server/domains/tenant-cache.ts
@@ -1,0 +1,43 @@
+import 'server-only';
+
+export type TenantCacheKeyParams = {
+  accessTenantId: string;
+  memberId?: string;
+  route: string;
+  scope: string;
+  values?: readonly string[];
+};
+
+function assertNonBlank(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`tenant cache key requires ${field}`);
+  return normalized;
+}
+
+export function tenantCacheKey(params: TenantCacheKeyParams): string[] {
+  const key = [
+    'scope',
+    assertNonBlank(params.scope, 'scope'),
+    'route',
+    assertNonBlank(params.route, 'route'),
+    'access_tenant_id',
+    assertNonBlank(params.accessTenantId, 'accessTenantId'),
+  ];
+
+  if (params.memberId !== undefined) {
+    key.push('member_id', assertNonBlank(params.memberId, 'memberId'));
+  }
+
+  for (const value of params.values ?? []) {
+    key.push(assertNonBlank(value, 'values[]'));
+  }
+
+  return key;
+}
+
+export function tenantCacheTag(kind: 'case' | 'member', tenantId: string, id: string): string {
+  return `${kind}:access_tenant_id:${assertNonBlank(tenantId, 'tenantId')}:${assertNonBlank(
+    id,
+    'id'
+  )}`;
+}

--- a/scripts/check-db-access-guard.mjs
+++ b/scripts/check-db-access-guard.mjs
@@ -10,6 +10,7 @@ import {
 import { callFirstArgumentName, collectDbAliases, escapeRegExp } from './ci/db-access-aliases.mjs';
 import { DIRECT_DB_METHODS } from './ci/db-access-constants.mjs';
 import { isSensitiveNewEntry } from './ci/db-access-sensitive-entry.mjs';
+import { stripCommentsAndStrings } from './ci/source-strip-comments.mjs';
 
 const DEFAULT_BASELINE_PATH = 'scripts/ci/db-access-baseline.json';
 const DEFAULT_REPORT_PATH = 'tmp/db-access-guard/report.json';
@@ -142,66 +143,6 @@ function walkFiles(rootDir, repoRoot, results = []) {
   }
 
   return results;
-}
-
-function stripCommentsAndStrings(source) {
-  let output = '';
-  let quote = null;
-  let escaped = false;
-
-  for (let index = 0; index < source.length; index += 1) {
-    const char = source[index];
-    const next = source[index + 1];
-
-    if (!quote && char === '/' && next === '/') {
-      while (index < source.length && source[index] !== '\n') {
-        output += ' ';
-        index += 1;
-      }
-      if (index < source.length) output += '\n';
-      continue;
-    }
-
-    if (!quote && char === '/' && next === '*') {
-      output += '  ';
-      index += 2;
-      while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) {
-        output += source[index] === '\n' ? '\n' : ' ';
-        index += 1;
-      }
-      if (index < source.length) {
-        output += '  ';
-        index += 1;
-      }
-      continue;
-    }
-
-    if (quote) {
-      output += char === '\n' ? '\n' : ' ';
-      if (escaped) {
-        escaped = false;
-        continue;
-      }
-      if (char === '\\') {
-        escaped = true;
-        continue;
-      }
-      if (char === quote) {
-        quote = null;
-      }
-      continue;
-    }
-
-    if (char === '"' || char === "'" || char === '`') {
-      quote = char;
-      output += ' ';
-      continue;
-    }
-
-    output += char;
-  }
-
-  return output;
 }
 
 function normalizeSource(source) {

--- a/scripts/check-tenant-cache-guard.mjs
+++ b/scripts/check-tenant-cache-guard.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  callSiteWindow,
+  commentText,
+  findClosingParen,
+  lineNumberForIndex,
+  splitTopLevelArgs,
+  stripCommentsAndStrings,
+} from './ci/tenant-cache-parser.mjs';
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+const SHARED_CACHE_KINDS = new Set([
+  'airline-registry',
+  'locale-messages',
+  'plan-catalogs',
+  'rule-packs',
+]);
+const PROTECTED_ROUTE_ROLES = new Set('member agent staff admin'.split(' '));
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+function walkFiles(root, files = []) {
+  if (!fs.existsSync(root)) return files;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (!['node_modules', '.next', 'dist', 'coverage'].includes(entry.name)) {
+        walkFiles(fullPath, files);
+      }
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function routeRole(relativePath) {
+  if (!relativePath.startsWith('apps/web/src/app/')) return null;
+  const segments = new Set(relativePath.split('/'));
+  for (const role of PROTECTED_ROUTE_ROLES) {
+    if (segments.has(role)) return role;
+  }
+  return null;
+}
+
+function sharedCacheKind(source) {
+  const match = /tenant-cache-guard:\s*shared-cache\s+([a-z-]+)/u.exec(commentText(source));
+  return match?.[1] ?? null;
+}
+
+function validateSharedCache(source, file, line, violations) {
+  const kind = sharedCacheKind(source);
+  if (kind && SHARED_CACHE_KINDS.has(kind)) return true;
+  if (kind) violations.push(`${file}:${line} shared cache kind is not allowlisted: ${kind}`);
+  return false;
+}
+
+function keySetHas(keyText, keyName) {
+  return [`'${keyName}'`, `"${keyName}"`, `\`${keyName}\``].some(marker =>
+    keyText.includes(marker)
+  );
+}
+
+function codeHasTenantIdentifier(codeText, keyName) {
+  const camelName = keyName.replace(/_([a-z])/gu, (_, letter) => letter.toUpperCase());
+  return new RegExp(String.raw`\b(?:${keyName}|${camelName})\b`, 'u').test(codeText);
+}
+
+function inspectUnstableCache(source, file, role, violations) {
+  const pattern = /\bunstable_cache\s*\(/gu;
+  for (const match of source.matchAll(pattern)) {
+    const openIndex = source.indexOf('(', match.index);
+    const end = findClosingParen(source, openIndex);
+    const line = lineNumberForIndex(source, match.index);
+    if (end === -1) {
+      violations.push(`${file}:${line} unstable_cache call is not parseable`);
+      continue;
+    }
+    if (validateSharedCache(callSiteWindow(source, match.index, end + 1), file, line, violations))
+      continue;
+    const args = splitTopLevelArgs(source.slice(openIndex + 1, end));
+    const keyText = args[1] ?? '';
+    if (!keySetHas(keyText, 'access_tenant_id')) {
+      violations.push(`${file}:${line} unstable_cache key set must include access_tenant_id`);
+    }
+    if (role === 'member' && !keySetHas(keyText, 'member_id')) {
+      violations.push(`${file}:${line} member unstable_cache key set must include member_id`);
+    }
+  }
+}
+
+function inspectUseCache(source, file, role, violations) {
+  const pattern = /['"]use cache['"]/gu;
+  const codeText = stripCommentsAndStrings(source);
+  for (const match of source.matchAll(pattern)) {
+    const line = lineNumberForIndex(source, match.index);
+    if (
+      validateSharedCache(
+        callSiteWindow(source, match.index, match.index + match[0].length),
+        file,
+        line,
+        violations
+      )
+    )
+      continue;
+    if (!codeHasTenantIdentifier(codeText, 'access_tenant_id')) {
+      violations.push(`${file}:${line} use cache file must declare access_tenant_id in key set`);
+    }
+    if (role === 'member' && !codeHasTenantIdentifier(codeText, 'member_id')) {
+      violations.push(`${file}:${line} member use cache file must declare member_id in key set`);
+    }
+  }
+}
+
+export function findTenantCacheGuardViolations(root = process.cwd()) {
+  const violations = [];
+  for (const filePath of walkFiles(path.join(root, 'apps/web/src/app'))) {
+    const relativePath = toPosix(path.relative(root, filePath));
+    const role = routeRole(relativePath);
+    if (!role) continue;
+    const source = fs.readFileSync(filePath, 'utf8');
+    inspectUnstableCache(source, relativePath, role, violations);
+    inspectUseCache(source, relativePath, role, violations);
+  }
+  return violations;
+}
+
+export function runTenantCacheGuard(root = process.cwd()) {
+  const violations = findTenantCacheGuardViolations(root);
+  if (violations.length > 0) {
+    console.error('Tenant cache guard failed:');
+    for (const violation of violations) console.error(`- ${violation}`);
+    return 1;
+  }
+  console.log('Tenant cache guard passed.');
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(runTenantCacheGuard());
+}

--- a/scripts/ci/source-strip-comments.mjs
+++ b/scripts/ci/source-strip-comments.mjs
@@ -1,0 +1,94 @@
+function isQuote(char) {
+  return char === '"' || char === "'" || char === '`';
+}
+
+function stripLineComment(source, index) {
+  let text = '';
+  while (index < source.length && source[index] !== '\n') {
+    text += ' ';
+    index += 1;
+  }
+  if (index < source.length) text += '\n';
+  return { index, text };
+}
+
+function stripBlockComment(source, index) {
+  let text = '  ';
+  index += 2;
+  while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) {
+    text += source[index] === '\n' ? '\n' : ' ';
+    index += 1;
+  }
+  if (index < source.length) {
+    text += '  ';
+    index += 1;
+  }
+  return { index, text };
+}
+
+function preserveTemplateExpression(source, index) {
+  let text = '  ';
+  let depth = 1;
+  index += 2;
+  while (index < source.length && depth > 0) {
+    if (source[index] === '{') depth += 1;
+    else if (source[index] === '}') depth -= 1;
+    text += depth > 0 ? source[index] : ' ';
+    index += 1;
+  }
+  return { index: index - 1, text };
+}
+
+function stripQuotedChar(char, quote, escaped) {
+  if (escaped) return { escaped: false, output: char === '\n' ? '\n' : ' ', quote };
+  if (char === '\\') return { escaped: true, output: ' ', quote };
+  return {
+    escaped: false,
+    output: char === '\n' ? '\n' : ' ',
+    quote: char === quote ? null : quote,
+  };
+}
+
+export function stripCommentsAndStrings(source, options = {}) {
+  const preserveTemplateExpressions = options.preserveTemplateExpressions === true;
+  let output = '';
+  let quote = null;
+  let escaped = false;
+  let index = 0;
+
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+    let replacement = null;
+
+    if (!quote && char === '/' && next === '/') replacement = stripLineComment(source, index);
+    else if (!quote && char === '/' && next === '*') replacement = stripBlockComment(source, index);
+    else if (preserveTemplateExpressions && quote === '`' && char === '$' && next === '{') {
+      replacement = preserveTemplateExpression(source, index);
+    }
+
+    if (replacement) {
+      output += replacement.text;
+      index = replacement.index + 1;
+      continue;
+    }
+
+    if (quote) {
+      const stripped = stripQuotedChar(char, quote, escaped);
+      ({ escaped, quote } = stripped);
+      output += stripped.output;
+      index += 1;
+      continue;
+    }
+
+    if (isQuote(char)) {
+      quote = char;
+      output += ' ';
+    } else {
+      output += char;
+    }
+    index += 1;
+  }
+
+  return output;
+}

--- a/scripts/ci/tenant-cache-guard-test-utils.mjs
+++ b/scripts/ci/tenant-cache-guard-test-utils.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { findTenantCacheGuardViolations } from '../check-tenant-cache-guard.mjs';
+
+export const TENANT_CACHE_AGENT_ROUTE = 'apps/web/src/app/[locale]/(agent)/agent/page.tsx';
+export const TENANT_CACHE_MEMBER_ROUTE = 'apps/web/src/app/[locale]/(app)/member/claims/page.tsx';
+export const TENANT_CACHE_STAFF_ROUTE = 'apps/web/src/app/[locale]/(staff)/staff/claims/page.ts';
+
+export function tempTenantCacheRepo(prefix = 'tenant-cache-guard-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+export function writeTenantCacheFixture(root, relativePath, source) {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${source.trim()}\n`);
+}
+
+export function writeUnstableCacheFixture(root, relativePath, source) {
+  writeTenantCacheFixture(
+    root,
+    relativePath,
+    `
+      import { unstable_cache } from 'next/cache';
+      ${source}
+    `
+  );
+}
+
+export function expectTenantCacheViolations(root, expected) {
+  assert.deepEqual(findTenantCacheGuardViolations(root), expected);
+}

--- a/scripts/ci/tenant-cache-guard.test.mjs
+++ b/scripts/ci/tenant-cache-guard.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runTenantCacheGuard } from '../check-tenant-cache-guard.mjs';
+import {
+  expectTenantCacheViolations,
+  tempTenantCacheRepo,
+  TENANT_CACHE_MEMBER_ROUTE,
+  TENANT_CACHE_STAFF_ROUTE,
+  writeTenantCacheFixture,
+  writeUnstableCacheFixture,
+} from './tenant-cache-guard-test-utils.mjs';
+
+test('fails tenant route unstable_cache without access tenant key', () => {
+  const root = tempTenantCacheRepo();
+  writeUnstableCacheFixture(
+    root,
+    TENANT_CACHE_STAFF_ROUTE,
+    `
+      export const getClaims = unstable_cache(async () => [], ['claims']);
+    `
+  );
+
+  expectTenantCacheViolations(root, [
+    `${TENANT_CACHE_STAFF_ROUTE}:3 unstable_cache key set must include access_tenant_id`,
+  ]);
+});
+
+test('requires member_id for member-scoped unstable_cache usage', () => {
+  const root = tempTenantCacheRepo();
+  writeUnstableCacheFixture(
+    root,
+    TENANT_CACHE_MEMBER_ROUTE,
+    `
+      export const getClaims = unstable_cache(async () => [], ['access_tenant_id', tenantId]);
+    `
+  );
+
+  expectTenantCacheViolations(root, [
+    `${TENANT_CACHE_MEMBER_ROUTE}:3 member unstable_cache key set must include member_id`,
+  ]);
+});
+
+test('passes tenant and member keyed cache usage', () => {
+  const root = tempTenantCacheRepo();
+  writeUnstableCacheFixture(
+    root,
+    TENANT_CACHE_MEMBER_ROUTE,
+    `
+      export const getClaims = unstable_cache(
+        async () => [],
+        ['access_tenant_id', tenantId, 'member_id', memberId, 'claim_id', claimId]
+      );
+    `
+  );
+
+  expectTenantCacheViolations(root, []);
+});
+
+test('allows only explicitly allowlisted shared data caches', () => {
+  const root = tempTenantCacheRepo();
+  writeTenantCacheFixture(
+    root,
+    'apps/web/src/app/[locale]/admin/plans/page.ts',
+    `
+      import { unstable_cache } from 'next/cache';
+      // tenant-cache-guard: shared-cache plan-catalogs
+      export const getPlans = unstable_cache(async () => [], ['plans']);
+    `
+  );
+  writeTenantCacheFixture(
+    root,
+    'apps/web/src/app/[locale]/admin/unsafe/page.ts',
+    `
+      import { unstable_cache } from 'next/cache';
+      // tenant-cache-guard: shared-cache global-users
+      export const getUsers = unstable_cache(async () => [], ['users']);
+    `
+  );
+
+  expectTenantCacheViolations(root, [
+    'apps/web/src/app/[locale]/admin/unsafe/page.ts:3 shared cache kind is not allowlisted: global-users',
+    'apps/web/src/app/[locale]/admin/unsafe/page.ts:3 unstable_cache key set must include access_tenant_id',
+  ]);
+});
+
+test('keeps shared-cache annotations scoped to the local call comments', () => {
+  const root = tempTenantCacheRepo();
+  writeTenantCacheFixture(
+    root,
+    'apps/web/src/app/[locale]/admin/mixed/page.ts',
+    `
+      import { unstable_cache } from 'next/cache';
+      // tenant-cache-guard: shared-cache plan-catalogs
+      export const getPlans = unstable_cache(async () => [], ['plans']);
+      export const getTenantUsers = unstable_cache(async () => [], ['users']);
+      const docs = 'tenant-cache-guard: shared-cache plan-catalogs';
+    `
+  );
+
+  expectTenantCacheViolations(root, [
+    'apps/web/src/app/[locale]/admin/mixed/page.ts:4 unstable_cache key set must include access_tenant_id',
+  ]);
+});
+
+test('is wired cleanly against the current repository', () => {
+  assert.equal(runTenantCacheGuard(process.cwd()), 0);
+});

--- a/scripts/ci/tenant-cache-parser.mjs
+++ b/scripts/ci/tenant-cache-parser.mjs
@@ -1,0 +1,77 @@
+import { stripCommentsAndStrings as stripSourceCommentsAndStrings } from './source-strip-comments.mjs';
+
+function quoteState(char, quote, escaped) {
+  if (!quote) return null;
+  if (escaped) return { quote, escaped: false };
+  if (char === '\\') return { quote, escaped: true };
+  return { quote: char === quote ? null : quote, escaped: false };
+}
+
+function isQuote(char) {
+  return char === '"' || char === "'" || char === '`';
+}
+
+function scanUnquotedChars(source, startIndex, visit) {
+  let quote = null;
+  let escaped = false;
+  for (let index = startIndex; index < source.length; index += 1) {
+    const char = source[index];
+    const nextQuote = quoteState(char, quote, escaped);
+    if (nextQuote) {
+      ({ quote, escaped } = nextQuote);
+      continue;
+    }
+    if (isQuote(char)) {
+      quote = char;
+      continue;
+    }
+    const result = visit(char, index);
+    if (result !== undefined) return result;
+  }
+}
+
+export function findClosingParen(source, openIndex) {
+  let depth = 0;
+  const found = scanUnquotedChars(source, openIndex, (char, index) => {
+    if (char === '(') depth += 1;
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  });
+  return found ?? -1;
+}
+
+export function splitTopLevelArgs(callText) {
+  const args = [];
+  let start = 0;
+  let depth = 0;
+  scanUnquotedChars(callText, 0, (char, index) => {
+    if ('([{'.includes(char)) depth += 1;
+    else if (')]}'.includes(char)) depth -= 1;
+    else if (char === ',' && depth === 0) {
+      args.push(callText.slice(start, index));
+      start = index + 1;
+    }
+  });
+  args.push(callText.slice(start));
+  return args;
+}
+
+export function stripCommentsAndStrings(source) {
+  return stripSourceCommentsAndStrings(source, { preserveTemplateExpressions: true });
+}
+
+export function commentText(source) {
+  return [...source.matchAll(/\/\/[^\n]*|\/\*[\s\S]*?\*\//gu)].map(match => match[0]).join('\n');
+}
+
+export function callSiteWindow(source, start, end) {
+  const lineStart = source.lastIndexOf('\n', start - 1) + 1;
+  const previousStart = source.lastIndexOf('\n', lineStart - 2) + 1;
+  return source.slice(previousStart, end);
+}
+
+export function lineNumberForIndex(source, index) {
+  return source.slice(0, index).split('\n').length;
+}

--- a/scripts/ci/tenant-cache-use-cache-guard.test.mjs
+++ b/scripts/ci/tenant-cache-use-cache-guard.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test';
+
+import {
+  expectTenantCacheViolations,
+  tempTenantCacheRepo,
+  TENANT_CACHE_AGENT_ROUTE,
+  TENANT_CACHE_MEMBER_ROUTE,
+  writeTenantCacheFixture,
+} from './tenant-cache-guard-test-utils.mjs';
+
+test('catches use cache directives in protected route files', () => {
+  const root = tempTenantCacheRepo('tenant-cache-use-cache-');
+  writeTenantCacheFixture(
+    root,
+    TENANT_CACHE_AGENT_ROUTE,
+    `
+      export async function AgentPage() {
+        'use cache';
+        return null;
+      }
+    `
+  );
+
+  expectTenantCacheViolations(root, [
+    `${TENANT_CACHE_AGENT_ROUTE}:2 use cache file must declare access_tenant_id in key set`,
+  ]);
+});
+
+test('does not accept comments or strings as use cache tenant keys', () => {
+  const root = tempTenantCacheRepo('tenant-cache-use-cache-');
+  writeTenantCacheFixture(
+    root,
+    TENANT_CACHE_MEMBER_ROUTE,
+    `
+      export async function MemberClaims() {
+        'use cache';
+        // access_tenant_id member_id
+        const label = 'access_tenant_id member_id';
+        return label;
+      }
+    `
+  );
+
+  expectTenantCacheViolations(root, [
+    `${TENANT_CACHE_MEMBER_ROUTE}:2 use cache file must declare access_tenant_id in key set`,
+    `${TENANT_CACHE_MEMBER_ROUTE}:2 member use cache file must declare member_id in key set`,
+  ]);
+});
+
+test('accepts code identifiers as use cache tenant key inputs', () => {
+  const root = tempTenantCacheRepo('tenant-cache-use-cache-');
+  writeTenantCacheFixture(
+    root,
+    TENANT_CACHE_MEMBER_ROUTE,
+    `
+      export async function MemberClaims({ accessTenantId, memberId }) {
+        'use cache';
+        return accessTenantId + memberId;
+      }
+    `
+  );
+
+  expectTenantCacheViolations(root, []);
+});
+
+test('accepts identifiers inside template literal interpolations', () => {
+  const root = tempTenantCacheRepo('tenant-cache-use-cache-');
+  writeTenantCacheFixture(
+    root,
+    TENANT_CACHE_MEMBER_ROUTE,
+    `
+      export async function MemberClaims({ accessTenantId, memberId }) {
+        'use cache';
+        return \`cache:\${accessTenantId}:\${memberId}\`;
+      }
+    `
+  );
+
+  expectTenantCacheViolations(root, []);
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36373863,
-  "maxTrackedFiles": 4342,
+  "maxTrackedBytes": 36424409,
+  "maxTrackedFiles": 4356,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17964557,
-    "source/scripts": 6814243,
-    "docs/text": 5205686,
-    "tests/e2e": 4719492,
+    "large support/generated-ish": 17975880,
+    "source/scripts": 6829740,
+    "docs/text": 5217132,
+    "tests/e2e": 4731772,
     "config/data/messages": 1540720,
     "other": 129165
   },
-  "maxLargestFileBytes": 3049583,
+  "maxLargestFileBytes": 3060906,
   "maxSourceOrTestLines": 3000
 }

--- a/scripts/security-guard.mjs
+++ b/scripts/security-guard.mjs
@@ -8,6 +8,7 @@ import { runRawRoleArrayGuard } from './check-raw-role-arrays.mjs';
 import { runServiceRoleStorageBoundaryGuard } from './check-service-role-storage-boundary.mjs';
 import { runClaimStatusWriterGuard } from './check-claim-status-writers.mjs';
 import { runSignedUrlExposureGuard } from './check-signed-url-exposure.mjs';
+import { runTenantCacheGuard } from './check-tenant-cache-guard.mjs';
 import { runWorkflowSeedCredentialGuard } from './check-workflow-seed-credentials.mjs';
 
 const LOCKFILE_PATH = path.join(process.cwd(), 'pnpm-lock.yaml');
@@ -110,6 +111,7 @@ async function runGuard() {
     runModularityGuard,
     runRawRoleArrayGuard,
     runClaimStatusWriterGuard,
+    runTenantCacheGuard,
     runBrandDisciplineGuard,
   ]) {
     runRequiredGuard(guard);


### PR DESCRIPTION
Summary
- Adds tenant-keyed cache key/tag helpers for case/member cache use.
- Adds an outbox relay consumer that selects domain events and calls revalidateTag(tag, 'max') for case/member tags, then records domain event delivery.
- Adds a static T-309 guard wired into security:guard so member/staff/agent/admin route-group unstable_cache/use cache usage fails unless tenant key requirements are visible.

Changed Areas
- apps/web/src/server/domains/tenant-cache.ts: tenant cache key/tag helpers.
- apps/web/src/server/domains/tenant-cache-revalidation.ts: event-driven revalidateTag relay consumer using the repo-local specialized relay pattern: selectDomainEventsForRelay -> side effect -> recordDomainEventDelivery, matching existing billing relays where delivery must be recorded after the side effect.
- apps/web/src/server/domains/*tenant-cache*.test*.ts: cross-tenant overlapping-id, non-case delivery, and per-event error-isolation proof.
- scripts/check-tenant-cache-guard.mjs and scripts/ci/tenant-cache-*.mjs: static guard, parser helpers, shared test helpers, and focused contract tests.
- scripts/security-guard.mjs: wires tenant cache guard into existing security gate.
- scripts/repo-size-budget.json: synced after adding tracked files.

Verification
- node --test scripts/ci/tenant-cache-guard.test.mjs scripts/ci/tenant-cache-use-cache-guard.test.mjs: pass (10 tests).
- node scripts/check-tenant-cache-guard.mjs: pass.
- pnpm --filter @interdomestik/web test:unit --run src/server/domains/tenant-cache.test.ts src/server/domains/tenant-cache-revalidation.test.ts src/server/domains/tenant-cache-revalidation-failure.test.ts: pass (3 files, 7 tests).
- pnpm check:modularity-guard: pass.
- node scripts/repo-size-budget-sync.mjs && pnpm repo:size:check: pass.
- pnpm security:guard: pass.
- git diff --cached --check before amend: pass, covering staged and newly added files.

Feedback Remediation
- Copilot #1: per-event try/catch added; failed events are counted/logged and do not block later events.
- Copilot #2/#4: shared-cache annotations are now comment-only and call-site/directive scoped, not file-wide or string-matchable.
- Copilot #3: parser preserves template literal interpolation code for use cache identifier detection.
- Copilot #5: non-case event proof added: delivery is recorded and no tags are revalidated.
- Sonar duplication: duplicated test fixture setup was extracted into shared helpers and revalidation failure proof split into a focused file.

Operational Evidence
- Event-driven invalidation path is covered by relayTenantCacheRevalidationEvents: domain event relay selection -> revalidateTag(case/member tenant-qualified tags, 'max') -> recordDomainEventDelivery.
- No client polling path added.
- @interdomestik/database imports used by the relay consumer were verified exported from the current repo.
- Overlapping-id proof calls the relay separately for tenant A and tenant B, matching existing tenant-filtered relay selection semantics.

Edge Cases
- Verified unstable_cache missing access_tenant_id fails.
- Verified member route unstable_cache missing member_id fails.
- Verified allowlisted shared cache kind passes and non-allowlisted shared cache kind fails.
- Verified shared cache annotation does not exempt a later tenant-scoped cache in the same file.
- Verified use cache detection is not satisfied by comments or string literals.
- Verified template literal interpolations preserve accessTenantId/memberId detection.
- Verified two tenants with same route/overlapping ids produce distinct keys/tags through realistic per-tenant relay invocations.

Review/Security
- Copilot review: requested again on current head e2e3c261.
- Sonar/CodeQL/gitleaks/pnpm-audit: pending current-head CI after remediation push.
- Senior reviewer/Codex Security scan: pending.

Rollback/Mitigation
- Revert this PR to remove the static guard, helper, and relay consumer. No schema, proxy, auth/session, RLS, billing, or route changes are included.

Residual Risk
- Static use cache detection strips comments/strings and detects real accessTenantId/memberId or snake_case identifiers, including template interpolations, but does not perform full TypeScript data-flow analysis. This is a bounded static guard for the delegated T-309 gate scope.
- Broad Phase C gates (pnpm pr:verify, pnpm e2e:gate) and current-head PR feedback are still pending for readiness.