### PR TITLE
test: add law-pack loader performance guard

### DIFF
--- a/packages/domain-recovery/src/law-pack-performance-guard.test.ts
+++ b/packages/domain-recovery/src/law-pack-performance-guard.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  createLawPackRegistry,
+  resolveRecoveryLawFromLawPack,
+  type LawPack,
+  type LawPackLoader,
+} from './index';
+
+type Country = 'MK' | 'XK' | 'DE';
+
+function lawPack(countryCode: Country): LawPack {
+  return {
+    countryCode,
+    recoveryLaw: countryCode,
+    recoveryLegalTenantId: `tenant_${countryCode.toLowerCase()}`,
+    regulatedActivityNoteRequired: true,
+    owner: 'domain-recovery-test',
+    effectiveFrom: '2026-06-20',
+    lastReviewed: '2026-06-20',
+    sourceReferences: [`test:${countryCode.toLowerCase()}`],
+  };
+}
+
+test('T-205b loads one law pack per country per warm isolate', async () => {
+  const loads: Record<Country, number> = { DE: 0, MK: 0, XK: 0 };
+  const loaderFor =
+    (countryCode: Country): LawPackLoader =>
+    () => {
+      loads[countryCode] += 1;
+      return lawPack(countryCode);
+    };
+  const registry = createLawPackRegistry({
+    DE: loaderFor('DE'),
+    MK: loaderFor('MK'),
+    XK: loaderFor('XK'),
+  });
+
+  assert.deepEqual(loads, { DE: 0, MK: 0, XK: 0 });
+
+  const [firstMk, secondMk] = await Promise.all([
+    registry.loadLawPack('mk'),
+    registry.loadLawPack(' MK '),
+  ]);
+  const firstXk = await registry.loadLawPack('XK');
+  const thirdMk = await registry.loadLawPack('MK');
+
+  assert.equal(firstMk, secondMk);
+  assert.equal(firstMk, thirdMk);
+  assert.equal(firstMk.countryCode, 'MK');
+  assert.equal(firstXk.countryCode, 'XK');
+  assert.deepEqual(loads, { DE: 0, MK: 1, XK: 1 });
+});
+
+test('T-205b transition and assistance checks load only the explicit incident country', async () => {
+  const requestedCountries: Array<string | null | undefined> = [];
+  const loads: Record<Country, number> = { DE: 0, MK: 0, XK: 0 };
+  const loaderFor =
+    (countryCode: Country): LawPackLoader =>
+    () => {
+      loads[countryCode] += 1;
+      if (countryCode === 'DE') throw new Error('all-country law-pack load must not run');
+      return lawPack(countryCode);
+    };
+  const registry = createLawPackRegistry({
+    DE: loaderFor('DE'),
+    MK: loaderFor('MK'),
+    XK: loaderFor('XK'),
+  });
+  const loadLawPack = async (countryCode: string | null | undefined) => {
+    requestedCountries.push(countryCode);
+    return registry.loadLawPack(countryCode);
+  };
+
+  for (const incidentCountryCode of ['MK', 'XK'] as const) {
+    const resolution = await resolveRecoveryLawFromLawPack({
+      incidentCountryCode,
+      loadLawPack,
+    });
+
+    assert.equal(resolution.outcome, 'recovery_law_resolved');
+    assert.equal(resolution.incidentCountryCode, incidentCountryCode);
+    assert.equal(resolution.recoveryLaw, incidentCountryCode);
+  }
+
+  assert.deepEqual(requestedCountries, ['MK', 'XK']);
+  assert.deepEqual(loads, { DE: 0, MK: 1, XK: 1 });
+});

--- a/packages/domain-recovery/src/law-pack-resolution.test.ts
+++ b/packages/domain-recovery/src/law-pack-resolution.test.ts
@@ -34,7 +34,7 @@ test('resolves recovery law from an injected law pack', async () => {
   assert.equal(resolution.posture, 'recovery_available');
 });
 
