### PR TITLE
feat: add AI document extraction consent boundary

### DIFF
--- a/apps/web/src/actions/claims.test-helpers.ts
+++ b/apps/web/src/actions/claims.test-helpers.ts
@@ -1,0 +1,15 @@
+type TxSelectParams = {
+  emptyConsentLimit: () => unknown;
+  paymentLimit: () => unknown;
+};
+
+export function createClaimActionTxSelect(params: TxSelectParams) {
+  const orderByConsent = () => ({ limit: params.emptyConsentLimit });
+  const wherePaymentOrConsent = () => ({
+    limit: params.paymentLimit,
+    orderBy: orderByConsent,
+  });
+  const fromAnyTable = () => ({ where: wherePaymentOrConsent });
+
+  return () => ({ from: fromAnyTable });
+}

--- a/apps/web/src/actions/claims.test.ts
+++ b/apps/web/src/actions/claims.test.ts
@@ -3,6 +3,7 @@ import { db } from '@interdomestik/database';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { submitClaim } from './claims.core';
 import { createClaim, updateClaimStatus } from './claims';
+import { createClaimActionTxSelect } from './claims.test-helpers';
 
 const mockGetSession = vi.fn();
 const mockDbInsert = vi.fn().mockReturnValue({
@@ -17,6 +18,7 @@ const mockTxSelectLimit = vi
   .mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 1, status: 'submitted' }]);
 const mockTxUpdateReturning = vi.fn().mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 2 }]);
 const mockPaymentLimit = vi.fn().mockResolvedValue([{ paymentAuthorizationState: 'authorized' }]);
+const mockEmptyConsentLimit = vi.fn().mockResolvedValue([]);
 const mockHasActiveMembership = vi.fn();
 const mockGetActiveSubscription = vi.fn();
 const mockValidateInitialClaimEvidenceUpload = vi.hoisted(() => vi.fn());
