### PR TITLE
fix: harden release-gate probe origin validation

### DIFF
--- a/scripts/release-gate/sec-cql-01-security.test.ts
+++ b/scripts/release-gate/sec-cql-01-security.test.ts
@@ -7,7 +7,15 @@ const {
   resolveVercelExecutable,
   shouldAllowConfiguredLoopbackBaseUrl,
 } = require('./run.ts');
-const { assertTrustedReleaseGateBaseUrl } = require('./url-policy.ts');
+const {
+  assertTrustedReleaseGateBaseUrl,
+  assertTrustedReleaseGateProbeOrigin,
+} = require('./url-policy.ts');
+
+const DEPLOY_HOST_OPTIONS = { allowedExtraHostname: 'deploy.example.vercel.app' };
+const RELEASE_GATE_HOST_ERROR = /release gate base url host is not allowed/i;
+
+const assertThrowsMessage = (action, message) => assert.throws(action, { message });
 
 test('resolveVercelExecutable rejects attacker-controlled executable overrides', () => {
   const resolved = resolveVercelExecutable({ VERCEL_BIN: process.execPath });
@@ -15,25 +23,27 @@ test('resolveVercelExecutable rejects attacker-controlled executable overrides',
   if (resolved) assert.match(resolved, /\/vercel$/);
 });
 
-test('resolveReachableBaseUrl rejects loopback targets unless explicitly allowed', async () => {
+test('resolveReachableBaseUrl probes only trusted release-gate origins', async () => {
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => new Response('', { status: 200 });
+  const fetchTargets = [];
+  globalThis.fetch = async input => {
+    fetchTargets.push(String(input));
+    return new Response('', { status: 200 });
+  };
 
   try {
-    const rejected = await resolveReachableBaseUrl('http://127.0.0.1:3000', {
-      deploymentUrl: 'https://deploy.example.vercel.app',
-    });
-    assert.equal(rejected.source, 'deployment_fallback');
-    assert.equal(rejected.allowedExtraHostname, 'deploy.example.vercel.app');
+    const deployment = { deploymentUrl: 'https://deploy.example.vercel.app' };
+    const noFallback = { allowDeploymentFallback: false };
+    const rejected = await resolveReachableBaseUrl('http://127.0.0.1:3000', deployment, noFallback);
+    assert.equal(rejected.source, 'configured_unreachable');
     assert.ok(rejected.failures[0].includes('Unsafe egress URL host'));
+    assert.deepEqual(fetchTargets, []);
 
-    const allowed = await resolveReachableBaseUrl(
-      'http://127.0.0.1:3000',
-      { deploymentUrl: 'https://deploy.example.vercel.app' },
-      { allowLoopback: true }
-    );
-    assert.equal(allowed.baseUrl, 'http://127.0.0.1:3000');
-    assert.equal(allowed.source, 'configured');
+    const allowedUrl =
+      'https://interdomestik-web.vercel.app/en/login?next=https://attacker.example';
+    const allowed = await resolveReachableBaseUrl(allowedUrl, deployment, noFallback);
+    assert.equal(allowed.baseUrl, allowedUrl);
+    assert.deepEqual(fetchTargets, ['https://interdomestik-web.vercel.app/']);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -48,27 +58,37 @@ test('release gate base URL policy rejects untrusted public egress hosts', () =>
     assertTrustedReleaseGateBaseUrl('https://app.interdomestik.com').origin,
     'https://app.interdomestik.com'
   );
-  assert.throws(() => assertTrustedReleaseGateBaseUrl('https://attacker.example'), {
-    message: /release gate base url host is not allowed/i,
-  });
-  assert.throws(() => assertTrustedReleaseGateBaseUrl('https://attacker.vercel.app'), {
-    message: /release gate base url host is not allowed/i,
-  });
+  assertThrowsMessage(
+    () => assertTrustedReleaseGateBaseUrl('https://attacker.example'),
+    RELEASE_GATE_HOST_ERROR
+  );
+  assertThrowsMessage(
+    () => assertTrustedReleaseGateBaseUrl('https://attacker.vercel.app'),
+    RELEASE_GATE_HOST_ERROR
+  );
   assert.equal(
-    assertTrustedReleaseGateBaseUrl('https://deploy.example.vercel.app', {
-      allowedExtraHostname: 'deploy.example.vercel.app',
-    }).origin,
+    assertTrustedReleaseGateBaseUrl('https://deploy.example.vercel.app', DEPLOY_HOST_OPTIONS)
+      .origin,
     'https://deploy.example.vercel.app'
   );
-  assert.throws(
-    () =>
-      assertTrustedReleaseGateBaseUrl('https://attacker.vercel.app', {
-        allowedExtraHostname: 'deploy.example.vercel.app',
-      }),
-    {
-      message: /release gate base url host is not allowed/i,
-    }
+  assertThrowsMessage(
+    () => assertTrustedReleaseGateBaseUrl('https://attacker.vercel.app', DEPLOY_HOST_OPTIONS),
+    RELEASE_GATE_HOST_ERROR
   );
+});
+
+test('release gate probe origin rejects protocol and port mismatches', () => {
+  assert.equal(
+    assertTrustedReleaseGateProbeOrigin('https://staging.interdomestik.com'),
+    'https://staging.interdomestik.com'
+  );
+  for (const [url, options, message] of [
+    ['http://staging.interdomestik.com', undefined, /must use https/i],
+    ['https://staging.interdomestik.com:444', undefined, /default https port/i],
+    ['https://deploy.example.vercel.app:444', DEPLOY_HOST_OPTIONS, /default https port/i],
+  ]) {
+    assertThrowsMessage(() => assertTrustedReleaseGateProbeOrigin(url, options), message);
+  }
 });
 
 test('auth preflight URL builder returns trusted URL objects before fetch', () => {
@@ -79,32 +99,22 @@ test('auth preflight URL builder returns trusted URL objects before fetch', () =
     'https://staging.interdomestik.com/api/auth/sign-in/email'
   );
   assert.ok(urls.endpoints.every(endpoint => endpoint.url instanceof URL));
-  assert.throws(() => buildAuthEndpointUrls('https://attacker.example'), {
-    message: /release gate base url host is not allowed/i,
-  });
-  assert.throws(() => buildAuthEndpointUrls('https://attacker.vercel.app'), {
-    message: /release gate base url host is not allowed/i,
-  });
+  assertThrowsMessage(
+    () => buildAuthEndpointUrls('https://attacker.example'),
+    RELEASE_GATE_HOST_ERROR
+  );
 });
 
 test('auth preflight allows only the exact validated deployment fallback host', () => {
-  const urls = buildAuthEndpointUrls('https://deploy.example.vercel.app', {
-    allowedExtraHostname: 'deploy.example.vercel.app',
-  });
+  const urls = buildAuthEndpointUrls('https://deploy.example.vercel.app', DEPLOY_HOST_OPTIONS);
   assert.equal(urls.origin, 'https://deploy.example.vercel.app');
   assert.equal(
     urls.signInEmailUrl.href,
     'https://deploy.example.vercel.app/api/auth/sign-in/email'
   );
-
-  assert.throws(
-    () =>
-      buildAuthEndpointUrls('https://attacker.vercel.app', {
-        allowedExtraHostname: 'deploy.example.vercel.app',
-      }),
-    {
-      message: /release gate base url host is not allowed/i,
-    }
+  assertThrowsMessage(
+    () => buildAuthEndpointUrls('https://attacker.vercel.app', DEPLOY_HOST_OPTIONS),
+    RELEASE_GATE_HOST_ERROR
   );
 });
 

--- a/scripts/release-gate/session-navigation.ts
+++ b/scripts/release-gate/session-navigation.ts
@@ -1,7 +1,7 @@
 const { TIMEOUTS } = require('./config.ts');
 const { gotoWithTransientRetry, loginAs, sleep } = require('./shared.ts');
 const {
-  assertTrustedReleaseGateBaseUrl,
+  assertTrustedReleaseGateProbeOrigin,
   normalizeTrustedVercelDeploymentBaseUrl,
 } = require('./url-policy.ts');
 
@@ -16,7 +16,7 @@ function compactErrorMessage(raw, maxLength = 420) {
 }
 
 async function probeBaseUrl(candidateBaseUrl, options = {}) {
-  const origin = new URL(assertTrustedReleaseGateBaseUrl(candidateBaseUrl, options).origin);
+  const origin = new URL(assertTrustedReleaseGateProbeOrigin(candidateBaseUrl, options));
   const response = await fetch(origin, {
     method: 'GET',
     redirect: 'manual',

--- a/scripts/release-gate/url-policy.ts
+++ b/scripts/release-gate/url-policy.ts
@@ -7,6 +7,14 @@ const { normalizeBaseUrl } = require('./shared.ts');
 
 const RELEASE_GATE_HOSTNAME_SUFFIXES = ['.interdomestik.com'];
 const RELEASE_GATE_HOSTNAMES = new Set(['interdomestik.com', 'interdomestik-web.vercel.app']);
+const RELEASE_GATE_KNOWN_ORIGINS = new Map([
+  ['app.interdomestik.com', 'https://app.interdomestik.com'],
+  ['interdomestik.com', 'https://interdomestik.com'],
+  ['interdomestik-web.vercel.app', 'https://interdomestik-web.vercel.app'],
+  ['mk.interdomestik.com', 'https://mk.interdomestik.com'],
+  ['staging.interdomestik.com', 'https://staging.interdomestik.com'],
+  ['www.interdomestik.com', 'https://www.interdomestik.com'],
+]);
 
 function normalizedHostname(hostname) {
   return String(hostname || '').toLowerCase();
@@ -32,6 +40,44 @@ function assertTrustedReleaseGateBaseUrl(rawValue, options = {}) {
     throw new Error(`Release gate base URL host is not allowed: ${parsed.hostname}`);
   }
   return parsed;
+}
+
+function buildTrustedOrigin(parsed) {
+  const normalized = normalizedHostname(parsed.hostname);
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Release gate public base URL must use https: ${parsed.hostname}`);
+  }
+  if (parsed.port) {
+    throw new Error(`Release gate public base URL must use the default https port: ${parsed.host}`);
+  }
+  const knownOrigin = RELEASE_GATE_KNOWN_ORIGINS.get(normalized);
+  if (knownOrigin) return knownOrigin;
+  return `https://${encodeURIComponent(normalized)}`;
+}
+
+function buildTrustedLoopbackOrigin(parsed) {
+  const protocol = parsed.protocol === 'https:' ? 'https:' : 'http:';
+  const port = parsed.port ? `:${encodeURIComponent(parsed.port)}` : '';
+  return `${protocol}//${encodeURIComponent(normalizedHostname(parsed.hostname))}${port}`;
+}
+
+function assertTrustedReleaseGateProbeOrigin(rawValue, options = {}) {
+  const parsed = assertTrustedReleaseGateBaseUrl(rawValue, options);
+  const normalized = normalizedHostname(parsed.hostname);
+  const extraHostname = normalizedHostname(options.allowedExtraHostname);
+  if (isLoopbackOrPrivateHost(parsed.hostname)) return buildTrustedLoopbackOrigin(parsed);
+  if (extraHostname && normalized === extraHostname && normalized.endsWith('.vercel.app')) {
+    if (parsed.protocol !== 'https:') {
+      throw new Error(`Release gate public base URL must use https: ${parsed.hostname}`);
+    }
+    if (parsed.port) {
+      throw new Error(
+        `Release gate public base URL must use the default https port: ${parsed.host}`
+      );
+    }
+    return `https://${encodeURIComponent(extraHostname)}`;
+  }
+  return buildTrustedOrigin(parsed);
 }
 
 function parseSafeOrigin(value) {
@@ -93,6 +139,7 @@ function buildAuthEndpointUrls(baseUrl, options = {}) {
 
 module.exports = {
   assertTrustedReleaseGateBaseUrl,
+  assertTrustedReleaseGateProbeOrigin,
   buildAuthEndpointUrls,
   isAllowedReleaseGateHostname,
   normalizeTrustedVercelDeploymentBaseUrl,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36919906,
+  "maxTrackedBytes": 36930060,
   "maxTrackedFiles": 4441,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18069492,
-    "source/scripts": 6921787,
-    "docs/text": 5446806,
-    "tests/e2e": 4811693,
+    "large support/generated-ish": 18072817,
+    "source/scripts": 6923900,
+    "docs/text": 5450933,
+    "tests/e2e": 4812282,
     "config/data/messages": 1540963,
     "other": 129165
   },
-  "maxLargestFileBytes": 3151044,
+  "maxLargestFileBytes": 3154369,
   "maxSourceOrTestLines": 3000
 }


### PR DESCRIPTION
## Summary
- Remediates CodeQL alert #44 (`js/request-forgery`) in `scripts/release-gate/session-navigation.ts`.
- Moves release-gate probing to `assertTrustedReleaseGateProbeOrigin`, which validates the candidate URL and then builds the probed origin from known trusted constants or encoded, allowlisted host components.
- Adds focused release-gate security coverage proving malicious URL candidates do not reach `fetch`, while allowed URLs with hostile path/query content probe only the trusted origin.
- Updates `scripts/repo-size-budget.json` with the required current tracked inventory after the scoped code/test growth.

## CodeQL Alert Evidence
- Alert: #44
- Rule: `js/request-forgery`
- State before remediation: `open`
- Ref: `refs/heads/main`
- Location: `scripts/release-gate/session-navigation.ts`, line 20, columns 26-5
- `fixed_at`: `null`

## Closure Expectation
This is a remediation, not a suppression. The previous flow let CodeQL trace untrusted `candidateBaseUrl` into `fetch`. The new flow validates the candidate URL, discards attacker-controlled path/query/userinfo, and constructs the probe origin from fixed trusted origins or `encodeURIComponent`-encoded, already allowlisted host/port values before calling `fetch`. CodeQL should no longer report `js/request-forgery` for this release-gate probe path once PR/main CodeQL analysis runs.

## Verification
- `pnpm exec prettier --write scripts/release-gate/session-navigation.ts scripts/release-gate/url-policy.ts scripts/release-gate/sec-cql-01-security.test.ts`
- `git diff --check`
- `pnpm check:modularity-guard`
- `pnpm test:release-gate`
- `node --test scripts/security/sec-cql-01.test.mjs`
- `pnpm slice:verify`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate` (136 passed, 8 skipped)

## Review / Residual Notes
- Optional senior reviewer route blocked with `reviewer_no_output_timeout` after ~300.5s.
- Gemini fallback blocked by missing configured auth (`GEMINI_API_KEY` / Vertex / GCA not configured).
- Codex Security diff scan setup reached workspace `4ee2a4ac-44eb-48be-8231-a9f127de43fe`, but no submit tool was exposed; manual-start blocked. Required local `pnpm security:guard` is green.
- `scripts/repo-size-budget.json` changed only to satisfy the repository size guard after the scoped release-gate code/test change.

Do not merge from this worker thread.
