### PR TITLE
fix: require AI call context at domain boundary

### DIFF
--- a/apps/web/src/lib/ai/claim-pipeline-input.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-input.ts
@@ -7,6 +7,7 @@ import {
   validateExtractionCandidate,
 } from '@/lib/ai/extraction-pipeline';
 import { extractClaimIntake } from '@interdomestik/domain-ai/claims/intake-extract';
+import { requireAICallContext, type DomainAiCallContext } from '@interdomestik/domain-ai/context';
 import { extractLegalDocument } from '@interdomestik/domain-ai/legal/extract';
 import { claimIntakeExtractSchema } from '@interdomestik/domain-ai/schemas/claim-intake-extract';
 import { legalDocExtractSchema } from '@interdomestik/domain-ai/schemas/legal-doc-extract';
@@ -48,6 +49,12 @@ function getClaimSnapshotFromRequestJson(
   };
 }
 
+function getAiCallContextFromRequestJson(
+  requestJson: Record<string, unknown>
+): DomainAiCallContext {
+  return requireAICallContext(requestJson.aiCallContext);
+}
+
 export function validateClaimAiCandidate(
   workflow: ClaimedClaimAiRun['workflow'],
   candidate: unknown
@@ -80,14 +87,17 @@ export async function extractClaimAiCandidate(
 ): Promise<ExtractionCandidate> {
   const requestJson =
     input.requestJson && typeof input.requestJson === 'object' ? input.requestJson : {};
+  const aiCallContext = getAiCallContextFromRequestJson(requestJson);
   const candidate =
     input.workflow === 'legal_doc_extract'
       ? await extractLegalDocument({
+          aiCallContext,
           documentText: input.documentText,
           fileName: input.fileName,
           uploadedAt: input.uploadedAt,
         })
       : await extractClaimIntake({
+          aiCallContext,
           claim: {
             title: input.claimTitle,
             description: input.claimDescription,

--- a/apps/web/src/lib/ai/claim-workflows-critique.test.ts
+++ b/apps/web/src/lib/ai/claim-workflows-critique.test.ts
@@ -40,6 +40,7 @@ vi.mock('@interdomestik/domain-ai/claims/intake-extract', () => ({
 }));
 
 import { processClaimDocumentWorkflowRunService } from './claim-workflows';
+import { claimIntakeAiCallContext } from '@/test/ai-call-context';
 
 describe('processClaimDocumentWorkflowRunService critique gate', () => {
   beforeEach(() => {
@@ -56,7 +57,7 @@ describe('processClaimDocumentWorkflowRunService critique gate', () => {
         mimeType: 'text/plain',
         uploadedAt: new Date('2026-03-08T10:00:00.000Z'),
         status: 'queued',
-        requestJson: { bucket: 'claim-evidence' },
+        requestJson: { aiCallContext: claimIntakeAiCallContext, bucket: 'claim-evidence' },
         claimTitle: 'Flight delay claim',
         claimDescription: 'Delay overnight.',
         claimCategory: 'travel',

--- a/apps/web/src/lib/ai/claim-workflows.test.ts
+++ b/apps/web/src/lib/ai/claim-workflows.test.ts
@@ -134,6 +134,7 @@ import {
   emitClaimAiRunRequestedService,
   processClaimDocumentWorkflowRunService,
 } from './claim-workflows';
+import { claimIntakeAiCallContext, createLegalAiCallContext } from '@/test/ai-call-context';
 
 function buildQueuedRun(
   overrides: Partial<{
@@ -156,6 +157,7 @@ function buildQueuedRun(
     uploadedAt: new Date('2026-03-08T10:00:00.000Z'),
     status: 'queued',
     requestJson: {
+      aiCallContext: claimIntakeAiCallContext,
       claimSnapshot: {
         incidentDate: '2026-02-15',
       },
@@ -294,7 +296,7 @@ describe('processClaimDocumentWorkflowRunService', () => {
         documentId: 'doc-2',
         storagePath: 'pii/tenants/tenant-1/claims/claim-1/demand-letter.pdf',
         fileName: 'demand-letter.pdf',
-        requestJson: {},
+        requestJson: { aiCallContext: createLegalAiCallContext('doc-2') },
       }),
     ]);
     mocks.extractLegalDocument.mockResolvedValue({
@@ -341,10 +343,8 @@ describe('processClaimDocumentWorkflowRunService', () => {
     mocks.selectWhere.mockResolvedValue([
       buildQueuedRun({
         requestJson: {
-          claimSnapshot: {
-            incidentDate: '15/02/2026',
-            other: 'ignored',
-          },
+          aiCallContext: claimIntakeAiCallContext,
+          claimSnapshot: { incidentDate: '15/02/2026', other: 'ignored' },
         },
       }),
     ]);

--- a/apps/web/src/test/ai-call-context.ts
+++ b/apps/web/src/test/ai-call-context.ts
@@ -1,0 +1,22 @@
+export const claimIntakeAiCallContext = {
+  workflowId: 'claim_intake_extract',
+  owner: 'domain-claims',
+  tenantId: 'tenant-1',
+  actorId: 'user-1',
+  subjectId: 'user-1',
+  scope: { claimId: 'claim-1', documentId: 'doc-1' },
+  purpose: 'document_extraction',
+  processingPurpose: 'ai_document_extraction',
+  retention: 'zero_retention_no_training',
+  posture: 'human_review_required',
+  consent: 'required_granted',
+  invalidityPosture: 'not_applicable',
+};
+
+export function createLegalAiCallContext(documentId: string) {
+  return {
+    ...claimIntakeAiCallContext,
+    workflowId: 'legal_doc_extract',
+    scope: { claimId: 'claim-1', documentId },
+  };
+}

--- a/packages/domain-ai/package.json
+++ b/packages/domain-ai/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
+    "./context": "./src/context.ts",
     "./claims/intake-extract": "./src/claims/intake-extract.ts",
     "./claims/summary": "./src/claims/summary.ts",
     "./legal/extract": "./src/legal/extract.ts",
@@ -27,6 +28,7 @@
   },
   "dependencies": {
     "@interdomestik/database": "workspace:*",
+    "@interdomestik/domain-privacy": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "openai": "^6.42.0",
     "zod": "^4.2.1"

--- a/packages/domain-ai/src/ai-call-context-required.compile-fail.ts
+++ b/packages/domain-ai/src/ai-call-context-required.compile-fail.ts
@@ -1,0 +1,35 @@
+// T-404 compile-fail fixture: every @ts-expect-error below must stay a type
+// error so public domain-ai call entry points cannot silently drop context.
+import { createAiClient } from './client';
+import { extractClaimIntake } from './claims/intake-extract';
+import { summarizeClaim } from './claims/summary';
+import { extractLegalDocument } from './legal/extract';
+
+// @ts-expect-error T-404: AI client construction requires trusted AICallContext.
+createAiClient();
+
+// @ts-expect-error T-404: claim intake extraction requires trusted AICallContext.
+extractClaimIntake({
+  claim: {
+    title: 'Flight cancellation reimbursement',
+    description: null,
+    category: 'travel',
+    claimAmount: null,
+    currency: null,
+  },
+});
+
+// @ts-expect-error T-404: claim summary requires trusted AICallContext.
+summarizeClaim({
+  claim: {
+    title: 'Delayed baggage claim',
+    description: null,
+    category: 'travel',
+    companyName: null,
+    claimAmount: null,
+    currency: null,
+  },
+});
+
+// @ts-expect-error T-404: legal extraction requires trusted AICallContext.
+extractLegalDocument({ documentText: 'Demand letter issued by Contoso Legal.' });

--- a/packages/domain-ai/src/claims/intake-extract.test.ts
+++ b/packages/domain-ai/src/claims/intake-extract.test.ts
@@ -59,6 +59,7 @@ describe('extractClaimIntake', () => {
   it('rejects missing runtime AI context before extraction behavior', async () => {
     await expect(
       extractClaimIntake({
+        // @ts-expect-error T-404 runtime guard rejects null context.
         aiCallContext: null,
         claim: {
           title: 'Unknown issue',
@@ -67,7 +68,7 @@ describe('extractClaimIntake', () => {
           claimAmount: null,
           currency: null,
         },
-      } as never)
+      })
     ).rejects.toThrow(/AI call context is required: context_missing/);
   });
 });

--- a/packages/domain-ai/src/claims/intake-extract.test.ts
+++ b/packages/domain-ai/src/claims/intake-extract.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { createDocumentExtractionAiContext } from '../test-helpers/ai-call-context';
 import { extractClaimIntake } from './intake-extract';
 
 describe('extractClaimIntake', () => {
   it('maps claim context and document text into the typed intake schema', async () => {
     const result = await extractClaimIntake({
+      aiCallContext: createDocumentExtractionAiContext(),
       claim: {
         title: 'Flight cancellation reimbursement',
         description: 'My flight from Berlin to Rome was cancelled and I had to rebook.',
@@ -35,6 +37,7 @@ describe('extractClaimIntake', () => {
 
   it('falls back safely when the claim payload is sparse', async () => {
     const result = await extractClaimIntake({
+      aiCallContext: createDocumentExtractionAiContext(),
       claim: {
         title: 'Unknown issue',
         description: '',
@@ -51,5 +54,20 @@ describe('extractClaimIntake', () => {
     expect(result.currency).toBe('EUR');
     expect(result.estimatedAmount).toBe(0);
     expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('rejects missing runtime AI context before extraction behavior', async () => {
+    await expect(
+      extractClaimIntake({
+        aiCallContext: null,
+        claim: {
+          title: 'Unknown issue',
+          description: '',
+          category: 'mystery',
+          claimAmount: null,
+          currency: null,
+        },
+      } as never)
+    ).rejects.toThrow(/AI call context is required: context_missing/);
   });
 });

--- a/packages/domain-ai/src/claims/intake-extract.ts
+++ b/packages/domain-ai/src/claims/intake-extract.ts
@@ -1,5 +1,6 @@
 import { claimIntakeExtractSchema, type ClaimIntakeExtract } from '../schemas/claim-intake-extract';
 import { extractFirstIsoLikeDate, normalizeText, toIsoDate } from '../shared/text';
+import { requireAICallContext, type DomainAiCallContext } from '../context';
 
 type ClaimContext = {
   title: string;
@@ -74,11 +75,14 @@ function parseAmount(value: string | number | null | undefined) {
 }
 
 export async function extractClaimIntake(args: {
+  aiCallContext: DomainAiCallContext;
   claim: ClaimContext;
   claimSnapshot?: ClaimSnapshot | null;
   documentText?: string | null;
   uploadedAt?: Date | string | null;
 }): Promise<ClaimIntakeExtract> {
+  requireAICallContext(args.aiCallContext);
+
   const documentText = normalizeText(args.documentText);
   const description = normalizeText(args.claim.description);
   const warnings: string[] = [];

--- a/packages/domain-ai/src/claims/summary.test.ts
+++ b/packages/domain-ai/src/claims/summary.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { createGeneralAiContext } from '../test-helpers/ai-call-context';
 import { summarizeClaim } from './summary';
 
 describe('summarizeClaim', () => {
   it('builds a typed staff summary from claim context', async () => {
     const result = await summarizeClaim({
+      aiCallContext: createGeneralAiContext(),
       claim: {
         title: 'Delayed baggage claim',
         description: 'Airline lost my luggage for three days.',
@@ -32,5 +34,21 @@ describe('summarizeClaim', () => {
       confidence: expect.any(Number),
       warnings: expect.arrayContaining(['Receipt totals still need confirmation']),
     });
+  });
+
+  it('rejects null runtime AI context before summary behavior', async () => {
+    await expect(
+      summarizeClaim({
+        aiCallContext: null,
+        claim: {
+          title: 'Delayed baggage claim',
+          description: 'Airline lost my luggage for three days.',
+          category: 'travel',
+          companyName: 'Airline Co',
+          claimAmount: '1200.00',
+          currency: 'EUR',
+        },
+      } as never)
+    ).rejects.toThrow(/context_missing/);
   });
 });

--- a/packages/domain-ai/src/claims/summary.test.ts
+++ b/packages/domain-ai/src/claims/summary.test.ts
@@ -39,6 +39,7 @@ describe('summarizeClaim', () => {
   it('rejects null runtime AI context before summary behavior', async () => {
     await expect(
       summarizeClaim({
+        // @ts-expect-error T-404 runtime guard rejects null context.
         aiCallContext: null,
         claim: {
           title: 'Delayed baggage claim',
@@ -48,7 +49,7 @@ describe('summarizeClaim', () => {
           claimAmount: '1200.00',
           currency: 'EUR',
         },
-      } as never)
+      })
     ).rejects.toThrow(/context_missing/);
   });
 });

--- a/packages/domain-ai/src/claims/summary.ts
+++ b/packages/domain-ai/src/claims/summary.ts
@@ -1,4 +1,5 @@
 import { claimSummarySchema, type ClaimSummary } from '../schemas/claim-summary';
+import { requireAICallContext, type DomainAiCallContext } from '../context';
 
 type ClaimSummaryContext = {
   title: string;
@@ -40,9 +41,12 @@ function getUrgency(amount: number): ClaimSummary['urgency'] {
 }
 
 export async function summarizeClaim(args: {
+  aiCallContext: DomainAiCallContext;
   claim: ClaimSummaryContext;
   extractions?: ExtractionSummary[] | null;
 }): Promise<ClaimSummary> {
+  requireAICallContext(args.aiCallContext);
+
   const amount = parseAmount(args.claim.claimAmount);
   const extractionWarnings = (args.extractions ?? []).flatMap(extraction =>
     Array.isArray(extraction.warnings) ? extraction.warnings.filter(Boolean) : []

--- a/packages/domain-ai/src/client.test.ts
+++ b/packages/domain-ai/src/client.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDocumentExtractionAiContext } from './test-helpers/ai-call-context';
+import { createAiClient } from './client';
+
+describe('createAiClient', () => {
+  it('rejects missing context before checking provider configuration', () => {
+    expect(() => createAiClient(undefined as never)).toThrow(
+      /AI call context is required: context_missing/
+    );
+  });
+
+  it('rejects null context before checking provider configuration', () => {
+    expect(() => createAiClient(null as never)).toThrow(/context_missing/);
+  });
+
+  it('rejects structurally invalid context before checking provider configuration', () => {
+    expect(() => createAiClient({ workflowId: 'claim_intake_extract' } as never)).toThrow(
+      /tenant_id_missing/
+    );
+  });
+
+  it('checks provider configuration after accepting a valid context', () => {
+    const previousApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+
+    try {
+      expect(() => createAiClient(createDocumentExtractionAiContext())).toThrow(
+        /OPENAI_API_KEY is required/
+      );
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previousApiKey;
+      }
+    }
+  });
+});

--- a/packages/domain-ai/src/client.test.ts
+++ b/packages/domain-ai/src/client.test.ts
@@ -5,19 +5,24 @@ import { createAiClient } from './client';
 
 describe('createAiClient', () => {
   it('rejects missing context before checking provider configuration', () => {
-    expect(() => createAiClient(undefined as never)).toThrow(
-      /AI call context is required: context_missing/
-    );
+    expect(() =>
+      // @ts-expect-error T-404 runtime guard rejects missing context.
+      createAiClient(undefined)
+    ).toThrow(/AI call context is required: context_missing/);
   });
 
   it('rejects null context before checking provider configuration', () => {
-    expect(() => createAiClient(null as never)).toThrow(/context_missing/);
+    expect(() =>
+      // @ts-expect-error T-404 runtime guard rejects null context.
+      createAiClient(null)
+    ).toThrow(/context_missing/);
   });
 
   it('rejects structurally invalid context before checking provider configuration', () => {
-    expect(() => createAiClient({ workflowId: 'claim_intake_extract' } as never)).toThrow(
-      /tenant_id_missing/
-    );
+    expect(() =>
+      // @ts-expect-error T-404 runtime guard rejects structurally invalid context.
+      createAiClient({ workflowId: 'claim_intake_extract' })
+    ).toThrow(/tenant_id_missing/);
   });
 
   it('checks provider configuration after accepting a valid context', () => {

--- a/packages/domain-ai/src/client.ts
+++ b/packages/domain-ai/src/client.ts
@@ -1,8 +1,15 @@
 import OpenAI from 'openai';
 
+import { requireAICallContext, type DomainAiCallContext } from './context';
+
 export type AiClientOptions = ConstructorParameters<typeof OpenAI>[0];
 
-export function createAiClient(options: AiClientOptions = {}): OpenAI {
+export function createAiClient(
+  context: DomainAiCallContext,
+  options: AiClientOptions = {}
+): OpenAI {
+  requireAICallContext(context);
+
   const apiKey = options.apiKey ?? process.env.OPENAI_API_KEY;
 
   if (!apiKey) {

--- a/packages/domain-ai/src/context.ts
+++ b/packages/domain-ai/src/context.ts
@@ -1,0 +1,13 @@
+import { validateAICallContext, type AICallContext } from '@interdomestik/domain-privacy';
+
+export type DomainAiCallContext = AICallContext;
+
+export function requireAICallContext(context: unknown): DomainAiCallContext {
+  const decision = validateAICallContext(context);
+
+  if (decision.kind === 'invalid') {
+    throw new Error(`AI call context is required: ${decision.reasons.join(',')}`);
+  }
+
+  return decision.context;
+}

--- a/packages/domain-ai/src/index.ts
+++ b/packages/domain-ai/src/index.ts
@@ -1,4 +1,5 @@
 export * from './client';
+export * from './context';
 export * from './claims/intake-extract';
 export * from './claims/summary';
 export * from './legal/extract';

--- a/packages/domain-ai/src/legal/extract.test.ts
+++ b/packages/domain-ai/src/legal/extract.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { createDocumentExtractionAiContext } from '../test-helpers/ai-call-context';
 import { extractLegalDocument } from './extract';
 
 describe('extractLegalDocument', () => {
   it('extracts a typed legal payload from document text', async () => {
     const result = await extractLegalDocument({
+      aiCallContext: createDocumentExtractionAiContext('legal_doc_extract'),
       documentText:
         'Demand letter issued by Contoso Legal in Germany on 2026-02-20. You must respond within 14 days and preserve all receipts.',
       fileName: 'demand-letter.pdf',
@@ -25,6 +27,7 @@ describe('extractLegalDocument', () => {
 
   it('returns a low-confidence placeholder when the document text is empty', async () => {
     const result = await extractLegalDocument({
+      aiCallContext: createDocumentExtractionAiContext('legal_doc_extract'),
       documentText: '',
       fileName: 'legal-upload.png',
       uploadedAt: new Date('2026-03-08T10:00:00.000Z'),
@@ -34,5 +37,14 @@ describe('extractLegalDocument', () => {
     expect(result.issuer).toBe('Unknown issuer');
     expect(result.jurisdiction).toBe('Unknown jurisdiction');
     expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('rejects structurally invalid runtime AI context before extraction behavior', async () => {
+    await expect(
+      extractLegalDocument({
+        aiCallContext: { workflowId: 'legal_doc_extract' },
+        documentText: 'Demand letter issued by Contoso Legal.',
+      } as never)
+    ).rejects.toThrow(/tenant_id_missing/);
   });
 });

--- a/packages/domain-ai/src/legal/extract.test.ts
+++ b/packages/domain-ai/src/legal/extract.test.ts
@@ -42,9 +42,10 @@ describe('extractLegalDocument', () => {
   it('rejects structurally invalid runtime AI context before extraction behavior', async () => {
     await expect(
       extractLegalDocument({
+        // @ts-expect-error T-404 runtime guard rejects structurally invalid context.
         aiCallContext: { workflowId: 'legal_doc_extract' },
         documentText: 'Demand letter issued by Contoso Legal.',
-      } as never)
+      })
     ).rejects.toThrow(/tenant_id_missing/);
   });
 });

--- a/packages/domain-ai/src/legal/extract.ts
+++ b/packages/domain-ai/src/legal/extract.ts
@@ -1,5 +1,6 @@
 import { legalDocExtractSchema, type LegalDocExtract } from '../schemas/legal-doc-extract';
 import { extractFirstIsoLikeDate, normalizeText, toIsoDate } from '../shared/text';
+import { requireAICallContext, type DomainAiCallContext } from '../context';
 
 function extractAfterLabel(
   text: string,
@@ -87,10 +88,13 @@ function extractObligations(text: string) {
 }
 
 export async function extractLegalDocument(args: {
+  aiCallContext: DomainAiCallContext;
   documentText?: string | null;
   fileName?: string | null;
   uploadedAt?: Date | string | null;
 }): Promise<LegalDocExtract> {
+  requireAICallContext(args.aiCallContext);
+
   const text = normalizeText(args.documentText);
   const fileName = normalizeText(args.fileName);
   const warnings: string[] = [];

--- a/packages/domain-ai/src/test-helpers/ai-call-context.ts
+++ b/packages/domain-ai/src/test-helpers/ai-call-context.ts
@@ -1,0 +1,36 @@
+import type { DomainAiCallContext } from '../context';
+
+export function createDocumentExtractionAiContext(
+  workflowId = 'claim_intake_extract'
+): DomainAiCallContext {
+  return {
+    workflowId,
+    owner: 'domain-ai-test',
+    tenantId: 'tenant-1',
+    actorId: 'user-1',
+    subjectId: 'user-1',
+    scope: { claimId: 'claim-1', documentId: 'document-1' },
+    purpose: 'document_extraction',
+    processingPurpose: 'ai_document_extraction',
+    retention: 'zero_retention_no_training',
+    posture: 'human_review_required',
+    consent: 'required_granted',
+    invalidityPosture: 'not_applicable',
+  };
+}
+
+export function createGeneralAiContext(workflowId = 'claim_summary'): DomainAiCallContext {
+  return {
+    workflowId,
+    owner: 'domain-ai-test',
+    tenantId: 'tenant-1',
+    actorId: 'staff-1',
+    scope: { claimId: 'claim-1' },
+    purpose: 'general_case',
+    processingPurpose: 'staff_triage',
+    retention: 'transient_no_training',
+    posture: 'advisory',
+    consent: 'not_required',
+    invalidityPosture: 'not_applicable',
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,9 @@ importers:
       '@interdomestik/database':
         specifier: workspace:*
         version: link:../database
+      '@interdomestik/domain-privacy':
+        specifier: workspace:*
+        version: link:../domain-privacy
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.28.17)(pg@8.21.0)(postgres@3.4.9)

--- a/scripts/ai/eval/ai-call-context.mjs
+++ b/scripts/ai/eval/ai-call-context.mjs
@@ -1,0 +1,78 @@
+function safeId(value, fallback) {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text.length > 0 ? text.replace(/[^a-zA-Z0-9_.-]/g, '_').slice(0, 80) : fallback;
+}
+
+function createGeneralCaseContext(workflowId) {
+  return {
+    workflowId,
+    owner: 'ai-fixture-eval',
+    tenantId: 'eval-tenant',
+    actorId: 'ai-eval-runner',
+    scope: { caseId: `${workflowId}-fixture` },
+    purpose: 'general_case',
+    processingPurpose: 'staff_triage',
+    retention: 'transient_no_training',
+    posture: 'advisory',
+    consent: 'not_required',
+    invalidityPosture: 'not_applicable',
+  };
+}
+
+function createDocumentExtractionContext(workflowId, input) {
+  const documentId = safeId(input?.fileName, 'document-fixture');
+
+  return {
+    workflowId,
+    owner: 'ai-fixture-eval',
+    tenantId: 'eval-tenant',
+    actorId: 'ai-eval-runner',
+    subjectId: 'eval-subject',
+    scope: {
+      caseId: `${workflowId}-fixture`,
+      documentId,
+    },
+    purpose: 'document_extraction',
+    processingPurpose: 'ai_document_extraction',
+    retention: 'zero_retention_no_training',
+    posture: 'human_review_required',
+    consent: 'required_granted',
+    invalidityPosture: 'not_applicable',
+  };
+}
+
+export function createEvalAiCallContext(workflowId, input) {
+  if (workflowId === 'legal_doc_extract') {
+    return createDocumentExtractionContext(workflowId, input);
+  }
+
+  return createGeneralCaseContext(workflowId);
+}
+
+export function createEvalWorkflowRunners(deps) {
+  return {
+    policy_extract: {
+      execute: async input => deps.analyzePolicyText(String(input.documentText ?? '')),
+      normalizeForSchema: value => value,
+      schema: deps.policyExtractSchema,
+    },
+    claim_summary: {
+      execute: async input =>
+        deps.summarizeClaim({
+          ...input,
+          aiCallContext: createEvalAiCallContext('claim_summary', input),
+        }),
+      normalizeForSchema: value => value,
+      schema: deps.claimSummarySchema,
+    },
+    legal_doc_extract: {
+      execute: async input =>
+        deps.extractLegalDocument({
+          ...input,
+          aiCallContext: createEvalAiCallContext('legal_doc_extract', input),
+        }),
+      normalizeForSchema: value => value,
+      schema: deps.legalDocExtractSchema,
+    },
+  };
+}

--- a/scripts/ai/eval/run.mjs
+++ b/scripts/ai/eval/run.mjs
@@ -10,6 +10,7 @@ import * as claimSummarySchemaModule from '../../../packages/domain-ai/src/schem
 import * as legalDocExtractSchemaModule from '../../../packages/domain-ai/src/schemas/legal-doc-extract.ts';
 import * as policyExtractSchemaModule from '../../../packages/domain-ai/src/schemas/policy-extract.ts';
 import * as telemetryModule from '../../../packages/domain-ai/src/telemetry.ts';
+import { createEvalWorkflowRunners } from './ai-call-context.mjs';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const DATASET_FILES = [
@@ -24,28 +25,18 @@ const { claimSummarySchema } = unwrapModule(claimSummarySchemaModule);
 const { legalDocExtractSchema } = unwrapModule(legalDocExtractSchemaModule);
 const { policyExtractSchema } = unwrapModule(policyExtractSchemaModule);
 const { aggregateAiTelemetry, createAiTelemetryEvent } = unwrapModule(telemetryModule);
+const WORKFLOW_RUNNERS = createEvalWorkflowRunners({
+  analyzePolicyText,
+  summarizeClaim,
+  extractLegalDocument,
+  claimSummarySchema,
+  legalDocExtractSchema,
+  policyExtractSchema,
+});
 
 function unwrapModule(module) {
   return module.default ?? module['module.exports'] ?? module;
 }
-
-const WORKFLOW_RUNNERS = {
-  policy_extract: {
-    execute: async input => analyzePolicyText(String(input.documentText ?? '')),
-    normalizeForSchema: value => value,
-    schema: policyExtractSchema,
-  },
-  claim_summary: {
-    execute: async input => summarizeClaim(input),
-    normalizeForSchema: value => value,
-    schema: claimSummarySchema,
-  },
-  legal_doc_extract: {
-    execute: async input => extractLegalDocument(input),
-    normalizeForSchema: value => value,
-    schema: legalDocExtractSchema,
-  },
-};
 
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36587183,
-  "maxTrackedFiles": 4385,
+  "maxTrackedBytes": 36621384,
+  "maxTrackedFiles": 4391,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18007846,
-    "source/scripts": 6858371,
-    "docs/text": 5289375,
-    "tests/e2e": 4761654,
-    "config/data/messages": 1540772,
+    "large support/generated-ish": 18015937,
+    "source/scripts": 6862794,
+    "docs/text": 5307449,
+    "tests/e2e": 4765178,
+    "config/data/messages": 1540861,
     "other": 129165
   },
-  "maxLargestFileBytes": 3089508,
+  "maxLargestFileBytes": 3097489,
   "maxSourceOrTestLines": 3000
 }


### PR DESCRIPTION
## Summary

Implements T-404 for the mandatory `domain-ai` `AICallContext` boundary.

- Makes `AICallContext` required on public `domain-ai` entry points: `createAiClient`, claim intake extraction, claim summary, and legal extraction.
- Adds `packages/domain-ai/src/context.ts` to validate context through the existing `@interdomestik/domain-privacy` validator and fail closed before provider/model behavior.
- Wires the queued claim AI pipeline to consume the persisted trusted T-404a `requestJson.aiCallContext` evidence path, without fabricating consent from upload custody, tenant/session, provider defaults, or purpose strings.
- Adds focused runtime and compile-fail proof for missing/null/invalid context and minimal caller fixture updates.
- Threads explicit fixture-only AI context through `scripts/ai/eval/run.mjs` so CI evals exercise the new boundary without bypassing it.

## Scope Control

- No proxy, routing, auth, tenant model, schema, migration, RLS, billing, README, AGENTS, or architecture-doc changes.
- No model/provider calls, prompt changes, extraction behavior changes, embeddings, classification, summarization, retrieval, outbox `ai.call_executed` events, or Operational Brain runtime integration.
- `apps/web/src/proxy.ts` remains untouched.

## Verification

Focused proof:

- `pnpm --filter @interdomestik/domain-ai type-check`
- `pnpm --filter @interdomestik/domain-ai test:unit`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm --filter @interdomestik/web test:unit --run src/lib/ai/claim-workflows.test.ts src/lib/ai/claim-workflows-critique.test.ts`
- `pnpm ai:eval`
- `pnpm check:modularity-guard`
- `pnpm repo:size:check`
- `git diff --check`

Slice/final gates:

- `pnpm slice:verify`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate` (`136 passed`, `8 skipped`)

After the first PR CI run exposed `ai-eval` as a missed script caller, the branch was amended and these targeted checks were rerun on the updated head:

- `pnpm ai:eval`
- `pnpm check:modularity-guard`
- `pnpm repo:size:check`
- `pnpm security:guard`
- `git diff --check`

## Reviewer / Security Notes

- Senior Sonnet review completed, but inspected the canonical worktree instead of this worker worktree and reported findings against nonexistent symbols/paths (`withAICallContext`, `getAiClient`, `test-helpers/index.ts`). Disposition: rejected as wrong-root/wrong-implementation. The one compile-fail concern was disproven by `packages/domain-ai/tsconfig.json` including `src/**/*` and `pnpm --filter @interdomestik/domain-ai type-check` passing with enforced `@ts-expect-error` fixtures.
- Gemini second-signal review was blocked by license error `403` / `#3501`.
- Opus escalation timed out with `reviewer_no_output_timeout` after 300468 ms.
- Codex Security workspace `a0416a26-896d-4d2f-901e-99dc33a2ef37` was created, but scan start timed out before a scan ID was issued. Local `pnpm security:guard` passed cleanly.

## Evidence

- Branch: `codex/t-404-ai-context-required`
- Head SHA: `45b36cb4f3b522b2260248759e2386c9a030e904`
- Base authority: OBR-DG16 merged at `0eb0ef120eaa07bf74647e8c8fceb5718e90fc67`