@@ -56,26 +58,20 @@ vi.mock('@interdomestik/database', () => ({
     transaction: async <T>(fn: (tx: unknown) => Promise<T>) =>
       fn({
         insert: () => ({ values: mockDbInsert }),
-        select: () => ({ from: () => ({ where: () => ({ limit: mockTxSelectLimit }) }) }),
+        select: createClaimActionTxSelect({
+          emptyConsentLimit: mockEmptyConsentLimit,
+          paymentLimit: mockTxSelectLimit,
+        }),
         update: () => ({ set: () => ({ where: () => ({ returning: mockTxUpdateReturning }) }) }),
         query: {
           tenants: { findFirst: vi.fn().mockResolvedValue({ id: 'tenant_mk', countryCode: 'MK' }) },
         },
       }),
     query: {
-      subscriptions: {
-        findFirst: vi.fn().mockResolvedValue({
-          id: 'sub-1',
-          userId: 'user-123',
-          status: 'active',
-        }),
-      },
-      agentClients: {
-        findFirst: vi.fn().mockResolvedValue(null),
-      },
-      tenantSettings: {
-        findFirst: vi.fn().mockResolvedValue(null),
-      },
+      // prettier-ignore
+      subscriptions: { findFirst: vi.fn().mockResolvedValue({ id: 'sub-1', userId: 'user-123', status: 'active' }) },
+      agentClients: { findFirst: vi.fn().mockResolvedValue(null) },
+      tenantSettings: { findFirst: vi.fn().mockResolvedValue(null) },
       claims: {
         findFirst: vi.fn().mockResolvedValue({
           id: 'claim-1',
@@ -118,6 +114,8 @@ vi.mock('@interdomestik/database', () => ({
   },
   claimStageHistory: { id: { name: 'id' }, tenantId: { name: 'tenantId' } },
   claimDocuments: { id: { name: 'id' }, tenantId: { name: 'tenantId' } },
+  // prettier-ignore
+  claimDocumentAiExtractionConsents: { id: { name: 'id' }, tenantId: { name: 'tenantId' }, actorId: { name: 'actorId' }, subjectId: { name: 'subjectId' }, claimId: { name: 'claimId' }, documentId: { name: 'documentId' }, consentType: { name: 'consentType' }, processingPurpose: { name: 'processingPurpose' }, status: { name: 'status' }, privacyVersion: { name: 'privacyVersion' }, locale: { name: 'locale' }, sourceSurface: { name: 'sourceSurface' }, recordedAt: { name: 'recordedAt' }, grantedAt: { name: 'grantedAt' }, withdrawnAt: { name: 'withdrawnAt' } },
   documents: { id: { name: 'id' }, tenantId: { name: 'tenantId' } },
   aiRuns: { id: { name: 'id' }, tenantId: { name: 'tenantId' } },
   user: { id: { name: 'id' }, tenantId: { name: 'tenantId' } },

--- a/apps/web/src/app/api/claims/evidence-upload/_core.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/_core.ts
@@ -1,4 +1,3 @@
-import { confirmAdminUpload } from '@/features/admin/claims/actions';
 import {
   resolveStorageUploadContentType,
   resolveUploadMimeType,
@@ -12,7 +11,6 @@ import {
   findAccessibleAdminUploadClaim,
   findOwnedMemberUploadClaim,
 } from '@/features/claims/upload/server/access';
-import { confirmUpload } from '@/features/member/claims/actions';
 import { LOCALES } from '@/i18n/locales';
 import { auth } from '@/lib/auth';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
@@ -21,6 +19,8 @@ import { resolveTenantFromHost } from '@/lib/tenant/tenant-hosts';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import * as Sentry from '@sentry/nextjs';
 import { randomUUID } from 'crypto';
+
+import { confirmEvidenceUpload } from './confirm';
 
 const ADMIN_UPLOAD_ROLES = new Set([
   'admin',
@@ -33,9 +33,11 @@ const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 
 type UploadCategory = 'evidence' | 'legal';
 type EvidenceUploadForm = {
+  aiExtractionConsentGranted: boolean;
   category: UploadCategory;
   claimId: string;
   file: File;
+  locale: string;
 };
 
 type ResponseResult<T> = { success: true; data: T } | { success: false; response: Response };
@@ -98,6 +100,7 @@ async function parseEvidenceUploadForm(
   const claimId = formData.get('claimId');
   const category = formData.get('category');
   const locale = formData.get('locale');
+  const aiExtractionConsentGranted = formData.get('aiExtractionConsentGranted');
   const file = formData.get('file');
 
   if (
@@ -118,7 +121,16 @@ async function parseEvidenceUploadForm(
     return { success: false, response: jsonError('File too large (max 50MB)', 413) };
   }
 
-  return { success: true, data: { category, claimId, file } };
+  return {
+    success: true,
+    data: {
+      aiExtractionConsentGranted: aiExtractionConsentGranted === 'true',
+      category,
+      claimId,
+      file,
+      locale,
+    },
+  };
 }
 
 function resolveTenantId(
@@ -206,36 +218,6 @@ async function uploadEvidenceObject(params: {
   return null;
 }
 
-async function confirmEvidenceUpload(params: {
-  bucket: string;
-  category: UploadCategory;
-  claimAccess: { isAdminSurface: boolean };
-  claimId: string;
-  file: File;
-  fileId: string;
-  resolvedMimeType: string;
-  storageContentType: string;
-  storagePath: string;
-  uploadIntentToken: string;
-}) {
-  const confirmation = {
-    claimId: params.claimId,
-    storagePath: params.storagePath,
-    originalName: params.file.name,
-    mimeType: params.resolvedMimeType,
-    fileSize: params.file.size,
-    fileId: params.fileId,
-    uploadIntentToken: params.uploadIntentToken,
-    storageContentType: params.storageContentType,
-    uploadedBucket: params.bucket,
-    category: params.category,
-  };
-
-  return params.claimAccess.isAdminSurface
-    ? confirmAdminUpload(confirmation)
-    : confirmUpload(confirmation);
-}
-
 function captureConfirmFailure(params: {
   bucket: string;
   category: UploadCategory;
@@ -269,7 +251,7 @@ export async function POST(request: Request) {
   const evidenceBucket = resolveEvidenceBucket();
   if (!evidenceBucket.success) return evidenceBucket.response;
 
-  const { category, claimId, file } = form.data;
+  const { aiExtractionConsentGranted, category, claimId, file, locale } = form.data;
   const tenantId = tenant.data;
   const bucket = evidenceBucket.data;
   const role = session.user.role ?? null;
@@ -340,12 +322,14 @@ export async function POST(request: Request) {
   if (uploadError) return uploadError;
 
   const confirmResult = await confirmEvidenceUpload({
+    aiExtractionConsentGranted,
     bucket,
     category,
-    claimAccess,
     claimId,
     file,
     fileId,
+    isAdminSurface: claimAccess.isAdminSurface,
+    locale,
     resolvedMimeType,
     storageContentType,
     storagePath,

--- a/apps/web/src/app/api/claims/evidence-upload/confirm.ts
+++ b/apps/web/src/app/api/claims/evidence-upload/confirm.ts
@@ -1,0 +1,38 @@
+import { confirmAdminUpload } from '@/features/admin/claims/actions';
+import { confirmUpload } from '@/features/member/claims/actions';
+
+type UploadCategory = 'evidence' | 'legal';
+
+export type EvidenceUploadConfirmationInput = {
+  aiExtractionConsentGranted: boolean;
+  bucket: string;
+  category: UploadCategory;
+  claimId: string;
+  file: File;
+  fileId: string;
+  isAdminSurface: boolean;
+  locale: string;
+  resolvedMimeType: string;
+  storageContentType: string;
+  storagePath: string;
+  uploadIntentToken: string;
+};
+
+export function confirmEvidenceUpload(params: EvidenceUploadConfirmationInput) {
+  const confirmation = {
+    aiExtractionConsentGranted: params.isAdminSurface ? false : params.aiExtractionConsentGranted,
+    aiExtractionConsentLocale: params.locale,
+    claimId: params.claimId,
+    storagePath: params.storagePath,
+    originalName: params.file.name,
+    mimeType: params.resolvedMimeType,
+    fileSize: params.file.size,
+    fileId: params.fileId,
+    uploadIntentToken: params.uploadIntentToken,
+    storageContentType: params.storageContentType,
+    uploadedBucket: params.bucket,
+    category: params.category,
+  };
+
+  return params.isAdminSurface ? confirmAdminUpload(confirmation) : confirmUpload(confirmation);
+}

--- a/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
+++ b/apps/web/src/features/admin/claims/actions/evidence-upload.test.ts
@@ -160,11 +160,11 @@ describe('admin claim evidence upload actions', () => {
       })
     ).resolves.toEqual({ success: true });
 
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/mk/admin/claims');
     expect(hoisted.revalidatePath).toHaveBeenCalledWith('/mk/admin/claims/claim-1');
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/mk/staff/claims/claim-1');
+    expect(hoisted.persistClaimDocumentAndQueueWorkflows).toHaveBeenCalledWith(
+      expect.not.objectContaining({ aiExtractionConsent: expect.anything() })
+    );
   });
-
   it('rejects forged upload metadata before persistence', async () => {
     hoisted.validateConfirmedClaimUpload.mockResolvedValueOnce({
       success: false,

--- a/apps/web/src/features/claims/components/SharedEvidenceUploadDialog.tsx
+++ b/apps/web/src/features/claims/components/SharedEvidenceUploadDialog.tsx
@@ -20,87 +20,18 @@ import {
 } from '@interdomestik/ui';
 import { Loader2, Upload } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import {
   EVIDENCE_FILE_ACCEPT,
   resolveStorageUploadContentType,
   resolveUploadMimeType,
 } from '@/features/admin/claims/components/ops/file-upload-meta';
-
-type EvidenceCategory = 'evidence' | 'legal';
-
-type UploadUrlSuccess = {
-  success: true;
-  bucket: string;
-  path: string;
-  token: string;
-  intentToken: string;
-  id: string;
-};
-
-type UploadUrlFailure = {
-  success: false;
-  error: string;
-};
-
-type ConfirmUploadSuccess = {
-  success: true;
-};
-
-type ConfirmUploadFailure = {
-  success: false;
-  error: string;
-};
-
-type GenerateUploadUrlFn = (
-  claimId: string,
-  fileName: string,
-  contentType: string,
-  fileSize: number
-) => Promise<UploadUrlSuccess | UploadUrlFailure>;
-
-type ConfirmUploadFn = (params: {
-  claimId: string;
-  storagePath: string;
-  originalName: string;
-  mimeType: string;
-  fileSize: number;
-  fileId: string;
-  uploadIntentToken: string;
-  storageContentType?: string;
-  uploadedBucket: string;
-  category: EvidenceCategory;
-}) => Promise<ConfirmUploadSuccess | ConfirmUploadFailure>;
-
-interface SharedEvidenceUploadDialogMessages {
-  dialogTitle: string;
-  dialogDescription: string;
-  documentTypeLabel: string;
-  documentTypePlaceholder: string;
-  fileLabel: string;
-  uploadButton: string;
-  uploading: string;
-  cancel: string;
-  uploadSuccess: string;
-  uploadFailed: string;
-  storageUnavailable: string;
-  types: {
-    evidence: string;
-    legal: string;
-  };
-}
-
-interface SharedEvidenceUploadDialogProps {
-  categoryFieldId: string;
-  claimId: string;
-  confirmUpload: ConfirmUploadFn;
-  fileFieldId: string;
-  generateUploadUrl: GenerateUploadUrlFn;
-  locale: string;
-  messages: SharedEvidenceUploadDialogMessages;
-  trigger: React.ReactNode;
-}
+import { AiExtractionConsentField } from './ai-extraction-consent-field';
+import type {
+  EvidenceCategory,
+  SharedEvidenceUploadDialogProps,
+} from './shared-evidence-upload-types';
 
 export function SharedEvidenceUploadDialog({
   categoryFieldId,
@@ -115,6 +46,7 @@ export function SharedEvidenceUploadDialog({
   const [open, setOpen] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [category, setCategory] = useState<EvidenceCategory>('evidence');
+  const [aiExtractionConsentGranted, setAiExtractionConsentGranted] = useState(false);
   const [uploading, setUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
@@ -127,14 +59,21 @@ export function SharedEvidenceUploadDialog({
     }
   }, []);
 
+  useEffect(() => {
+    if (!open) {
+      setFile(null);
+      setAiExtractionConsentGranted(false);
+    }
+  }, [open]);
+
   const resetDialog = () => {
     setOpen(false);
-    setFile(null);
   };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const selected = event.target.files?.[0] ?? null;
     setFile(selected);
+    setAiExtractionConsentGranted(false);
   };
 
   const handleDirectUpload = async (selectedFile: File, selectedCategory: EvidenceCategory) => {
@@ -143,6 +82,7 @@ export function SharedEvidenceUploadDialog({
     formData.append('category', selectedCategory);
     formData.append('locale', locale);
     formData.append('file', selectedFile);
+    formData.append('aiExtractionConsentGranted', String(aiExtractionConsentGranted));
 
     const response = await fetch('/api/claims/evidence-upload', {
       method: 'POST',
@@ -209,6 +149,8 @@ export function SharedEvidenceUploadDialog({
       storageContentType,
       uploadedBucket: uploadUrlResult.bucket,
       category: selectedCategory,
+      aiExtractionConsentGranted,
+      aiExtractionConsentLocale: locale,
     });
 
     if (!confirmResult.success) {
@@ -272,6 +214,15 @@ export function SharedEvidenceUploadDialog({
               disabled={uploading}
             />
           </div>
+          {messages.aiExtractionConsent ? (
+            <AiExtractionConsentField
+              id={`${fileFieldId}-ai-consent`}
+              checked={aiExtractionConsentGranted}
+              disabled={uploading}
+              label={messages.aiExtractionConsent}
+              onCheckedChange={setAiExtractionConsentGranted}
+            />
+          ) : null}
         </div>
         <DialogFooter className="sm:justify-start">
           <Button type="button" variant="default" onClick={handleUpload} disabled={uploading}>

--- a/apps/web/src/features/claims/components/ai-extraction-consent-field.tsx
+++ b/apps/web/src/features/claims/components/ai-extraction-consent-field.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Checkbox, Label } from '@interdomestik/ui';
+
+export function AiExtractionConsentField({
+  checked,
+  disabled,
+  id,
+  label,
+  onCheckedChange,
+}: {
+  readonly checked: boolean;
+  readonly disabled: boolean;
+  readonly id: string;
+  readonly label: string;
+  readonly onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={value => onCheckedChange(value === true)}
+        disabled={disabled}
+      />
+      <Label htmlFor={id} className="text-sm leading-5">
+        {label}
+      </Label>
+    </div>
+  );
+}

--- a/apps/web/src/features/claims/components/shared-evidence-upload-dialog.test-helpers.tsx
+++ b/apps/web/src/features/claims/components/shared-evidence-upload-dialog.test-helpers.tsx
@@ -92,6 +92,8 @@ export function runSharedEvidenceUploadDialogTests({
         );
         expect(uploadMocks.uploadToSignedUrl).toHaveBeenCalled();
         expect(uploadMocks.confirmUpload).toHaveBeenCalledWith({
+          aiExtractionConsentGranted: false,
+          aiExtractionConsentLocale: expect.any(String),
           claimId: 'claim-1',
           storagePath: 'pii/tenants/t1/claims/c1/file.pdf',
           originalName: 'evidence.pdf',

--- a/apps/web/src/features/claims/components/shared-evidence-upload-types.ts
+++ b/apps/web/src/features/claims/components/shared-evidence-upload-types.ts
@@ -1,0 +1,70 @@
+import type React from 'react';
+
+type EvidenceCategory = 'evidence' | 'legal';
+
+type UploadUrlSuccess = {
+  success: true;
+  bucket: string;
+  path: string;
+  token: string;
+  intentToken: string;
+  id: string;
+};
+
+type UploadUrlFailure = { success: false; error: string };
+type ConfirmUploadSuccess = { success: true };
+type ConfirmUploadFailure = { success: false; error: string };
+
+export type GenerateUploadUrlFn = (
+  claimId: string,
+  fileName: string,
+  contentType: string,
+  fileSize: number
+) => Promise<UploadUrlSuccess | UploadUrlFailure>;
+
+export type ConfirmUploadFn = (params: {
+  aiExtractionConsentGranted?: boolean;
+  aiExtractionConsentLocale?: string;
+  claimId: string;
+  storagePath: string;
+  originalName: string;
+  mimeType: string;
+  fileSize: number;
+  fileId: string;
+  uploadIntentToken: string;
+  storageContentType?: string;
+  uploadedBucket: string;
+  category: EvidenceCategory;
+}) => Promise<ConfirmUploadSuccess | ConfirmUploadFailure>;
+
+export interface SharedEvidenceUploadDialogMessages {
+  dialogTitle: string;
+  dialogDescription: string;
+  documentTypeLabel: string;
+  documentTypePlaceholder: string;
+  fileLabel: string;
+  uploadButton: string;
+  uploading: string;
+  cancel: string;
+  uploadSuccess: string;
+  uploadFailed: string;
+  storageUnavailable: string;
+  aiExtractionConsent?: string;
+  types: {
+    evidence: string;
+    legal: string;
+  };
+}
+
+export interface SharedEvidenceUploadDialogProps {
+  categoryFieldId: string;
+  claimId: string;
+  confirmUpload: ConfirmUploadFn;
+  fileFieldId: string;
+  generateUploadUrl: GenerateUploadUrlFn;
+  locale: string;
+  messages: SharedEvidenceUploadDialogMessages;
+  trigger: React.ReactNode;
+}
+
+export type { EvidenceCategory };

--- a/apps/web/src/features/claims/upload/server/claim-document-persistence.test.ts
+++ b/apps/web/src/features/claims/upload/server/claim-document-persistence.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  emit: vi.fn(),
+  insert: vi.fn(),
+  markDispatchFailed: vi.fn(),
+  queue: vi.fn(),
+  randomUUID: vi.fn(() => 'consent-1'),
+  values: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/claim-workflows', () => ({
+  emitClaimAiRunRequestedService: hoisted.emit,
+  markClaimAiRunDispatchFailedService: hoisted.markDispatchFailed,
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  claimDocumentAiExtractionConsents: 'claim_document_ai_extraction_consents',
+  claimDocuments: 'claim_documents',
+  db: {
+    transaction: vi.fn(async callback => callback({ insert: hoisted.insert })),
+  },
+}));
+
+vi.mock('@interdomestik/domain-claims/claims/ai-workflows', () => ({
+  queueClaimDocumentAiWorkflows: hoisted.queue,
+}));
+
+vi.mock('node:crypto', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  return { ...actual, default: actual, randomUUID: hoisted.randomUUID };
+});
+
+import { persistClaimDocumentAndQueueWorkflows } from './claim-document-persistence';
+
+function baseParams() {
+  return {
+    category: 'evidence' as const,
+    claimId: 'claim-1',
+    fileId: 'doc-1',
+    fileSize: 1024,
+    logPrefix: '[test]',
+    mimeType: 'application/pdf',
+    originalName: 'evidence.pdf',
+    resolvedBucket: 'claim-evidence',
+    storagePath: 'pii/tenants/tenant-1/claims/claim-1/doc-1.pdf',
+    tenantId: 'tenant-1',
+    userId: 'member-1',
+  };
+}
+
+describe('persistClaimDocumentAndQueueWorkflows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.insert.mockReturnValue({ values: hoisted.values });
+    hoisted.values.mockResolvedValue(undefined);
+    hoisted.queue.mockResolvedValue([]);
+  });
+
+  it('preserves document upload and skips dispatch when unchecked consent queues no AI runs', async () => {
+    await persistClaimDocumentAndQueueWorkflows({
+      ...baseParams(),
+      aiExtractionConsent: {
+        granted: false,
+        locale: 'en',
+        privacyVersion: 'privacy-2026-05',
+        sourceSurface: 'member_claim_evidence_upload',
+      },
+    });
+
+    expect(hoisted.insert).toHaveBeenCalledWith('claim_documents');
+    expect(hoisted.insert).not.toHaveBeenCalledWith('claim_document_ai_extraction_consents');
+    expect(hoisted.queue).toHaveBeenCalledWith(
+      expect.objectContaining({ claimId: 'claim-1', tenantId: 'tenant-1', userId: 'member-1' })
+    );
+    expect(hoisted.emit).not.toHaveBeenCalled();
+  });
+
+  it('persists scoped consent row only for explicit member opt-in', async () => {
+    await persistClaimDocumentAndQueueWorkflows({
+      ...baseParams(),
+      aiExtractionConsent: {
+        granted: true,
+        locale: 'en',
+        privacyVersion: 'privacy-2026-05',
+        sourceSurface: 'member_claim_evidence_upload',
+      },
+    });
+
+    expect(hoisted.insert).toHaveBeenCalledWith('claim_document_ai_extraction_consents');
+    expect(hoisted.values).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        actorId: 'member-1',
+        claimId: 'claim-1',
+        consentType: 'ai_document_extraction',
+        documentId: 'doc-1',
+        id: expect.any(String),
+        processingPurpose: 'ai_document_extraction',
+        privacyVersion: 'privacy-2026-05',
+        sourceSurface: 'member_claim_evidence_upload',
+        status: 'accepted',
+        subjectId: 'member-1',
+        tenantId: 'tenant-1',
+      })
+    );
+  });
+});

--- a/apps/web/src/features/claims/upload/server/claim-document-persistence.ts
+++ b/apps/web/src/features/claims/upload/server/claim-document-persistence.ts
@@ -1,0 +1,120 @@
+import {
+  emitClaimAiRunRequestedService,
+  markClaimAiRunDispatchFailedService,
+} from '@/lib/ai/claim-workflows';
+import { claimDocumentAiExtractionConsents, claimDocuments, db } from '@interdomestik/database';
+import { queueClaimDocumentAiWorkflows } from '@interdomestik/domain-claims/claims/ai-workflows';
+import { randomUUID } from 'node:crypto';
+
+export type UploadCategory = 'evidence' | 'legal';
+
+type AiExtractionConsentCapture = {
+  granted: boolean;
+  locale: string;
+  privacyVersion: string;
+  sourceSurface: string;
+};
+
+type PersistClaimDocumentParams = {
+  aiExtractionConsent?: AiExtractionConsentCapture;
+  category: UploadCategory;
+  claimId: string;
+  fileId: string;
+  fileSize: number;
+  logPrefix: string;
+  mimeType: string;
+  originalName: string;
+  resolvedBucket: string;
+  storagePath: string;
+  tenantId: string;
+  userId: string;
+};
+
+async function insertClaimDocument(params: PersistClaimDocumentParams): Promise<void> {
+  // db-access-guard: tenant-scoped -- reason: transaction writes only document metadata and optional consent rows scoped by validated tenant, user, claim, and document ids.
+  await db.transaction(async tx => {
+    // db-access-guard: tenant-scoped -- reason: document metadata copies tenant, claim, and uploader scope from the validated upload session.
+    await tx.insert(claimDocuments).values({
+      id: params.fileId,
+      tenantId: params.tenantId,
+      claimId: params.claimId,
+      name: params.originalName,
+      filePath: params.storagePath,
+      fileType: params.mimeType,
+      fileSize: params.fileSize,
+      bucket: params.resolvedBucket,
+      category: params.category,
+      uploadedBy: params.userId,
+    });
+
+    if (params.aiExtractionConsent?.granted === true) {
+      const now = new Date();
+      // db-access-guard: tenant-scoped -- reason: consent row copies exact tenant, subject, actor, claim, and document scope from the validated upload session.
+      await tx.insert(claimDocumentAiExtractionConsents).values({
+        id: randomUUID(),
+        tenantId: params.tenantId,
+        subjectId: params.userId,
+        actorId: params.userId,
+        claimId: params.claimId,
+        documentId: params.fileId,
+        consentType: 'ai_document_extraction',
+        processingPurpose: 'ai_document_extraction',
+        status: 'accepted',
+        privacyVersion: params.aiExtractionConsent.privacyVersion,
+        locale: params.aiExtractionConsent.locale,
+        sourceSurface: params.aiExtractionConsent.sourceSurface,
+        recordedAt: now,
+        grantedAt: now,
+      });
+    }
+  });
+}
+
+async function queueAiWorkflows(params: PersistClaimDocumentParams) {
+  // db-access-guard: tenant-scoped -- reason: queue resolver filters exact tenant/user/claim/document scope
+  return db.transaction(async tx =>
+    queueClaimDocumentAiWorkflows({
+      tx,
+      claimId: params.claimId,
+      tenantId: params.tenantId,
+      userId: params.userId,
+      files: [
+        {
+          documentId: params.fileId,
+          name: params.originalName,
+          path: params.storagePath,
+          type: params.mimeType,
+          size: params.fileSize,
+          bucket: params.resolvedBucket,
+          category: params.category,
+        },
+      ],
+    })
+  );
+}
+
+export async function persistClaimDocumentAndQueueWorkflows(
+  params: PersistClaimDocumentParams
+): Promise<void> {
+  await insertClaimDocument(params);
+
+  try {
+    const queuedRuns = await queueAiWorkflows(params);
+    for (const queuedRun of queuedRuns) {
+      try {
+        await emitClaimAiRunRequestedService(queuedRun);
+      } catch (error) {
+        await markClaimAiRunDispatchFailedService({
+          runId: queuedRun.runId,
+          message: error instanceof Error ? error.message : 'Failed to dispatch claim AI run.',
+        });
+      }
+    }
+  } catch (queueError) {
+    console.error(`${params.logPrefix} AI queue failed after metadata persisted`, {
+      claimId: params.claimId,
+      fileId: params.fileId,
+      message: queueError instanceof Error ? queueError.message : String(queueError),
+    });
+  }
+}

--- a/apps/web/src/features/claims/upload/server/shared-upload.ts
+++ b/apps/web/src/features/claims/upload/server/shared-upload.ts
@@ -1,15 +1,13 @@
-import {
-  emitClaimAiRunRequestedService,
-  markClaimAiRunDispatchFailedService,
-} from '@/lib/ai/claim-workflows';
 import { LOCALES } from '@/i18n/locales';
 import { redactSignedUrlErrorDetails } from '@/lib/storage/signed-url-exposure';
-import { claimDocuments, db } from '@interdomestik/database';
-import { queueClaimDocumentAiWorkflows } from '@interdomestik/domain-claims/claims/ai-workflows';
 import { createHmac, randomUUID, timingSafeEqual } from 'crypto';
 import { revalidatePath } from 'next/cache';
 
 import { assertEvidenceStoragePath, buildEvidenceStoragePath } from './storage-path';
+export {
+  persistClaimDocumentAndQueueWorkflows,
+  type UploadCategory,
+} from './claim-document-persistence';
 
 const SIGNED_UPLOAD_MAX_ATTEMPTS = 3;
 const SIGNED_UPLOAD_RETRY_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 250;
@@ -27,8 +25,6 @@ const TRANSIENT_UPLOAD_ERROR_PATTERNS = [
   /service unavailable/i,
   /too many requests/i,
 ];
-
-export type UploadCategory = 'evidence' | 'legal';
 
 export type SharedGenerateUploadUrlResult =
   | {
@@ -487,90 +483,5 @@ export async function createSignedUploadUrl(params: {
   } catch (error) {
     console.error(`${logPrefix} generate upload URL error`, redactSignedUrlErrorDetails(error));
     return { success: false, error: 'Unexpected error', status: 500 };
-  }
-}
-
-export async function persistClaimDocumentAndQueueWorkflows(params: {
-  category: UploadCategory;
-  claimId: string;
-  fileId: string;
-  fileSize: number;
-  logPrefix: string;
-  mimeType: string;
-  originalName: string;
-  resolvedBucket: string;
-  storagePath: string;
-  tenantId: string;
-  userId: string;
-}): Promise<void> {
-  const {
-    category,
-    claimId,
-    fileId,
-    fileSize,
-    logPrefix,
-    mimeType,
-    originalName,
-    resolvedBucket,
-    storagePath,
-    tenantId,
-    userId,
-  } = params;
-
-  // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
-  await db.transaction(async tx => {
-    // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
-    await tx.insert(claimDocuments).values({
-      id: fileId,
-      tenantId,
-      claimId,
-      name: originalName,
-      filePath: storagePath,
-      fileType: mimeType,
-      fileSize,
-      bucket: resolvedBucket,
-      category,
-      uploadedBy: userId,
-    });
-  });
-
-  try {
-    // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
-    const queuedRuns = await db.transaction(async tx =>
-      queueClaimDocumentAiWorkflows({
-        tx,
-        claimId,
-        tenantId,
-        userId,
-        files: [
-          {
-            documentId: fileId,
-            name: originalName,
-            path: storagePath,
-            type: mimeType,
-            size: fileSize,
-            bucket: resolvedBucket,
-            category,
-          },
-        ],
-      })
-    );
-
-    for (const queuedRun of queuedRuns) {
-      try {
-        await emitClaimAiRunRequestedService(queuedRun);
-      } catch (error) {
-        await markClaimAiRunDispatchFailedService({
-          runId: queuedRun.runId,
-          message: error instanceof Error ? error.message : 'Failed to dispatch claim AI run.',
-        });
-      }
-    }
-  } catch (queueError) {
-    console.error(`${logPrefix} AI queue failed after metadata persisted`, {
-      claimId,
-      fileId,
-      message: queueError instanceof Error ? queueError.message : String(queueError),
-    });
   }
 }

--- a/apps/web/src/features/member/claims/actions.test.ts
+++ b/apps/web/src/features/member/claims/actions.test.ts
@@ -61,6 +61,7 @@ vi.mock('@interdomestik/database', () => ({
     transaction: hoisted.transaction,
   },
   claimDocuments: 'claim_documents',
+  claimDocumentAiExtractionConsents: 'claim_document_ai_extraction_consents',
 }));
 
 vi.mock('@interdomestik/domain-claims/claims/ai-workflows', () => ({
@@ -168,14 +169,7 @@ describe('member claim upload actions', () => {
       })
     );
     hoisted.insertValues.mockResolvedValue(undefined);
-    hoisted.queueClaimDocumentAiWorkflows.mockResolvedValue([
-      {
-        runId: 'run-1',
-        workflow: 'legal_doc_extract',
-        claimId: 'claim-1',
-        documentId: 'uuid-1',
-      },
-    ]);
+    hoisted.queueClaimDocumentAiWorkflows.mockResolvedValue([]);
 
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://supabase.example.com');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
@@ -334,7 +328,7 @@ describe('member claim upload actions', () => {
     expect(hoisted.insert).not.toHaveBeenCalled();
   });
 
-  it('queues a legal-document ai run after confirming the upload metadata', async () => {
+  it('preserves upload and skips AI dispatch when member consent is unchecked', async () => {
     const result = await confirmUpload(
       createConfirmUploadParams({ originalName: 'demand-letter.pdf', category: 'legal' })
     );
@@ -342,6 +336,7 @@ describe('member claim upload actions', () => {
     expect(result).toEqual({ success: true });
     expect(hoisted.transaction).toHaveBeenCalledTimes(2);
     expect(hoisted.insert).toHaveBeenCalledWith('claim_documents');
+    expect(hoisted.insert).not.toHaveBeenCalledWith('claim_document_ai_extraction_consents');
     expect(hoisted.queueClaimDocumentAiWorkflows).toHaveBeenCalledWith(
       expect.objectContaining({
         claimId: 'claim-1',
@@ -356,31 +351,32 @@ describe('member claim upload actions', () => {
         ],
       })
     );
-    expect(hoisted.emitClaimAiRunRequestedService).toHaveBeenCalledWith(
-      expect.objectContaining({
-        runId: 'run-1',
-        workflow: 'legal_doc_extract',
-      })
-    );
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/sq/member/claims/claim-1');
+    expect(hoisted.emitClaimAiRunRequestedService).not.toHaveBeenCalled();
     expect(hoisted.revalidatePath).toHaveBeenCalledWith('/en/member/claims/claim-1');
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/sr/member/claims/claim-1');
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/mk/member/claims/claim-1');
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/sq/member/documents');
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/en/member/documents');
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/sr/member/documents');
-    expect(hoisted.revalidatePath).toHaveBeenCalledWith('/mk/member/documents');
   });
 
-  it('keeps the upload persisted when ai queueing fails after metadata is saved', async () => {
-    hoisted.queueClaimDocumentAiWorkflows.mockRejectedValueOnce(new Error('ai queue unavailable'));
-
-    const result = await confirmUpload(createConfirmUploadParams({ category: 'evidence' }));
+  it('records scoped ai document extraction consent only when checked', async () => {
+    const result = await confirmUpload(
+      createConfirmUploadParams({
+        aiExtractionConsentGranted: true,
+        aiExtractionConsentLocale: 'sq',
+      })
+    );
 
     expect(result).toEqual({ success: true });
-    expect(hoisted.insert).toHaveBeenCalledWith('claim_documents');
-    expect(hoisted.queueClaimDocumentAiWorkflows).toHaveBeenCalledOnce();
-    expect(hoisted.emitClaimAiRunRequestedService).not.toHaveBeenCalled();
-    expect(hoisted.markClaimAiRunDispatchFailedService).not.toHaveBeenCalled();
+    expect(hoisted.insert).toHaveBeenCalledWith('claim_document_ai_extraction_consents');
+    expect(hoisted.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'member-1',
+        claimId: 'claim-1',
+        documentId: 'uuid-1',
+        locale: 'sq',
+        privacyVersion: 'privacy-2026-05',
+        sourceSurface: 'member_claim_evidence_upload',
+        status: 'accepted',
+        subjectId: 'member-1',
+        tenantId: 'tenant-1',
+      })
+    );
   });
 });

--- a/apps/web/src/features/member/claims/actions.ts
+++ b/apps/web/src/features/member/claims/actions.ts
@@ -11,6 +11,7 @@ import { findOwnedMemberUploadClaim } from '@/features/claims/upload/server/acce
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 import { headers } from 'next/headers';
+import { buildMemberAiExtractionConsent, type ConfirmUploadParams } from './upload-consent';
 
 export type GenerateUploadUrlResult =
   | {
@@ -77,19 +78,6 @@ export async function generateUploadUrl(
 export type ConfirmUploadResult =
   | { success: true }
   | { success: false; error: string; status: 401 | 404 | 409 | 500 };
-
-export type ConfirmUploadParams = {
-  claimId: string;
-  storagePath: string;
-  originalName: string;
-  mimeType: string;
-  fileSize: number;
-  fileId: string;
-  uploadIntentToken: string;
-  storageContentType?: string;
-  uploadedBucket?: string;
-  category?: 'evidence' | 'legal';
-};
 
 type ConfirmUploadContext =
   | {
@@ -191,6 +179,7 @@ export async function confirmUpload(params: ConfirmUploadParams): Promise<Confir
       storagePath,
       tenantId,
       userId: session.user.id,
+      aiExtractionConsent: buildMemberAiExtractionConsent(params),
     });
 
     revalidatePathForAllLocales(`/member/claims/${claimId}`);

--- a/apps/web/src/features/member/claims/components/ClaimEvidenceUploadDialog.test.tsx
+++ b/apps/web/src/features/member/claims/components/ClaimEvidenceUploadDialog.test.tsx
@@ -1,4 +1,5 @@
-import { vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ClaimEvidenceUploadDialog } from './ClaimEvidenceUploadDialog';
 import { runSharedEvidenceUploadDialogTests } from '@/features/claims/components/shared-evidence-upload-dialog.test-helpers';
 
@@ -40,6 +41,65 @@ vi.mock('sonner', () => ({
     error: mocks.toastError,
   },
 }));
+
+describe('ClaimEvidenceUploadDialog AI extraction consent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.generateUploadUrl.mockResolvedValue({
+      success: true,
+      bucket: 'claim-evidence',
+      path: 'pii/tenants/t1/claims/c1/file.pdf',
+      token: 'signed-token',
+      intentToken: 'upload-intent-token',
+      id: 'file-id',
+    });
+    mocks.uploadToSignedUrl.mockResolvedValue({ error: null });
+    mocks.confirmUpload.mockResolvedValue({ success: true });
+  });
+
+  it('sends explicit member opt-in through signed upload confirmation', async () => {
+    render(
+      <ClaimEvidenceUploadDialog claimId="claim-1" trigger={<button type="button">Open</button>} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    fireEvent.change(screen.getByLabelText('File'), {
+      target: { files: [new File(['dummy'], 'evidence.pdf', { type: 'application/pdf' })] },
+    });
+    fireEvent.click(screen.getByLabelText(/AI document extraction/u));
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => {
+      expect(mocks.confirmUpload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aiExtractionConsentGranted: true,
+          aiExtractionConsentLocale: 'mk',
+        })
+      );
+    });
+  });
+
+  it('does not carry opt-in across selected files', async () => {
+    render(
+      <ClaimEvidenceUploadDialog claimId="claim-1" trigger={<button type="button">Open</button>} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    const fileInput = screen.getByLabelText('File');
+    fireEvent.change(fileInput, {
+      target: { files: [new File(['one'], 'one.pdf', { type: 'application/pdf' })] },
+    });
+    fireEvent.click(screen.getByLabelText(/AI document extraction/u));
+    fireEvent.change(fileInput, {
+      target: { files: [new File(['two'], 'two.pdf', { type: 'application/pdf' })] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => {
+      expect(mocks.confirmUpload).toHaveBeenCalledWith(
+        expect.objectContaining({ aiExtractionConsentGranted: false })
+      );
+    });
+  });
+});
 
 runSharedEvidenceUploadDialogTests({
   dialogName: 'ClaimEvidenceUploadDialog',

--- a/apps/web/src/features/member/claims/components/ClaimEvidenceUploadDialog.tsx
+++ b/apps/web/src/features/member/claims/components/ClaimEvidenceUploadDialog.tsx
@@ -33,6 +33,8 @@ export function ClaimEvidenceUploadDialog({ claimId, trigger }: ClaimEvidenceUpl
         uploadSuccess: 'Evidence uploaded successfully',
         uploadFailed: 'Failed to upload evidence',
         storageUnavailable: 'Storage client unavailable',
+        aiExtractionConsent:
+          'I agree to AI document extraction for this uploaded file to prepare claim fields for human review.',
         types: {
           evidence: 'Evidence',
           legal: 'Legal document',

--- a/apps/web/src/features/member/claims/upload-consent.ts
+++ b/apps/web/src/features/member/claims/upload-consent.ts
@@ -1,0 +1,25 @@
+export const AI_DOCUMENT_EXTRACTION_PRIVACY_VERSION = 'privacy-2026-05';
+
+export type ConfirmUploadParams = {
+  aiExtractionConsentGranted?: boolean;
+  aiExtractionConsentLocale?: string;
+  claimId: string;
+  storagePath: string;
+  originalName: string;
+  mimeType: string;
+  fileSize: number;
+  fileId: string;
+  uploadIntentToken: string;
+  storageContentType?: string;
+  uploadedBucket?: string;
+  category?: 'evidence' | 'legal';
+};
+
+export function buildMemberAiExtractionConsent(params: ConfirmUploadParams) {
+  return {
+    granted: params.aiExtractionConsentGranted === true,
+    locale: params.aiExtractionConsentLocale ?? 'en',
+    privacyVersion: AI_DOCUMENT_EXTRACTION_PRIVACY_VERSION,
+    sourceSurface: 'member_claim_evidence_upload',
+  };
+}

--- a/packages/database/drizzle/0087_claim_document_ai_extraction_consents.sql
+++ b/packages/database/drizzle/0087_claim_document_ai_extraction_consents.sql
@@ -1,0 +1,72 @@
+CREATE TABLE IF NOT EXISTS "claim_document_ai_extraction_consents" (
+  "id" text PRIMARY KEY NOT NULL,
+  "tenant_id" text NOT NULL,
+  "subject_id" text NOT NULL,
+  "actor_id" text NOT NULL,
+  "claim_id" text NOT NULL,
+  "document_id" text NOT NULL,
+  "consent_type" text NOT NULL,
+  "processing_purpose" text NOT NULL,
+  "status" text NOT NULL,
+  "privacy_version" text NOT NULL,
+  "locale" text NOT NULL,
+  "source_surface" text NOT NULL,
+  "recorded_at" timestamp DEFAULT now() NOT NULL,
+  "granted_at" timestamp,
+  "withdrawn_at" timestamp,
+  "supersedes_consent_id" text,
+  CONSTRAINT "claim_doc_ai_consent_type_check"
+    CHECK ("consent_type" = 'ai_document_extraction'),
+  CONSTRAINT "claim_doc_ai_processing_purpose_check"
+    CHECK ("processing_purpose" = 'ai_document_extraction'),
+  CONSTRAINT "claim_doc_ai_consent_status_check"
+    CHECK ("status" IN ('accepted', 'withdrawn'))
+);
+--> statement-breakpoint
+ALTER TABLE "claim_document_ai_extraction_consents"
+  ADD CONSTRAINT "claim_doc_ai_consents_tenant_id_tenants_id_fk"
+  FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id")
+  ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "claim_document_ai_extraction_consents"
+  ADD CONSTRAINT "claim_doc_ai_consents_subject_id_user_id_fk"
+  FOREIGN KEY ("subject_id") REFERENCES "public"."user"("id")
+  ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "claim_document_ai_extraction_consents"
+  ADD CONSTRAINT "claim_doc_ai_consents_actor_id_user_id_fk"
+  FOREIGN KEY ("actor_id") REFERENCES "public"."user"("id")
+  ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "claim_document_ai_extraction_consents"
+  ADD CONSTRAINT "claim_doc_ai_consents_claim_id_claim_id_fk"
+  FOREIGN KEY ("claim_id") REFERENCES "public"."claim"("id")
+  ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "claim_document_ai_extraction_consents"
+  ADD CONSTRAINT "claim_doc_ai_consents_document_id_claim_documents_id_fk"
+  FOREIGN KEY ("document_id") REFERENCES "public"."claim_documents"("id")
+  ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_claim_doc_ai_consents_scope"
+  ON "claim_document_ai_extraction_consents"
+  USING btree ("tenant_id","subject_id","claim_id","document_id","processing_purpose","recorded_at");
+--> statement-breakpoint
+ALTER TABLE public."claim_document_ai_extraction_consents" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'claim_document_ai_extraction_consents'
+      AND policyname = 'tenant_isolation_claim_document_ai_extraction_consents'
+  ) THEN
+    CREATE POLICY "tenant_isolation_claim_document_ai_extraction_consents"
+      ON public."claim_document_ai_extraction_consents"
+      USING (tenant_id = (select current_setting('app.current_tenant_id', true))::text)
+      WITH CHECK (tenant_id = (select current_setting('app.current_tenant_id', true))::text);
+  END IF;
+END
+$$;

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1781932800000,
       "tag": "0086_access_tenant_divergent_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1782019200000,
+      "tag": "0087_claim_document_ai_extraction_consents",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/claim-document-ai-consents.ts
+++ b/packages/database/src/schema/claim-document-ai-consents.ts
@@ -1,0 +1,59 @@
+import { sql } from 'drizzle-orm';
+import { check, index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { user } from './auth';
+import { claimDocuments, claims } from './claims';
+import { tenants } from './tenants';
+
+export const claimDocumentAiExtractionConsents = pgTable(
+  'claim_document_ai_extraction_consents',
+  {
+    id: text('id').primaryKey(),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    subjectId: text('subject_id')
+      .notNull()
+      .references(() => user.id),
+    actorId: text('actor_id')
+      .notNull()
+      .references(() => user.id),
+    claimId: text('claim_id')
+      .notNull()
+      .references(() => claims.id),
+    documentId: text('document_id')
+      .notNull()
+      .references(() => claimDocuments.id),
+    consentType: text('consent_type').notNull(),
+    processingPurpose: text('processing_purpose').notNull(),
+    status: text('status').notNull(),
+    privacyVersion: text('privacy_version').notNull(),
+    locale: text('locale').notNull(),
+    sourceSurface: text('source_surface').notNull(),
+    recordedAt: timestamp('recorded_at').defaultNow().notNull(),
+    grantedAt: timestamp('granted_at'),
+    withdrawnAt: timestamp('withdrawn_at'),
+    supersedesConsentId: text('supersedes_consent_id'),
+  },
+  table => [
+    index('idx_claim_doc_ai_consents_scope').on(
+      table.tenantId,
+      table.subjectId,
+      table.claimId,
+      table.documentId,
+      table.processingPurpose,
+      table.recordedAt
+    ),
+    check('claim_doc_ai_consent_type_check', sql`${table.consentType} = 'ai_document_extraction'`),
+    check(
+      'claim_doc_ai_processing_purpose_check',
+      sql`${table.processingPurpose} = 'ai_document_extraction'`
+    ),
+    check('claim_doc_ai_consent_status_check', sql`${table.status} in ('accepted', 'withdrawn')`),
+  ]
+);
+
+export type ClaimDocumentAiExtractionConsent =
+  typeof claimDocumentAiExtractionConsents.$inferSelect;
+export type NewClaimDocumentAiExtractionConsent =
+  typeof claimDocumentAiExtractionConsents.$inferInsert;

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -13,6 +13,7 @@ export * from './billing';
 export * from './case-scoped-access-grants';
 export * from './commercial-action-idempotency';
 export * from './claim-commercial';
+export * from './claim-document-ai-consents';
 export * from './claim-recovery-no-fee';
 export * from './claim-threads';
 export * from './claims';

--- a/packages/database/test/claim-document-ai-consents-migration.test.ts
+++ b/packages/database/test/claim-document-ai-consents-migration.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const MIGRATION_PATH = fileURLToPath(
+  new URL('../drizzle/0087_claim_document_ai_extraction_consents.sql', import.meta.url)
+);
+
+function migrationSql(): string {
+  return readFileSync(MIGRATION_PATH, 'utf8');
+}
+
+test('T-404a migration creates scoped AI document extraction consent table', () => {
+  const sql = migrationSql();
+
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS "claim_document_ai_extraction_consents"/u);
+  assert.match(sql, /"tenant_id" text NOT NULL/u);
+  assert.match(sql, /"subject_id" text NOT NULL/u);
+  assert.match(sql, /"actor_id" text NOT NULL/u);
+  assert.match(sql, /"claim_id" text NOT NULL/u);
+  assert.match(sql, /"document_id" text NOT NULL/u);
+  assert.match(sql, /"privacy_version" text NOT NULL/u);
+  assert.match(sql, /"source_surface" text NOT NULL/u);
+  assert.doesNotMatch(sql, /DEFAULT 'ai_document_extraction'/u);
+  assert.match(sql, /CHECK \("consent_type" = 'ai_document_extraction'\)/u);
+  assert.match(sql, /CHECK \("processing_purpose" = 'ai_document_extraction'\)/u);
+  assert.match(sql, /CHECK \("status" IN \('accepted', 'withdrawn'\)\)/u);
+});
+
+test('T-404a migration indexes the exact consent resolver scope', () => {
+  const sql = migrationSql();
+
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS "idx_claim_doc_ai_consents_scope"/u);
+  assert.match(
+    sql,
+    /USING btree \("tenant_id","subject_id","claim_id","document_id","processing_purpose","recorded_at"\)/u
+  );
+});
+
+test('T-404a migration enables tenant-scoped RLS for AI consent rows', () => {
+  const sql = migrationSql();
+
+  assert.match(
+    sql,
+    /ALTER TABLE public\."claim_document_ai_extraction_consents" ENABLE ROW LEVEL SECURITY/u
+  );
+  assert.match(sql, /policyname = 'tenant_isolation_claim_document_ai_extraction_consents'/u);
+  assert.match(
+    sql,
+    /USING \(tenant_id = \(select current_setting\('app\.current_tenant_id', true\)\)::text\)/u
+  );
+  assert.match(
+    sql,
+    /WITH CHECK \(tenant_id = \(select current_setting\('app\.current_tenant_id', true\)\)::text\)/u
+  );
+});
+
+test('schema exports claim document AI extraction consents table', async () => {
+  const schema = await import('../src/schema');
+
+  assert.ok(schema.claimDocumentAiExtractionConsents);
+  assert.ok(schema.claimDocumentAiExtractionConsents.tenantId);
+  assert.ok(schema.claimDocumentAiExtractionConsents.subjectId);
+  assert.ok(schema.claimDocumentAiExtractionConsents.claimId);
+  assert.ok(schema.claimDocumentAiExtractionConsents.documentId);
+  assert.ok(schema.claimDocumentAiExtractionConsents.processingPurpose);
+});

--- a/packages/domain-claims/package.json
+++ b/packages/domain-claims/package.json
@@ -54,6 +54,7 @@
     "@interdomestik/domain-case": "workspace:*",
     "@interdomestik/domain-crm": "workspace:*",
     "@interdomestik/domain-membership-billing": "workspace:*",
+    "@interdomestik/domain-privacy": "workspace:*",
     "@interdomestik/domain-recovery": "workspace:*",
     "@interdomestik/shared-auth": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/packages/domain-claims/src/claims/ai-workflow-preparation.ts
+++ b/packages/domain-claims/src/claims/ai-workflow-preparation.ts
@@ -1,0 +1,99 @@
+import { createHash } from 'node:crypto';
+
+import { getResponsesWorkflowConfig } from '@interdomestik/domain-ai/models';
+import { nanoid } from 'nanoid';
+
+import {
+  buildClaimDocumentAiCallContext,
+  type ClaimDocumentAiCallContext,
+} from './claim-ai-context';
+import { resolveClaimDocumentAiExtractionConsent } from './claim-document-ai-consent';
+import type {
+  ClaimAiClaimSnapshot,
+  ClaimAiDocumentCategory,
+  ClaimAiWorkflow,
+  ClaimAiWorkflowQueueInput,
+} from './ai-workflow-types';
+
+export type PreparedQueuedClaimAiRun = {
+  runId: string;
+  workflow: ClaimAiWorkflow;
+  claimId: string;
+  documentId: string;
+  category: ClaimAiDocumentCategory;
+  model: string;
+  promptVersion: string;
+  promptCacheKey: string;
+  file: ClaimAiWorkflowQueueInput['files'][number];
+  inputHash: string;
+  aiCallContext: ClaimDocumentAiCallContext;
+};
+
+function normalizeCategory(category: string | null | undefined): ClaimAiDocumentCategory {
+  return category === 'legal' ? 'legal' : 'evidence';
+}
+
+function resolveWorkflow(category: ClaimAiDocumentCategory): ClaimAiWorkflow {
+  return category === 'legal' ? 'legal_doc_extract' : 'claim_intake_extract';
+}
+
+function buildInputHash(args: {
+  workflow: ClaimAiWorkflow;
+  claimId: string;
+  documentId: string;
+  path: string;
+  category: ClaimAiDocumentCategory;
+  claimSnapshot?: ClaimAiClaimSnapshot | null;
+}): string {
+  return createHash('sha256').update(JSON.stringify(args)).digest('hex');
+}
+
+export async function prepareClaimDocumentAiRun(params: {
+  args: ClaimAiWorkflowQueueInput;
+  file: ClaimAiWorkflowQueueInput['files'][number];
+}): Promise<PreparedQueuedClaimAiRun | null> {
+  const { args, file } = params;
+  const category = normalizeCategory(file.category);
+  const workflow = resolveWorkflow(category);
+  const documentId = file.documentId ?? nanoid();
+  const consent = await resolveClaimDocumentAiExtractionConsent({
+    tx: args.tx,
+    tenantId: args.tenantId,
+    subjectId: args.userId,
+    claimId: args.claimId,
+    documentId,
+  });
+
+  if (consent.kind !== 'granted') return null;
+
+  const runId = nanoid();
+  const config = getResponsesWorkflowConfig(workflow);
+
+  return {
+    runId,
+    workflow,
+    claimId: args.claimId,
+    documentId,
+    category,
+    model: config.model,
+    promptVersion: config.promptVersion,
+    promptCacheKey: config.promptCacheKey,
+    file,
+    inputHash: buildInputHash({
+      workflow,
+      claimId: args.claimId,
+      documentId,
+      path: file.path,
+      category,
+      claimSnapshot: args.claimSnapshot,
+    }),
+    aiCallContext: buildClaimDocumentAiCallContext({
+      claimId: args.claimId,
+      documentId,
+      grant: consent.grant,
+      tenantId: args.tenantId,
+      userId: args.userId,
+      workflow,
+    }),
+  };
+}

--- a/packages/domain-claims/src/claims/ai-workflow-types.ts
+++ b/packages/domain-claims/src/claims/ai-workflow-types.ts
@@ -1,0 +1,44 @@
+export type ClaimAiWorkflow = 'claim_intake_extract' | 'legal_doc_extract';
+
+export type ClaimAiDocumentCategory = 'evidence' | 'legal';
+
+export type ClaimAiFileInput = {
+  documentId?: string;
+  name: string;
+  path: string;
+  type: string;
+  size: number;
+  bucket: string;
+  category?: string | null;
+};
+
+export type ClaimAiClaimSnapshot = {
+  title: string;
+  description?: string | null;
+  category: string;
+  companyName: string;
+  claimAmount?: string | null;
+  currency?: string | null;
+  incidentDate?: string | null;
+};
+
+export type QueuedClaimAiRun = {
+  runId: string;
+  workflow: ClaimAiWorkflow;
+  claimId: string;
+  documentId: string;
+};
+
+export type ClaimAiConsentGrant = {
+  consentEventId: string;
+  recordedAt: string;
+};
+
+export type ClaimAiWorkflowQueueInput = {
+  tx: unknown;
+  claimId: string;
+  tenantId: string;
+  userId: string;
+  files: ClaimAiFileInput[];
+  claimSnapshot?: ClaimAiClaimSnapshot | null;
+};

--- a/packages/domain-claims/src/claims/ai-workflows-consented-shape.test.ts
+++ b/packages/domain-claims/src/claims/ai-workflows-consented-shape.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  config: vi.fn((workflow: string) => ({
+    model: 'gpt-5.5',
+    promptVersion: `${workflow}_v1`,
+    promptCacheKey: `key:${workflow}`,
+  })),
+  nanoid: vi.fn(),
+  txInsert: vi.fn(() => ({ values: vi.fn() })),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  aiRuns: { __name: 'ai_runs' },
+  documents: { __name: 'documents' },
+  claimDocumentAiExtractionConsents: new Proxy({}, { get: (_target, key) => String(key) }),
+}));
+vi.mock('@interdomestik/domain-ai/models', () => ({ getResponsesWorkflowConfig: hoisted.config }));
+vi.mock('nanoid', () => ({ nanoid: hoisted.nanoid }));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...conditions) => conditions),
+  desc: vi.fn(field => field),
+  eq: vi.fn((field, value) => ({ field, value })),
+}));
+
+import { queueClaimDocumentAiWorkflows } from './ai-workflows';
+
+const baseConsent = {
+  tenantId: 'tenant-1',
+  actorId: 'member-1',
+  subjectId: 'member-1',
+  claimId: 'claim-1',
+  consentType: 'ai_document_extraction',
+  processingPurpose: 'ai_document_extraction',
+  status: 'accepted',
+  privacyVersion: 'privacy-2026-05',
+  locale: 'en',
+  sourceSurface: 'member_claim_evidence_upload',
+  recordedAt: new Date('2026-06-21T10:00:00Z'),
+};
+
+function conditionValue(
+  condition: Array<{ field: string; value: unknown }>,
+  field: string
+): unknown {
+  return condition.find(item => item.field === field)?.value;
+}
+
+function matchingConsentRows(condition: Array<{ field: string; value: unknown }>) {
+  const documentId = conditionValue(condition, 'documentId');
+  return vi.fn(async () => [
+    {
+      ...baseConsent,
+      id: `consent-${String(documentId)}`,
+      documentId,
+    },
+  ]);
+}
+
+function orderMatchingConsent(condition: Array<{ field: string; value: unknown }>) {
+  return vi.fn(() => ({ limit: matchingConsentRows(condition) }));
+}
+
+function whereMatchingConsent() {
+  return vi.fn((condition: Array<{ field: string; value: unknown }>) => ({
+    orderBy: orderMatchingConsent(condition),
+  }));
+}
+
+function fromConsentTable() {
+  return vi.fn(() => ({ where: whereMatchingConsent() }));
+}
+
+function createTx() {
+  return {
+    insert: hoisted.txInsert,
+    select: vi.fn(() => ({ from: fromConsentTable() })),
+  };
+}
+
+describe('queueClaimDocumentAiWorkflows consented insert shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.nanoid.mockReturnValue('run-1');
+  });
+
+  it('preserves legal and evidence workflow/category mapping when consent is granted', async () => {
+    await queueClaimDocumentAiWorkflows({
+      tx: createTx(),
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      userId: 'member-1',
+      files: [
+        {
+          documentId: 'doc-evidence-1',
+          name: 'evidence.pdf',
+          path: 'p1',
+          type: 'application/pdf',
+          size: 1,
+          bucket: 'b',
+          category: 'evidence',
+        },
+        {
+          documentId: 'doc-legal-1',
+          name: 'legal.pdf',
+          path: 'p2',
+          type: 'application/pdf',
+          size: 2,
+          bucket: 'b',
+          category: 'legal',
+        },
+      ],
+    });
+
+    const documentValues = hoisted.txInsert.mock.results[0].value.values.mock.calls[0][0];
+    const aiRunValues = hoisted.txInsert.mock.results[1].value.values.mock.calls[0][0];
+    expect(documentValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: 'evidence',
+          description: expect.stringContaining('intake'),
+        }),
+        expect.objectContaining({
+          category: 'legal',
+          description: expect.stringContaining('legal'),
+        }),
+      ])
+    );
+    expect(aiRunValues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ workflow: 'claim_intake_extract' }),
+        expect.objectContaining({ workflow: 'legal_doc_extract' }),
+      ])
+    );
+  });
+});

--- a/packages/domain-claims/src/claims/ai-workflows.test.ts
+++ b/packages/domain-claims/src/claims/ai-workflows.test.ts
@@ -2,31 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => {
   const txInsertValues = vi.fn();
-  const txInsert = vi.fn(() => ({
-    values: txInsertValues,
-  }));
-
+  const txInsert = vi.fn(() => ({ values: txInsertValues }));
   return {
-    getResponsesWorkflowConfig: vi.fn((workflow: string) => {
-      const model = 'gpt-5.5';
-      const promptVersion =
-        workflow === 'legal_doc_extract' ? 'legal_doc_extract_v1' : 'claim_intake_extract_v1';
-
-      return {
-        workflow,
-        model,
-        promptVersion,
-        promptCacheKey: `interdomestik:${workflow}:${model}:${promptVersion}`,
-        reasoning: {
-          effort: workflow === 'legal_doc_extract' ? 'high' : 'medium',
-        },
-        text: {
-          verbosity: 'low',
-        },
-        maxOutputTokens: workflow === 'legal_doc_extract' ? 4_000 : 2_000,
-      };
-    }),
-    nanoid: vi.fn().mockReturnValueOnce('run-1').mockReturnValueOnce('run-2'),
+    getResponsesWorkflowConfig: vi.fn((workflow: string) => ({
+      workflow,
+      model: 'gpt-5.5',
+      promptVersion:
+        workflow === 'legal_doc_extract' ? 'legal_doc_extract_v1' : 'claim_intake_extract_v1',
+      promptCacheKey: `interdomestik:${workflow}:gpt-5.5`,
+    })),
+    nanoid: vi.fn(),
     txInsert,
     txInsertValues,
   };
@@ -35,131 +20,140 @@ const hoisted = vi.hoisted(() => {
 vi.mock('@interdomestik/database', () => ({
   aiRuns: { __name: 'ai_runs' },
   documents: { __name: 'documents' },
+  claimDocumentAiExtractionConsents: new Proxy(
+    { __name: 'claim_document_ai_extraction_consents' },
+    { get: (target, key) => Reflect.get(target, key) ?? String(key) }
+  ),
 }));
 
 vi.mock('@interdomestik/domain-ai/models', () => ({
   getResponsesWorkflowConfig: hoisted.getResponsesWorkflowConfig,
 }));
 
-vi.mock('nanoid', () => ({
-  nanoid: hoisted.nanoid,
-}));
+vi.mock('nanoid', () => ({ nanoid: hoisted.nanoid }));
+vi.mock('drizzle-orm', () => ({ and: vi.fn(), desc: vi.fn(), eq: vi.fn() }));
 
 import { queueClaimDocumentAiWorkflows } from './ai-workflows';
+
+const acceptedConsent = {
+  id: 'consent-1',
+  tenantId: 'tenant-1',
+  actorId: 'member-1',
+  subjectId: 'member-1',
+  claimId: 'claim-1',
+  documentId: 'doc-1',
+  consentType: 'ai_document_extraction',
+  processingPurpose: 'ai_document_extraction',
+  status: 'accepted',
+  privacyVersion: 'privacy-2026-05',
+  locale: 'en',
+  sourceSurface: 'member_claim_evidence_upload',
+  recordedAt: new Date('2026-06-21T10:00:00Z'),
+  grantedAt: new Date('2026-06-21T10:00:00Z'),
+  withdrawnAt: null,
+};
+
+function limitConsentRows(consentRows: unknown[]) {
+  return vi.fn(async () => consentRows);
+}
+
+function orderConsentRows(consentRows: unknown[]) {
+  return vi.fn(() => ({ limit: limitConsentRows(consentRows) }));
+}
+
+function whereConsentRows(consentRows: unknown[]) {
+  return vi.fn(() => ({ orderBy: orderConsentRows(consentRows) }));
+}
+
+function fromConsentRows(consentRows: unknown[]) {
+  return vi.fn(() => ({ where: whereConsentRows(consentRows) }));
+}
+
+function createTx(consentRows: unknown[]) {
+  return {
+    insert: hoisted.txInsert,
+    select: vi.fn(() => ({ from: fromConsentRows(consentRows) })),
+  };
+}
+
+function queueWith(consentRows: unknown[]) {
+  return queueClaimDocumentAiWorkflows({
+    tx: createTx(consentRows),
+    claimId: 'claim-1',
+    tenantId: 'tenant-1',
+    userId: 'member-1',
+    files: [
+      {
+        documentId: 'doc-1',
+        name: 'evidence.pdf',
+        path: 'pii/tenants/tenant-1/claims/claim-1/doc-1.pdf',
+        type: 'application/pdf',
+        size: 1024,
+        bucket: 'claim-evidence',
+        category: 'evidence',
+      },
+    ],
+  });
+}
 
 describe('queueClaimDocumentAiWorkflows', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    hoisted.nanoid.mockReturnValueOnce('run-1').mockReturnValueOnce('run-2');
+    hoisted.nanoid.mockReturnValue('run-1');
   });
 
-  it('dual-writes canonical documents and queued ai runs for claim and legal categories', async () => {
+  it('skips AI queueing when no trusted consent resolver exists', async () => {
     const queuedRuns = await queueClaimDocumentAiWorkflows({
-      tx: {
-        insert: hoisted.txInsert,
-      },
+      tx: { insert: hoisted.txInsert },
       claimId: 'claim-1',
       tenantId: 'tenant-1',
       userId: 'member-1',
       files: [
         {
-          documentId: 'legacy-doc-1',
+          documentId: 'doc-1',
           name: 'evidence.pdf',
-          path: 'pii/tenants/tenant-1/claims/member-1/evidence.pdf',
+          path: 'p',
           type: 'application/pdf',
-          size: 1024,
-          bucket: 'claim-evidence',
-          category: 'evidence',
-        },
-        {
-          documentId: 'legacy-doc-2',
-          name: 'demand-letter.pdf',
-          path: 'pii/tenants/tenant-1/claims/claim-1/demand-letter.pdf',
-          type: 'application/pdf',
-          size: 2048,
-          bucket: 'claim-evidence',
-          category: 'legal',
+          size: 1,
+          bucket: 'b',
         },
       ],
-      claimSnapshot: {
-        title: 'Damaged baggage',
-        description: 'The airline lost my luggage.',
-        category: 'travel',
-        companyName: 'Airline Co',
-        claimAmount: '1200.00',
-        currency: 'EUR',
-        incidentDate: '2026-02-15',
-      },
     });
 
-    expect(queuedRuns).toEqual([
-      expect.objectContaining({
-        runId: 'run-1',
-        workflow: 'claim_intake_extract',
-        claimId: 'claim-1',
-        documentId: 'legacy-doc-1',
-      }),
-      expect.objectContaining({
-        runId: 'run-2',
-        workflow: 'legal_doc_extract',
-        claimId: 'claim-1',
-        documentId: 'legacy-doc-2',
-      }),
-    ]);
+    expect(queuedRuns).toEqual([]);
+    expect(hoisted.txInsert).not.toHaveBeenCalled();
+  });
 
-    expect(hoisted.txInsert).toHaveBeenNthCalledWith(1, { __name: 'documents' });
-    expect(hoisted.txInsertValues).toHaveBeenNthCalledWith(
-      1,
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: 'legacy-doc-1',
-          tenantId: 'tenant-1',
-          entityType: 'claim',
-          entityId: 'claim-1',
-          fileName: 'evidence.pdf',
-          category: 'evidence',
-          storagePath: 'pii/tenants/tenant-1/claims/member-1/evidence.pdf',
-          uploadedBy: 'member-1',
-          uploadedAt: expect.any(Date),
-        }),
-        expect.objectContaining({
-          id: 'legacy-doc-2',
-          category: 'legal',
-        }),
-      ])
+  it('skips AI queueing without matching accepted consent', async () => {
+    await expect(queueWith([])).resolves.toEqual([]);
+    await expect(queueWith([{ ...acceptedConsent, subjectId: 'other-member' }])).resolves.toEqual(
+      []
     );
+    await expect(queueWith([{ ...acceptedConsent, status: 'withdrawn' }])).resolves.toEqual([]);
+    expect(hoisted.txInsert).not.toHaveBeenCalled();
+  });
 
+  it('queues an AI run with auditable context for matching accepted consent', async () => {
+    const queuedRuns = await queueWith([acceptedConsent]);
+
+    expect(queuedRuns).toEqual([
+      { runId: 'run-1', workflow: 'claim_intake_extract', claimId: 'claim-1', documentId: 'doc-1' },
+    ]);
+    expect(hoisted.txInsert).toHaveBeenNthCalledWith(1, { __name: 'documents' });
     expect(hoisted.txInsert).toHaveBeenNthCalledWith(2, { __name: 'ai_runs' });
     expect(hoisted.txInsertValues).toHaveBeenNthCalledWith(
       2,
       expect.arrayContaining([
         expect.objectContaining({
           id: 'run-1',
-          workflow: 'claim_intake_extract',
-          documentId: 'legacy-doc-1',
-          entityType: 'claim',
-          entityId: 'claim-1',
-          model: 'gpt-5.5',
-          promptVersion: 'claim_intake_extract_v1',
-          reviewStatus: 'pending',
           requestJson: expect.objectContaining({
-            category: 'evidence',
-            bucket: 'claim-evidence',
-            promptCacheKey: 'interdomestik:claim_intake_extract:gpt-5.5:claim_intake_extract_v1',
-            claimSnapshot: expect.objectContaining({
-              incidentDate: '2026-02-15',
+            aiCallContext: expect.objectContaining({
+              consent: 'required_granted',
+              consentEventId: 'consent-1',
+              consentRecordedAt: '2026-06-21T10:00:00.000Z',
+              processingPurpose: 'ai_document_extraction',
+              scope: { claimId: 'claim-1', documentId: 'doc-1' },
             }),
-          }),
-        }),
-        expect.objectContaining({
-          id: 'run-2',
-          workflow: 'legal_doc_extract',
-          documentId: 'legacy-doc-2',
-          model: 'gpt-5.5',
-          promptVersion: 'legal_doc_extract_v1',
-          requestJson: expect.objectContaining({
-            category: 'legal',
-            promptCacheKey: 'interdomestik:legal_doc_extract:gpt-5.5:legal_doc_extract_v1',
           }),
         }),
       ])

--- a/packages/domain-claims/src/claims/ai-workflows.ts
+++ b/packages/domain-claims/src/claims/ai-workflows.ts
@@ -1,107 +1,60 @@
-import { createHash } from 'node:crypto';
-
 import { aiRuns, documents } from '@interdomestik/database';
-import { getResponsesWorkflowConfig } from '@interdomestik/domain-ai/models';
-import { nanoid } from 'nanoid';
 
-export type ClaimAiWorkflow = 'claim_intake_extract' | 'legal_doc_extract';
+import {
+  prepareClaimDocumentAiRun,
+  type PreparedQueuedClaimAiRun,
+} from './ai-workflow-preparation';
+import type { ClaimAiWorkflowQueueInput, QueuedClaimAiRun } from './ai-workflow-types';
 
-export type ClaimAiDocumentCategory = 'evidence' | 'legal';
-
-export type ClaimAiFileInput = {
-  documentId?: string;
-  name: string;
-  path: string;
-  type: string;
-  size: number;
-  bucket: string;
-  category?: string | null;
+type QueueInsertTx = {
+  insert: (table: unknown) => { values: (rows: unknown) => unknown };
 };
 
-export type ClaimAiClaimSnapshot = {
-  title: string;
-  description?: string | null;
-  category: string;
-  companyName: string;
-  claimAmount?: string | null;
-  currency?: string | null;
-  incidentDate?: string | null;
-};
+export type {
+  ClaimAiClaimSnapshot,
+  ClaimAiDocumentCategory,
+  ClaimAiFileInput,
+  ClaimAiWorkflow,
+  QueuedClaimAiRun,
+} from './ai-workflow-types';
 
-export type QueuedClaimAiRun = {
-  runId: string;
-  workflow: ClaimAiWorkflow;
-  claimId: string;
-  documentId: string;
-};
-
-type InsertableTx = {
-  insert: (table: any) => {
-    values: (value: Record<string, unknown> | Array<Record<string, unknown>>) => unknown;
-  };
-};
-
-function normalizeCategory(category: string | null | undefined): ClaimAiDocumentCategory {
-  return category === 'legal' ? 'legal' : 'evidence';
+function canInsertQueueRows(tx: unknown): tx is QueueInsertTx {
+  return typeof (tx as { insert?: unknown }).insert === 'function';
 }
 
-function resolveWorkflow(category: ClaimAiDocumentCategory): ClaimAiWorkflow {
-  return category === 'legal' ? 'legal_doc_extract' : 'claim_intake_extract';
-}
+async function insertQueueRows(tx: unknown, table: unknown, rows: unknown): Promise<void> {
+  if (!canInsertQueueRows(tx)) {
+    throw new Error('Claim document AI workflow queue requires an insert-capable transaction.');
+  }
 
-function buildInputHash(args: {
-  workflow: ClaimAiWorkflow;
-  claimId: string;
-  documentId: string;
-  path: string;
-  category: ClaimAiDocumentCategory;
-  claimSnapshot?: ClaimAiClaimSnapshot | null;
-}) {
-  return createHash('sha256').update(JSON.stringify(args)).digest('hex');
+  await tx.insert(table).values(rows);
 }
 
 export async function queueClaimDocumentAiWorkflows(args: {
-  tx: InsertableTx;
-  claimId: string;
-  tenantId: string;
-  userId: string;
-  files: ClaimAiFileInput[];
-  claimSnapshot?: ClaimAiClaimSnapshot | null;
+  tx: ClaimAiWorkflowQueueInput['tx'];
+  claimId: ClaimAiWorkflowQueueInput['claimId'];
+  tenantId: ClaimAiWorkflowQueueInput['tenantId'];
+  userId: ClaimAiWorkflowQueueInput['userId'];
+  files: ClaimAiWorkflowQueueInput['files'];
+  claimSnapshot?: ClaimAiWorkflowQueueInput['claimSnapshot'];
 }): Promise<QueuedClaimAiRun[]> {
   if (args.files.length === 0) {
     return [];
   }
 
+  const queuedRuns: PreparedQueuedClaimAiRun[] = [];
+  for (const file of args.files) {
+    const queuedRun = await prepareClaimDocumentAiRun({ args, file });
+    if (queuedRun) queuedRuns.push(queuedRun);
+  }
+
+  if (queuedRuns.length === 0) return [];
+
   const now = new Date();
-  const queuedRuns = args.files.map(file => {
-    const category = normalizeCategory(file.category);
-    const workflow = resolveWorkflow(category);
-    const documentId = file.documentId ?? nanoid();
-    const runId = nanoid();
-    const config = getResponsesWorkflowConfig(workflow);
 
-    return {
-      runId,
-      workflow,
-      claimId: args.claimId,
-      documentId,
-      category,
-      model: config.model,
-      promptVersion: config.promptVersion,
-      promptCacheKey: config.promptCacheKey,
-      file,
-      inputHash: buildInputHash({
-        workflow,
-        claimId: args.claimId,
-        documentId,
-        path: file.path,
-        category,
-        claimSnapshot: args.claimSnapshot,
-      }),
-    };
-  });
-
-  await args.tx.insert(documents).values(
+  await insertQueueRows(
+    args.tx,
+    documents,
     queuedRuns.map(queuedRun => ({
       id: queuedRun.documentId,
       tenantId: args.tenantId,
@@ -121,7 +74,9 @@ export async function queueClaimDocumentAiWorkflows(args: {
     }))
   );
 
-  await args.tx.insert(aiRuns).values(
+  await insertQueueRows(
+    args.tx,
+    aiRuns,
     queuedRuns.map(queuedRun => ({
       id: queuedRun.runId,
       tenantId: args.tenantId,
@@ -143,6 +98,7 @@ export async function queueClaimDocumentAiWorkflows(args: {
         bucket: queuedRun.file.bucket,
         category: queuedRun.category,
         promptCacheKey: queuedRun.promptCacheKey,
+        aiCallContext: queuedRun.aiCallContext,
         claimSnapshot: args.claimSnapshot ?? null,
       },
       reviewStatus: 'pending',

--- a/packages/domain-claims/src/claims/claim-ai-context.ts
+++ b/packages/domain-claims/src/claims/claim-ai-context.ts
@@ -1,0 +1,46 @@
+import { validateAICallContext, type AICallContext } from '@interdomestik/domain-privacy';
+
+import type { ClaimAiConsentGrant, ClaimAiWorkflow } from './ai-workflow-types';
+
+export type ClaimDocumentAiCallContext = AICallContext & {
+  consentEventId: string;
+  consentRecordedAt: string;
+};
+
+export function buildClaimDocumentAiCallContext(params: {
+  claimId: string;
+  documentId: string;
+  grant: ClaimAiConsentGrant;
+  tenantId: string;
+  userId: string;
+  workflow: ClaimAiWorkflow;
+}): ClaimDocumentAiCallContext {
+  const context = {
+    workflowId: params.workflow,
+    owner: 'domain-claims',
+    tenantId: params.tenantId,
+    actorId: params.userId,
+    subjectId: params.userId,
+    scope: {
+      claimId: params.claimId,
+      documentId: params.documentId,
+    },
+    purpose: 'document_extraction',
+    processingPurpose: 'ai_document_extraction',
+    retention: 'zero_retention_no_training',
+    posture: 'human_review_required',
+    consent: 'required_granted',
+    invalidityPosture: 'not_applicable',
+  } as const;
+  const decision = validateAICallContext(context);
+
+  if (decision.kind === 'invalid') {
+    throw new Error(`Invalid claim document AI context: ${decision.reasons.join(',')}`);
+  }
+
+  return {
+    ...decision.context,
+    consentEventId: params.grant.consentEventId,
+    consentRecordedAt: params.grant.recordedAt,
+  };
+}

--- a/packages/domain-claims/src/claims/claim-document-ai-consent.test.ts
+++ b/packages/domain-claims/src/claims/claim-document-ai-consent.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@interdomestik/database', () => ({
+  claimDocumentAiExtractionConsents: new Proxy(
+    { __name: 'claim_document_ai_extraction_consents' },
+    { get: (target, key) => Reflect.get(target, key) ?? String(key) }
+  ),
+}));
+
+vi.mock('drizzle-orm', () => ({ and: vi.fn(), desc: vi.fn(), eq: vi.fn() }));
+
+import { resolveClaimDocumentAiExtractionConsent } from './claim-document-ai-consent';
+
+const acceptedConsent = {
+  id: 'consent-1',
+  tenantId: 'tenant-1',
+  actorId: 'member-1',
+  subjectId: 'member-1',
+  claimId: 'claim-1',
+  documentId: 'doc-1',
+  consentType: 'ai_document_extraction',
+  processingPurpose: 'ai_document_extraction',
+  status: 'accepted',
+  privacyVersion: 'privacy-2026-05',
+  locale: 'en',
+  sourceSurface: 'member_claim_evidence_upload',
+  recordedAt: new Date('2026-06-21T10:00:00Z'),
+  grantedAt: new Date('2026-06-21T10:00:00Z'),
+  withdrawnAt: null,
+};
+
+function limitConsentRow(row: unknown) {
+  return vi.fn(async () => (row ? [row] : []));
+}
+
+function orderConsentRow(row: unknown) {
+  return vi.fn(() => ({ limit: limitConsentRow(row) }));
+}
+
+function whereConsentRow(row: unknown) {
+  return vi.fn(() => ({ orderBy: orderConsentRow(row) }));
+}
+
+function fromConsentRow(row: unknown) {
+  return vi.fn(() => ({ where: whereConsentRow(row) }));
+}
+
+function createTx(row: unknown) {
+  return {
+    select: vi.fn(() => ({ from: fromConsentRow(row) })),
+  };
+}
+
+function resolve(row: unknown) {
+  return resolveClaimDocumentAiExtractionConsent({
+    tx: createTx(row),
+    tenantId: 'tenant-1',
+    subjectId: 'member-1',
+    claimId: 'claim-1',
+    documentId: 'doc-1',
+  });
+}
+
+describe('resolveClaimDocumentAiExtractionConsent', () => {
+  it('grants only matching accepted ai_document_extraction consent', async () => {
+    await expect(resolve(acceptedConsent)).resolves.toEqual({
+      kind: 'granted',
+      grant: { consentEventId: 'consent-1', recordedAt: '2026-06-21T10:00:00.000Z' },
+    });
+  });
+
+  it.each([
+    ['wrong tenant', { tenantId: 'tenant-2' }],
+    ['wrong subject', { subjectId: 'member-2' }],
+    ['wrong claim', { claimId: 'claim-2' }],
+    ['wrong document', { documentId: 'doc-2' }],
+    ['withdrawn latest consent', { status: 'withdrawn' }],
+    ['generic terms consent', { consentType: 'privacy_policy' }],
+    ['generic purpose consent', { processingPurpose: 'document_storage' }],
+  ])('blocks %s', async (_label, override) => {
+    await expect(resolve({ ...acceptedConsent, ...override })).resolves.toMatchObject({
+      kind: 'blocked',
+    });
+  });
+});

--- a/packages/domain-claims/src/claims/claim-document-ai-consent.ts
+++ b/packages/domain-claims/src/claims/claim-document-ai-consent.ts
@@ -1,0 +1,130 @@
+import { claimDocumentAiExtractionConsents } from '@interdomestik/database';
+import { evaluateConsentRequirement, type ConsentEvent } from '@interdomestik/domain-privacy';
+import { and, desc, eq } from 'drizzle-orm';
+
+import type { ClaimAiConsentGrant } from './ai-workflow-types';
+
+type ConsentRow = {
+  id: string;
+  tenantId: string;
+  actorId: string;
+  subjectId: string;
+  claimId: string;
+  documentId: string;
+  consentType: 'ai_document_extraction';
+  processingPurpose: 'ai_document_extraction';
+  status: 'accepted' | 'withdrawn';
+  privacyVersion: string;
+  locale: string;
+  sourceSurface: string;
+  recordedAt: Date | string;
+  grantedAt?: Date | string | null;
+  withdrawnAt?: Date | string | null;
+};
+
+type ConsentSelectableTx = {
+  select: (fields: Record<string, unknown>) => {
+    from: (table: unknown) => {
+      where: (condition: unknown) => {
+        orderBy: (...order: unknown[]) => {
+          limit: (limit: number) => Promise<ConsentRow[]>;
+        };
+      };
+    };
+  };
+};
+
+export type ClaimDocumentAiConsentResolution =
+  | { kind: 'granted'; grant: ClaimAiConsentGrant }
+  | { kind: 'blocked'; reason: string };
+
+function toIso(value: Date | string | null | undefined): string | undefined {
+  if (value == null) return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : undefined;
+}
+
+function toConsentEvent(row: ConsentRow): ConsentEvent {
+  const recordedAt = toIso(row.recordedAt) ?? '';
+
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    actorId: row.actorId,
+    subjectId: row.subjectId,
+    scope: { claimId: row.claimId, documentId: row.documentId },
+    consentType: row.consentType,
+    purpose: row.processingPurpose,
+    lawfulBasis: 'consent',
+    privacyVersion: row.privacyVersion,
+    locale: row.locale,
+    status: row.status,
+    recordedAt,
+    ...(row.status === 'accepted' ? { acceptedAt: toIso(row.grantedAt) ?? recordedAt } : {}),
+    ...(row.status === 'withdrawn' ? { withdrawnAt: toIso(row.withdrawnAt) ?? recordedAt } : {}),
+    sourceSurface: row.sourceSurface,
+  };
+}
+
+function canSelectConsent(tx: unknown): tx is ConsentSelectableTx {
+  return typeof (tx as { select?: unknown }).select === 'function';
+}
+
+export async function resolveClaimDocumentAiExtractionConsent(params: {
+  tx: unknown;
+  tenantId: string;
+  subjectId: string;
+  claimId: string;
+  documentId: string;
+}): Promise<ClaimDocumentAiConsentResolution> {
+  if (!canSelectConsent(params.tx)) {
+    return { kind: 'blocked', reason: 'consent_resolver_unavailable' };
+  }
+
+  const [row] = await params.tx
+    .select({
+      id: claimDocumentAiExtractionConsents.id,
+      tenantId: claimDocumentAiExtractionConsents.tenantId,
+      actorId: claimDocumentAiExtractionConsents.actorId,
+      subjectId: claimDocumentAiExtractionConsents.subjectId,
+      claimId: claimDocumentAiExtractionConsents.claimId,
+      documentId: claimDocumentAiExtractionConsents.documentId,
+      consentType: claimDocumentAiExtractionConsents.consentType,
+      processingPurpose: claimDocumentAiExtractionConsents.processingPurpose,
+      status: claimDocumentAiExtractionConsents.status,
+      privacyVersion: claimDocumentAiExtractionConsents.privacyVersion,
+      locale: claimDocumentAiExtractionConsents.locale,
+      sourceSurface: claimDocumentAiExtractionConsents.sourceSurface,
+      recordedAt: claimDocumentAiExtractionConsents.recordedAt,
+      grantedAt: claimDocumentAiExtractionConsents.grantedAt,
+      withdrawnAt: claimDocumentAiExtractionConsents.withdrawnAt,
+    })
+    .from(claimDocumentAiExtractionConsents)
+    .where(
+      and(
+        eq(claimDocumentAiExtractionConsents.tenantId, params.tenantId),
+        eq(claimDocumentAiExtractionConsents.subjectId, params.subjectId),
+        eq(claimDocumentAiExtractionConsents.claimId, params.claimId),
+        eq(claimDocumentAiExtractionConsents.documentId, params.documentId),
+        eq(claimDocumentAiExtractionConsents.consentType, 'ai_document_extraction'),
+        eq(claimDocumentAiExtractionConsents.processingPurpose, 'ai_document_extraction')
+      )
+    )
+    .orderBy(desc(claimDocumentAiExtractionConsents.recordedAt))
+    .limit(1);
+
+  if (!row) return { kind: 'blocked', reason: 'consent_missing' };
+
+  const event = toConsentEvent(row);
+  const decision = evaluateConsentRequirement([event], {
+    tenantId: params.tenantId,
+    subjectId: params.subjectId,
+    consentType: 'ai_document_extraction',
+    purpose: 'ai_document_extraction',
+    scope: { claimId: params.claimId, documentId: params.documentId },
+  });
+
+  return decision.kind === 'allowed'
+    ? { kind: 'granted', grant: { consentEventId: event.id, recordedAt: event.recordedAt } }
+    : { kind: 'blocked', reason: decision.reasons[0] ?? 'consent_blocked' };
+}

--- a/packages/domain-claims/src/claims/submit.test.ts
+++ b/packages/domain-claims/src/claims/submit.test.ts
@@ -171,7 +171,7 @@ describe('submitClaimCore', () => {
     });
   });
 
-  it('queues claim AI after documents persist', async () => {
+  it('persists initial documents without queueing AI when no explicit extraction consent exists', async () => {
     const dispatchClaimAiRun = vi.fn().mockResolvedValue(undefined);
     const validateSubmittedClaimFile = vi.fn().mockResolvedValue(undefined);
 
@@ -214,22 +214,8 @@ describe('submitClaimCore', () => {
         tenantId: 'tenant-1',
       })
     );
-    expect(hoisted.queueClaimDocumentAiWorkflows).toHaveBeenCalledWith(
-      expect.objectContaining({
-        claimId: 'claim-1',
-        tenantId: 'tenant-1',
-        userId: 'member-1',
-        claimSnapshot: expect.objectContaining({
-          incidentDate: '2026-02-15',
-        }),
-      })
-    );
-    expect(dispatchClaimAiRun).toHaveBeenCalledWith(
-      expect.objectContaining({
-        runId: 'run-1',
-        workflow: 'claim_intake_extract',
-      })
-    );
+    expect(hoisted.queueClaimDocumentAiWorkflows).not.toHaveBeenCalled();
+    expect(dispatchClaimAiRun).not.toHaveBeenCalled();
     expect(validateSubmittedClaimFile).toHaveBeenCalledWith({
       actorId: 'member-1',
       tenantId: 'tenant-1',

--- a/packages/domain-claims/src/claims/submit.ts
+++ b/packages/domain-claims/src/claims/submit.ts
@@ -7,7 +7,7 @@ import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
 import { createClaimSchema, type CreateClaimValues } from '../validators/claims';
-import { queueClaimDocumentAiWorkflows, type QueuedClaimAiRun } from './ai-workflows';
+import type { QueuedClaimAiRun } from './ai-workflow-types';
 import { buildClaimDocumentRows } from './documents';
 import {
   buildClaimStartPublicNote,
@@ -133,14 +133,12 @@ async function persistSubmittedClaim(args: {
   handoffContext?: ClaimStartHandoffContext | null;
   data: CreateClaimValues;
 }): Promise<{ claimNumber: string; queuedRuns: QueuedClaimAiRun[] }> {
-  const { title, description, category, companyName, claimAmount, currency, incidentDate, files } =
-    args.data;
+  const { title, description, category, companyName, claimAmount, currency, files } = args.data;
   const publicNote = buildClaimStartPublicNote(args.handoffContext);
   const incidentCountry = resolveSubmittedClaimIncidentCountry({
     data: args.data,
     handoffContext: args.handoffContext,
   });
-  let queuedRuns: QueuedClaimAiRun[] = [];
   let claimNumber = '';
 
   // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
@@ -195,36 +193,11 @@ async function persistSubmittedClaim(args: {
 
     // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
     await tx.insert(claimDocuments).values(documentRows);
-
-    queuedRuns = await queueClaimDocumentAiWorkflows({
-      tx,
-      claimId: args.claimId,
-      tenantId: args.tenantId,
-      userId: args.userId,
-      files: documentRows.map(documentRow => ({
-        documentId: documentRow.id,
-        name: documentRow.name,
-        path: documentRow.filePath,
-        type: documentRow.fileType,
-        size: documentRow.fileSize,
-        bucket: documentRow.bucket,
-        category: documentRow.category,
-      })),
-      claimSnapshot: {
-        title,
-        description,
-        category,
-        companyName,
-        claimAmount,
-        currency,
-        incidentDate,
-      },
-    });
   });
 
   return {
     claimNumber,
-    queuedRuns,
+    queuedRuns: [],
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,6 +587,9 @@ importers:
       '@interdomestik/domain-membership-billing':
         specifier: workspace:*
         version: link:../domain-membership-billing
+      '@interdomestik/domain-privacy':
+        specifier: workspace:*
+        version: link:../domain-privacy
       '@interdomestik/domain-recovery':
         specifier: workspace:*
         version: link:../domain-recovery

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36553407,
-  "maxTrackedFiles": 4369,
+  "maxTrackedBytes": 36587183,
+  "maxTrackedFiles": 4385,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18004482,
-    "source/scripts": 6842668,
+    "large support/generated-ish": 18007846,
+    "source/scripts": 6858371,
     "docs/text": 5289375,
-    "tests/e2e": 4746997,
-    "config/data/messages": 1540720,
+    "tests/e2e": 4761654,
+    "config/data/messages": 1540772,
     "other": 129165
   },
   "maxLargestFileBytes": 3089508,


### PR DESCRIPTION
## Summary

Implements T-404a only: explicit durable `ai_document_extraction` consent for claim document AI extraction, scoped to tenant + subject/user + claim + document/purpose.

- Adds `claim_document_ai_extraction_consents` schema/migration/RLS/indexes for the narrow T-404a consent boundary.
- Wires member evidence upload opt-in through `ClaimEvidenceUploadDialog` -> `SharedEvidenceUploadDialog` -> member confirm action -> persistence helper.
- Resolves consent in trusted server/domain code from transaction/database state before queueing document AI workflows.
- Preserves ordinary upload when consent is unchecked/missing; AI extraction queueing skips instead of fabricating context.
- Keeps admin/direct upload path from creating member AI consent.

## Scope Audit

- T-404 remains parked; no T-404 runtime/prompt/provider/domain-ai entrypoint expansion.
- No Operational Brain runtime changes.
- No proxy/routing/auth/session/tenancy refactor.
- No `apps/web/src/proxy.ts`, README, AGENTS, broad architecture docs, billing, prompt/model/provider, or outbox AI event expansion changes.

## Consent Boundary

- Durable store: `claim_document_ai_extraction_consents` with tenantId, actorId, subjectId, claimId, documentId, fixed `consentType`/`processingPurpose` = `ai_document_extraction`, status, privacyVersion, locale, sourceSurface, recorded/granted/withdrawn timestamps, supersession pointer, tenant RLS, and scope indexes.
- Trusted resolver: `packages/domain-claims/src/claims/claim-document-ai-consent.ts` selects exact tenant + subject + claim + document + consent type + purpose and evaluates via domain privacy rules. Caller-provided consent/tenant/role posture does not authorize extraction.
- Queue integration: `queueClaimDocumentAiWorkflows` prepares runs only when resolver returns granted consent and writes consent metadata into `requestJson.aiCallContext`.

## Test Matrix

Focused domain-claims tests cover:
- resolver unavailable/no select -> skip;
- missing consent -> skip;
- wrong subject -> skip;
- wrong tenant, wrong claim, wrong document -> blocked by resolver;
- withdrawn consent -> skip;
- generic/non-`ai_document_extraction` consent type and purpose substitution -> blocked;
- accepted matching consent -> queues AI run with `requestJson.aiCallContext` consent metadata;
- evidence/legal workflow/category insert shape preserved when consent is granted.

Focused web/database tests cover:
- unchecked member upload persists claim document, does not insert consent row, and does not dispatch AI;
- checked member upload inserts scoped consent row with tenantId, subjectId/actorId, claimId, documentId, purpose/type, privacy version, locale, source surface;
- ordinary upload remains successful when unchecked;
- admin/direct admin upload path cannot create member AI consent;
- upload dialog resets consent on success/close/cancel and selected file changes;
- migration/schema test asserts table, RLS, scope index, and schema export.

## Verification

- `pnpm --filter @interdomestik/web test:unit --run src/actions/claims.test.ts` -> passed, 23 tests.
- `pnpm --filter @interdomestik/domain-claims test:unit --run src/claims/ai-workflows.test.ts src/claims/claim-document-ai-consent.test.ts src/claims/ai-workflows-consented-shape.test.ts` -> passed, 12 tests.
- `pnpm --filter @interdomestik/web test:unit --run src/features/member/claims/actions.test.ts src/features/member/claims/components/ClaimEvidenceUploadDialog.test.tsx src/features/claims/upload/server/claim-document-persistence.test.ts src/features/admin/claims/actions/evidence-upload.test.ts` -> passed, 27 tests.
- `pnpm --filter @interdomestik/database exec tsx --test test/claim-document-ai-consents-migration.test.ts` -> passed, 4 tests.
- `pnpm check:modularity-guard` -> passed after commit amend; `apps/web/src/actions/claims.test.ts` is 636 lines vs 637 base, `packages/domain-claims/src/claims/ai-workflows.ts` is 112 lines.
- `node scripts/repo-size-budget-sync.mjs && pnpm repo:size:check` -> budget drift synced, size check passed.
- `pnpm check:db-access` -> passed.
- `pnpm db:rls:test:required` -> passed, total=74 enabled=74 missing=0.
- `pnpm slice:verify` -> passed.
- `pnpm pr:verify` -> passed.
- `pnpm security:guard` -> passed.
- `pnpm e2e:gate` -> passed, 136 passed / 8 skipped.

## Reviewer Route

- Sonnet: `pnpm review:sonnet`, receipt `tmp/reviewer-routes/20260621T002623-sonnet.json`, exit 0, elapsed 219695ms. Findings reviewed; no code blockers after checking against actual symbols/schema. One durability note on FK delete behavior is intentional for consent audit retention.
- Gemini: `pnpm review:gemini`, receipt `tmp/reviewer-routes/20260621T003021-gemini.json`, blocked by Gemini CLI license/auth 403 (#3501), elapsed 19224ms.
- Opus fallback: `pnpm review:opus`, receipt `tmp/reviewer-routes/20260621T003058-opus.json`, blocked by `reviewer_no_output_timeout`, exit 143/wrapper 125.
