### PR TITLE
T-503b lifecycle completeness repair readiness

### DIFF
--- a/apps/web/e2e/gate/agent-workspace-claims-selection.spec.ts
+++ b/apps/web/e2e/gate/agent-workspace-claims-selection.spec.ts
@@ -1,4 +1,5 @@
 import { E2E_USERS, agentClients, claimMessages, claims, db, user } from '@interdomestik/database';
+import { claimLifecycleFieldsForStatus } from '@interdomestik/database/claim-lifecycle';
 import { and, desc, eq, like, ne } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { expect, test } from '../fixtures/auth.fixture';
@@ -8,12 +9,10 @@ import { gotoApp } from '../utils/navigation';
 function isMkProject(testInfo: import('@playwright/test').TestInfo): boolean {
   return testInfo.project.name.includes('mk');
 }
-
 type AccessibleClaimResult = {
   claimId: string;
   createdFallback: boolean;
 };
-
 type CrossAgentClaimResult = {
   claimId: string;
   assignmentId: string | null;
@@ -24,7 +23,6 @@ type CrossAgentClaimResult = {
   createdMember: boolean;
   createdOtherAgent: boolean;
 };
-
 async function resolveAccessibleClaimId(agentEmail: string): Promise<AccessibleClaimResult> {
   const seededAgent = await db.query.user.findFirst({
     where: eq(user.email, agentEmail),
@@ -78,6 +76,7 @@ async function resolveAccessibleClaimId(agentEmail: string): Promise<AccessibleC
     category: 'vehicle',
     branchId: seededAgent.branchId ?? null,
     status: 'submitted',
+    ...claimLifecycleFieldsForStatus('submitted'),
   });
 
   return { claimId: fallbackClaimId, createdFallback: true };
@@ -212,6 +211,7 @@ async function resolveCrossAgentClaimId(agentEmail: string): Promise<CrossAgentC
     companyName: 'Interdomestik QA',
     category: 'vehicle',
     status: 'submitted',
+    ...claimLifecycleFieldsForStatus('submitted'),
   });
 
   return {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -12,6 +12,7 @@
     "./server": "./src/server.ts",
     "./db": "./src/db.ts",
     "./schema": "./src/schema.ts",
+    "./claim-lifecycle": "./src/claim-lifecycle.ts",
     "./tenant-security": "./src/tenant-security.ts",
     "./member-number": "./src/member-number.ts",
     "./claim-number": "./src/claim-number.ts"

--- a/packages/database/src/claim-lifecycle.ts
+++ b/packages/database/src/claim-lifecycle.ts
@@ -1,0 +1,25 @@
+import type {
+  ClaimCaseLifecycleState,
+  ClaimRecoveryLifecycleState,
+  ClaimStatus,
+} from './constants';
+
+export type ClaimLifecycleFields = {
+  caseLifecycleState: ClaimCaseLifecycleState;
+  recoveryLifecycleState: ClaimRecoveryLifecycleState;
+};
+
+export const CLAIM_STATUS_LIFECYCLE_FIELDS = {
+  draft: { caseLifecycleState: 'draft', recoveryLifecycleState: 'not_started' },
+  submitted: { caseLifecycleState: 'submitted', recoveryLifecycleState: 'not_started' },
+  verification: { caseLifecycleState: 'verification', recoveryLifecycleState: 'not_started' },
+  evaluation: { caseLifecycleState: 'evaluation', recoveryLifecycleState: 'not_started' },
+  negotiation: { caseLifecycleState: 'recovery', recoveryLifecycleState: 'negotiation' },
+  court: { caseLifecycleState: 'recovery', recoveryLifecycleState: 'court' },
+  resolved: { caseLifecycleState: 'resolved', recoveryLifecycleState: 'resolved' },
+  rejected: { caseLifecycleState: 'rejected', recoveryLifecycleState: 'closed' },
+} as const satisfies Record<ClaimStatus, ClaimLifecycleFields>;
+
+export function claimLifecycleFieldsForStatus(status: ClaimStatus): ClaimLifecycleFields {
+  return CLAIM_STATUS_LIFECYCLE_FIELDS[status];
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -54,6 +54,11 @@ export {
   relayClaimStatusAuditProjectionEvents,
   type ProjectClaimStatusChangedAuditResult,
 } from './domain-event-audit-projection';
+export {
+  CLAIM_STATUS_LIFECYCLE_FIELDS,
+  claimLifecycleFieldsForStatus,
+  type ClaimLifecycleFields,
+} from './claim-lifecycle';
 export { withTenantContext, withTenantDb, type TenantTransaction } from './tenant';
 
 // Export Drizzle instance and schema

--- a/packages/database/src/seed-full/claims.ts
+++ b/packages/database/src/seed-full/claims.ts
@@ -1,5 +1,6 @@
 import { db } from '../db';
 import * as schema from '../schema';
+import { withClaimLifecycleFields } from '../seed-utils/claim-lifecycle';
 import { BRANCHES, TENANTS } from './constants';
 
 import type { SeedConfig } from '../seed-types';
@@ -76,7 +77,7 @@ export async function seedClaimsAndFlows(config: SeedConfig) {
         userId: c.userId,
         tenantId: tenantId,
         branchId: c.branchId,
-        status: c.status as any,
+        ...withClaimLifecycleFields({ status: c.status as any }),
         title: c.title,
         claimAmount: c.amount,
         currency: 'EUR',
@@ -86,7 +87,10 @@ export async function seedClaimsAndFlows(config: SeedConfig) {
         createdAt: at(),
         updatedAt: at(),
       })
-      .onConflictDoUpdate({ target: schema.claims.id, set: { status: c.status as any } });
+      .onConflictDoUpdate({
+        target: schema.claims.id,
+        set: withClaimLifecycleFields({ status: c.status as any }),
+      });
 
     if (c.id === 'full_claim_mk_1') {
       await db

--- a/packages/database/src/seed-golden/claims.ts
+++ b/packages/database/src/seed-golden/claims.ts
@@ -1,11 +1,12 @@
 import { goldenId } from '../seed-utils/seed-ids';
+import { withClaimLifecycleFields } from '../seed-utils/claim-lifecycle';
 import {
   buildCommercialAgreementsToSeed,
   upsertCommercialAgreements,
 } from './commercial-agreements';
 import { TENANTS } from './constants';
-import type { ClaimInsert, SeedGoldenContext } from './types';
-
+import type { ClaimStatus } from '../constants';
+import type { SeedGoldenContext } from './types';
 const ksAStatuses = [
   'submitted',
   'submitted',
@@ -28,12 +29,9 @@ const ksAStatuses = [
   'negotiation',
   'negotiation',
   'court',
-] as any[];
+] as ClaimStatus[];
 
-export function buildClaimsToSeed({
-  at,
-  schema,
-}: Pick<SeedGoldenContext, 'at' | 'schema'>): ClaimInsert[] {
+export function buildClaimsToSeed({ at, schema }: Pick<SeedGoldenContext, 'at' | 'schema'>) {
   const now = at();
   const claimsToSeed: (typeof schema.claims.$inferInsert)[] = [];
 
@@ -180,7 +178,7 @@ export function buildClaimsToSeed({
     }
   );
 
-  return claimsToSeed;
+  return claimsToSeed.map(withClaimLifecycleFields);
 }
 
 export async function seedClaims(context: SeedGoldenContext) {
@@ -196,6 +194,8 @@ export async function seedClaims(context: SeedGoldenContext) {
         target: schema.claims.id,
         set: {
           status: c.status,
+          caseLifecycleState: c.caseLifecycleState,
+          recoveryLifecycleState: c.recoveryLifecycleState,
           staffId: c.staffId,
           branchId: c.branchId,
           createdAt: c.createdAt,

--- a/packages/database/src/seed-packs/ks-workflow-pack.ts
+++ b/packages/database/src/seed-packs/ks-workflow-pack.ts
@@ -1,8 +1,8 @@
 import { cleanupByPrefixes } from '../seed-utils/cleanup';
 import { hashPassword } from '../seed-utils/hash-password';
+import { withClaimLifecycleFields } from '../seed-utils/claim-lifecycle';
 import { goldenId, packId } from '../seed-utils/seed-ids';
 import { E2E_PASSWORD } from '../e2e-users';
-// Needed imports for sanity check
 import { inArray, sql } from 'drizzle-orm';
 import type { SeedConfig } from '../seed-types';
 
@@ -54,7 +54,6 @@ export async function seedKsWorkflowPack(config: SeedConfig) {
     KS: 'tenant_ks',
   };
 
-  // 1.0 Ensure Tenants Exist (Both KS and MK for Isolation Testing)
   const allTenants = [
     {
       id: TENANTS.KS,
@@ -86,10 +85,8 @@ export async function seedKsWorkflowPack(config: SeedConfig) {
       set: { name: sql`excluded.name` },
     });
 
-  // 1. Cleanup previous Pack Data specifically
   await cleanupByPrefixes(db, schema, ['pack_ks_'], false);
 
-  // 2. Ensure Branches Exist (A/B/C)
   const BRANCHES = [
     {
       id: packId('ks', 'branch_a'),
@@ -123,7 +120,6 @@ export async function seedKsWorkflowPack(config: SeedConfig) {
       set: { name: schema.branches.name, code: schema.branches.code },
     });
 
-  // 3. Seed Users
   console.log('👥 Seeding Pack Users...');
   const PACK_PASSWORD = E2E_PASSWORD;
   const hashedPass = hashPassword(PACK_PASSWORD);
@@ -489,33 +485,35 @@ export async function seedKsWorkflowPack(config: SeedConfig) {
       await withTransientDbWriteRetry(`${claimId}:claim`, () =>
         db
           .insert(schema.claims)
-          .values({
-            id: claimId,
-            userId: memberId,
-            staffId: status !== 'submitted' ? staffId : null,
-            tenantId: TENANTS.KS,
-            branchId: branchId,
-            claimNumber: makeClaimNumber(globalClaimIdx),
-            status: status as any,
-            title: title,
-            description: description,
-            category: category,
-            companyName: 'Siguria Kosova',
-            claimAmount: randomAmount(),
-            currency: 'EUR',
-            createdAt: createdAt,
-            updatedAt: createdAt,
-            statusUpdatedAt: createdAt,
-          })
+          .values(
+            withClaimLifecycleFields({
+              id: claimId,
+              userId: memberId,
+              staffId: status !== 'submitted' ? staffId : null,
+              tenantId: TENANTS.KS,
+              branchId: branchId,
+              claimNumber: makeClaimNumber(globalClaimIdx),
+              status: status as any,
+              title: title,
+              description: description,
+              category: category,
+              companyName: 'Siguria Kosova',
+              claimAmount: randomAmount(),
+              currency: 'EUR',
+              createdAt: createdAt,
+              updatedAt: createdAt,
+              statusUpdatedAt: createdAt,
+            })
+          )
           .onConflictDoUpdate({
             target: schema.claims.id,
-            set: {
+            set: withClaimLifecycleFields({
               status: status as any,
               description,
               title,
               staffId: status !== 'submitted' ? staffId : null,
               updatedAt: createdAt,
-            },
+            }),
           })
       );
 
@@ -541,23 +539,25 @@ export async function seedKsWorkflowPack(config: SeedConfig) {
     await withTransientDbWriteRetry(`sla-claim:${i}`, () =>
       db
         .insert(schema.claims)
-        .values({
-          id: packId('ks', 'claim', 'ks_a', 'sla', i),
-          userId: getPackMemberId(i),
-          tenantId: TENANTS.KS,
-          branchId: packId('ks', 'branch_a'),
-          claimNumber: makeClaimNumber(globalClaimIdx),
-          status: 'submitted',
-          title: `Vonesë Kritike SLA - ${days} ditë`,
-          category: 'vehicle',
-          companyName: 'Siguria Kosova',
-          claimAmount: '2500.00',
-          currency: 'EUR',
-          createdAt: date,
-        })
+        .values(
+          withClaimLifecycleFields({
+            id: packId('ks', 'claim', 'ks_a', 'sla', i),
+            userId: getPackMemberId(i),
+            tenantId: TENANTS.KS,
+            branchId: packId('ks', 'branch_a'),
+            claimNumber: makeClaimNumber(globalClaimIdx),
+            status: 'submitted',
+            title: `Vonesë Kritike SLA - ${days} ditë`,
+            category: 'vehicle',
+            companyName: 'Siguria Kosova',
+            claimAmount: '2500.00',
+            currency: 'EUR',
+            createdAt: date,
+          })
+        )
         .onConflictDoUpdate({
           target: schema.claims.id,
-          set: { status: 'submitted', createdAt: date },
+          set: withClaimLifecycleFields({ status: 'submitted', createdAt: date }),
         })
     );
   }

--- a/packages/database/src/seed-utils/claim-lifecycle.ts
+++ b/packages/database/src/seed-utils/claim-lifecycle.ts
@@ -1,0 +1,14 @@
+import type { ClaimStatus } from '../constants';
+import { claimLifecycleFieldsForStatus } from '../claim-lifecycle';
+
+type ClaimSeedRow = {
+  caseLifecycleState?: unknown;
+  recoveryLifecycleState?: unknown;
+  status?: ClaimStatus | null;
+  [key: string]: unknown;
+};
+
+export function withClaimLifecycleFields<T extends ClaimSeedRow>(claim: T): T {
+  if (!claim.status) return claim;
+  return { ...claim, ...claimLifecycleFieldsForStatus(claim.status) };
+}

--- a/packages/database/src/seed-workload/claims.ts
+++ b/packages/database/src/seed-workload/claims.ts
@@ -1,4 +1,5 @@
 import type { SeedConfig } from '../seed-types';
+import { withClaimLifecycleFields } from '../seed-utils/claim-lifecycle';
 import { statuses, TENANTS, WORKLOAD_PREFIX } from './constants';
 
 export async function seedWorkloadClaims(
@@ -81,7 +82,7 @@ export async function seedWorkloadClaims(
   }
 
   if (claims.length > 0) {
-    const chunks = chunkArray(claims, 20);
+    const chunks = chunkArray(claims.map(withClaimLifecycleFields), 20);
     for (const chunk of chunks) {
       await db.insert(schema.claims).values(chunk).onConflictDoNothing();
     }

--- a/packages/database/test/claim-lifecycle.test.ts
+++ b/packages/database/test/claim-lifecycle.test.ts
@@ -9,7 +9,10 @@ import {
 import { withClaimLifecycleFields } from '../src/seed-utils/claim-lifecycle';
 
 test('claim lifecycle helper covers every status and fixture state', () => {
-  assert.deepEqual(Object.keys(CLAIM_STATUS_LIFECYCLE_FIELDS).sort(), [...CLAIM_STATUSES].sort());
+  assert.deepEqual(
+    Object.keys(CLAIM_STATUS_LIFECYCLE_FIELDS).sort((left, right) => left.localeCompare(right)),
+    [...CLAIM_STATUSES].sort((left, right) => left.localeCompare(right))
+  );
   assert.deepEqual(claimLifecycleFieldsForStatus('submitted'), {
     caseLifecycleState: 'submitted',
     recoveryLifecycleState: 'not_started',

--- a/packages/database/test/claim-lifecycle.test.ts
+++ b/packages/database/test/claim-lifecycle.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CLAIM_STATUSES } from '../src/constants';
+import {
+  CLAIM_STATUS_LIFECYCLE_FIELDS,
+  claimLifecycleFieldsForStatus,
+} from '../src/claim-lifecycle';
+import { withClaimLifecycleFields } from '../src/seed-utils/claim-lifecycle';
+
+test('claim lifecycle helper covers every status and fixture state', () => {
+  assert.deepEqual(Object.keys(CLAIM_STATUS_LIFECYCLE_FIELDS).sort(), [...CLAIM_STATUSES].sort());
+  assert.deepEqual(claimLifecycleFieldsForStatus('submitted'), {
+    caseLifecycleState: 'submitted',
+    recoveryLifecycleState: 'not_started',
+  });
+  assert.deepEqual(claimLifecycleFieldsForStatus('negotiation'), {
+    caseLifecycleState: 'recovery',
+    recoveryLifecycleState: 'negotiation',
+  });
+  assert.deepEqual(claimLifecycleFieldsForStatus('rejected'), {
+    caseLifecycleState: 'rejected',
+    recoveryLifecycleState: 'closed',
+  });
+});
+
+test('seed helper hardens status-shaped claim fixture rows', () => {
+  assert.deepEqual(withClaimLifecycleFields({ id: 'claim-1', status: 'resolved' }), {
+    id: 'claim-1',
+    status: 'resolved',
+    caseLifecycleState: 'resolved',
+    recoveryLifecycleState: 'resolved',
+  });
+});

--- a/scripts/ci/claim-lifecycle-completeness-repair.test.mjs
+++ b/scripts/ci/claim-lifecycle-completeness-repair.test.mjs
@@ -20,7 +20,10 @@ test('repair SQL is dry-run-first, aggregate-only, and non-destructive', () => {
   assert.doesNotMatch(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /\b(delete|drop|alter)\b/iu);
   assert.doesNotMatch(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /\breturning\s+c\.id\b/iu);
   assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /"updatedAt" = now\(\)/u);
-  assert.doesNotMatch(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /(^|\n)\s+updatedAt = now\(\)/u);
+  assert.equal(
+    CLAIM_LIFECYCLE_REPAIR_APPLY_SQL.split('\n').some(line => line.trim() === 'updatedAt = now()'),
+    false
+  );
 });
 
 test('repair SQL does not overwrite non-null lifecycle mismatches', () => {

--- a/scripts/ci/claim-lifecycle-completeness-repair.test.mjs
+++ b/scripts/ci/claim-lifecycle-completeness-repair.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+  CLAIM_LIFECYCLE_REPAIR_APPLY_SQL,
+  CLAIM_LIFECYCLE_REPAIR_DRY_RUN_SQL,
+  formatLifecycleRepairReport,
+  normalizeRepairExecuteRows,
+  summarizeLifecycleRepair,
+} from '../claim-lifecycle-completeness-repair-report.mjs';
+
+test('repair SQL is dry-run-first, aggregate-only, and non-destructive', () => {
+  assert.match(CLAIM_LIFECYCLE_REPAIR_DRY_RUN_SQL, /\bselect\b/iu);
+  assert.doesNotMatch(
+    CLAIM_LIFECYCLE_REPAIR_DRY_RUN_SQL,
+    /\b(update|insert|delete|drop|alter)\b/iu
+  );
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /\bupdate claim\b/iu);
+  assert.doesNotMatch(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /\b(delete|drop|alter)\b/iu);
+  assert.doesNotMatch(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /\breturning\s+c\.id\b/iu);
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /"updatedAt" = now\(\)/u);
+  assert.doesNotMatch(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /(^|\n)\s+updatedAt = now\(\)/u);
+});
+
+test('repair SQL does not overwrite non-null lifecycle mismatches', () => {
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /case_lifecycle_state is null/u);
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /recovery_lifecycle_state is null/u);
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /coalesce/u);
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /from expected e/u);
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /where e\.status = c\.status::text/u);
+  assert.match(CLAIM_LIFECYCLE_REPAIR_DRY_RUN_SQL, /blocked_partial_mismatch/u);
+});
+
+test('apply path only targets mappable incomplete rows and returns aggregate counts', () => {
+  assert.match(
+    CLAIM_LIFECYCLE_REPAIR_APPLY_SQL,
+    /\(c\.case_lifecycle_state is null or c\.recovery_lifecycle_state is null\)/u
+  );
+  assert.match(
+    CLAIM_LIFECYCLE_REPAIR_APPLY_SQL,
+    /c\.case_lifecycle_state is null or c\.case_lifecycle_state::text = e\.case_lifecycle_state/u
+  );
+  assert.match(
+    CLAIM_LIFECYCLE_REPAIR_APPLY_SQL,
+    /c\.recovery_lifecycle_state is null\s+or c\.recovery_lifecycle_state::text = e\.recovery_lifecycle_state/u
+  );
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /select 'repaired' as action/u);
+  assert.match(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /count\(\*\)::int as count/u);
+  assert.doesNotMatch(CLAIM_LIFECYCLE_REPAIR_APPLY_SQL, /\breturning\s+c\.\*/iu);
+});
+
+test('repair report summarizes repairable, blocked, unmappable, and repaired groups', () => {
+  const summary = summarizeLifecycleRepair([
+    { action: 'repairable', status: 'submitted', case_lifecycle_state: null, count: 3 },
+    {
+      action: 'blocked_partial_mismatch',
+      status: 'resolved',
+      case_lifecycle_state: 'recovery',
+      recovery_lifecycle_state: null,
+      count: '2',
+    },
+    { action: 'unmappable_incomplete', status: null, count: 1 },
+    {
+      action: 'repaired',
+      status: 'court',
+      case_lifecycle_state: 'recovery',
+      recovery_lifecycle_state: 'court',
+      count: 4,
+    },
+  ]);
+
+  assert.equal(summary.total, 10);
+  assert.deepEqual(summary.byAction, {
+    repairable: 3,
+    blocked_partial_mismatch: 2,
+    unmappable_incomplete: 1,
+    repaired: 4,
+  });
+});
+
+test('live repair script uses admin system connection and defaults to dry-run', () => {
+  const source = readFileSync('scripts/claim-lifecycle-completeness-repair.ts', 'utf8');
+
+  assert.match(source, /\{\s*dbAdmin,\s*sql\s*\}\s*=\s*await import/u);
+  assert.match(source, /dbAdmin\.execute/u);
+  assert.match(source, /process\.argv\.includes\('--apply'\)/u);
+  assert.doesNotMatch(source, /\{\s*db,\s*sql\s*\}\s*=\s*await import/u);
+});
+
+test('normalizes execute rows without accepting ambiguous shapes', () => {
+  const rows = [{ action: 'repairable', status: 'draft', count: 1 }];
+  assert.deepEqual(normalizeRepairExecuteRows(rows), rows);
+  assert.deepEqual(normalizeRepairExecuteRows({ rows }), rows);
+  assert.throws(
+    () => normalizeRepairExecuteRows({ rowCount: 1 }),
+    /Unexpected lifecycle repair query result shape/u
+  );
+});
+
+test('formats aggregate-only rollback and observability handoff evidence', () => {
+  const report = JSON.parse(
+    formatLifecycleRepairReport([{ action: 'repairable', status: 'draft', count: 1 }], {
+      generatedAt: '2026-06-22T00:00:00.000Z',
+    })
+  );
+
+  assert.equal(report.mode, 'dry_run');
+  assert.equal(report.pii, 'aggregate_counts_only');
+  assert.match(report.rollback, /Re-run inventory/u);
+  assert.equal(report.byAction.repairable, 1);
+});

--- a/scripts/claim-lifecycle-completeness-repair-report.mjs
+++ b/scripts/claim-lifecycle-completeness-repair-report.mjs
@@ -1,0 +1,135 @@
+export const CLAIM_LIFECYCLE_REPAIR_DRY_RUN_SQL = `
+with expected(status, case_lifecycle_state, recovery_lifecycle_state) as (
+  values
+    ('draft', 'draft', 'not_started'),
+    ('submitted', 'submitted', 'not_started'),
+    ('verification', 'verification', 'not_started'),
+    ('evaluation', 'evaluation', 'not_started'),
+    ('negotiation', 'recovery', 'negotiation'),
+    ('court', 'recovery', 'court'),
+    ('resolved', 'resolved', 'resolved'),
+    ('rejected', 'rejected', 'closed')
+),
+classified as (
+  select
+    c.status::text as status,
+    c.case_lifecycle_state::text as case_lifecycle_state,
+    c.recovery_lifecycle_state::text as recovery_lifecycle_state,
+    case
+      when e.status is null and (
+        c.case_lifecycle_state is null or c.recovery_lifecycle_state is null
+      ) then 'unmappable_incomplete'
+      when e.status is not null
+       and (c.case_lifecycle_state is null or c.recovery_lifecycle_state is null)
+       and (c.case_lifecycle_state is null or c.case_lifecycle_state::text = e.case_lifecycle_state)
+       and (
+         c.recovery_lifecycle_state is null
+         or c.recovery_lifecycle_state::text = e.recovery_lifecycle_state
+       ) then 'repairable'
+      when e.status is not null
+       and (c.case_lifecycle_state is null or c.recovery_lifecycle_state is null)
+        then 'blocked_partial_mismatch'
+      else 'not_in_scope'
+    end as action
+  from claim c
+  left join expected e on e.status = c.status::text
+)
+select action, status, case_lifecycle_state, recovery_lifecycle_state, count(*)::int as count
+from classified
+where action <> 'not_in_scope'
+group by action, status, case_lifecycle_state, recovery_lifecycle_state
+order by action, status nulls first, case_lifecycle_state nulls first, recovery_lifecycle_state nulls first;
+`.trim();
+
+export const CLAIM_LIFECYCLE_REPAIR_APPLY_SQL = `
+with expected(status, case_lifecycle_state, recovery_lifecycle_state) as (
+  values
+    ('draft', 'draft', 'not_started'),
+    ('submitted', 'submitted', 'not_started'),
+    ('verification', 'verification', 'not_started'),
+    ('evaluation', 'evaluation', 'not_started'),
+    ('negotiation', 'recovery', 'negotiation'),
+    ('court', 'recovery', 'court'),
+    ('resolved', 'resolved', 'resolved'),
+    ('rejected', 'rejected', 'closed')
+),
+updated as (
+  update claim c
+     set case_lifecycle_state = coalesce(c.case_lifecycle_state::text, e.case_lifecycle_state),
+         recovery_lifecycle_state = coalesce(
+           c.recovery_lifecycle_state::text,
+           e.recovery_lifecycle_state
+         ),
+         "updatedAt" = now()
+    from expected e
+   where e.status = c.status::text
+     and (c.case_lifecycle_state is null or c.recovery_lifecycle_state is null)
+     and (c.case_lifecycle_state is null or c.case_lifecycle_state::text = e.case_lifecycle_state)
+     and (
+       c.recovery_lifecycle_state is null
+       or c.recovery_lifecycle_state::text = e.recovery_lifecycle_state
+     )
+ returning c.status::text as status,
+           c.case_lifecycle_state::text as case_lifecycle_state,
+           c.recovery_lifecycle_state::text as recovery_lifecycle_state
+)
+select 'repaired' as action, status, case_lifecycle_state, recovery_lifecycle_state, count(*)::int as count
+from updated
+group by status, case_lifecycle_state, recovery_lifecycle_state
+order by status, case_lifecycle_state, recovery_lifecycle_state;
+`.trim();
+
+const ACTIONS = ['repairable', 'blocked_partial_mismatch', 'unmappable_incomplete', 'repaired'];
+
+function countValue(value) {
+  const count = Number(value ?? 0);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error(`Invalid lifecycle repair count: ${value}`);
+  }
+  return count;
+}
+
+export function normalizeRepairExecuteRows(result) {
+  if (Array.isArray(result)) return result;
+  if (result && typeof result === 'object' && Array.isArray(result.rows)) return result.rows;
+  throw new Error('Unexpected lifecycle repair query result shape');
+}
+
+export function summarizeLifecycleRepair(rows) {
+  const byAction = Object.fromEntries(ACTIONS.map(action => [action, 0]));
+  const groups = rows.map(row => {
+    const action = String(row.action ?? '');
+    if (!ACTIONS.includes(action)) throw new Error(`Unknown lifecycle repair action: ${action}`);
+    const count = countValue(row.count);
+    byAction[action] += count;
+    return {
+      action,
+      status: row.status ?? null,
+      caseLifecycleState: row.case_lifecycle_state ?? row.caseLifecycleState ?? null,
+      recoveryLifecycleState: row.recovery_lifecycle_state ?? row.recoveryLifecycleState ?? null,
+      count,
+    };
+  });
+  return {
+    byAction,
+    total: Object.values(byAction).reduce((sum, count) => sum + count, 0),
+    groups,
+  };
+}
+
+export function formatLifecycleRepairReport(rows, meta = {}) {
+  return JSON.stringify(
+    {
+      report: 'claim_lifecycle_completeness_repair',
+      generatedAt: meta.generatedAt ?? new Date().toISOString(),
+      mode: meta.mode ?? 'dry_run',
+      durableSource: 'claim(status, case_lifecycle_state, recovery_lifecycle_state)',
+      pii: 'aggregate_counts_only',
+      rollback:
+        'Re-run inventory; restore lifecycle fields from backup/snapshot if apply output differs from expected aggregate counts.',
+      ...summarizeLifecycleRepair(rows),
+    },
+    null,
+    2
+  );
+}

--- a/scripts/claim-lifecycle-completeness-repair.ts
+++ b/scripts/claim-lifecycle-completeness-repair.ts
@@ -1,0 +1,59 @@
+import {
+  CLAIM_LIFECYCLE_REPAIR_APPLY_SQL,
+  CLAIM_LIFECYCLE_REPAIR_DRY_RUN_SQL,
+  formatLifecycleRepairReport,
+  normalizeRepairExecuteRows,
+} from './claim-lifecycle-completeness-repair-report.mjs';
+
+type RepairRow = {
+  action: string;
+  status: string | null;
+  case_lifecycle_state: string | null;
+  recovery_lifecycle_state: string | null;
+  count: number | string;
+};
+
+function mode(): 'apply' | 'dry_run' {
+  return process.argv.includes('--apply') ? 'apply' : 'dry_run';
+}
+
+async function readRepairRows(repairMode: 'apply' | 'dry_run'): Promise<RepairRow[]> {
+  const { dbAdmin, sql } = await import('@interdomestik/database');
+  const query =
+    repairMode === 'apply' ? CLAIM_LIFECYCLE_REPAIR_APPLY_SQL : CLAIM_LIFECYCLE_REPAIR_DRY_RUN_SQL;
+  // db-access-guard: system-exempt -- reason: aggregate dry-run-first data repair emits no row-level claim data
+  const result = await dbAdmin.execute(sql.raw(query));
+  return normalizeRepairExecuteRows(result) as RepairRow[];
+}
+
+async function main(): Promise<void> {
+  const repairMode = mode();
+  if (process.argv.includes('--sql')) {
+    console.log(
+      repairMode === 'apply' ? CLAIM_LIFECYCLE_REPAIR_APPLY_SQL : CLAIM_LIFECYCLE_REPAIR_DRY_RUN_SQL
+    );
+    return;
+  }
+
+  const fromJsonIndex = process.argv.indexOf('--from-json');
+  if (fromJsonIndex !== -1) {
+    const filePath = process.argv[fromJsonIndex + 1];
+    if (!filePath) throw new Error('--from-json requires a file path');
+    const { readFile } = await import('node:fs/promises');
+    const rows = JSON.parse(await readFile(filePath, 'utf8')) as RepairRow[];
+    console.log(formatLifecycleRepairReport(rows, { mode: repairMode }));
+    return;
+  }
+
+  const rows = await readRepairRows(repairMode);
+  console.log(formatLifecycleRepairReport(rows, { mode: repairMode }));
+}
+
+void main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36795813,
-  "maxTrackedFiles": 4418,
+  "maxTrackedBytes": 36829209,
+  "maxTrackedFiles": 4425,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18046564,
-    "source/scripts": 6889948,
-    "docs/text": 5408544,
-    "tests/e2e": 4780731,
-    "config/data/messages": 1540861,
+    "large support/generated-ish": 18051758,
+    "source/scripts": 6899547,
+    "docs/text": 5421175,
+    "tests/e2e": 4786650,
+    "config/data/messages": 1540914,
     "other": 129165
   },
-  "maxLargestFileBytes": 3128116,
+  "maxLargestFileBytes": 3133310,
   "maxSourceOrTestLines": 3000
 }


### PR DESCRIPTION
## Scope
- Implements T-503b only: non-destructive lifecycle completeness readiness before any direct T-503 reconsideration.
- Adds aggregate-only, dry-run-by-default lifecycle completeness repair/report scripts for mappable null/incomplete claim lifecycle fields.
- Adds lifecycle initialization helpers and hardens seed/E2E fixture claim inserts to populate lifecycle fields from legacy claims.status.
- Keeps claims.status intact; no schema/RLS/destructive migration; no proxy/routing/auth/session/tenancy/billing/product UI changes.

## Safety notes
- Repair apply path is explicit --apply only; default is dry run.
- Apply SQL only targets mappable rows where case/recovery lifecycle fields are null/incomplete and any existing non-null lifecycle value already matches the expected mapping.
- Reports are aggregate counts only; no claim IDs or row-level PII are returned.
- Raw SQL uses the quoted camelCase "updatedAt" identifier and has focused coverage to catch unquoted updatedAt = now().

## Local proof
- pnpm install --frozen-lockfile: passed; pnpm-lock.yaml unchanged.
- node --test scripts/ci/claim-lifecycle-consistency-inventory.test.mjs scripts/ci/claim-lifecycle-completeness-repair.test.mjs: passed.
- pnpm --filter @interdomestik/database type-check: passed.
- pnpm --filter @interdomestik/database test:unit -- claim-lifecycle.test.ts: passed.
- pnpm --filter @interdomestik/domain-claims test:unit --run lifecycle-state.test.ts lifecycle-initialization.test.ts: passed.
- pnpm exec prettier --check on touched files: passed before commit; lint-staged also passed during commit.
- git diff --check: passed before commit.
- pnpm check:modularity-guard: passed.
- pnpm check:db-access: passed.
- node scripts/repo-size-budget-sync.mjs && pnpm repo:size:check: passed.
- pnpm check:e2e-contracts: passed.
- pnpm db:rls:test:required: passed.
- pnpm slice:verify: passed.
- pnpm pr:verify: passed, including PR E2E lane 136 passed / 8 skipped and smoke 13 passed / 9 skipped.
- pnpm security:guard: passed.
- pnpm e2e:gate: passed, 136 passed / 8 skipped.

## Reviewer/security disposition
- Sonnet bounded review route attempted pre-edit; blocked by CLI prompt/input issue, then first-output timeout.
- Gemini fallback attempted; blocked by 403 license/auth.
- Codex Security diff scan: unavailable/manual-start friction; not used as required evidence.
- Required local Phase C gates are green.

## Residual risks
- CI/Sonar/CodeQL/gitleaks/Vercel must be monitored on this PR head after creation.
- Direct destructive T-503 remains blocked; this PR is readiness/backfill/fixture hardening only.
- Lifecycle command-path CAS deprecation is not implemented here and remains future work.

## Supervisor action
Review PR checks and reviewer feedback. Do not merge until supervisor approves current-head CI/security/reviewer disposition.