### PR TITLE
T-503c command-path lifecycle CAS readiness

### DIFF
--- a/apps/web/src/actions/agent-claims.test.ts
+++ b/apps/web/src/actions/agent-claims.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   dbUpdate: vi.fn(),
@@ -57,7 +56,8 @@ vi.mock('@interdomestik/database', () => ({
           from: () => ({
             where: () => ({
               limit: () =>
-                Promise.resolve([{ id: 'claim-1', lifecycleVersion: 1, status: 'submitted' }]),
+                // prettier-ignore
+                Promise.resolve([{ id: 'claim-1', lifecycleVersion: 1, caseLifecycleState: 'submitted', recoveryLifecycleState: 'not_started', status: 'submitted' }]),
             }),
           }),
         }),

--- a/apps/web/src/actions/claims.test.ts
+++ b/apps/web/src/actions/claims.test.ts
@@ -13,9 +13,9 @@ const mockDbInsert = vi.fn().mockReturnValue({
   returning: vi.fn().mockResolvedValue([{ id: 'claim-1' }]),
 });
 const mockDbUpdate = vi.fn();
-const mockTxSelectLimit = vi
-  .fn()
-  .mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 1, status: 'submitted' }]);
+// prettier-ignore
+const submittedLifecycleCurrentClaim = { id: 'claim-1', lifecycleVersion: 1, caseLifecycleState: 'submitted', recoveryLifecycleState: 'not_started', status: 'submitted' };
+const mockTxSelectLimit = vi.fn().mockResolvedValue([submittedLifecycleCurrentClaim]);
 const mockTxUpdateReturning = vi.fn().mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 2 }]);
 const mockPaymentLimit = vi.fn().mockResolvedValue([{ paymentAuthorizationState: 'authorized' }]);
 const mockEmptyConsentLimit = vi.fn().mockResolvedValue([]);