-test('T-208b unsupported incident country cannot fall back to membership governing law', async () => {
+test('T-208b unsupported incident country cannot fall back to tenant or session context', async () => {
   const requestedCountries: Array<string | null | undefined> = [];
 
   const resolution = await resolveRecoveryLawFromLawPack({
@@ -46,6 +46,10 @@ test('T-208b unsupported incident country cannot fall back to membership governi
       hostTenantId: 'tenant_host',
       membershipGoverningLaw: 'MK',
       membershipLegalTenantId: 'tenant_mk',
+      sessionCountryCode: 'MK',
+      sessionTenantId: 'tenant_session',
+      tenantCountryCode: 'MK',
+      tenantId: 'tenant_default',
     },
     loadLawPack: async countryCode => {
       requestedCountries.push(countryCode);
@@ -65,6 +69,8 @@ test('T-208b unsupported incident country cannot fall back to membership governi
   assert.notEqual(resolution.recoveryLegalTenantId, 'tenant_booking');
   assert.notEqual(resolution.recoveryLegalTenantId, 'tenant_host');
   assert.notEqual(resolution.recoveryLegalTenantId, 'tenant_access');
+  assert.notEqual(resolution.recoveryLegalTenantId, 'tenant_default');
+  assert.notEqual(resolution.recoveryLegalTenantId, 'tenant_session');
 });
 
 test('unexpected law-pack loader errors propagate', async () => {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36424409,
-  "maxTrackedFiles": 4356,
+  "maxTrackedBytes": 36451664,
+  "maxTrackedFiles": 4358,
   "maxCategoryBytes": {
-    "large support/generated-ish": 17975880,
+    "large support/generated-ish": 17985802,
     "source/scripts": 6829740,
-    "docs/text": 5217132,
-    "tests/e2e": 4731772,
+    "docs/text": 5231397,
+    "tests/e2e": 4734840,
     "config/data/messages": 1540720,
     "other": 129165
   },
-  "maxLargestFileBytes": 3060906,
+  "maxLargestFileBytes": 3070828,
   "maxSourceOrTestLines": 3000
 }


### PR DESCRIPTION
## Summary
- Adds T-205b domain-recovery performance guard coverage for law-pack loading.
- Proves per-country warm-isolate caching and explicit incident-country-only loading with an extra `DE` loader that fails if an all-country/eager load path runs.
- Extends unsupported-country resolver coverage to include tenant/session fallback context attempts.

## Changed Areas
- `packages/domain-recovery/src/law-pack-performance-guard.test.ts`
- `packages/domain-recovery/src/law-pack-resolution.test.ts`
- `scripts/repo-size-budget.json` generated by `node scripts/repo-size-budget-sync.mjs` because the slice adds a tracked test file.

## Verification
- `git diff --check` — pass
- `pnpm repo:size:check` — pass after generated budget sync
- `pnpm --filter @interdomestik/domain-recovery test:unit --run law-pack-performance-guard.test.ts` — pass (`24` tests; local `DATABASE_URL is missing in db.ts!` warning is non-fatal)
- `pnpm --filter @interdomestik/domain-recovery type-check` — pass
- `pnpm check:modularity-guard` — pass
- `pnpm slice:verify` — pass
- `pnpm security:guard` — pass standalone
- `pnpm pr:verify` — pass before commit; post-commit focused diff/test proof reran after commit hook formatting

## Reviewer / Security Disposition
- Senior reviewer Sonnet route: blocked by `reviewer_no_output_timeout` after 300s.
- Gemini fallback route: blocked by Gemini CLI 403 license/authentication error `#3501`.
- Security guard: pass.
- Copilot review: will be requested after PR creation.

## Residual Risks
- This is test-only guard evidence; it does not change runtime loader behavior.
- `pnpm e2e:gate` was intentionally not counted after supervisor interruption; `pnpm pr:verify` did complete a PR E2E lane earlier with `136 passed / 8 skipped` plus smoke `13 passed / 9 skipped`.

## Explicit Scope Boundaries
- No docs/tracker/closeout edits.
- No `apps/web/src/proxy.ts` changes.
- No auth, routing, tenancy, schema/RLS, billing, UI, or Operational Brain runtime changes.
- No runtime fix was needed; existing loader behavior satisfied the new guard.