@@ -173,9 +173,7 @@ describe('Claim Actions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockValidateInitialClaimEvidenceUpload.mockResolvedValue(undefined);
-    mockTxSelectLimit.mockResolvedValue([
-      { id: 'claim-1', lifecycleVersion: 1, status: 'submitted' },
-    ]);
+    mockTxSelectLimit.mockResolvedValue([submittedLifecycleCurrentClaim]);
     mockTxUpdateReturning.mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 2 }]);
     mockHasActiveMembership.mockResolvedValue(true);
     mockGetActiveSubscription.mockResolvedValue({
@@ -544,9 +542,7 @@ describe('Claim Actions', () => {
       mockGetSession.mockResolvedValue({
         user: { id: 'admin-1', role: 'admin', tenantId: 'tenant_mk' },
       });
-      mockTxSelectLimit.mockResolvedValueOnce([
-        { id: 'claim-1', lifecycleVersion: 1, status: 'submitted' },
-      ]);
+      mockTxSelectLimit.mockResolvedValueOnce([submittedLifecycleCurrentClaim]);
       const result = await updateClaimStatus('claim-1', 'submitted');
       expect(result).toEqual({ success: true });
     });

--- a/apps/web/src/actions/staff-claims/update-status.test.ts
+++ b/apps/web/src/actions/staff-claims/update-status.test.ts
@@ -46,6 +46,7 @@ describe('updateClaimStatusCore', () => {
     mocks.dbSelect.mockResolvedValue([
       {
         caseLifecycleState: 'submitted',
+        legacyStatus: 'submitted',
         recoveryLifecycleState: 'not_started',
         status: 'submitted',
       },

--- a/apps/web/src/actions/staff-claims/update-status.test.ts
+++ b/apps/web/src/actions/staff-claims/update-status.test.ts
@@ -7,7 +7,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
-  claims: { id: { name: 'id' }, tenantId: { name: 'tenantId' }, status: { name: 'status' } },
+  claims: {
+    caseLifecycleState: { name: 'caseLifecycleState' },
+    id: { name: 'id' },
+    recoveryLifecycleState: { name: 'recoveryLifecycleState' },
+    tenantId: { name: 'tenantId' },
+    status: { name: 'status' },
+  },
   claimStageHistory: { tenantId: { name: 'tenantId' } },
   db: {
     select: () => ({
@@ -37,7 +43,13 @@ describe('updateClaimStatusCore', () => {
   });
 
   it('no-ops when status unchanged and no note', async () => {
-    mocks.dbSelect.mockResolvedValue([{ status: 'submitted' }]);
+    mocks.dbSelect.mockResolvedValue([
+      {
+        caseLifecycleState: 'submitted',
+        recoveryLifecycleState: 'not_started',
+        status: 'submitted',
+      },
+    ]);
 
     const result = await updateClaimStatusCore({
       claimId: 'claim-1',

--- a/apps/web/src/features/admin/claims/actions/ops-status-action.test.ts
+++ b/apps/web/src/features/admin/claims/actions/ops-status-action.test.ts
@@ -29,7 +29,9 @@ const session = {
   user: { id: 'admin-1', role: 'admin' },
 };
 const claim = {
+  caseLifecycleState: 'evaluation',
   id: 'claim-1',
+  recoveryLifecycleState: 'not_started',
   staffId: 'staff-1',
   status: 'evaluation',
 };
@@ -56,8 +58,9 @@ describe('updateStatusAction', () => {
     expect(mocks.assertTransitionAllowed).toHaveBeenCalledWith('evaluation', 'negotiation');
     expect(mocks.transitionAdminClaimStatus).toHaveBeenCalledWith({
       actor: { id: 'admin-1', role: 'admin' },
+      expectedCaseLifecycleState: 'evaluation',
+      expectedRecoveryLifecycleState: 'not_started',
       claimId: 'claim-1',
-      fromStatus: 'evaluation',
       tenantId: 'tenant-1',
       toStatus: 'negotiation',
     });
@@ -96,8 +99,9 @@ describe('updateStatusAction', () => {
 
     expect(mocks.transitionAdminClaimStatus).toHaveBeenCalledWith({
       actor: { id: 'admin-1', role: 'admin' },
+      expectedCaseLifecycleState: 'evaluation',
+      expectedRecoveryLifecycleState: 'not_started',
       claimId: 'claim-1',
-      fromStatus: 'evaluation',
       tenantId: 'tenant-1',
       toStatus: 'court',
     });
@@ -118,5 +122,24 @@ describe('updateStatusAction', () => {
 
     expect(mocks.transitionAdminClaimStatus).not.toHaveBeenCalled();
     expect(mocks.logAudit).not.toHaveBeenCalled();
+  });
+
+  it('derives admin transition guards and CAS from lifecycle state when compat status is stale', async () => {
+    const staleCompatClaim = { ...claim, status: 'submitted' };
+    mocks.getClaimForMutation.mockResolvedValueOnce(staleCompatClaim);
+
+    await expect(updateStatusAction('claim-1', 'negotiation', 'sq')).resolves.toEqual({
+      success: true,
+    });
+
+    expect(mocks.assertTransitionAllowed).toHaveBeenCalledWith('evaluation', 'negotiation');
+    expect(mocks.transitionAdminClaimStatus).toHaveBeenCalledWith({
+      actor: { id: 'admin-1', role: 'admin' },
+      expectedCaseLifecycleState: 'evaluation',
+      expectedRecoveryLifecycleState: 'not_started',
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      toStatus: 'negotiation',
+    });
   });
 });

--- a/apps/web/src/features/admin/claims/actions/ops-status-action.test.ts
+++ b/apps/web/src/features/admin/claims/actions/ops-status-action.test.ts
@@ -25,9 +25,7 @@ vi.mock('@interdomestik/domain-claims/admin-claims/status-transition', () => ({
 
 import { updateStatusAction } from './ops-status-action';
 
-const session = {
-  user: { id: 'admin-1', role: 'admin' },
-};
+const session = { user: { id: 'admin-1', role: 'admin' } };
 const claim = {
   caseLifecycleState: 'evaluation',
   id: 'claim-1',
@@ -35,6 +33,21 @@ const claim = {
   staffId: 'staff-1',
   status: 'evaluation',
 };
+
+type TransitionParamOverrides = { toStatus: string; [key: string]: string };
+
+function expectTransitionParams(params: TransitionParamOverrides) {
+  expect(mocks.transitionAdminClaimStatus).toHaveBeenCalledWith({
+    actor: { id: 'admin-1', role: 'admin' },
+    expectedCaseLifecycleState: params.expectedCaseLifecycleState ?? 'evaluation',
+    expectedLifecycleAuthority: params.expectedLifecycleAuthority ?? 'lifecycle',
+    expectedRecoveryLifecycleState: params.expectedRecoveryLifecycleState ?? 'not_started',
+    expectedStatus: params.expectedStatus ?? 'evaluation',
+    claimId: 'claim-1',
+    tenantId: 'tenant-1',
+    toStatus: params.toStatus,
+  });
+}
 
 describe('updateStatusAction', () => {
   beforeEach(() => {
@@ -56,14 +69,7 @@ describe('updateStatusAction', () => {
 
     expect(mocks.assertCanMutateClaim).toHaveBeenCalledWith(claim, 'admin', 'status_change');
     expect(mocks.assertTransitionAllowed).toHaveBeenCalledWith('evaluation', 'negotiation');
-    expect(mocks.transitionAdminClaimStatus).toHaveBeenCalledWith({
-      actor: { id: 'admin-1', role: 'admin' },
-      expectedCaseLifecycleState: 'evaluation',
-      expectedRecoveryLifecycleState: 'not_started',
-      claimId: 'claim-1',
-      tenantId: 'tenant-1',
-      toStatus: 'negotiation',
-    });
+    expectTransitionParams({ toStatus: 'negotiation' });
     expect(mocks.logAudit).toHaveBeenCalledWith('tenant-1', 'admin-1', 'update_status', 'claim-1', {
       previousStatus: 'evaluation',
       newStatus: 'negotiation',
@@ -97,14 +103,7 @@ describe('updateStatusAction', () => {
       error: 'Illegal transition from evaluation to court',
     });
 
-    expect(mocks.transitionAdminClaimStatus).toHaveBeenCalledWith({
-      actor: { id: 'admin-1', role: 'admin' },
-      expectedCaseLifecycleState: 'evaluation',
-      expectedRecoveryLifecycleState: 'not_started',
-      claimId: 'claim-1',
-      tenantId: 'tenant-1',
-      toStatus: 'court',
-    });
+    expectTransitionParams({ toStatus: 'court' });
     expect(mocks.logAudit).not.toHaveBeenCalled();
     expect(mocks.revalidateClaim).not.toHaveBeenCalled();
   });
@@ -124,22 +123,26 @@ describe('updateStatusAction', () => {
     expect(mocks.logAudit).not.toHaveBeenCalled();
   });
 
-  it('derives admin transition guards and CAS from lifecycle state when compat status is stale', async () => {
-    const staleCompatClaim = { ...claim, status: 'submitted' };
-    mocks.getClaimForMutation.mockResolvedValueOnce(staleCompatClaim);
+  it('passes fallback authority for legacy null lifecycle rows', async () => {
+    const legacyClaim = {
+      ...claim,
+      caseLifecycleState: null,
+      recoveryLifecycleState: null,
+      status: 'submitted',
+    };
+    mocks.getClaimForMutation.mockResolvedValueOnce(legacyClaim);
 
-    await expect(updateStatusAction('claim-1', 'negotiation', 'sq')).resolves.toEqual({
+    await expect(updateStatusAction('claim-1', 'verification', 'sq')).resolves.toEqual({
       success: true,
     });
 
-    expect(mocks.assertTransitionAllowed).toHaveBeenCalledWith('evaluation', 'negotiation');
-    expect(mocks.transitionAdminClaimStatus).toHaveBeenCalledWith({
-      actor: { id: 'admin-1', role: 'admin' },
-      expectedCaseLifecycleState: 'evaluation',
+    expect(mocks.assertTransitionAllowed).toHaveBeenCalledWith('submitted', 'verification');
+    expectTransitionParams({
+      expectedCaseLifecycleState: 'submitted',
+      expectedLifecycleAuthority: 'status_fallback',
       expectedRecoveryLifecycleState: 'not_started',
-      claimId: 'claim-1',
-      tenantId: 'tenant-1',
-      toStatus: 'negotiation',
+      expectedStatus: 'submitted',
+      toStatus: 'verification',
     });
   });
 });

--- a/apps/web/src/features/admin/claims/actions/ops-status-action.ts
+++ b/apps/web/src/features/admin/claims/actions/ops-status-action.ts
@@ -42,7 +42,9 @@ export async function updateStatusAction(
     const transitionResult = await transitionAdminClaimStatus({
       actor: { id: ctx.session.user.id, role: ctx.session.user.role ?? null },
       expectedCaseLifecycleState: currentLifecycle.caseLifecycleState,
+      expectedLifecycleAuthority: currentLifecycle.authority,
       expectedRecoveryLifecycleState: currentLifecycle.recoveryLifecycleState,
+      expectedStatus: currentStatus,
       claimId,
       tenantId: ctx.tenantId,
       toStatus: newStatus,

--- a/apps/web/src/features/admin/claims/actions/ops-status-action.ts
+++ b/apps/web/src/features/admin/claims/actions/ops-status-action.ts
@@ -1,4 +1,5 @@
 import type { ClaimStatus } from '@interdomestik/database/constants';
+import { resolveClaimLifecycleReadProjection } from '@interdomestik/domain-claims';
 import { transitionAdminClaimStatus } from '@interdomestik/domain-claims/admin-claims/status-transition';
 
 import {
@@ -25,7 +26,8 @@ export async function updateStatusAction(
     if (!ctx) return { success: false, error: 'Unauthorized' };
 
     const claim = await getClaimForMutation(claimId, ctx.tenantId);
-    const currentStatus = claim.status as ClaimStatus;
+    const currentLifecycle = resolveClaimLifecycleReadProjection(claim);
+    const currentStatus = currentLifecycle.status;
     assertCanMutateClaim(claim, ctx.session.user.role, 'status_change');
     assertTransitionAllowed(currentStatus, newStatus);
 
@@ -39,8 +41,9 @@ export async function updateStatusAction(
 
     const transitionResult = await transitionAdminClaimStatus({
       actor: { id: ctx.session.user.id, role: ctx.session.user.role ?? null },
+      expectedCaseLifecycleState: currentLifecycle.caseLifecycleState,
+      expectedRecoveryLifecycleState: currentLifecycle.recoveryLifecycleState,
       claimId,
-      fromStatus: currentStatus,
       tenantId: ctx.tenantId,
       toStatus: newStatus,
     });

--- a/packages/domain-claims/src/admin-claims/status-transition.test.ts
+++ b/packages/domain-claims/src/admin-claims/status-transition.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   and: vi.fn((...conditions) => ({ op: 'and', conditions })),
   dbTransaction: vi.fn(async callback => callback({ tx: true })),
   eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
+  isNull: vi.fn(value => ({ op: 'isNull', value })),
   transition: vi.fn(),
 }));
 
@@ -21,6 +22,7 @@ vi.mock('@interdomestik/database', () => ({
   },
   db: { transaction: mocks.dbTransaction },
   eq: mocks.eq,
+  isNull: mocks.isNull,
   sql: vi.fn(() => ({ op: 'sql' })),
 }));
 
@@ -45,7 +47,9 @@ describe('transitionAdminClaimStatus', () => {
     await transitionAdminClaimStatus({
       actor: { id: 'admin-1', role: 'admin' },
       expectedCaseLifecycleState: 'submitted',
+      expectedLifecycleAuthority: 'lifecycle',
       expectedRecoveryLifecycleState: 'not_started',
+      expectedStatus: 'submitted',
       claimId: 'claim-1',
       tenantId: 'tenant-1',
       toStatus: 'verification',
@@ -64,5 +68,65 @@ describe('transitionAdminClaimStatus', () => {
       })
     );
     expect(mocks.eq).not.toHaveBeenCalledWith('claims.status', expect.anything());
+  });
+
+  it('allows legacy null lifecycle rows through the fallback precondition', async () => {
+    await transitionAdminClaimStatus({
+      actor: { id: 'admin-1', role: 'admin' },
+      expectedCaseLifecycleState: 'submitted',
+      expectedLifecycleAuthority: 'status_fallback',
+      expectedRecoveryLifecycleState: 'not_started',
+      expectedStatus: 'submitted',
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      toStatus: 'verification',
+    });
+
+    expect(mocks.transition).toHaveBeenCalledWith(
+      { tx: true },
+      expect.objectContaining({
+        requiredWhereCondition: {
+          op: 'and',
+          conditions: [
+            { op: 'isNull', value: 'claims.case_lifecycle_state' },
+            { op: 'isNull', value: 'claims.recovery_lifecycle_state' },
+            { op: 'eq', left: 'claims.status', right: 'submitted' },
+          ],
+        },
+      })
+    );
+  });
+
+  it('layers payment authorization on top of the fallback precondition', async () => {
+    await transitionAdminClaimStatus({
+      actor: { id: 'admin-1', role: 'admin' },
+      expectedCaseLifecycleState: 'evaluation',
+      expectedLifecycleAuthority: 'status_fallback',
+      expectedRecoveryLifecycleState: 'not_started',
+      expectedStatus: 'evaluation',
+      claimId: 'claim-1',
+      tenantId: 'tenant-1',
+      toStatus: 'court',
+    });
+
+    expect(mocks.transition).toHaveBeenCalledWith(
+      { tx: true },
+      expect.objectContaining({
+        requiredWhereCondition: {
+          op: 'and',
+          conditions: [
+            {
+              op: 'and',
+              conditions: [
+                { op: 'isNull', value: 'claims.case_lifecycle_state' },
+                { op: 'isNull', value: 'claims.recovery_lifecycle_state' },
+                { op: 'eq', left: 'claims.status', right: 'evaluation' },
+              ],
+            },
+            { op: 'sql' },
+          ],
+        },
+      })
+    );
   });
 });

--- a/packages/domain-claims/src/admin-claims/status-transition.test.ts
+++ b/packages/domain-claims/src/admin-claims/status-transition.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+  dbTransaction: vi.fn(async callback => callback({ tx: true })),
+  eq: vi.fn((left, right) => ({ op: 'eq', left, right })),
+  transition: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  and: mocks.and,
+  claimEscalationAgreements: {
+    claimId: 'claim_escalation_agreements.claim_id',
+    paymentAuthorizationState: 'claim_escalation_agreements.payment_authorization_state',
+    tenantId: 'claim_escalation_agreements.tenant_id',
+  },
+  claims: {
+    caseLifecycleState: 'claims.case_lifecycle_state',
+    recoveryLifecycleState: 'claims.recovery_lifecycle_state',
+    status: 'claims.status',
+  },
+  db: { transaction: mocks.dbTransaction },
+  eq: mocks.eq,
+  sql: vi.fn(() => ({ op: 'sql' })),
+}));
+
+vi.mock('../claims/transition', () => ({
+  transitionClaimStatusInTransaction: mocks.transition,
+}));
+
+import { transitionAdminClaimStatus } from './status-transition';
+
+describe('transitionAdminClaimStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.transition.mockResolvedValue({
+      success: true,
+      fromStatus: 'submitted',
+      lifecycleVersion: 2,
+      status: 'verification',
+    });
+  });
+
+  it('binds expected lifecycle state instead of legacy status in the precondition', async () => {
+    await transitionAdminClaimStatus({
+      actor: { id: 'admin-1', role: 'admin' },
+      claimId: 'claim-1',
+      fromStatus: 'submitted',
+      tenantId: 'tenant-1',
+      toStatus: 'verification',
+    });
+
+    expect(mocks.transition).toHaveBeenCalledWith(
+      { tx: true },
+      expect.objectContaining({
+        requiredWhereCondition: {
+          op: 'and',
+          conditions: [
+            { op: 'eq', left: 'claims.case_lifecycle_state', right: 'submitted' },
+            { op: 'eq', left: 'claims.recovery_lifecycle_state', right: 'not_started' },
+          ],
+        },
+      })
+    );
+    expect(mocks.eq).not.toHaveBeenCalledWith('claims.status', expect.anything());
+  });
+});

--- a/packages/domain-claims/src/admin-claims/status-transition.test.ts
+++ b/packages/domain-claims/src/admin-claims/status-transition.test.ts
@@ -44,8 +44,9 @@ describe('transitionAdminClaimStatus', () => {
   it('binds expected lifecycle state instead of legacy status in the precondition', async () => {
     await transitionAdminClaimStatus({
       actor: { id: 'admin-1', role: 'admin' },
+      expectedCaseLifecycleState: 'submitted',
+      expectedRecoveryLifecycleState: 'not_started',
       claimId: 'claim-1',
-      fromStatus: 'submitted',
       tenantId: 'tenant-1',
       toStatus: 'verification',
     });

--- a/packages/domain-claims/src/admin-claims/status-transition.ts
+++ b/packages/domain-claims/src/admin-claims/status-transition.ts
@@ -6,15 +6,16 @@ import {
   transitionClaimStatusInTransaction,
   type TransitionClaimStatusResult,
 } from '../claims/transition';
+import type { CaseLifecycleState, RecoveryLifecycleState } from '../claims/lifecycle-state';
 import type { ClaimTransitionActor } from '../claims/transition-guard';
-import { mapClaimStatusToLifecycleStates } from '../claims/lifecycle-state';
 
 const paymentGatedStatuses = new Set<ClaimStatus>(['negotiation', 'court']);
 
 export type TransitionAdminClaimStatusParams = {
   actor: ClaimTransitionActor;
+  expectedCaseLifecycleState: CaseLifecycleState;
+  expectedRecoveryLifecycleState: RecoveryLifecycleState;
   claimId: string;
-  fromStatus: ClaimStatus;
   tenantId: string;
   toStatus: ClaimStatus;
 };
@@ -29,10 +30,9 @@ function paymentAuthorizationRequired(params: { claimId: string; tenantId: strin
 }
 
 function requiredTransitionCondition(params: TransitionAdminClaimStatusParams): SQLWrapper {
-  const fromState = mapClaimStatusToLifecycleStates(params.fromStatus);
   const fromStateCondition = and(
-    eq(claims.caseLifecycleState, fromState.caseLifecycleState),
-    eq(claims.recoveryLifecycleState, fromState.recoveryLifecycleState)
+    eq(claims.caseLifecycleState, params.expectedCaseLifecycleState),
+    eq(claims.recoveryLifecycleState, params.expectedRecoveryLifecycleState)
   ) as SQLWrapper;
   if (!paymentGatedStatuses.has(params.toStatus)) return fromStateCondition;
 

--- a/packages/domain-claims/src/admin-claims/status-transition.ts
+++ b/packages/domain-claims/src/admin-claims/status-transition.ts
@@ -1,4 +1,12 @@
-import { and, claimEscalationAgreements, claims, db, eq, sql } from '@interdomestik/database';
+import {
+  and,
+  claimEscalationAgreements,
+  claims,
+  db,
+  eq,
+  isNull,
+  sql,
+} from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { SQLWrapper } from 'drizzle-orm';
 
@@ -6,6 +14,7 @@ import {
   transitionClaimStatusInTransaction,
   type TransitionClaimStatusResult,
 } from '../claims/transition';
+import type { ClaimLifecycleReadProjection } from '../claims/lifecycle-read-model';
 import type { CaseLifecycleState, RecoveryLifecycleState } from '../claims/lifecycle-state';
 import type { ClaimTransitionActor } from '../claims/transition-guard';
 
@@ -14,7 +23,9 @@ const paymentGatedStatuses = new Set<ClaimStatus>(['negotiation', 'court']);
 export type TransitionAdminClaimStatusParams = {
   actor: ClaimTransitionActor;
   expectedCaseLifecycleState: CaseLifecycleState;
+  expectedLifecycleAuthority: ClaimLifecycleReadProjection['authority'];
   expectedRecoveryLifecycleState: RecoveryLifecycleState;
+  expectedStatus: ClaimStatus;
   claimId: string;
   tenantId: string;
   toStatus: ClaimStatus;
@@ -29,11 +40,23 @@ function paymentAuthorizationRequired(params: { claimId: string; tenantId: strin
   )`;
 }
 
-function requiredTransitionCondition(params: TransitionAdminClaimStatusParams): SQLWrapper {
-  const fromStateCondition = and(
+function expectedFromStateCondition(params: TransitionAdminClaimStatusParams): SQLWrapper {
+  if (params.expectedLifecycleAuthority === 'status_fallback') {
+    return and(
+      isNull(claims.caseLifecycleState),
+      isNull(claims.recoveryLifecycleState),
+      eq(claims.status, params.expectedStatus)
+    ) as SQLWrapper;
+  }
+
+  return and(
     eq(claims.caseLifecycleState, params.expectedCaseLifecycleState),
     eq(claims.recoveryLifecycleState, params.expectedRecoveryLifecycleState)
   ) as SQLWrapper;
+}
+
+function requiredTransitionCondition(params: TransitionAdminClaimStatusParams): SQLWrapper {
+  const fromStateCondition = expectedFromStateCondition(params);
   if (!paymentGatedStatuses.has(params.toStatus)) return fromStateCondition;
 
   return and(

--- a/packages/domain-claims/src/admin-claims/status-transition.ts
+++ b/packages/domain-claims/src/admin-claims/status-transition.ts
@@ -7,6 +7,7 @@ import {
   type TransitionClaimStatusResult,
 } from '../claims/transition';
 import type { ClaimTransitionActor } from '../claims/transition-guard';
+import { mapClaimStatusToLifecycleStates } from '../claims/lifecycle-state';
 
 const paymentGatedStatuses = new Set<ClaimStatus>(['negotiation', 'court']);
 
@@ -28,11 +29,15 @@ function paymentAuthorizationRequired(params: { claimId: string; tenantId: strin
 }
 
 function requiredTransitionCondition(params: TransitionAdminClaimStatusParams): SQLWrapper {
-  const fromStatusCondition = eq(claims.status, params.fromStatus);
-  if (!paymentGatedStatuses.has(params.toStatus)) return fromStatusCondition;
+  const fromState = mapClaimStatusToLifecycleStates(params.fromStatus);
+  const fromStateCondition = and(
+    eq(claims.caseLifecycleState, fromState.caseLifecycleState),
+    eq(claims.recoveryLifecycleState, fromState.recoveryLifecycleState)
+  ) as SQLWrapper;
+  if (!paymentGatedStatuses.has(params.toStatus)) return fromStateCondition;
 
   return and(
-    fromStatusCondition,
+    fromStateCondition,
     paymentAuthorizationRequired({ claimId: params.claimId, tenantId: params.tenantId })
   ) as SQLWrapper;
 }

--- a/packages/domain-claims/src/admin-claims/update-status.test-support.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test-support.ts
@@ -6,6 +6,7 @@ type UpdateStatusMocks = {
   agreementFrom: MockFunction;
   agreementLimit: MockFunction;
   agreementWhere: MockFunction;
+  and: MockFunction;
   claimFrom: MockFunction;
   claimLeftJoin: MockFunction;
   claimWhere: MockFunction;
@@ -21,6 +22,7 @@ const updateStatusMocks: UpdateStatusMocks = vi.hoisted(() => ({
   agreementFrom: vi.fn(),
   agreementLimit: vi.fn(),
   agreementWhere: vi.fn(),
+  and: vi.fn((...conditions) => ({ conditions })),
   claimFrom: vi.fn(),
   claimLeftJoin: vi.fn(),
   claimWhere: vi.fn(),
@@ -45,6 +47,7 @@ updateStatusMocks.dbSelect.mockImplementation((fields: { paymentAuthorizationSta
 );
 
 vi.mock('@interdomestik/database', () => ({
+  and: updateStatusMocks.and,
   db: {
     select: updateStatusMocks.dbSelect,
     update: updateStatusMocks.dbUpdate,
@@ -86,14 +89,7 @@ export const adminSession = {
 export const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
 
 export function mockClaim(status: string, compatStatus = status): void {
-  const states =
-    status === 'resolved'
-      ? { caseLifecycleState: 'resolved', recoveryLifecycleState: 'resolved' }
-      : status === 'submitted'
-        ? { caseLifecycleState: 'submitted', recoveryLifecycleState: 'not_started' }
-        : status === 'evaluation'
-          ? { caseLifecycleState: 'evaluation', recoveryLifecycleState: 'not_started' }
-          : {};
+  const states = lifecycleStatesForStatus(status);
   updateStatusMocks.claimWhere.mockResolvedValueOnce([
     {
       ...states,
@@ -108,4 +104,17 @@ export function mockClaim(status: string, compatStatus = status): void {
 
 export function getUpdateStatusMocks(): UpdateStatusMocks {
   return updateStatusMocks;
+}
+
+function lifecycleStatesForStatus(status: string): Record<string, string> {
+  if (status === 'resolved') {
+    return { caseLifecycleState: 'resolved', recoveryLifecycleState: 'resolved' };
+  }
+  if (status === 'submitted') {
+    return { caseLifecycleState: 'submitted', recoveryLifecycleState: 'not_started' };
+  }
+  if (status === 'evaluation') {
+    return { caseLifecycleState: 'evaluation', recoveryLifecycleState: 'not_started' };
+  }
+  return {};
 }

--- a/packages/domain-claims/src/admin-claims/update-status.test-support.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test-support.ts
@@ -12,6 +12,8 @@ type UpdateStatusMocks = {
   dbSelect: MockFunction;
   dbUpdate: MockFunction;
   transitionClaimStatus: MockFunction;
+  updateSet: MockFunction;
+  updateWhere: MockFunction;
   withTenant: MockFunction;
 };
 
@@ -25,6 +27,8 @@ const updateStatusMocks: UpdateStatusMocks = vi.hoisted(() => ({
   dbSelect: vi.fn(),
   dbUpdate: vi.fn(),
   transitionClaimStatus: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
   withTenant: vi.fn((tenantId, tenantColumn, condition) => ({ tenantId, tenantColumn, condition })),
 }));
 
@@ -32,6 +36,8 @@ updateStatusMocks.claimLeftJoin.mockReturnValue({ where: updateStatusMocks.claim
 updateStatusMocks.claimFrom.mockReturnValue({ leftJoin: updateStatusMocks.claimLeftJoin });
 updateStatusMocks.agreementWhere.mockReturnValue({ limit: updateStatusMocks.agreementLimit });
 updateStatusMocks.agreementFrom.mockReturnValue({ where: updateStatusMocks.agreementWhere });
+updateStatusMocks.updateSet.mockReturnValue({ where: updateStatusMocks.updateWhere });
+updateStatusMocks.dbUpdate.mockReturnValue({ set: updateStatusMocks.updateSet });
 updateStatusMocks.dbSelect.mockImplementation((fields: { paymentAuthorizationState?: unknown }) =>
   fields.paymentAuthorizationState
     ? { from: updateStatusMocks.agreementFrom }
@@ -53,6 +59,7 @@ vi.mock('@interdomestik/database', () => ({
     caseLifecycleState: 'claims.case_lifecycle_state',
     id: 'claims.id',
     recoveryLifecycleState: 'claims.recovery_lifecycle_state',
+    status: 'claims.status',
     tenantId: 'claims.tenant_id',
     userId: 'claims.user_id',
   },
@@ -78,7 +85,7 @@ export const adminSession = {
 
 export const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
 
-export function mockClaim(status: string): void {
+export function mockClaim(status: string, compatStatus = status): void {
   const states =
     status === 'resolved'
       ? { caseLifecycleState: 'resolved', recoveryLifecycleState: 'resolved' }
@@ -92,7 +99,7 @@ export function mockClaim(status: string): void {
       ...states,
       id: 'claim-1',
       title: 'Claim',
-      status,
+      status: compatStatus,
       userId: 'member-1',
       userEmail: 'member@example.com',
     },

--- a/packages/domain-claims/src/admin-claims/update-status.test-support.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test-support.ts
@@ -49,7 +49,13 @@ vi.mock('@interdomestik/database', () => ({
     paymentAuthorizationState: 'claim_escalation_agreements.payment_authorization_state',
     tenantId: 'claim_escalation_agreements.tenant_id',
   },
-  claims: { id: 'claims.id', tenantId: 'claims.tenant_id', userId: 'claims.user_id' },
+  claims: {
+    caseLifecycleState: 'claims.case_lifecycle_state',
+    id: 'claims.id',
+    recoveryLifecycleState: 'claims.recovery_lifecycle_state',
+    tenantId: 'claims.tenant_id',
+    userId: 'claims.user_id',
+  },
   user: { id: 'user.id', email: 'user.email' },
   eq: vi.fn((left, right) => ({ left, right })),
 }));
@@ -73,8 +79,17 @@ export const adminSession = {
 export const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
 
 export function mockClaim(status: string): void {
+  const states =
+    status === 'resolved'
+      ? { caseLifecycleState: 'resolved', recoveryLifecycleState: 'resolved' }
+      : status === 'submitted'
+        ? { caseLifecycleState: 'submitted', recoveryLifecycleState: 'not_started' }
+        : status === 'evaluation'
+          ? { caseLifecycleState: 'evaluation', recoveryLifecycleState: 'not_started' }
+          : {};
   updateStatusMocks.claimWhere.mockResolvedValueOnce([
     {
+      ...states,
       id: 'claim-1',
       title: 'Claim',
       status,

--- a/packages/domain-claims/src/admin-claims/update-status.test.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test.ts
@@ -56,6 +56,24 @@ describe('admin updateClaimStatusCore', () => {
     await runStatusUpdate('resolved');
 
     expect(mocks.transitionClaimStatus).not.toHaveBeenCalled();
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('repairs stale compat status when lifecycle state already matches the request', async () => {
+    mockClaim('resolved', 'verification');
+
+    await runStatusUpdate('resolved');
+
+    expect(mocks.transitionClaimStatus).not.toHaveBeenCalled();
+    expect(mocks.dbUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'claims.status' })
+    );
+    expect(mocks.updateSet).toHaveBeenCalledWith({ status: 'resolved' });
+    expect(mocks.updateWhere).toHaveBeenCalledWith({
+      condition: { left: 'claims.id', right: 'claim-1' },
+      tenantColumn: 'claims.tenant_id',
+      tenantId: 'tenant-1',
+    });
   });
 
   it('routes admin status changes through the transition command', async () => {

--- a/packages/domain-claims/src/admin-claims/update-status.test.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test.ts
@@ -64,16 +64,13 @@ describe('admin updateClaimStatusCore', () => {
 
     await runStatusUpdate('resolved');
 
-    expect(mocks.transitionClaimStatus).not.toHaveBeenCalled();
-    expect(mocks.dbUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'claims.status' })
-    );
-    expect(mocks.updateSet).toHaveBeenCalledWith({ status: 'resolved' });
-    expect(mocks.updateWhere).toHaveBeenCalledWith({
-      condition: { left: 'claims.id', right: 'claim-1' },
-      tenantColumn: 'claims.tenant_id',
+    expect(mocks.transitionClaimStatus).toHaveBeenCalledWith({
+      actor: { id: 'admin-1', role: 'tenant_admin' },
+      claimId: 'claim-1',
       tenantId: 'tenant-1',
+      toStatus: 'resolved',
     });
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
   });
 
   it('routes admin status changes through the transition command', async () => {

--- a/packages/domain-claims/src/admin-claims/update-status.test.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.test.ts
@@ -73,6 +73,18 @@ describe('admin updateClaimStatusCore', () => {
     expect(mocks.dbUpdate).not.toHaveBeenCalled();
   });
 
+  it('surfaces stale compat repair failures without pretending the no-op succeeded', async () => {
+    mockClaim('resolved', 'verification');
+    mocks.transitionClaimStatus.mockResolvedValueOnce({
+      success: false,
+      error: 'claim_not_found',
+    });
+
+    await expect(runStatusUpdate('resolved')).rejects.toThrow('Claim not found');
+
+    expect(mocks.dbUpdate).not.toHaveBeenCalled();
+  });
+
   it('routes admin status changes through the transition command', async () => {
     const logAuditEvent = vi.fn();
     const projectClaimStatusAuditProjection = vi.fn();

--- a/packages/domain-claims/src/admin-claims/update-status.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.ts
@@ -142,10 +142,7 @@ export async function updateClaimStatusCore(
     throwTransitionFailure(result);
   }
 
-  const persistedOldStatus = result.fromStatus;
-  const persistedNewStatus = result.status;
-
   await activateClaimStatusAuditProjection({ deps, tenantId });
 
-  notifyClaimOwner(deps, claimWithUser, persistedOldStatus, persistedNewStatus);
+  notifyClaimOwner(deps, claimWithUser, result.fromStatus, result.status);
 }

--- a/packages/domain-claims/src/admin-claims/update-status.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.ts
@@ -1,5 +1,4 @@
-import { claims, db, eq, user } from '@interdomestik/database';
-import { withTenant } from '@interdomestik/database/tenant-security';
+import { and, claims, db, eq, user } from '@interdomestik/database';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 
 import type { ClaimsDeps, ClaimsSession } from '../claims/types';
@@ -27,6 +26,39 @@ const validStatuses: ClaimStatus[] = [
   'resolved',
   'rejected',
 ];
+
+type ClaimOwnerNotificationRow = {
+  id: string;
+  title: string;
+  userEmail: string | null;
+  userId: string | null;
+};
+
+function claimTenantWhere(tenantId: string, claimId: string) {
+  return and(eq(claims.tenantId, tenantId), eq(claims.id, claimId));
+}
+
+function notifyClaimOwner(
+  deps: ClaimsDeps,
+  claim: ClaimOwnerNotificationRow,
+  oldStatus: ClaimStatus,
+  newStatus: ClaimStatus
+): void {
+  const notifyStatusChanged = deps.notifyStatusChanged;
+  if (!claim.userId || !claim.userEmail || oldStatus === newStatus || !notifyStatusChanged) {
+    return;
+  }
+
+  Promise.resolve(
+    notifyStatusChanged(
+      claim.userId,
+      claim.userEmail,
+      { id: claim.id, title: claim.title },
+      oldStatus,
+      newStatus
+    )
+  ).catch((err: Error) => console.error('Failed to send status notification:', err));
+}
 
 export async function updateClaimStatusCore(
   params: {
@@ -65,7 +97,7 @@ export async function updateClaimStatusCore(
     })
     .from(claims)
     .leftJoin(user, eq(claims.userId, user.id))
-    .where(withTenant(tenantId, claims.tenantId, eq(claims.id, claimId)));
+    .where(claimTenantWhere(tenantId, claimId));
 
   if (!claimWithUser) {
     throw new Error('Claim not found');
@@ -74,10 +106,12 @@ export async function updateClaimStatusCore(
   const currentState = resolveClaimLifecycleCommandProjection(claimWithUser);
   if (currentState.success && currentState.status === newStatus) {
     if (claimWithUser.status !== newStatus) {
-      await db
-        .update(claims)
-        .set({ status: newStatus })
-        .where(withTenant(tenantId, claims.tenantId, eq(claims.id, claimId)));
+      await transitionClaimStatus({
+        actor: { id: session.user.id, role: session.user.role ?? null },
+        claimId,
+        tenantId,
+        toStatus: newStatus,
+      });
     }
     return;
   }
@@ -104,22 +138,5 @@ export async function updateClaimStatusCore(
 
   await activateClaimStatusAuditProjection({ deps, tenantId });
 
-  // Send notification to claim owner (fire-and-forget)
-  if (
-    claimWithUser.userId &&
-    claimWithUser.userEmail &&
-    persistedOldStatus !== persistedNewStatus
-  ) {
-    if (deps.notifyStatusChanged) {
-      Promise.resolve(
-        deps.notifyStatusChanged(
-          claimWithUser.userId,
-          claimWithUser.userEmail,
-          { id: claimWithUser.id, title: claimWithUser.title },
-          persistedOldStatus,
-          persistedNewStatus
-        )
-      ).catch((err: Error) => console.error('Failed to send status notification:', err));
-    }
-  }
+  notifyClaimOwner(deps, claimWithUser, persistedOldStatus, persistedNewStatus);
 }

--- a/packages/domain-claims/src/admin-claims/update-status.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.ts
@@ -58,6 +58,7 @@ export async function updateClaimStatusCore(
       caseLifecycleState: claims.caseLifecycleState,
       id: claims.id,
       recoveryLifecycleState: claims.recoveryLifecycleState,
+      status: claims.status,
       title: claims.title,
       userId: claims.userId,
       userEmail: user.email,
@@ -72,6 +73,12 @@ export async function updateClaimStatusCore(
 
   const currentState = resolveClaimLifecycleCommandProjection(claimWithUser);
   if (currentState.success && currentState.status === newStatus) {
+    if (claimWithUser.status !== newStatus) {
+      await db
+        .update(claims)
+        .set({ status: newStatus })
+        .where(withTenant(tenantId, claims.tenantId, eq(claims.id, claimId)));
+    }
     return;
   }
 

--- a/packages/domain-claims/src/admin-claims/update-status.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.ts
@@ -4,7 +4,7 @@ import { ensureTenantId } from '@interdomestik/shared-auth';
 import type { ClaimsDeps, ClaimsSession } from '../claims/types';
 import { activateClaimStatusAuditProjection } from '../claims/audit-projection';
 import { resolveClaimLifecycleCommandProjection } from '../claims/lifecycle-read-model';
-import { transitionClaimStatus } from '../claims/transition';
+import { transitionClaimStatus, type TransitionClaimStatusResult } from '../claims/transition';
 
 type ClaimStatus =
   | 'draft'
@@ -60,6 +60,18 @@ function notifyClaimOwner(
   ).catch((err: Error) => console.error('Failed to send status notification:', err));
 }
 
+function throwTransitionFailure(
+  result: Extract<TransitionClaimStatusResult, { success: false }>
+): never {
+  if (result.error === 'claim_not_found') {
+    throw new Error('Claim not found');
+  }
+  if (result.error === 'transition_rejected') {
+    throw new Error('Invalid status transition');
+  }
+  throw new Error('Failed to update claim status');
+}
+
 export async function updateClaimStatusCore(
   params: {
     claimId: string;
@@ -106,12 +118,15 @@ export async function updateClaimStatusCore(
   const currentState = resolveClaimLifecycleCommandProjection(claimWithUser);
   if (currentState.success && currentState.status === newStatus) {
     if (claimWithUser.status !== newStatus) {
-      await transitionClaimStatus({
+      const repairResult = await transitionClaimStatus({
         actor: { id: session.user.id, role: session.user.role ?? null },
         claimId,
         tenantId,
         toStatus: newStatus,
       });
+      if (!repairResult.success) {
+        throwTransitionFailure(repairResult);
+      }
     }
     return;
   }
@@ -124,13 +139,7 @@ export async function updateClaimStatusCore(
   });
 
   if (!result.success) {
-    if (result.error === 'claim_not_found') {
-      throw new Error('Claim not found');
-    }
-    if (result.error === 'transition_rejected') {
-      throw new Error('Invalid status transition');
-    }
-    throw new Error('Failed to update claim status');
+    throwTransitionFailure(result);
   }
 
   const persistedOldStatus = result.fromStatus;

--- a/packages/domain-claims/src/admin-claims/update-status.ts
+++ b/packages/domain-claims/src/admin-claims/update-status.ts
@@ -4,6 +4,7 @@ import { ensureTenantId } from '@interdomestik/shared-auth';
 
 import type { ClaimsDeps, ClaimsSession } from '../claims/types';
 import { activateClaimStatusAuditProjection } from '../claims/audit-projection';
+import { resolveClaimLifecycleCommandProjection } from '../claims/lifecycle-read-model';
 import { transitionClaimStatus } from '../claims/transition';
 
 type ClaimStatus =
@@ -54,9 +55,10 @@ export async function updateClaimStatusCore(
   // Fetch claim with user info before update
   const [claimWithUser] = await db
     .select({
+      caseLifecycleState: claims.caseLifecycleState,
       id: claims.id,
+      recoveryLifecycleState: claims.recoveryLifecycleState,
       title: claims.title,
-      status: claims.status,
       userId: claims.userId,
       userEmail: user.email,
     })
@@ -68,9 +70,8 @@ export async function updateClaimStatusCore(
     throw new Error('Claim not found');
   }
 
-  const oldStatus = claimWithUser.status || 'draft';
-
-  if (oldStatus === newStatus) {
+  const currentState = resolveClaimLifecycleCommandProjection(claimWithUser);
+  if (currentState.success && currentState.status === newStatus) {
     return;
   }
 

--- a/packages/domain-claims/src/agent-claims/update-status.ts
+++ b/packages/domain-claims/src/agent-claims/update-status.ts
@@ -56,7 +56,6 @@ export async function updateClaimStatusCore(
     .select({
       id: claims.id,
       title: claims.title,
-      status: claims.status,
       staffId: claims.staffId,
       userId: claims.userId,
       userEmail: user.email,

--- a/packages/domain-claims/src/claims/lifecycle-command-projection.test.ts
+++ b/packages/domain-claims/src/claims/lifecycle-command-projection.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { CLAIM_STATUS_LIFECYCLE_STATE_MAP } from './lifecycle-state';
+import { resolveClaimLifecycleCommandProjection } from './lifecycle-read-model';
+
+describe('claim lifecycle command projection map', () => {
+  it('keeps every status mapped to a unique lifecycle pair', () => {
+    const pairKeys = Object.values(CLAIM_STATUS_LIFECYCLE_STATE_MAP).map(
+      pair => `${pair.caseLifecycleState}:${pair.recoveryLifecycleState}`
+    );
+
+    expect(new Set(pairKeys).size).toBe(pairKeys.length);
+  });
+
+  it('uses lifecycle pairs and preserves status fallback for legacy rows', () => {
+    expect(
+      resolveClaimLifecycleCommandProjection({
+        caseLifecycleState: 'recovery',
+        recoveryLifecycleState: 'court',
+      })
+    ).toEqual({
+      authority: 'lifecycle',
+      success: true,
+      caseLifecycleState: 'recovery',
+      recoveryLifecycleState: 'court',
+      status: 'court',
+    });
+
+    expect(
+      resolveClaimLifecycleCommandProjection({
+        caseLifecycleState: null,
+        recoveryLifecycleState: null,
+      })
+    ).toEqual({ success: false, error: 'invalid_lifecycle_state' });
+
+    expect(
+      resolveClaimLifecycleCommandProjection({
+        caseLifecycleState: null,
+        recoveryLifecycleState: null,
+        status: 'evaluation',
+      })
+    ).toEqual({
+      authority: 'status_fallback',
+      success: true,
+      caseLifecycleState: 'evaluation',
+      recoveryLifecycleState: 'not_started',
+      status: 'evaluation',
+    });
+
+    expect(
+      resolveClaimLifecycleCommandProjection({
+        caseLifecycleState: 'resolved',
+        recoveryLifecycleState: 'not_started',
+      })
+    ).toEqual({ success: false, error: 'invalid_lifecycle_pair' });
+  });
+});

--- a/packages/domain-claims/src/claims/lifecycle-read-model.test.ts
+++ b/packages/domain-claims/src/claims/lifecycle-read-model.test.ts
@@ -1,7 +1,48 @@
 import { describe, expect, it } from 'vitest';
 
 import { CLAIM_STATUS_LIFECYCLE_STATE_MAP } from './lifecycle-state';
-import { resolveClaimLifecycleReadProjection } from './lifecycle-read-model';
+import {
+  resolveClaimLifecycleCommandProjection,
+  resolveClaimLifecycleReadProjection,
+} from './lifecycle-read-model';
+
+describe('claim lifecycle command projection map', () => {
+  it('keeps every status mapped to a unique lifecycle pair', () => {
+    const pairKeys = Object.values(CLAIM_STATUS_LIFECYCLE_STATE_MAP).map(
+      pair => `${pair.caseLifecycleState}:${pair.recoveryLifecycleState}`
+    );
+
+    expect(new Set(pairKeys).size).toBe(pairKeys.length);
+  });
+
+  it('requires valid lifecycle values and pairs without status fallback', () => {
+    expect(
+      resolveClaimLifecycleCommandProjection({
+        caseLifecycleState: 'recovery',
+        recoveryLifecycleState: 'court',
+      })
+    ).toEqual({
+      success: true,
+      caseLifecycleState: 'recovery',
+      recoveryLifecycleState: 'court',
+      status: 'court',
+    });
+
+    expect(
+      resolveClaimLifecycleCommandProjection({
+        caseLifecycleState: null,
+        recoveryLifecycleState: null,
+      })
+    ).toEqual({ success: false, error: 'invalid_lifecycle_state' });
+
+    expect(
+      resolveClaimLifecycleCommandProjection({
+        caseLifecycleState: 'resolved',
+        recoveryLifecycleState: 'not_started',
+      })
+    ).toEqual({ success: false, error: 'invalid_lifecycle_pair' });
+  });
+});
 
 describe('resolveClaimLifecycleReadProjection', () => {
   it('keeps lifecycle states authoritative when they match compat status', () => {

--- a/packages/domain-claims/src/claims/lifecycle-read-model.test.ts
+++ b/packages/domain-claims/src/claims/lifecycle-read-model.test.ts
@@ -1,48 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { CLAIM_STATUS_LIFECYCLE_STATE_MAP } from './lifecycle-state';
-import {
-  resolveClaimLifecycleCommandProjection,
-  resolveClaimLifecycleReadProjection,
-} from './lifecycle-read-model';
-
-describe('claim lifecycle command projection map', () => {
-  it('keeps every status mapped to a unique lifecycle pair', () => {
-    const pairKeys = Object.values(CLAIM_STATUS_LIFECYCLE_STATE_MAP).map(
-      pair => `${pair.caseLifecycleState}:${pair.recoveryLifecycleState}`
-    );
-
-    expect(new Set(pairKeys).size).toBe(pairKeys.length);
-  });
-
-  it('requires valid lifecycle values and pairs without status fallback', () => {
-    expect(
-      resolveClaimLifecycleCommandProjection({
-        caseLifecycleState: 'recovery',
-        recoveryLifecycleState: 'court',
-      })
-    ).toEqual({
-      success: true,
-      caseLifecycleState: 'recovery',
-      recoveryLifecycleState: 'court',
-      status: 'court',
-    });
-
-    expect(
-      resolveClaimLifecycleCommandProjection({
-        caseLifecycleState: null,
-        recoveryLifecycleState: null,
-      })
-    ).toEqual({ success: false, error: 'invalid_lifecycle_state' });
-
-    expect(
-      resolveClaimLifecycleCommandProjection({
-        caseLifecycleState: 'resolved',
-        recoveryLifecycleState: 'not_started',
-      })
-    ).toEqual({ success: false, error: 'invalid_lifecycle_pair' });
-  });
-});
+import { resolveClaimLifecycleReadProjection } from './lifecycle-read-model';
 
 describe('resolveClaimLifecycleReadProjection', () => {
   it('keeps lifecycle states authoritative when they match compat status', () => {

--- a/packages/domain-claims/src/claims/lifecycle-read-model.ts
+++ b/packages/domain-claims/src/claims/lifecycle-read-model.ts
@@ -16,7 +16,7 @@ type LifecycleAuthority = 'lifecycle' | 'status_fallback';
 type LifecycleConsistency = 'consistent' | 'status_mismatch' | 'invalid_lifecycle_pair';
 
 export type ClaimLifecycleReadInput = {
-  status: string | null | undefined;
+  status?: string | null | undefined;
   caseLifecycleState: string | null | undefined;
   recoveryLifecycleState: string | null | undefined;
 };
@@ -31,6 +31,7 @@ export type ClaimLifecycleReadProjection = {
 
 export type ClaimLifecycleCommandProjection =
   | {
+      authority: LifecycleAuthority;
       success: true;
       caseLifecycleState: CaseLifecycleState;
       recoveryLifecycleState: RecoveryLifecycleState;
@@ -105,24 +106,34 @@ export function resolveClaimLifecycleReadProjection(
 }
 
 export function resolveClaimLifecycleCommandProjection(
-  input: Pick<ClaimLifecycleReadInput, 'caseLifecycleState' | 'recoveryLifecycleState'>
+  input: ClaimLifecycleReadInput
 ): ClaimLifecycleCommandProjection {
   const inputCaseState = input.caseLifecycleState;
   const inputRecoveryState = input.recoveryLifecycleState;
 
-  if (!isCaseLifecycleState(inputCaseState) || !isRecoveryLifecycleState(inputRecoveryState)) {
-    return { success: false, error: 'invalid_lifecycle_state' };
+  if (isCaseLifecycleState(inputCaseState) && isRecoveryLifecycleState(inputRecoveryState)) {
+    const status = STATUS_BY_LIFECYCLE_PAIR[lifecyclePairKey(inputCaseState, inputRecoveryState)];
+    if (!status) {
+      return { success: false, error: 'invalid_lifecycle_pair' };
+    }
+
+    return {
+      authority: 'lifecycle',
+      success: true,
+      caseLifecycleState: inputCaseState,
+      recoveryLifecycleState: inputRecoveryState,
+      status,
+    };
   }
 
-  const status = STATUS_BY_LIFECYCLE_PAIR[lifecyclePairKey(inputCaseState, inputRecoveryState)];
-  if (!status) {
-    return { success: false, error: 'invalid_lifecycle_pair' };
+  if (inputCaseState == null && inputRecoveryState == null && isClaimStatus(input.status)) {
+    return {
+      authority: 'status_fallback',
+      success: true,
+      ...mapClaimStatusToLifecycleStates(input.status),
+      status: input.status,
+    };
   }
 
-  return {
-    success: true,
-    caseLifecycleState: inputCaseState,
-    recoveryLifecycleState: inputRecoveryState,
-    status,
-  };
+  return { success: false, error: 'invalid_lifecycle_state' };
 }

--- a/packages/domain-claims/src/claims/lifecycle-read-model.ts
+++ b/packages/domain-claims/src/claims/lifecycle-read-model.ts
@@ -16,7 +16,7 @@ type LifecycleAuthority = 'lifecycle' | 'status_fallback';
 type LifecycleConsistency = 'consistent' | 'status_mismatch' | 'invalid_lifecycle_pair';
 
 export type ClaimLifecycleReadInput = {
-  status?: string | null | undefined;
+  status?: string | null;
   caseLifecycleState: string | null | undefined;
   recoveryLifecycleState: string | null | undefined;
 };

--- a/packages/domain-claims/src/claims/lifecycle-read-model.ts
+++ b/packages/domain-claims/src/claims/lifecycle-read-model.ts
@@ -29,6 +29,15 @@ export type ClaimLifecycleReadProjection = {
   consistency: LifecycleConsistency;
 };
 
+export type ClaimLifecycleCommandProjection =
+  | {
+      success: true;
+      caseLifecycleState: CaseLifecycleState;
+      recoveryLifecycleState: RecoveryLifecycleState;
+      status: ClaimStatus;
+    }
+  | { success: false; error: 'invalid_lifecycle_state' | 'invalid_lifecycle_pair' };
+
 const CASE_STATE_SET = new Set<string>(CLAIM_CASE_LIFECYCLE_STATES);
 const RECOVERY_STATE_SET = new Set<string>(CLAIM_RECOVERY_LIFECYCLE_STATES);
 
@@ -92,5 +101,28 @@ export function resolveClaimLifecycleReadProjection(
     recoveryLifecycleState,
     status,
     consistency,
+  };
+}
+
+export function resolveClaimLifecycleCommandProjection(
+  input: Pick<ClaimLifecycleReadInput, 'caseLifecycleState' | 'recoveryLifecycleState'>
+): ClaimLifecycleCommandProjection {
+  const inputCaseState = input.caseLifecycleState;
+  const inputRecoveryState = input.recoveryLifecycleState;
+
+  if (!isCaseLifecycleState(inputCaseState) || !isRecoveryLifecycleState(inputRecoveryState)) {
+    return { success: false, error: 'invalid_lifecycle_state' };
+  }
+
+  const status = STATUS_BY_LIFECYCLE_PAIR[lifecyclePairKey(inputCaseState, inputRecoveryState)];
+  if (!status) {
+    return { success: false, error: 'invalid_lifecycle_pair' };
+  }
+
+  return {
+    success: true,
+    caseLifecycleState: inputCaseState,
+    recoveryLifecycleState: inputRecoveryState,
+    status,
   };
 }

--- a/packages/domain-claims/src/claims/lifecycle-state.test.ts
+++ b/packages/domain-claims/src/claims/lifecycle-state.test.ts
@@ -114,9 +114,9 @@ describe('claim lifecycle state mapping', () => {
 
   it('persists mapped states during status-changing transitions', async () => {
     const state: ClaimState = {
-      caseLifecycleState: null,
+      caseLifecycleState: 'evaluation',
       lifecycleVersion: 6,
-      recoveryLifecycleState: null,
+      recoveryLifecycleState: 'not_started',
       status: 'evaluation',
     };
 

--- a/packages/domain-claims/src/claims/lifecycle-test-support.ts
+++ b/packages/domain-claims/src/claims/lifecycle-test-support.ts
@@ -1,7 +1,7 @@
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
 
-type LifecycleFixtureStatus = ClaimStatus | string | null;
+type LifecycleFixtureStatus = string | null;
 
 export function withClaimLifecycle<T extends { status: LifecycleFixtureStatus }>(claim: T): T {
   if (!claim.status) return claim;

--- a/packages/domain-claims/src/claims/lifecycle-test-support.ts
+++ b/packages/domain-claims/src/claims/lifecycle-test-support.ts
@@ -1,0 +1,43 @@
+import type { ClaimStatus } from '@interdomestik/database/constants';
+import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
+
+type LifecycleFixtureStatus = ClaimStatus | string | null;
+
+export function withClaimLifecycle<T extends { status: LifecycleFixtureStatus }>(claim: T): T {
+  if (!claim.status) return claim;
+  if (!isClaimStatusFixture(claim.status)) return claim;
+  return { ...mapClaimStatusToLifecycleStates(claim.status), ...claim };
+}
+
+export function claimFixture(
+  status: ClaimStatus,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return withClaimLifecycle({
+    id: 'claim-1',
+    userId: 'member-1',
+    category: 'vehicle',
+    status,
+    ...overrides,
+  });
+}
+
+export function transitionClaimFixture(
+  status: ClaimStatus | null,
+  lifecycleVersion = 1
+): Record<string, unknown> {
+  return withClaimLifecycle({ id: 'claim-1', lifecycleVersion, status });
+}
+
+function isClaimStatusFixture(value: string): value is ClaimStatus {
+  return [
+    'draft',
+    'submitted',
+    'verification',
+    'evaluation',
+    'negotiation',
+    'court',
+    'resolved',
+    'rejected',
+  ].includes(value);
+}

--- a/packages/domain-claims/src/claims/recovery-evidence-test-support.ts
+++ b/packages/domain-claims/src/claims/recovery-evidence-test-support.ts
@@ -1,15 +1,25 @@
 import type { ClaimStatus } from '@interdomestik/database/constants';
+import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
 
 export function authorizedRecoveryReadRow(params: {
   claimId?: string;
+  caseLifecycleState?: string | null;
   lifecycleVersion: number;
+  recoveryLifecycleState?: string | null;
   status: ClaimStatus | null;
 }) {
+  const lifecycleStates: Partial<ReturnType<typeof mapClaimStatusToLifecycleStates>> = params.status
+    ? mapClaimStatusToLifecycleStates(params.status)
+    : {};
+
   return {
+    caseLifecycleState: params.caseLifecycleState ?? lifecycleStates.caseLifecycleState ?? null,
     claimId: params.claimId ?? 'claim-1',
     legalActionCapPercentage: 25,
     lifecycleVersion: params.lifecycleVersion,
     paymentAuthorizationState: 'authorized',
+    recoveryLifecycleState:
+      params.recoveryLifecycleState ?? lifecycleStates.recoveryLifecycleState ?? null,
     signedAt: new Date('2026-03-12T09:00:00Z'),
     status: params.status,
   };

--- a/packages/domain-claims/src/claims/recovery-invariant-evidence.test.ts
+++ b/packages/domain-claims/src/claims/recovery-invariant-evidence.test.ts
@@ -23,7 +23,9 @@ describe('loadRecoveryInvariantReadRow', () => {
       noFeeReasonCode: 'no_recovery',
     };
     const current = {
+      caseLifecycleState: 'recovery',
       lifecycleVersion: 4,
+      recoveryLifecycleState: 'negotiation',
       status: 'negotiation',
     };
     const tx = {
@@ -49,7 +51,12 @@ describe('loadRecoveryInvariantReadRow', () => {
         tenantId: 'tenant-1',
       })
     ).resolves.toEqual({
-      current: { lifecycleVersion: 4, status: 'negotiation' },
+      current: {
+        caseLifecycleState: 'recovery',
+        lifecycleVersion: 4,
+        recoveryLifecycleState: 'negotiation',
+        status: 'negotiation',
+      },
       evidence: { claimId: 'claim-1', ...agreement, ...noFee },
     });
 

--- a/packages/domain-claims/src/claims/recovery-invariant-evidence.test.ts
+++ b/packages/domain-claims/src/claims/recovery-invariant-evidence.test.ts
@@ -52,6 +52,7 @@ describe('loadRecoveryInvariantReadRow', () => {
       })
     ).resolves.toEqual({
       current: {
+        authority: 'lifecycle',
         caseLifecycleState: 'recovery',
         lifecycleVersion: 4,
         recoveryLifecycleState: 'negotiation',

--- a/packages/domain-claims/src/claims/recovery-invariant-evidence.ts
+++ b/packages/domain-claims/src/claims/recovery-invariant-evidence.ts
@@ -94,6 +94,7 @@ export async function loadRecoveryInvariantReadRow(
       caseLifecycleState: claims.caseLifecycleState,
       lifecycleVersion: claims.lifecycleVersion,
       recoveryLifecycleState: claims.recoveryLifecycleState,
+      status: claims.status,
     })
     .from(claims)
     .where(params.readWhere)

--- a/packages/domain-claims/src/claims/recovery-invariant-evidence.ts
+++ b/packages/domain-claims/src/claims/recovery-invariant-evidence.ts
@@ -1,16 +1,15 @@
 import { claims, sql } from '@interdomestik/database';
-import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { SQL } from 'drizzle-orm';
 import type { TransitionTx } from './transition-side-effects';
 import type { RecoveryInvariantEvidence } from './recovery-invariants';
+import type {
+  InvalidTransitionCurrentState,
+  TransitionCurrentState,
+} from './transition-current-state';
+import { resolveTransitionCurrentState } from './transition-current-state';
 
 export type RecoveryInvariantReadRow = {
-  current:
-    | {
-        lifecycleVersion: number;
-        status: ClaimStatus | null;
-      }
-    | undefined;
+  current: TransitionCurrentState | InvalidTransitionCurrentState | undefined;
   evidence: RecoveryInvariantEvidence | null;
 };
 
@@ -92,8 +91,9 @@ export async function loadRecoveryInvariantReadRow(
   const noFee = await lockNoFeeEvidence(tx, params);
   const [current] = await tx
     .select({
+      caseLifecycleState: claims.caseLifecycleState,
       lifecycleVersion: claims.lifecycleVersion,
-      status: claims.status,
+      recoveryLifecycleState: claims.recoveryLifecycleState,
     })
     .from(claims)
     .where(params.readWhere)
@@ -102,10 +102,7 @@ export async function loadRecoveryInvariantReadRow(
   if (!current) return { current: undefined, evidence: null };
 
   return {
-    current: {
-      lifecycleVersion: current.lifecycleVersion,
-      status: current.status,
-    },
+    current: resolveTransitionCurrentState(current),
     evidence: { claimId: params.claimId, ...agreement, ...noFee },
   };
 }

--- a/packages/domain-claims/src/claims/transition-authorization.compile-fail.ts
+++ b/packages/domain-claims/src/claims/transition-authorization.compile-fail.ts
@@ -5,6 +5,7 @@ import type { SQLWrapper } from 'drizzle-orm';
 import type { AuthorizedTransition } from './transition-guard';
 import { persistAuthorizedTransition } from './transition';
 import type { TransitionTx } from './transition-side-effects';
+import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
 
 declare const tx: TransitionTx;
 declare const from: ClaimStatus;
@@ -20,7 +21,7 @@ export async function rawPersistenceCallMustFail(): Promise<void> {
     // @ts-expect-error T-002d: unbranded object is not proof.
     authorization: { actorId: 'actor-1', from, to },
     claimId: 'claim-1',
-    current: { lifecycleVersion: 1, status: from },
+    current: { lifecycleVersion: 1, status: from, ...mapClaimStatusToLifecycleStates(from) },
     isPublic: true,
     note: null,
     readWhere: scopedReadWhere,
@@ -34,7 +35,7 @@ export async function rawStatusOverloadMustNotExist(): Promise<void> {
     // @ts-expect-error T-002d: bare status cannot replace proof.
     authorization: to,
     claimId: 'claim-1',
-    current: { lifecycleVersion: 1, status: from },
+    current: { lifecycleVersion: 1, status: from, ...mapClaimStatusToLifecycleStates(from) },
     isPublic: true,
     note: null,
     readWhere: scopedReadWhere,
@@ -48,7 +49,7 @@ export async function scopedWhereMustBeProvided(): Promise<void> {
     actor: { id: 'actor-1', role: 'staff' },
     authorization: proof,
     claimId: 'claim-1',
-    current: { lifecycleVersion: 1, status: from },
+    current: { lifecycleVersion: 1, status: from, ...mapClaimStatusToLifecycleStates(from) },
     isPublic: true,
     note: null,
     // @ts-expect-error T-002d: scoped predicate is required.

--- a/packages/domain-claims/src/claims/transition-current-state-cas.ts
+++ b/packages/domain-claims/src/claims/transition-current-state-cas.ts
@@ -1,0 +1,19 @@
+import { and, claims, eq, isNull } from '@interdomestik/database';
+import type { SQLWrapper } from 'drizzle-orm';
+
+import type { TransitionCurrentState } from './transition-current-state';
+
+export function transitionCurrentStateCas(current: TransitionCurrentState): SQLWrapper {
+  if (current.authority === 'status_fallback') {
+    return and(
+      isNull(claims.caseLifecycleState),
+      isNull(claims.recoveryLifecycleState),
+      eq(claims.status, current.status)
+    ) as SQLWrapper;
+  }
+
+  return and(
+    eq(claims.caseLifecycleState, current.caseLifecycleState),
+    eq(claims.recoveryLifecycleState, current.recoveryLifecycleState)
+  ) as SQLWrapper;
+}

--- a/packages/domain-claims/src/claims/transition-current-state.ts
+++ b/packages/domain-claims/src/claims/transition-current-state.ts
@@ -1,0 +1,51 @@
+import type { ClaimStatus } from '@interdomestik/database/constants';
+
+import type { CaseLifecycleState, RecoveryLifecycleState } from './lifecycle-state';
+import { resolveClaimLifecycleCommandProjection } from './lifecycle-read-model';
+
+export type TransitionCurrentReadRow = {
+  lifecycleVersion: number;
+  caseLifecycleState: string | null | undefined;
+  recoveryLifecycleState: string | null | undefined;
+};
+
+export type TransitionCurrentState = {
+  lifecycleVersion: number;
+  status: ClaimStatus;
+  caseLifecycleState: CaseLifecycleState;
+  recoveryLifecycleState: RecoveryLifecycleState;
+};
+
+export type InvalidTransitionCurrentState = {
+  lifecycleVersion: number;
+  status: null;
+  caseLifecycleState: string | null;
+  recoveryLifecycleState: string | null;
+};
+
+export function resolveTransitionCurrentState(
+  row: TransitionCurrentReadRow
+): TransitionCurrentState | InvalidTransitionCurrentState {
+  const projection = resolveClaimLifecycleCommandProjection(row);
+  if (!projection.success) {
+    return {
+      lifecycleVersion: row.lifecycleVersion,
+      status: null,
+      caseLifecycleState: row.caseLifecycleState ?? null,
+      recoveryLifecycleState: row.recoveryLifecycleState ?? null,
+    };
+  }
+
+  return {
+    lifecycleVersion: row.lifecycleVersion,
+    caseLifecycleState: projection.caseLifecycleState,
+    recoveryLifecycleState: projection.recoveryLifecycleState,
+    status: projection.status,
+  };
+}
+
+export function isValidTransitionCurrentState(
+  current: TransitionCurrentState | InvalidTransitionCurrentState
+): current is TransitionCurrentState {
+  return current.status !== null;
+}

--- a/packages/domain-claims/src/claims/transition-current-state.ts
+++ b/packages/domain-claims/src/claims/transition-current-state.ts
@@ -7,9 +7,11 @@ export type TransitionCurrentReadRow = {
   lifecycleVersion: number;
   caseLifecycleState: string | null | undefined;
   recoveryLifecycleState: string | null | undefined;
+  status: string | null | undefined;
 };
 
 export type TransitionCurrentState = {
+  authority?: 'lifecycle' | 'status_fallback';
   lifecycleVersion: number;
   status: ClaimStatus;
   caseLifecycleState: CaseLifecycleState;
@@ -37,6 +39,7 @@ export function resolveTransitionCurrentState(
   }
 
   return {
+    authority: projection.authority,
     lifecycleVersion: row.lifecycleVersion,
     caseLifecycleState: projection.caseLifecycleState,
     recoveryLifecycleState: projection.recoveryLifecycleState,

--- a/packages/domain-claims/src/claims/transition-events-test-support.ts
+++ b/packages/domain-claims/src/claims/transition-events-test-support.ts
@@ -6,17 +6,21 @@ import { transitionClaimStatusInTransaction, type TransitionTx } from './transit
 
 type Row = Record<string, unknown>;
 export type ClaimState = {
+  caseLifecycleState: string;
   events: Row[];
   histories: Row[];
   lifecycleVersion: number;
+  recoveryLifecycleState: string;
   status: ClaimStatus;
 };
 type FailOn = 'history' | 'event';
 
 export const initialState = (): ClaimState => ({
+  caseLifecycleState: 'evaluation',
   events: [],
   histories: [],
   lifecycleVersion: 6,
+  recoveryLifecycleState: 'not_started',
   status: 'evaluation',
 });
 
@@ -52,8 +56,15 @@ class FakeUpdate {
     return this;
   }
   async returning(): Promise<Row[]> {
-    if (typeof this.values.status === 'string')
+    if (typeof this.values.status === 'string') {
       this.staged.status = this.values.status as ClaimStatus;
+    }
+    if (typeof this.values.caseLifecycleState === 'string') {
+      this.staged.caseLifecycleState = this.values.caseLifecycleState;
+    }
+    if (typeof this.values.recoveryLifecycleState === 'string') {
+      this.staged.recoveryLifecycleState = this.values.recoveryLifecycleState;
+    }
     if ('lifecycleVersion' in this.values) this.staged.lifecycleVersion += 1;
     return [{ id: 'claim-1', lifecycleVersion: this.staged.lifecycleVersion }];
   }

--- a/packages/domain-claims/src/claims/transition-events.test.ts
+++ b/packages/domain-claims/src/claims/transition-events.test.ts
@@ -53,7 +53,7 @@ describe('transitionClaimStatusInTransaction event atomicity', () => {
 
     await expect(runTransaction(state, 'event')).rejects.toThrow('event failed');
 
-    expect(state).toEqual({ events: [], histories: [], lifecycleVersion: 6, status: 'evaluation' });
+    expect(state).toEqual(initialState());
   });
 
   it('does not commit status or event when history insert fails', async () => {
@@ -61,6 +61,6 @@ describe('transitionClaimStatusInTransaction event atomicity', () => {
 
     await expect(runTransaction(state, 'history')).rejects.toThrow('history failed');
 
-    expect(state).toEqual({ events: [], histories: [], lifecycleVersion: 6, status: 'evaluation' });
+    expect(state).toEqual(initialState());
   });
 });

--- a/packages/domain-claims/src/claims/transition-lifecycle-cas.test.ts
+++ b/packages/domain-claims/src/claims/transition-lifecycle-cas.test.ts
@@ -1,0 +1,86 @@
+import { inspect } from 'node:util';
+import type { ClaimStatus } from '@interdomestik/database/constants';
+import { describe, expect, it } from 'vitest';
+
+import { ClaimTransitionConflictError, transitionClaimStatusInTransaction } from './transition';
+import { makeTransitionTx } from './transition-test-support';
+
+function params(toStatus: ClaimStatus = 'negotiation') {
+  return {
+    actor: { id: 'staff-1', role: 'staff' },
+    claimId: 'claim-1',
+    tenantId: 'tenant-1',
+    toStatus,
+  };
+}
+
+describe('transition lifecycle CAS deprecation readiness', () => {
+  it('authorizes from lifecycle state when legacy compat status is stale', async () => {
+    const { calls, tx } = makeTransitionTx({
+      current: {
+        id: 'claim-1',
+        lifecycleVersion: 6,
+        status: 'draft',
+        caseLifecycleState: 'evaluation',
+        recoveryLifecycleState: 'not_started',
+      },
+      updated: [{ id: 'claim-1', lifecycleVersion: 7 }],
+    });
+
+    const result = await transitionClaimStatusInTransaction(tx, params());
+
+    expect(result).toEqual({
+      success: true,
+      fromStatus: 'evaluation',
+      lifecycleVersion: 7,
+      status: 'negotiation',
+    });
+    expect(calls.historyValues).toEqual(
+      expect.objectContaining({ fromStatus: 'evaluation', toStatus: 'negotiation' })
+    );
+    const updateWhere = inspect(calls.whereConditions.at(-1), { depth: 20 });
+    expect(updateWhere).toContain('case_lifecycle_state');
+    expect(updateWhere).toContain('recovery_lifecycle_state');
+    expect(updateWhere).toContain('lifecycle_version');
+    expect(updateWhere).not.toContain('claims.status');
+  });
+
+  it('rejects from lifecycle state even when legacy compat status would permit', async () => {
+    const { calls, tx } = makeTransitionTx({
+      current: {
+        id: 'claim-1',
+        lifecycleVersion: 6,
+        status: 'evaluation',
+        caseLifecycleState: 'draft',
+        recoveryLifecycleState: 'not_started',
+      },
+      updated: [{ id: 'claim-1', lifecycleVersion: 7 }],
+    });
+
+    const result = await transitionClaimStatusInTransaction(tx, params('resolved'));
+
+    expect(result).toEqual({ success: false, error: 'transition_rejected' });
+    expect(calls.updateValues).toBeUndefined();
+    expect(calls.historyValues).toBeUndefined();
+    expect(calls.eventValues).toBeUndefined();
+  });
+
+  it('fails stale lifecycle-pair CAS before history or events are recorded', async () => {
+    const { calls, tx } = makeTransitionTx({
+      current: {
+        id: 'claim-1',
+        lifecycleVersion: 6,
+        status: 'evaluation',
+        caseLifecycleState: 'evaluation',
+        recoveryLifecycleState: 'not_started',
+      },
+      updated: [],
+    });
+
+    await expect(transitionClaimStatusInTransaction(tx, params())).rejects.toThrow(
+      ClaimTransitionConflictError
+    );
+    expect(calls.historyValues).toBeUndefined();
+    expect(calls.eventValues).toBeUndefined();
+  });
+});

--- a/packages/domain-claims/src/claims/transition-lifecycle-cas.test.ts
+++ b/packages/domain-claims/src/claims/transition-lifecycle-cas.test.ts
@@ -32,6 +32,14 @@ function expectLifecycleCas(whereConditions: unknown[]) {
   expect(updateWhere).not.toContain('claims.status');
 }
 
+function expectLegacyStatusFallbackCas(whereConditions: unknown[]) {
+  const updateWhere = inspect(whereConditions.at(-1), { depth: 20 });
+  for (const column of ['case_lifecycle_state', 'recovery_lifecycle_state', 'lifecycle_version']) {
+    expect(updateWhere).toContain(column);
+  }
+  expect(updateWhere).toContain("name: 'status'");
+}
+
 describe('transition lifecycle CAS deprecation readiness', () => {
   it('authorizes from lifecycle state when legacy compat status is stale', async () => {
     const { calls, tx } = makeTransitionTx({
@@ -51,6 +59,29 @@ describe('transition lifecycle CAS deprecation readiness', () => {
       expect.objectContaining({ fromStatus: 'evaluation', toStatus: 'negotiation' })
     );
     expectLifecycleCas(calls.whereConditions);
+  });
+
+  it('transitions legacy rows with null lifecycle fields from compat status fallback', async () => {
+    const { calls, tx } = makeTransitionTx({
+      current: {
+        id: 'claim-1',
+        lifecycleVersion: 6,
+        status: 'evaluation',
+        caseLifecycleState: null,
+        recoveryLifecycleState: null,
+      },
+      updated: [{ id: 'claim-1', lifecycleVersion: 7 }],
+    });
+
+    const result = await transitionClaimStatusInTransaction(tx, params());
+
+    expect(result).toEqual({
+      success: true,
+      fromStatus: 'evaluation',
+      lifecycleVersion: 7,
+      status: 'negotiation',
+    });
+    expectLegacyStatusFallbackCas(calls.whereConditions);
   });
 
   it('rejects from lifecycle state even when legacy compat status would permit', async () => {

--- a/packages/domain-claims/src/claims/transition-lifecycle-cas.test.ts
+++ b/packages/domain-claims/src/claims/transition-lifecycle-cas.test.ts
@@ -65,6 +65,37 @@ describe('transition lifecycle CAS deprecation readiness', () => {
     expect(calls.eventValues).toBeUndefined();
   });
 
+  it('repairs stale legacy status on same-status transitions under lifecycle CAS', async () => {
+    const { calls, tx } = makeTransitionTx({
+      current: {
+        id: 'claim-1',
+        lifecycleVersion: 6,
+        status: 'draft',
+        caseLifecycleState: 'evaluation',
+        recoveryLifecycleState: 'not_started',
+      },
+      updated: [{ id: 'claim-1', lifecycleVersion: 6 }],
+    });
+
+    const result = await transitionClaimStatusInTransaction(tx, params('evaluation'));
+
+    expect(result).toEqual({
+      success: true,
+      fromStatus: 'evaluation',
+      lifecycleVersion: 6,
+      status: 'evaluation',
+    });
+    expect(calls.updateValues).toEqual({
+      status: 'evaluation',
+      updatedAt: expect.any(Date),
+    });
+    const updateWhere = inspect(calls.whereConditions.at(-1), { depth: 20 });
+    expect(updateWhere).toContain('case_lifecycle_state');
+    expect(updateWhere).toContain('recovery_lifecycle_state');
+    expect(updateWhere).toContain('lifecycle_version');
+    expect(updateWhere).not.toContain('claims.status');
+  });
+
   it('fails stale lifecycle-pair CAS before history or events are recorded', async () => {
     const { calls, tx } = makeTransitionTx({
       current: {

--- a/packages/domain-claims/src/claims/transition-lifecycle-cas.test.ts
+++ b/packages/domain-claims/src/claims/transition-lifecycle-cas.test.ts
@@ -14,16 +14,28 @@ function params(toStatus: ClaimStatus = 'negotiation') {
   };
 }
 
+function staleEvaluationClaim() {
+  return {
+    id: 'claim-1',
+    lifecycleVersion: 6,
+    status: 'draft' as const,
+    caseLifecycleState: 'evaluation',
+    recoveryLifecycleState: 'not_started',
+  };
+}
+
+function expectLifecycleCas(whereConditions: unknown[]) {
+  const updateWhere = inspect(whereConditions.at(-1), { depth: 20 });
+  for (const column of ['case_lifecycle_state', 'recovery_lifecycle_state', 'lifecycle_version']) {
+    expect(updateWhere).toContain(column);
+  }
+  expect(updateWhere).not.toContain('claims.status');
+}
+
 describe('transition lifecycle CAS deprecation readiness', () => {
   it('authorizes from lifecycle state when legacy compat status is stale', async () => {
     const { calls, tx } = makeTransitionTx({
-      current: {
-        id: 'claim-1',
-        lifecycleVersion: 6,
-        status: 'draft',
-        caseLifecycleState: 'evaluation',
-        recoveryLifecycleState: 'not_started',
-      },
+      current: staleEvaluationClaim(),
       updated: [{ id: 'claim-1', lifecycleVersion: 7 }],
     });
 
@@ -38,11 +50,7 @@ describe('transition lifecycle CAS deprecation readiness', () => {
     expect(calls.historyValues).toEqual(
       expect.objectContaining({ fromStatus: 'evaluation', toStatus: 'negotiation' })
     );
-    const updateWhere = inspect(calls.whereConditions.at(-1), { depth: 20 });
-    expect(updateWhere).toContain('case_lifecycle_state');
-    expect(updateWhere).toContain('recovery_lifecycle_state');
-    expect(updateWhere).toContain('lifecycle_version');
-    expect(updateWhere).not.toContain('claims.status');
+    expectLifecycleCas(calls.whereConditions);
   });
 
   it('rejects from lifecycle state even when legacy compat status would permit', async () => {
@@ -67,13 +75,7 @@ describe('transition lifecycle CAS deprecation readiness', () => {
 
   it('repairs stale legacy status on same-status transitions under lifecycle CAS', async () => {
     const { calls, tx } = makeTransitionTx({
-      current: {
-        id: 'claim-1',
-        lifecycleVersion: 6,
-        status: 'draft',
-        caseLifecycleState: 'evaluation',
-        recoveryLifecycleState: 'not_started',
-      },
+      current: staleEvaluationClaim(),
       updated: [{ id: 'claim-1', lifecycleVersion: 6 }],
     });
 
@@ -89,11 +91,7 @@ describe('transition lifecycle CAS deprecation readiness', () => {
       status: 'evaluation',
       updatedAt: expect.any(Date),
     });
-    const updateWhere = inspect(calls.whereConditions.at(-1), { depth: 20 });
-    expect(updateWhere).toContain('case_lifecycle_state');
-    expect(updateWhere).toContain('recovery_lifecycle_state');
-    expect(updateWhere).toContain('lifecycle_version');
-    expect(updateWhere).not.toContain('claims.status');
+    expectLifecycleCas(calls.whereConditions);
   });
 
   it('fails stale lifecycle-pair CAS before history or events are recorded', async () => {

--- a/packages/domain-claims/src/claims/transition-read-context.ts
+++ b/packages/domain-claims/src/claims/transition-read-context.ts
@@ -3,16 +3,16 @@ import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { SQL, SQLWrapper } from 'drizzle-orm';
 import { loadRecoveryInvariantReadRow } from './recovery-invariant-evidence';
 import { evaluateRecoveryInvariants, needsRecoveryInvariantEvidence } from './recovery-invariants';
+import type {
+  InvalidTransitionCurrentState,
+  TransitionCurrentState,
+} from './transition-current-state';
+import { resolveTransitionCurrentState } from './transition-current-state';
 import type { ClaimTransitionContext } from './transition-guard';
 import type { TransitionTx } from './transition-side-effects';
 
 export type TransitionReadContext = {
-  current:
-    | {
-        lifecycleVersion: number;
-        status: ClaimStatus | null;
-      }
-    | undefined;
+  current: TransitionCurrentState | InvalidTransitionCurrentState | undefined;
   guardContext: ClaimTransitionContext;
   readWhere: SQLWrapper;
 };
@@ -56,15 +56,16 @@ export async function loadTransitionReadContext(
 
   const [current] = await tx
     .select({
+      caseLifecycleState: claims.caseLifecycleState,
       lifecycleVersion: claims.lifecycleVersion,
-      status: claims.status,
+      recoveryLifecycleState: claims.recoveryLifecycleState,
     })
     .from(claims)
     .where(readWhere)
     .limit(1);
 
   return {
-    current,
+    current: current ? resolveTransitionCurrentState(current) : undefined,
     guardContext: {
       paymentAuthorizationState: null,
       recoveryInvariantRejection: null,

--- a/packages/domain-claims/src/claims/transition-read-context.ts
+++ b/packages/domain-claims/src/claims/transition-read-context.ts
@@ -59,6 +59,7 @@ export async function loadTransitionReadContext(
       caseLifecycleState: claims.caseLifecycleState,
       lifecycleVersion: claims.lifecycleVersion,
       recoveryLifecycleState: claims.recoveryLifecycleState,
+      status: claims.status,
     })
     .from(claims)
     .where(readWhere)

--- a/packages/domain-claims/src/claims/transition-rejection.test.ts
+++ b/packages/domain-claims/src/claims/transition-rejection.test.ts
@@ -1,4 +1,3 @@
-import type { ClaimStatus } from '@interdomestik/database/constants';
 import { sql } from '@interdomestik/database';
 import { describe, expect, it } from 'vitest';
 
@@ -10,6 +9,7 @@ import {
 } from './transition';
 import { authorizedRecoveryReadRow } from './recovery-evidence-test-support';
 import { canTransition } from './transition-guard';
+import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
 
 type FakeTxCalls = {
   historyValues?: unknown;
@@ -21,8 +21,8 @@ const selectFromStep = { leftJoin: () => selectFromStep, where: () => selectWher
 const selectWhereStep = { limit: limitCurrentClaim };
 const updateWhereStep = { returning: returnUpdatedClaim };
 
-function limitCurrentClaim(): Array<{ id: string; lifecycleVersion: number; status: ClaimStatus }> {
-  return [{ id: 'claim-1', lifecycleVersion: 1, status: 'draft' }];
+function limitCurrentClaim() {
+  return [authorizedRecoveryReadRow({ lifecycleVersion: 1, status: 'draft' })];
 }
 
 function returnUpdatedClaim(): Array<{ id: string; lifecycleVersion: number }> {
@@ -110,6 +110,10 @@ function mintProof(from: 'evaluation', to: 'negotiation') {
   return decision.authorization;
 }
 
+function current(status: 'draft' | 'evaluation') {
+  return { lifecycleVersion: 3, status, ...mapClaimStatusToLifecycleStates(status) };
+}
+
 describe('persistAuthorizedTransition runtime re-check (T-002d)', () => {
   it('rejects a proof minted for a different current status before any write', async () => {
     await expect(
@@ -117,7 +121,7 @@ describe('persistAuthorizedTransition runtime re-check (T-002d)', () => {
         actor,
         authorization: mintProof('evaluation', 'negotiation'),
         claimId: 'claim-1',
-        current: { lifecycleVersion: 3, status: 'draft' },
+        current: current('draft'),
         isPublic: true,
         note: null,
         readWhere: sql`tenant_scoped_claim = true`,
@@ -132,7 +136,7 @@ describe('persistAuthorizedTransition runtime re-check (T-002d)', () => {
         actor: { id: 'someone-else', role: 'staff' },
         authorization: mintProof('evaluation', 'negotiation'),
         claimId: 'claim-1',
-        current: { lifecycleVersion: 3, status: 'evaluation' },
+        current: current('evaluation'),
         isPublic: true,
         note: null,
         readWhere: sql`tenant_scoped_claim = true`,

--- a/packages/domain-claims/src/claims/transition-side-effects.ts
+++ b/packages/domain-claims/src/claims/transition-side-effects.ts
@@ -2,6 +2,7 @@ import { claimStageHistory, db } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
 import type { SQLWrapper } from 'drizzle-orm';
 import type { AuthorizedTransition, ClaimTransitionActor } from './transition-guard';
+import type { TransitionCurrentState } from './transition-current-state';
 import { recordCaseCreatedEvent } from './case-created-event';
 import { recordTransitionDomainEvents } from './transition-domain-events';
 import type { CreateClaimValues } from '../validators/claims';
@@ -67,7 +68,7 @@ export type PersistAuthorizedTransitionArgs = {
   authorization: AuthorizedTransition;
   claimId: string;
   correlationId?: string;
-  current: { lifecycleVersion: number; status: ClaimStatus };
+  current: TransitionCurrentState;
   isPublic: boolean;
   note: string | null;
   readWhere: SQLWrapper;

--- a/packages/domain-claims/src/claims/transition-test-support.ts
+++ b/packages/domain-claims/src/claims/transition-test-support.ts
@@ -2,12 +2,20 @@ import { inspect } from 'node:util';
 
 import { domainEvents } from '@interdomestik/database';
 import type { ClaimStatus } from '@interdomestik/database/constants';
+import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
 import type { RecoveryInvariantEvidence } from './recovery-invariants';
 import type { TransitionTx } from './transition';
 
 type UpdatedRows = Array<{ id: string; lifecycleVersion: number }>;
+type CurrentFixture = {
+  id: string;
+  lifecycleVersion: number;
+  status?: ClaimStatus | null;
+  caseLifecycleState?: string | null;
+  recoveryLifecycleState?: string | null;
+};
 type TransitionTxOptions = {
-  current?: { id: string; lifecycleVersion: number; status: ClaimStatus | null };
+  current?: CurrentFixture;
   evidence?: RecoveryInvariantEvidence | null;
   updated?: UpdatedRows | (() => UpdatedRows);
 };
@@ -29,6 +37,14 @@ export const authorizedRecoveryEvidence: RecoveryInvariantEvidence = {
   signedAt: new Date('2026-03-12T09:00:00Z'),
 };
 
+function withLifecycleStateDefaults(current: CurrentFixture): CurrentFixture {
+  if (current.caseLifecycleState !== undefined || current.recoveryLifecycleState !== undefined) {
+    return current;
+  }
+  if (!current.status) return current;
+  return { ...current, ...mapClaimStatusToLifecycleStates(current.status) };
+}
+
 class FakeSelect {
   constructor(
     private readonly options: TransitionTxOptions,
@@ -47,7 +63,7 @@ class FakeSelect {
   async limit(): Promise<Record<string, unknown>[]> {
     if (!this.options.current) return [];
     this.calls.operations.push('select:current');
-    return [this.options.current];
+    return [withLifecycleStateDefaults(this.options.current)];
   }
 }
 

--- a/packages/domain-claims/src/claims/transition.test.ts
+++ b/packages/domain-claims/src/claims/transition.test.ts
@@ -43,7 +43,9 @@ describe('transitionClaimStatusInTransaction', () => {
     );
     const updateWhere = inspect(calls.whereConditions.at(-1), { depth: 20 });
     expect(updateWhere).toContain('lifecycle_version');
-    expect(updateWhere).toContain('status');
+    expect(updateWhere).toContain('case_lifecycle_state');
+    expect(updateWhere).toContain('recovery_lifecycle_state');
+    expect(updateWhere).not.toContain('claims.status');
     expect(calls.historyValues).toEqual(
       expect.objectContaining({
         changedById: 'staff-1',
@@ -123,7 +125,9 @@ describe('transitionClaimStatusInTransaction', () => {
     expect(calls.updateValues).toEqual({ updatedAt: expect.any(Date) });
     const updateWhere = inspect(calls.whereConditions.at(-1), { depth: 20 });
     expect(updateWhere).toContain('lifecycle_version');
-    expect(updateWhere).toContain('status');
+    expect(updateWhere).toContain('case_lifecycle_state');
+    expect(updateWhere).toContain('recovery_lifecycle_state');
+    expect(updateWhere).not.toContain('claims.status');
     expect(calls.historyValues).toEqual(
       expect.objectContaining({
         fromStatus: 'evaluation',

--- a/packages/domain-claims/src/claims/transition.test.ts
+++ b/packages/domain-claims/src/claims/transition.test.ts
@@ -122,7 +122,10 @@ describe('transitionClaimStatusInTransaction', () => {
       lifecycleVersion: 6,
       status: 'evaluation',
     });
-    expect(calls.updateValues).toEqual({ updatedAt: expect.any(Date) });
+    expect(calls.updateValues).toEqual({
+      status: 'evaluation',
+      updatedAt: expect.any(Date),
+    });
     const updateWhere = inspect(calls.whereConditions.at(-1), { depth: 20 });
     expect(updateWhere).toContain('lifecycle_version');
     expect(updateWhere).toContain('case_lifecycle_state');

--- a/packages/domain-claims/src/claims/transition.test.ts
+++ b/packages/domain-claims/src/claims/transition.test.ts
@@ -122,10 +122,8 @@ describe('transitionClaimStatusInTransaction', () => {
       lifecycleVersion: 6,
       status: 'evaluation',
     });
-    expect(calls.updateValues).toEqual({
-      status: 'evaluation',
-      updatedAt: expect.any(Date),
-    });
+    expect(calls.updateValues?.status).toBe('evaluation');
+    expect(calls.updateValues?.updatedAt).toBeInstanceOf(Date);
     const updateWhere = inspect(calls.whereConditions.at(-1), { depth: 20 });
     expect(updateWhere).toContain('lifecycle_version');
     expect(updateWhere).toContain('case_lifecycle_state');

--- a/packages/domain-claims/src/claims/transition.ts
+++ b/packages/domain-claims/src/claims/transition.ts
@@ -2,6 +2,7 @@ import { and, claims, db, eq, sql } from '@interdomestik/database';
 import { canTransition } from './transition-guard';
 import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
 import { loadTransitionReadContext } from './transition-read-context';
+import { transitionCurrentStateCas } from './transition-current-state-cas';
 import { isValidTransitionCurrentState } from './transition-current-state';
 import {
   ClaimTransitionAuthorizationError,
@@ -50,7 +51,6 @@ export async function persistAuthorizedTransition(
           statusUpdatedAt: now,
           updatedAt: now,
         };
-
   // db-access-guard: tenant-scoped -- reason: tenant scope plus lifecycle CAS are in the where clause.
   const updated = await tx
     .update(claims)
@@ -58,8 +58,7 @@ export async function persistAuthorizedTransition(
     .where(
       and(
         readWhere,
-        eq(claims.caseLifecycleState, current.caseLifecycleState),
-        eq(claims.recoveryLifecycleState, current.recoveryLifecycleState),
+        transitionCurrentStateCas(current),
         eq(claims.lifecycleVersion, current.lifecycleVersion)
       )
     )

--- a/packages/domain-claims/src/claims/transition.ts
+++ b/packages/domain-claims/src/claims/transition.ts
@@ -42,7 +42,7 @@ export async function persistAuthorizedTransition(
   const now = new Date();
   const updateData =
     current.status === toStatus
-      ? { updatedAt: now }
+      ? { status: toStatus, updatedAt: now }
       : {
           ...mapClaimStatusToLifecycleStates(toStatus),
           lifecycleVersion: sql`${claims.lifecycleVersion} + 1`,

--- a/packages/domain-claims/src/claims/transition.ts
+++ b/packages/domain-claims/src/claims/transition.ts
@@ -1,7 +1,8 @@
 import { and, claims, db, eq, sql } from '@interdomestik/database';
-import { canTransition, isClaimStatus } from './transition-guard';
+import { canTransition } from './transition-guard';
 import { mapClaimStatusToLifecycleStates } from './lifecycle-state';
 import { loadTransitionReadContext } from './transition-read-context';
+import { isValidTransitionCurrentState } from './transition-current-state';
 import {
   ClaimTransitionAuthorizationError,
   ClaimTransitionConflictError,
@@ -57,7 +58,8 @@ export async function persistAuthorizedTransition(
     .where(
       and(
         readWhere,
-        eq(claims.status, current.status),
+        eq(claims.caseLifecycleState, current.caseLifecycleState),
+        eq(claims.recoveryLifecycleState, current.recoveryLifecycleState),
         eq(claims.lifecycleVersion, current.lifecycleVersion)
       )
     )
@@ -105,7 +107,9 @@ export async function transitionClaimStatusInTransaction(
   });
 
   if (!current) return { success: false, error: 'claim_not_found' };
-  if (!isClaimStatus(current.status)) return { success: false, error: 'invalid_current_status' };
+  if (!isValidTransitionCurrentState(current)) {
+    return { success: false, error: 'invalid_current_status' };
+  }
 
   const decision = canTransition({
     actor,
@@ -126,7 +130,7 @@ export async function transitionClaimStatusInTransaction(
     authorization: decision.authorization,
     claimId,
     correlationId,
-    current: { lifecycleVersion: current.lifecycleVersion, status: current.status },
+    current,
     isPublic,
     note: note ?? null,
     readWhere,

--- a/packages/domain-claims/src/staff-claims/current-claim-record.ts
+++ b/packages/domain-claims/src/staff-claims/current-claim-record.ts
@@ -6,6 +6,7 @@ import type { ClaimStatus } from './types';
 
 export type CurrentClaimRecord = {
   category: string;
+  legacyStatus: ClaimStatus | null;
   staffId: string | null;
   status: ClaimStatus;
   title: string;
@@ -26,6 +27,7 @@ export async function loadStaffCurrentClaimRecord(
       caseLifecycleState: claims.caseLifecycleState,
       category: claims.category,
       recoveryLifecycleState: claims.recoveryLifecycleState,
+      legacyStatus: claims.status,
       title: claims.title,
       userId: claims.userId,
       staffId: claims.staffId,

--- a/packages/domain-claims/src/staff-claims/current-claim-record.ts
+++ b/packages/domain-claims/src/staff-claims/current-claim-record.ts
@@ -38,7 +38,10 @@ export async function loadStaffCurrentClaimRecord(
 
   if (!currentClaimRow) return { status: 'not_found' };
 
-  const currentState = resolveClaimLifecycleCommandProjection(currentClaimRow);
+  const currentState = resolveClaimLifecycleCommandProjection({
+    ...currentClaimRow,
+    status: currentClaimRow.legacyStatus,
+  });
   if (!currentState.success) return { status: 'invalid_current_status' };
 
   return {

--- a/packages/domain-claims/src/staff-claims/current-claim-record.ts
+++ b/packages/domain-claims/src/staff-claims/current-claim-record.ts
@@ -1,0 +1,46 @@
+import { claims, db } from '@interdomestik/database';
+import type { SQL } from 'drizzle-orm';
+
+import { resolveClaimLifecycleCommandProjection } from '../claims/lifecycle-read-model';
+import type { ClaimStatus } from './types';
+
+export type CurrentClaimRecord = {
+  category: string;
+  staffId: string | null;
+  status: ClaimStatus;
+  title: string;
+  userId: string;
+};
+
+export type StaffCurrentClaimResult =
+  | { status: 'found'; currentClaim: CurrentClaimRecord }
+  | { status: 'not_found' }
+  | { status: 'invalid_current_status' };
+
+export async function loadStaffCurrentClaimRecord(
+  staffScopeWhere: SQL
+): Promise<StaffCurrentClaimResult> {
+  // db-access-guard: tenant-scoped -- reason: caller supplies scoped staff claim predicate.
+  const [currentClaimRow] = await db
+    .select({
+      caseLifecycleState: claims.caseLifecycleState,
+      category: claims.category,
+      recoveryLifecycleState: claims.recoveryLifecycleState,
+      title: claims.title,
+      userId: claims.userId,
+      staffId: claims.staffId,
+    })
+    .from(claims)
+    .where(staffScopeWhere)
+    .limit(1);
+
+  if (!currentClaimRow) return { status: 'not_found' };
+
+  const currentState = resolveClaimLifecycleCommandProjection(currentClaimRow);
+  if (!currentState.success) return { status: 'invalid_current_status' };
+
+  return {
+    status: 'found',
+    currentClaim: { ...currentClaimRow, status: currentState.status },
+  };
+}

--- a/packages/domain-claims/src/staff-claims/update-status.test.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.test.ts
@@ -1,6 +1,11 @@
 import { inspect } from 'node:util';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClaimsSession } from '../claims/types';
+import {
+  claimFixture,
+  transitionClaimFixture,
+  withClaimLifecycle,
+} from '../claims/lifecycle-test-support';
 import type {
   PaymentAuthorizationState,
   RecoveryDeclineReasonCode,
@@ -122,11 +127,13 @@ const mocks = vi.hoisted(() => {
       id: 'claims.id',
       tenantId: 'claims.tenant_id',
       branchId: 'claims.branch_id',
+      caseLifecycleState: 'claims.case_lifecycle_state',
       category: 'claims.category',
       staffId: 'claims.staff_id',
       assignedAt: 'claims.assigned_at',
       assignedById: 'claims.assigned_by_id',
       lifecycleVersion: 'claims.lifecycle_version',
+      recoveryLifecycleState: 'claims.recovery_lifecycle_state',
       status: 'claims.status',
       updatedAt: 'claims.updated_at',
       userId: 'claims.user_id',
@@ -290,16 +297,18 @@ function mockRecoverySelects(options?: {
     mocks.db.select.mockReturnValueOnce(mocks.serviceUsageCountSelectChain);
   }
   mocks.claimSelectChain.limit.mockResolvedValue(
-    options?.claim ?? [
-      {
-        id: 'claim-1',
-        status: 'evaluation',
-        userId: 'member-1',
-        category: 'vehicle',
-        title: 'Vehicle claim',
-        staffId: null,
-      },
-    ]
+    (
+      options?.claim ?? [
+        {
+          id: 'claim-1',
+          status: 'evaluation',
+          userId: 'member-1',
+          category: 'vehicle',
+          title: 'Vehicle claim',
+          staffId: null,
+        },
+      ]
+    ).map(withClaimLifecycle)
   );
   mocks.agreementSelectChain.limit.mockResolvedValue(
     options?.agreement ?? [READY_ACCEPTED_RECOVERY_RECORD]
@@ -356,9 +365,7 @@ describe('staff updateClaimStatusCore', () => {
     mocks.txSelectChain.from.mockReturnValue(mocks.txSelectChain);
     mocks.txSelectChain.leftJoin.mockReturnValue(mocks.txSelectChain);
     mocks.txSelectChain.where.mockReturnValue(mocks.txSelectChain);
-    mocks.txSelectChain.limit.mockResolvedValue([
-      { id: 'claim-1', lifecycleVersion: 1, status: 'evaluation' },
-    ]);
+    mocks.txSelectChain.limit.mockResolvedValue([transitionClaimFixture('evaluation')]);
     mocks.txInsertReturning.mockResolvedValue([{ id: 'usage-claim-1' }]);
     mocks.txUpdateReturning.mockResolvedValue([{ id: 'claim-1', lifecycleVersion: 2 }]);
     mocks.projectClaimStatusAuditProjection.mockResolvedValue(undefined);
@@ -478,14 +485,7 @@ describe('staff updateClaimStatusCore', () => {
   it('auto-assigns the acting staff member when an unassigned claim is triaged', async () => {
     mocks.db.select.mockReturnValueOnce(mocks.claimSelectChain);
     mocks.claimSelectChain.limit.mockResolvedValue([
-      {
-        id: 'claim-1',
-        status: 'submitted',
-        userId: 'member-1',
-        category: 'vehicle',
-        title: 'Vehicle claim',
-        staffId: null,
-      },
+      claimFixture('submitted', { title: 'Vehicle claim', staffId: null }),
     ]);
 
     const result = await updateClaimStatusCore({
@@ -509,7 +509,9 @@ describe('staff updateClaimStatusCore', () => {
     const transitionWhere = inspect(transitionWhereArg, { depth: 20 });
     expect(transitionWhere).toContain('claims.branch_id');
     expect(transitionWhere).toContain('claims.lifecycle_version');
-    expect(transitionWhere).toContain('claims.status');
+    expect(transitionWhere).toContain('claims.case_lifecycle_state');
+    expect(transitionWhere).toContain('claims.recovery_lifecycle_state');
+    expect(transitionWhere).not.toContain('claims.status');
     expect(mocks.txUpdateSet).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
@@ -543,18 +545,9 @@ describe('staff updateClaimStatusCore', () => {
     const notifyStatusChanged = vi.fn().mockResolvedValue({ success: true });
     mocks.db.select.mockReturnValueOnce(mocks.claimSelectChain);
     mocks.claimSelectChain.limit.mockResolvedValue([
-      {
-        id: 'claim-1',
-        status: 'submitted',
-        userId: 'member-1',
-        category: 'vehicle',
-        title: 'Vehicle claim',
-        staffId: 'staff-1',
-      },
+      claimFixture('submitted', { title: 'Vehicle claim', staffId: 'staff-1' }),
     ]);
-    mocks.txSelectChain.limit.mockResolvedValueOnce([
-      { id: 'claim-1', lifecycleVersion: 1, status: 'submitted' },
-    ]);
+    mocks.txSelectChain.limit.mockResolvedValueOnce([transitionClaimFixture('submitted')]);
 
     const result = await updateClaimStatusCore(
       {
@@ -606,14 +599,7 @@ describe('staff updateClaimStatusCore', () => {
   it('rejects invalid guarded transitions before status, history, or assignment writes', async () => {
     mocks.db.select.mockReturnValueOnce(mocks.claimSelectChain);
     mocks.claimSelectChain.limit.mockResolvedValue([
-      {
-        id: 'claim-1',
-        status: 'submitted',
-        userId: 'member-1',
-        category: 'vehicle',
-        title: 'Vehicle claim',
-        staffId: null,
-      },
+      claimFixture('submitted', { title: 'Vehicle claim', staffId: null }),
     ]);
     mocks.txSelectChain.limit.mockResolvedValueOnce([
       { id: 'claim-1', lifecycleVersion: 1, status: null },
@@ -753,9 +739,7 @@ describe('staff updateClaimStatusCore', () => {
 
   it('requires an explicit reason when staff reject a recovery matter', async () => {
     mocks.db.select.mockReturnValueOnce(mocks.claimSelectChain);
-    mocks.claimSelectChain.limit.mockResolvedValue([
-      { id: 'claim-1', status: 'negotiation', userId: 'member-1', category: 'vehicle' },
-    ]);
+    mocks.claimSelectChain.limit.mockResolvedValue([claimFixture('negotiation')]);
 
     const result = await updateClaimStatusCore({
       claimId: 'claim-1',
@@ -775,11 +759,9 @@ describe('staff updateClaimStatusCore', () => {
     const requestHeaders = new Headers({ 'user-agent': 'Vitest' });
 
     mocks.db.select.mockReturnValueOnce(mocks.claimSelectChain);
-    mocks.claimSelectChain.limit.mockResolvedValue([
-      { id: 'claim-1', status: 'negotiation', userId: 'member-1', category: 'vehicle' },
-    ]);
+    mocks.claimSelectChain.limit.mockResolvedValue([claimFixture('negotiation')]);
     mocks.txSelectChain.limit
-      .mockResolvedValueOnce([{ id: 'claim-1', lifecycleVersion: 1, status: 'negotiation' }])
+      .mockResolvedValueOnce([transitionClaimFixture('negotiation')])
       .mockResolvedValueOnce([]);
 
     const result = await updateClaimStatusCore(

--- a/packages/domain-claims/src/staff-claims/update-status.test.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.test.ts
@@ -541,6 +541,24 @@ describe('staff updateClaimStatusCore', () => {
     );
   });
 
+  it('routes stale staff same-status requests through transition compat repair', async () => {
+    const staleClaim = claimFixture('evaluation', { title: 'Vehicle claim', staffId: 'staff-1' });
+    staleClaim.status = 'submitted';
+    mocks.db.select.mockReturnValueOnce(mocks.claimSelectChain);
+    mocks.claimSelectChain.limit.mockResolvedValue([staleClaim]);
+    mocks.txSelectChain.limit.mockResolvedValueOnce([transitionClaimFixture('evaluation', 6)]);
+    const result = await updateClaimStatusCore({
+      claimId: 'claim-1',
+      newStatus: 'evaluation',
+      session: createSession({ userId: 'staff-1', branchId: 'branch-1' }),
+    });
+
+    expect(result).toEqual({ success: true, error: undefined });
+    expect(mocks.txUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'evaluation', updatedAt: expect.any(Date) })
+    );
+  });
+
   it('sends a tenant-scoped notification for public staff status changes', async () => {
     const notifyStatusChanged = vi.fn().mockResolvedValue({ success: true });
     mocks.db.select.mockReturnValueOnce(mocks.claimSelectChain);

--- a/packages/domain-claims/src/staff-claims/update-status.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.ts
@@ -454,7 +454,7 @@ export async function updateClaimStatusCore(
     }
     const { currentClaim } = currentClaimResult;
 
-    if (currentClaim.status === status && !trimmedNote) {
+    if (currentClaim.status === status && currentClaim.legacyStatus === status && !trimmedNote) {
       return { success: true }; // No change needed
     }
 

--- a/packages/domain-claims/src/staff-claims/update-status.ts
+++ b/packages/domain-claims/src/staff-claims/update-status.ts
@@ -38,6 +38,7 @@ import {
   transitionClaimStatusInTransaction,
   type AuthorizedTransitionHookTx,
 } from '../claims/transition';
+import { loadStaffCurrentClaimRecord, type CurrentClaimRecord } from './current-claim-record';
 
 type StaffScopeWhere = ReturnType<typeof buildScopedStaffClaimWhere>;
 
@@ -60,13 +61,6 @@ type UpdateClaimStatusParams = {
   isPublicChange?: boolean;
   session: ClaimsSession | null;
   requestHeaders?: Headers;
-};
-type CurrentClaimRecord = {
-  category: string;
-  staffId: string | null;
-  status: ClaimStatus | null;
-  title: string;
-  userId: string;
 };
 type RecoveryStatusChangeParams = {
   claimId: string;
@@ -451,22 +445,14 @@ export async function updateClaimStatusCore(
   const trimmedDecisionExplanation = params.decisionExplanation?.trim() || undefined;
 
   try {
-    // db-access-guard: tenant-scoped -- reason: tenantId resolved into local variable before this DB call
-    const [currentClaim] = await db
-      .select({
-        category: claims.category,
-        status: claims.status,
-        title: claims.title,
-        userId: claims.userId,
-        staffId: claims.staffId,
-      })
-      .from(claims)
-      .where(staffScopeWhere)
-      .limit(1);
-
-    if (!currentClaim) {
+    const currentClaimResult = await loadStaffCurrentClaimRecord(staffScopeWhere);
+    if (currentClaimResult.status === 'not_found') {
       return { success: false, error: STAFF_SCOPE_ACCESS_DENIED_ERROR };
     }
+    if (currentClaimResult.status === 'invalid_current_status') {
+      return { success: false, error: 'Invalid current claim status' };
+    }
+    const { currentClaim } = currentClaimResult;
 
     if (currentClaim.status === status && !trimmedNote) {
       return { success: true }; // No change needed

--- a/packages/domain-claims/src/update-claim-status.test.ts
+++ b/packages/domain-claims/src/update-claim-status.test.ts
@@ -92,25 +92,15 @@ describe('updateClaimStatus', () => {
   it('keeps branch scope and delegates success to the transition command', async () => {
     await expect(call({ note: 'picked for review' })).resolves.toEqual(ok);
     expect(mocks.eq).toHaveBeenCalledWith('claims.branch_id', 'branch-1');
-    expect(mocks.withTenant).toHaveBeenCalledWith(
-      'tenant-1',
-      'claims.tenant_id',
-      expect.any(Object)
-    );
     expect(mocks.transition).toHaveBeenCalledWith(
       mocks.tx,
       expect.objectContaining({
         actor: { id: 'staff-1', role: 'staff' },
-        claimId: 'claim-1',
-        isPublic: true,
         note: 'picked for review',
-        requiredWhereCondition: expect.any(Object),
         tenantId: 'tenant-1',
         toStatus: 'evaluation',
       })
     );
-    expect(mocks.tx.update).not.toHaveBeenCalled();
-    expect(mocks.tx.insert).not.toHaveBeenCalled();
   });
 
   it('keeps assigned-staff scope when the staff user has no branch', async () => {
@@ -124,8 +114,18 @@ describe('updateClaimStatus', () => {
     mocks.selectChain.limit.mockResolvedValueOnce([]);
     await expect(call()).resolves.toEqual(failure('Claim not found or access denied'));
 
-    mocks.selectChain.limit.mockResolvedValueOnce([claimRow('evaluation')]);
+    mocks.selectChain.limit.mockResolvedValueOnce([
+      {
+        caseLifecycleState: null,
+        id: 'claim-1',
+        recoveryLifecycleState: null,
+        status: 'evaluation',
+      },
+    ]);
     await expect(call()).resolves.toEqual(ok);
+    expect(mocks.tx.select).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'claims.status' })
+    );
     expect(mocks.transition).not.toHaveBeenCalled();
 
     mocks.selectChain.limit.mockResolvedValueOnce([claimRow('evaluation')]);

--- a/packages/domain-claims/src/update-claim-status.test.ts
+++ b/packages/domain-claims/src/update-claim-status.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ClaimsSession } from './claims/types';
+import { transitionClaimFixture as claimRow } from './claims/lifecycle-test-support';
 import { updateClaimStatus } from './update-claim-status';
 
 const mocks = vi.hoisted(() => {
@@ -12,7 +13,9 @@ const mocks = vi.hoisted(() => {
     and: vi.fn((...conditions) => ({ op: 'and', conditions })),
     claims: {
       branchId: 'claims.branch_id',
+      caseLifecycleState: 'claims.case_lifecycle_state',
       id: 'claims.id',
+      recoveryLifecycleState: 'claims.recovery_lifecycle_state',
       staffId: 'claims.staff_id',
       status: 'claims.status',
       tenantId: 'claims.tenant_id',
@@ -69,7 +72,7 @@ describe('updateClaimStatus', () => {
     vi.clearAllMocks();
     mocks.selectChain.from.mockReturnValue(mocks.selectChain);
     mocks.selectChain.where.mockReturnValue(mocks.selectChain);
-    mocks.selectChain.limit.mockResolvedValue([{ id: 'claim-1', status: 'submitted' }]);
+    mocks.selectChain.limit.mockResolvedValue([claimRow('submitted')]);
     mocks.transition.mockResolvedValue({
       fromStatus: 'submitted',
       lifecycleVersion: 2,
@@ -121,11 +124,11 @@ describe('updateClaimStatus', () => {
     mocks.selectChain.limit.mockResolvedValueOnce([]);
     await expect(call()).resolves.toEqual(failure('Claim not found or access denied'));
 
-    mocks.selectChain.limit.mockResolvedValueOnce([{ id: 'claim-1', status: 'evaluation' }]);
+    mocks.selectChain.limit.mockResolvedValueOnce([claimRow('evaluation')]);
     await expect(call()).resolves.toEqual(ok);
     expect(mocks.transition).not.toHaveBeenCalled();
 
-    mocks.selectChain.limit.mockResolvedValueOnce([{ id: 'claim-1', status: 'evaluation' }]);
+    mocks.selectChain.limit.mockResolvedValueOnce([claimRow('evaluation')]);
     await expect(call({ note: 'status context only' })).resolves.toEqual(ok);
     expect(mocks.transition).toHaveBeenCalledWith(
       mocks.tx,

--- a/packages/domain-claims/src/update-claim-status.ts
+++ b/packages/domain-claims/src/update-claim-status.ts
@@ -46,6 +46,7 @@ export async function updateClaimStatus(params: {
           caseLifecycleState: claims.caseLifecycleState,
           id: claims.id,
           recoveryLifecycleState: claims.recoveryLifecycleState,
+          status: claims.status,
         })
         .from(claims)
         .where(scopedWhere)

--- a/packages/domain-claims/src/update-claim-status.ts
+++ b/packages/domain-claims/src/update-claim-status.ts
@@ -3,6 +3,7 @@ import type { ClaimStatus } from '@interdomestik/database/constants';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { ensureTenantId } from '@interdomestik/shared-auth';
 
+import { resolveClaimLifecycleCommandProjection } from './claims/lifecycle-read-model';
 import {
   ClaimTransitionConflictError,
   transitionClaimStatusInTransaction,
@@ -42,8 +43,9 @@ export async function updateClaimStatus(params: {
       // db-access-guard: tenant-scoped -- reason: tenant proof is enforced inside transaction by values or where clause
       const [existingClaim] = await tx
         .select({
+          caseLifecycleState: claims.caseLifecycleState,
           id: claims.id,
-          status: claims.status,
+          recoveryLifecycleState: claims.recoveryLifecycleState,
         })
         .from(claims)
         .where(scopedWhere)
@@ -53,7 +55,8 @@ export async function updateClaimStatus(params: {
         return { success: false, error: 'Claim not found or access denied', data: undefined };
       }
 
-      if (existingClaim.status === parsed.data.status && !note) {
+      const currentState = resolveClaimLifecycleCommandProjection(existingClaim);
+      if (currentState.success && currentState.status === parsed.data.status && !note) {
         return { success: true, error: undefined };
       }
 

--- a/scripts/check-claim-status-writers.mjs
+++ b/scripts/check-claim-status-writers.mjs
@@ -34,9 +34,7 @@ export const CLAIM_STATUS_INITIALIZATION_WRITERS = new Set([
   'packages/domain-claims/src/claims/submit.ts',
 ]);
 
-export const CLAIM_STATUS_COMPAT_REPAIR_WRITERS = new Set([
-  'packages/domain-claims/src/admin-claims/update-status.ts',
-]);
+export const CLAIM_STATUS_COMPAT_REPAIR_WRITERS = new Set([]);
 
 export const CLAIM_STATUS_FIXTURE_WRITERS = new Set([
   'apps/web/e2e/gate/agent-workspace-claims-selection.spec.ts',

--- a/scripts/check-claim-status-writers.mjs
+++ b/scripts/check-claim-status-writers.mjs
@@ -34,6 +34,10 @@ export const CLAIM_STATUS_INITIALIZATION_WRITERS = new Set([
   'packages/domain-claims/src/claims/submit.ts',
 ]);
 
+export const CLAIM_STATUS_COMPAT_REPAIR_WRITERS = new Set([
+  'packages/domain-claims/src/admin-claims/update-status.ts',
+]);
+
 export const CLAIM_STATUS_FIXTURE_WRITERS = new Set([
   'apps/web/e2e/gate/agent-workspace-claims-selection.spec.ts',
   'packages/database/src/seed-full/claims.ts',
@@ -50,6 +54,7 @@ export const CLAIM_STATUS_FIXTURE_WRITERS = new Set([
 export const CLAIM_STATUS_WRITER_ALLOWLIST = new Set([
   ...CLAIM_STATUS_TRANSITION_WRITERS,
   ...CLAIM_STATUS_INITIALIZATION_WRITERS,
+  ...CLAIM_STATUS_COMPAT_REPAIR_WRITERS,
   ...CLAIM_STATUS_FIXTURE_WRITERS,
 ]);
 

--- a/scripts/ci/claim-status-writer-guard.test.mjs
+++ b/scripts/ci/claim-status-writer-guard.test.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
+  CLAIM_STATUS_COMPAT_REPAIR_WRITERS,
   CLAIM_STATUS_FIXTURE_WRITERS,
   CLAIM_STATUS_INITIALIZATION_WRITERS,
   CLAIM_STATUS_TRANSITION_WRITERS,
@@ -74,6 +75,17 @@ test('classifies claim creation and submit as initial status writers', () => {
   );
   assert.equal(
     CLAIM_STATUS_FIXTURE_WRITERS.has('packages/domain-claims/src/claims/submit.ts'),
+    false
+  );
+});
+
+test('classifies admin stale compat repair as a compatibility writer', () => {
+  assert.deepEqual(
+    [...CLAIM_STATUS_COMPAT_REPAIR_WRITERS],
+    ['packages/domain-claims/src/admin-claims/update-status.ts']
+  );
+  assert.equal(
+    CLAIM_STATUS_TRANSITION_WRITERS.has('packages/domain-claims/src/admin-claims/update-status.ts'),
     false
   );
 });

--- a/scripts/ci/claim-status-writer-guard.test.mjs
+++ b/scripts/ci/claim-status-writer-guard.test.mjs
@@ -79,14 +79,15 @@ test('classifies claim creation and submit as initial status writers', () => {
   );
 });
 
-test('classifies admin stale compat repair as a compatibility writer', () => {
-  assert.deepEqual(
-    [...CLAIM_STATUS_COMPAT_REPAIR_WRITERS],
-    ['packages/domain-claims/src/admin-claims/update-status.ts']
-  );
+test('keeps stale compat repair transition-owned', () => {
+  assert.deepEqual([...CLAIM_STATUS_COMPAT_REPAIR_WRITERS], []);
   assert.equal(
     CLAIM_STATUS_TRANSITION_WRITERS.has('packages/domain-claims/src/admin-claims/update-status.ts'),
     false
+  );
+  assert.equal(
+    CLAIM_STATUS_TRANSITION_WRITERS.has('packages/domain-claims/src/claims/transition.ts'),
+    true
   );
 });
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36860626,
+  "maxTrackedBytes": 36864756,
   "maxTrackedFiles": 4431,
   "maxCategoryBytes": {
     "large support/generated-ish": 18058552,
-    "source/scripts": 6907712,
+    "source/scripts": 6908971,
     "docs/text": 5432172,
-    "tests/e2e": 4792111,
+    "tests/e2e": 4794982,
     "config/data/messages": 1540914,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36866890,
+  "maxTrackedBytes": 36868931,
   "maxTrackedFiles": 4431,
   "maxCategoryBytes": {
     "large support/generated-ish": 18058552,
-    "source/scripts": 6909538,
+    "source/scripts": 6910119,
     "docs/text": 5432172,
-    "tests/e2e": 4796549,
+    "tests/e2e": 4798009,
     "config/data/messages": 1540914,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36874511,
+  "maxTrackedBytes": 36874450,
   "maxTrackedFiles": 4433,
   "maxCategoryBytes": {
     "large support/generated-ish": 18058552,
-    "source/scripts": 6911866,
+    "source/scripts": 6911899,
     "docs/text": 5432172,
-    "tests/e2e": 4801842,
+    "tests/e2e": 4801748,
     "config/data/messages": 1540914,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36829209,
-  "maxTrackedFiles": 4425,
+  "maxTrackedBytes": 36860626,
+  "maxTrackedFiles": 4431,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18051758,
-    "source/scripts": 6899547,
-    "docs/text": 5421175,
-    "tests/e2e": 4786650,
+    "large support/generated-ish": 18058552,
+    "source/scripts": 6907712,
+    "docs/text": 5432172,
+    "tests/e2e": 4792111,
     "config/data/messages": 1540914,
     "other": 129165
   },
-  "maxLargestFileBytes": 3133310,
+  "maxLargestFileBytes": 3140104,
   "maxSourceOrTestLines": 3000
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36866165,
+  "maxTrackedBytes": 36866890,
   "maxTrackedFiles": 4431,
   "maxCategoryBytes": {
     "large support/generated-ish": 18058552,
-    "source/scripts": 6909427,
+    "source/scripts": 6909538,
     "docs/text": 5432172,
-    "tests/e2e": 4795935,
+    "tests/e2e": 4796549,
     "config/data/messages": 1540914,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36868931,
-  "maxTrackedFiles": 4431,
+  "maxTrackedBytes": 36871569,
+  "maxTrackedFiles": 4433,
   "maxCategoryBytes": {
     "large support/generated-ish": 18058552,
-    "source/scripts": 6910119,
+    "source/scripts": 6911188,
     "docs/text": 5432172,
-    "tests/e2e": 4798009,
+    "tests/e2e": 4799578,
     "config/data/messages": 1540914,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36871569,
+  "maxTrackedBytes": 36871589,
   "maxTrackedFiles": 4433,
   "maxCategoryBytes": {
     "large support/generated-ish": 18058552,
-    "source/scripts": 6911188,
+    "source/scripts": 6911176,
     "docs/text": 5432172,
-    "tests/e2e": 4799578,
+    "tests/e2e": 4799610,
     "config/data/messages": 1540914,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36871589,
+  "maxTrackedBytes": 36874511,
   "maxTrackedFiles": 4433,
   "maxCategoryBytes": {
     "large support/generated-ish": 18058552,
-    "source/scripts": 6911176,
+    "source/scripts": 6911866,
     "docs/text": 5432172,
-    "tests/e2e": 4799610,
+    "tests/e2e": 4801842,
     "config/data/messages": 1540914,
     "other": 129165
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36864756,
+  "maxTrackedBytes": 36866165,
   "maxTrackedFiles": 4431,
   "maxCategoryBytes": {
     "large support/generated-ish": 18058552,
-    "source/scripts": 6908971,
+    "source/scripts": 6909427,
     "docs/text": 5432172,
-    "tests/e2e": 4794982,
+    "tests/e2e": 4795935,
     "config/data/messages": 1540914,
     "other": 129165
   },


### PR DESCRIPTION
## Summary

Implements T-503c Command-Path Lifecycle CAS Deprecation Readiness.

- Decouples claim command current-state and optimistic CAS checks from legacy `claims.status`.
- Uses lifecycle/current-state columns (`caseLifecycleState`, `recoveryLifecycleState`, `lifecycleVersion`) as the command-path authority.
- Keeps `claims.status` as a compatibility/derived read/write surface; this PR does not drop, rename, or destructively migrate it.
- Adds focused stale legacy-status and lifecycle CAS tests for admin/staff/agent/domain command paths.

Direct T-503 and destructive `claims.status` removal remain blocked and out of scope.

## Changed Surfaces

- `packages/domain-claims/src/claims/*`: lifecycle command projection, current-state typing, transition read context, transition CAS predicates, recovery invariant evidence, and focused lifecycle/CAS tests.
- `packages/domain-claims/src/admin-claims/*`: lifecycle-based transition precondition/no-op behavior and focused tests.
- `packages/domain-claims/src/staff-claims/*`: lifecycle-derived current claim helper and update-status tests.
- `packages/domain-claims/src/agent-claims/update-status.ts`, `packages/domain-claims/src/update-claim-status.ts`: remove runtime dependence on `claims.status` for command/no-op decisions.
- `apps/web/src/actions/*claim*.test.ts`: fixture updates for lifecycle fields.
- `scripts/repo-size-budget.json`: slice-owned repo-size metadata update.

Protected surfaces intentionally untouched: `apps/web/src/proxy.ts`, README, AGENTS.md, architecture docs, current program/tracker docs, schema migrations, RLS, billing, auth/session, routing.

## Verification

Local gates completed in the worker worktree:

- `node /Users/arbenlila/.codex/skills/interdomestik-slice-runner/scripts/next-slice.mjs .` confirmed active slice `T-503c`.
- Focused domain/web tests for transition, lifecycle CAS, admin/staff/agent update status, and web claim actions passed.
- `pnpm --filter @interdomestik/domain-claims test:unit` passed: 68 files / 451 tests.
- `pnpm --filter @interdomestik/domain-claims type-check` passed.
- `pnpm check:modularity-guard` passed.
- `node scripts/check-claim-status-writers.mjs` passed.
- `pnpm repo:size:check` passed after slice-owned budget sync.
- `pnpm check:db-access` passed with existing baseline drift warning only.
- `pnpm check:e2e-contracts` passed.
- `pnpm slice:verify` passed.
- `pnpm pr:verify` passed after resolving local Playwright Chromium cache setup.
- `pnpm security:guard` passed.
- `pnpm e2e:gate` passed: 136 passed, 8 skipped.

## Reviewer And Security Disposition

- Senior reviewer: Sonnet route ran; no merge-blocking findings. Non-blocking hardening feedback was addressed with added projection/injectivity tests.
- Second signal: Gemini route blocked before review with 403 license/auth. Recorded as tooling/license blocker, not approval.
- Escalation reviewer: Opus route ran; no code blockers. It identified an operational deploy-order precondition: T-503b lifecycle backfill must be complete in target environments before this command-path dependency change is deployed/merged.
- Codex Security diff scan: unavailable/manual-start setup friction; optional scan not advanced after bounded wait.
- Required local security evidence: `pnpm security:guard` passed.

## Residual Risk And Rollback

Residual risk: command paths now require valid lifecycle state/version data. Confirm T-503b lifecycle backfill completion in all target environments before deployment/merge readiness.

Rollback: revert this PR to restore previous command-path status-based CAS behavior. Compatibility is preserved because `claims.status` remains present and continues to be written as a derived/read surface.

## Scope Notes

- No direct T-503 destructive removal.
- No `claims.status` drop, rename, destructive migration, or source-of-truth promotion.
- No proxy/routing/auth/session/tenancy/RLS/billing/product UI expansion.
- No tracker/program closeout in this PR.
