### PR TITLE
feat: add T-504 tenant entity decomposition foundation

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts
@@ -102,6 +102,7 @@ function subscriptionRecord(
     branchId: null,
     agentId: null,
     legalTenantId,
+    legalEntityId: null,
     billingEntity: null,
     governingLawSnapshot,
     termsVersionAccepted: null,

--- a/packages/database/drizzle/0088_tenant_entity_decomposition.sql
+++ b/packages/database/drizzle/0088_tenant_entity_decomposition.sql
@@ -1,0 +1,195 @@
+-- T-504 additive entity-decomposition foundation.
+-- Rollback/data-repair plan: tenants and existing tenant FKs remain intact; no
+-- destructive tenant/member/status changes occur. If interrupted, rerun this
+-- migration: INSERT ... ON CONFLICT repairs from tenants. To rollback behavior,
+-- ignore tenant_entity_boundaries and subscriptions.legal_entity_id; physical
+-- rollback after backup/code rollback is reverse order: view, subscription FK
+-- and column, default_booking_links, marketing_hosts, legal_entities.
+
+CREATE TABLE IF NOT EXISTS public."legal_entities" (
+  "id" text PRIMARY KEY,
+  "tenant_id" text NOT NULL,
+  "legal_name" text NOT NULL,
+  "country_code" text NOT NULL,
+  "governing_law" text,
+  "terms_version" text,
+  "currency" text DEFAULT 'EUR' NOT NULL,
+  "tax_id" text,
+  "address" jsonb,
+  "contact" jsonb,
+  "is_active" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "legal_entities_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id") ON DELETE no action ON UPDATE no action,
+  CONSTRAINT "legal_entities_country_code_check" CHECK ("country_code" ~ '^[A-Z]{2}$'),
+  CONSTRAINT "legal_entities_governing_law_check" CHECK ("governing_law" IS NULL OR "governing_law" ~ '^[A-Z]{2}$')
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS public."marketing_hosts" (
+  "id" text PRIMARY KEY,
+  "tenant_id" text NOT NULL,
+  "label" text NOT NULL,
+  "host" text NOT NULL,
+  "is_primary" boolean DEFAULT true NOT NULL,
+  "is_active" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "marketing_hosts_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id") ON DELETE no action ON UPDATE no action,
+  CONSTRAINT "marketing_hosts_host_normalized_check" CHECK ("host" = lower("host") AND position('/' in "host") = 0 AND position(':' in "host") = 0 AND "host" = btrim("host") AND length("host") > 0)
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS public."default_booking_links" (
+  "id" text PRIMARY KEY,
+  "tenant_id" text NOT NULL,
+  "marketing_host_id" text NOT NULL,
+  "default_booking_tenant_id" text NOT NULL,
+  "legal_entity_id" text NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "default_booking_links_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id") ON DELETE no action ON UPDATE no action,
+  CONSTRAINT "default_booking_links_marketing_host_id_fk" FOREIGN KEY ("marketing_host_id") REFERENCES public."marketing_hosts"("id") ON DELETE no action ON UPDATE no action,
+  CONSTRAINT "default_booking_links_default_booking_tenant_id_fk" FOREIGN KEY ("default_booking_tenant_id") REFERENCES public."tenants"("id") ON DELETE no action ON UPDATE no action,
+  CONSTRAINT "default_booking_links_legal_entity_id_fk" FOREIGN KEY ("legal_entity_id") REFERENCES public."legal_entities"("id") ON DELETE no action ON UPDATE no action
+);--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "legal_entities_tenant_idx" ON public."legal_entities" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "marketing_hosts_tenant_idx" ON public."marketing_hosts" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "marketing_hosts_host_uq" ON public."marketing_hosts" USING btree ("host");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "marketing_hosts_primary_tenant_uq" ON public."marketing_hosts" USING btree ("tenant_id") WHERE "is_primary" = true;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "default_booking_links_tenant_uq" ON public."default_booking_links" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "default_booking_links_marketing_host_uq" ON public."default_booking_links" USING btree ("marketing_host_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "default_booking_links_booking_tenant_idx" ON public."default_booking_links" USING btree ("default_booking_tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "default_booking_links_legal_entity_idx" ON public."default_booking_links" USING btree ("legal_entity_id");--> statement-breakpoint
+
+INSERT INTO public."legal_entities" ("id", "tenant_id", "legal_name", "country_code", "governing_law", "terms_version", "currency", "tax_id", "address", "contact", "is_active")
+SELECT t."id", t."id", t."legal_name", t."country_code", t."governing_law", t."terms_version", t."currency", t."tax_id", t."address", t."contact", t."is_active"
+FROM public."tenants" t
+ON CONFLICT ("id") DO UPDATE SET
+  "tenant_id" = excluded."tenant_id",
+  "legal_name" = excluded."legal_name",
+  "country_code" = excluded."country_code",
+  "governing_law" = excluded."governing_law",
+  "terms_version" = excluded."terms_version",
+  "currency" = excluded."currency",
+  "tax_id" = excluded."tax_id",
+  "address" = excluded."address",
+  "contact" = excluded."contact",
+  "is_active" = excluded."is_active",
+  "updated_at" = now();--> statement-breakpoint
+
+WITH tenant_host_candidates AS (
+  SELECT t."id" AS tenant_id, t."is_active",
+    CASE t."id"
+      WHEN 'tenant_mk' THEN 'mk'
+      WHEN 'tenant_ks' THEN 'ks'
+      WHEN 'tenant_al' THEN 'al'
+      WHEN 'pilot-mk' THEN 'pilot'
+      ELSE lower(regexp_replace(coalesce(nullif(t."code", ''), t."id"), '[^a-zA-Z0-9-]+', '-', 'g'))
+    END AS base_host_label
+  FROM public."tenants" t
+),
+tenant_hosts AS (
+  SELECT tenant_id, is_active,
+    CASE
+      WHEN count(*) OVER (PARTITION BY base_host_label) > 1 THEN base_host_label || '-' || lower(regexp_replace(tenant_id, '[^a-zA-Z0-9-]+', '-', 'g'))
+      ELSE base_host_label
+    END AS host_label
+  FROM tenant_host_candidates
+)
+INSERT INTO public."marketing_hosts" ("id", "tenant_id", "label", "host", "is_primary", "is_active")
+SELECT tenant_id || ':primary-host', tenant_id, host_label, host_label || '.interdomestik.com', true, "is_active"
+FROM tenant_hosts
+ON CONFLICT ("id") DO UPDATE SET
+  "tenant_id" = excluded."tenant_id",
+  "label" = excluded."label",
+  "host" = excluded."host",
+  "is_primary" = excluded."is_primary",
+  "is_active" = excluded."is_active",
+  "updated_at" = now();--> statement-breakpoint
+
+INSERT INTO public."default_booking_links" ("id", "tenant_id", "marketing_host_id", "default_booking_tenant_id", "legal_entity_id")
+SELECT t."id" || ':default-booking', t."id", mh."id", t."id", le."id"
+FROM public."tenants" t
+JOIN public."marketing_hosts" mh ON mh."id" = t."id" || ':primary-host'
+JOIN public."legal_entities" le ON le."id" = t."id"
+ON CONFLICT ("id") DO UPDATE SET
+  "tenant_id" = excluded."tenant_id",
+  "marketing_host_id" = excluded."marketing_host_id",
+  "default_booking_tenant_id" = excluded."default_booking_tenant_id",
+  "legal_entity_id" = excluded."legal_entity_id",
+  "updated_at" = now();--> statement-breakpoint
+
+ALTER TABLE public."subscriptions" ADD COLUMN IF NOT EXISTS "legal_entity_id" text;--> statement-breakpoint
+WITH subscription_legal_entities AS (
+  SELECT s."id", coalesce(legal_le."id", home_le."id") AS legal_entity_id
+  FROM public."subscriptions" s
+  LEFT JOIN public."legal_entities" legal_le ON legal_le."id" = s."legal_tenant_id"
+  LEFT JOIN public."legal_entities" home_le ON home_le."id" = s."tenant_id"
+)
+UPDATE public."subscriptions" s
+SET "legal_entity_id" = sle.legal_entity_id
+FROM subscription_legal_entities sle
+WHERE s."id" = sle."id"
+  AND sle.legal_entity_id IS NOT NULL
+  AND (s."legal_entity_id" IS NULL OR NOT EXISTS (SELECT 1 FROM public."legal_entities" existing WHERE existing."id" = s."legal_entity_id"));--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint c JOIN pg_class r ON r.oid = c.conrelid JOIN pg_namespace n ON n.oid = r.relnamespace WHERE n.nspname = 'public' AND r.relname = 'subscriptions' AND c.conname = 'subscriptions_legal_entity_id_fk') THEN
+    ALTER TABLE public."subscriptions" ADD CONSTRAINT "subscriptions_legal_entity_id_fk" FOREIGN KEY ("legal_entity_id") REFERENCES public."legal_entities"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END;
+$$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "subscriptions_legal_entity_idx" ON public."subscriptions" USING btree ("legal_entity_id");--> statement-breakpoint
+
+DO $$
+DECLARE
+  target record;
+  policy_expr constant text := 'tenant_id = (select current_setting(''app.current_tenant_id'', true))::text';
+BEGIN
+  FOR target IN SELECT * FROM (VALUES ('legal_entities'), ('marketing_hosts'), ('default_booking_links')) AS t(table_name)
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', target.table_name);
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', format('tenant_isolation_%s', target.table_name), target.table_name);
+    EXECUTE format('CREATE POLICY %I ON public.%I USING (%s) WITH CHECK (%s)', format('tenant_isolation_%s', target.table_name), target.table_name, policy_expr, policy_expr);
+  END LOOP;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE VIEW public."tenant_entity_boundaries" AS
+SELECT t."id" AS "home_tenant_id", le."id" AS "legal_entity_id", mh."id" AS "marketing_host_id",
+  dbl."id" AS "default_booking_link_id", dbl."default_booking_tenant_id",
+  t."name" AS "tenant_name", le."legal_name", le."governing_law", le."terms_version",
+  mh."host" AS "marketing_host", mh."label" AS "marketing_host_label"
+FROM public."tenants" t
+LEFT JOIN public."default_booking_links" dbl ON dbl."tenant_id" = t."id"
+LEFT JOIN public."legal_entities" le ON le."id" = dbl."legal_entity_id"
+LEFT JOIN public."marketing_hosts" mh ON mh."id" = dbl."marketing_host_id"
+WHERE t."id" = (select current_setting('app.current_tenant_id', true))::text;--> statement-breakpoint
+ALTER VIEW public."tenant_entity_boundaries" SET (security_invoker = true);--> statement-breakpoint
+
+COMMENT ON TABLE public."legal_entities" IS 'T-504 legal entity authority split from tenants; one row per existing tenant at backfill, no member migration.';--> statement-breakpoint
+COMMENT ON TABLE public."marketing_hosts" IS 'T-504 durable marketing host aliases; host/default booking hints do not grant access tenant authority.';--> statement-breakpoint
+COMMENT ON TABLE public."default_booking_links" IS 'T-504 explicit marketing host to default booking tenant and legal entity mapping.';--> statement-breakpoint
+COMMENT ON COLUMN public."subscriptions"."legal_entity_id" IS 'T-504 compatibility FK to legal_entities; legal_tenant_id remains the historical tenant compatibility column until later cutover.';--> statement-breakpoint
+
+DO $$
+DECLARE
+  missing_legal integer; missing_host integer; missing_booking integer; unresolved_subscriptions integer; unmapped_subscriptions integer;
+  legal_count integer; host_count integer; booking_count integer; subscription_link_count integer;
+BEGIN
+  SELECT count(*) INTO missing_legal FROM public."tenants" t WHERE NOT EXISTS (SELECT 1 FROM public."legal_entities" le WHERE le."tenant_id" = t."id");
+  SELECT count(*) INTO missing_host FROM public."tenants" t WHERE NOT EXISTS (SELECT 1 FROM public."marketing_hosts" mh WHERE mh."tenant_id" = t."id");
+  SELECT count(*) INTO missing_booking FROM public."tenants" t WHERE NOT EXISTS (SELECT 1 FROM public."default_booking_links" dbl WHERE dbl."tenant_id" = t."id" AND dbl."default_booking_tenant_id" = t."id");
+  SELECT count(*) INTO unresolved_subscriptions FROM public."subscriptions" s WHERE s."legal_entity_id" IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."legal_entities" le WHERE le."id" = s."legal_entity_id");
+  SELECT count(*) INTO unmapped_subscriptions FROM public."subscriptions" s WHERE s."legal_entity_id" IS NULL AND EXISTS (SELECT 1 FROM public."legal_entities" le WHERE le."id" = s."tenant_id");
+  IF missing_legal > 0 OR missing_host > 0 OR missing_booking > 0 OR unresolved_subscriptions > 0 OR unmapped_subscriptions > 0 THEN
+    RAISE EXCEPTION 'T-504 unresolved references legal=%, host=%, booking=%, subscriptions=%, unmapped_subscriptions=%', missing_legal, missing_host, missing_booking, unresolved_subscriptions, unmapped_subscriptions;
+  END IF;
+  SELECT count(*) INTO legal_count FROM public."legal_entities";
+  SELECT count(*) INTO host_count FROM public."marketing_hosts";
+  SELECT count(*) INTO booking_count FROM public."default_booking_links";
+  SELECT count(*) INTO subscription_link_count FROM public."subscriptions" WHERE "legal_entity_id" IS NOT NULL;
+  RAISE NOTICE 'T-504 entity decomposition backfill legal_entities=% marketing_hosts=% default_booking_links=% subscription_links=%', legal_count, host_count, booking_count, subscription_link_count;
+END;
+$$;

--- a/packages/database/drizzle/0088_tenant_entity_decomposition.sql
+++ b/packages/database/drizzle/0088_tenant_entity_decomposition.sql
@@ -157,15 +157,15 @@ END;
 $$;--> statement-breakpoint
 
 CREATE OR REPLACE VIEW public."tenant_entity_boundaries" AS
-SELECT t."id" AS "home_tenant_id", le."id" AS "legal_entity_id", mh."id" AS "marketing_host_id",
+SELECT dbl."tenant_id" AS "home_tenant_id", le."id" AS "legal_entity_id", mh."id" AS "marketing_host_id",
   dbl."id" AS "default_booking_link_id", dbl."default_booking_tenant_id",
-  t."name" AS "tenant_name", le."legal_name", le."governing_law", le."terms_version",
+  coalesce(t."name", le."legal_name") AS "tenant_name", le."legal_name", le."governing_law", le."terms_version",
   mh."host" AS "marketing_host", mh."label" AS "marketing_host_label"
-FROM public."tenants" t
-LEFT JOIN public."default_booking_links" dbl ON dbl."tenant_id" = t."id"
+FROM public."default_booking_links" dbl
+LEFT JOIN public."tenants" t ON t."id" = dbl."tenant_id"
 LEFT JOIN public."legal_entities" le ON le."id" = dbl."legal_entity_id"
 LEFT JOIN public."marketing_hosts" mh ON mh."id" = dbl."marketing_host_id"
-WHERE t."id" = (select current_setting('app.current_tenant_id', true))::text;--> statement-breakpoint
+WHERE dbl."tenant_id" = (select current_setting('app.current_tenant_id', true))::text;--> statement-breakpoint
 ALTER VIEW public."tenant_entity_boundaries" SET (security_invoker = true);--> statement-breakpoint
 
 COMMENT ON TABLE public."legal_entities" IS 'T-504 legal entity authority split from tenants; one row per existing tenant at backfill, no member migration.';--> statement-breakpoint

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -617,6 +617,13 @@
       "when": 1782019200000,
       "tag": "0087_claim_document_ai_extraction_consents",
       "breakpoints": true
+    },
+    {
+      "idx": 88,
+      "version": "7",
+      "when": 1782105600000,
+      "tag": "0088_tenant_entity_decomposition",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -27,7 +27,7 @@
     "studio": "drizzle-kit studio",
     "type-check": "tsc --noEmit",
     "test:unit": "tsx --test 'test/*.test.ts'",
-    "test:rls": "tsx --test test/critical-rls-tables.test.ts test/rls-engaged.test.ts test/rls-role-assertion.test.ts test/no-domain-db-admin-import.test.ts test/rls-coverage.test.ts test/seed-cleanup.test.ts",
+    "test:rls": "tsx --test test/critical-rls-tables.test.ts test/rls-engaged.test.ts test/tenant-entity-decomposition-rls.test.ts test/rls-role-assertion.test.ts test/no-domain-db-admin-import.test.ts test/rls-coverage.test.ts test/seed-cleanup.test.ts",
     "seed:golden": "tsx src/seed.ts golden",
     "seed:workload": "tsx src/seed.ts workload",
     "seed:full": "tsx src/seed.ts full",

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -32,6 +32,7 @@ export * from './notifications';
 export * from './policies';
 export * from './rbac';
 export * from './services';
+export * from './tenant-entity-decomposition';
 export * from './tenants';
 export * from './webhooks';
 

--- a/packages/database/src/schema/subscriptions.ts
+++ b/packages/database/src/schema/subscriptions.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import {
   boolean,
   check,
+  foreignKey,
   index,
   integer,
   pgTable,
@@ -14,6 +15,7 @@ import { user } from './auth';
 import { membershipPlans } from './membership-plans';
 import { subscriptionStatusEnum } from './enums';
 import { branches } from './rbac';
+import { legalEntities } from './tenant-entity-decomposition';
 import { tenants } from './tenants';
 
 export const subscriptions = pgTable(
@@ -58,6 +60,7 @@ export const subscriptions = pgTable(
     billingEntity: text('billing_entity'),
     governingLawSnapshot: text('governing_law_snapshot'),
     termsVersionAccepted: text('terms_version_accepted'),
+    legalEntityId: text('legal_entity_id'),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').$onUpdate(() => new Date()),
   },
@@ -67,9 +70,15 @@ export const subscriptions = pgTable(
     uniqueIndex('idx_subscriptions_user').on(table.userId),
     uniqueIndex('idx_subscriptions_provider_subscription').on(table.providerSubscriptionId),
     uniqueIndex('subscriptions_tenant_id_id_uq').on(table.tenantId, table.id),
+    index('subscriptions_legal_entity_idx').on(table.legalEntityId),
     check(
       'subscriptions_governing_law_snapshot_check',
       sql`${table.governingLawSnapshot} IS NULL OR ${table.governingLawSnapshot} ~ '^[A-Z]{2}$'`
     ),
+    foreignKey({
+      columns: [table.legalEntityId],
+      foreignColumns: [legalEntities.id],
+      name: 'subscriptions_legal_entity_id_fk',
+    }),
   ]
 );

--- a/packages/database/src/schema/tenant-entity-decomposition.ts
+++ b/packages/database/src/schema/tenant-entity-decomposition.ts
@@ -1,0 +1,134 @@
+import { sql } from 'drizzle-orm';
+import {
+  boolean,
+  check,
+  foreignKey,
+  index,
+  jsonb,
+  pgTable,
+  pgView,
+  text,
+  timestamp,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+
+import { tenants } from './tenants';
+
+export const legalEntities = pgTable(
+  'legal_entities',
+  {
+    id: text('id').primaryKey(),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    legalName: text('legal_name').notNull(),
+    countryCode: text('country_code').notNull(),
+    governingLaw: text('governing_law'),
+    termsVersion: text('terms_version'),
+    currency: text('currency').default('EUR').notNull(),
+    taxId: text('tax_id'),
+    address: jsonb('address').$type<Record<string, unknown>>(),
+    contact: jsonb('contact').$type<Record<string, unknown>>(),
+    isActive: boolean('is_active').default(true).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at')
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  table => [
+    index('legal_entities_tenant_idx').on(table.tenantId),
+    check('legal_entities_country_code_check', sql`${table.countryCode} ~ '^[A-Z]{2}$'`),
+    check(
+      'legal_entities_governing_law_check',
+      sql`${table.governingLaw} IS NULL OR ${table.governingLaw} ~ '^[A-Z]{2}$'`
+    ),
+  ]
+);
+
+export const marketingHosts = pgTable(
+  'marketing_hosts',
+  {
+    id: text('id').primaryKey(),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    label: text('label').notNull(),
+    host: text('host').notNull(),
+    isPrimary: boolean('is_primary').default(true).notNull(),
+    isActive: boolean('is_active').default(true).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at')
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  table => [
+    index('marketing_hosts_tenant_idx').on(table.tenantId),
+    uniqueIndex('marketing_hosts_host_uq').on(table.host),
+    uniqueIndex('marketing_hosts_primary_tenant_uq')
+      .on(table.tenantId)
+      .where(sql`${table.isPrimary} = true`),
+    check(
+      'marketing_hosts_host_normalized_check',
+      sql`${table.host} = lower(${table.host})
+        and position('/' in ${table.host}) = 0
+        and position(':' in ${table.host}) = 0
+        and ${table.host} = btrim(${table.host})
+        and length(${table.host}) > 0`
+    ),
+  ]
+);
+
+export const defaultBookingLinks = pgTable(
+  'default_booking_links',
+  {
+    id: text('id').primaryKey(),
+    tenantId: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    marketingHostId: text('marketing_host_id').notNull(),
+    defaultBookingTenantId: text('default_booking_tenant_id').notNull(),
+    legalEntityId: text('legal_entity_id').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at')
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  table => [
+    uniqueIndex('default_booking_links_tenant_uq').on(table.tenantId),
+    uniqueIndex('default_booking_links_marketing_host_uq').on(table.marketingHostId),
+    index('default_booking_links_booking_tenant_idx').on(table.defaultBookingTenantId),
+    index('default_booking_links_legal_entity_idx').on(table.legalEntityId),
+    foreignKey({
+      columns: [table.marketingHostId],
+      foreignColumns: [marketingHosts.id],
+      name: 'default_booking_links_marketing_host_id_fk',
+    }),
+    foreignKey({
+      columns: [table.defaultBookingTenantId],
+      foreignColumns: [tenants.id],
+      name: 'default_booking_links_default_booking_tenant_id_fk',
+    }),
+    foreignKey({
+      columns: [table.legalEntityId],
+      foreignColumns: [legalEntities.id],
+      name: 'default_booking_links_legal_entity_id_fk',
+    }),
+  ]
+);
+
+export const tenantEntityBoundaries = pgView('tenant_entity_boundaries', {
+  homeTenantId: text('home_tenant_id'),
+  legalEntityId: text('legal_entity_id'),
+  marketingHostId: text('marketing_host_id'),
+  defaultBookingLinkId: text('default_booking_link_id'),
+  defaultBookingTenantId: text('default_booking_tenant_id'),
+  tenantName: text('tenant_name'),
+  legalName: text('legal_name'),
+  governingLaw: text('governing_law'),
+  termsVersion: text('terms_version'),
+  marketingHost: text('marketing_host'),
+  marketingHostLabel: text('marketing_host_label'),
+}).existing();

--- a/packages/database/test/tenant-entity-decomposition-migration.test.ts
+++ b/packages/database/test/tenant-entity-decomposition-migration.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const MIGRATION_PATH = fileURLToPath(
+  new URL('../drizzle/0088_tenant_entity_decomposition.sql', import.meta.url)
+);
+
+function migrationSql(): string {
+  return readFileSync(MIGRATION_PATH, 'utf8');
+}
+
+test('T-504 migration creates the three additive entity decomposition tables', () => {
+  const sql = migrationSql();
+
+  for (const tableName of ['legal_entities', 'marketing_hosts', 'default_booking_links']) {
+    assert.match(sql, new RegExp(`CREATE TABLE IF NOT EXISTS public\\."${tableName}"`, 'u'));
+    assert.match(sql, new RegExp(`\\('${tableName}'\\)`, 'u'));
+  }
+
+  assert.match(sql, /ALTER TABLE public\.%I ENABLE ROW LEVEL SECURITY/u);
+  assert.match(sql, /CREATE POLICY %I ON public\.%I USING \(%s\) WITH CHECK \(%s\)/u);
+  assert.match(sql, /FOREIGN KEY \("tenant_id"\) REFERENCES public\."tenants"\("id"\)/u);
+  assert.match(
+    sql,
+    /"legal_entities_country_code_check" CHECK \("country_code" ~ '\^\[A-Z\]\{2\}\$'\)/u
+  );
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS "marketing_hosts_host_uq"/u);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS "default_booking_links_tenant_uq"/u);
+});
+
+test('T-504 migration backfills idempotently from tenants without destructive cutover', () => {
+  const sql = migrationSql();
+
+  assert.match(sql, /INSERT INTO public\."legal_entities"/u);
+  assert.match(sql, /FROM public\."tenants" t/u);
+  assert.match(sql, /ON CONFLICT \("id"\) DO UPDATE/u);
+  assert.match(sql, /tenant_host_candidates AS/u);
+  assert.match(sql, /count\(\*\) OVER \(PARTITION BY base_host_label\)/u);
+  assert.match(
+    sql,
+    /ALTER TABLE public\."subscriptions"\s+ADD COLUMN IF NOT EXISTS "legal_entity_id" text/u
+  );
+  assert.match(sql, /coalesce\(legal_le\."id", home_le\."id"\) AS legal_entity_id/u);
+  assert.match(sql, /subscriptions_legal_entity_id_fk/u);
+  assert.doesNotMatch(sql, /DROP\s+TABLE\s+public\."tenants"/iu);
+  assert.doesNotMatch(sql, /ALTER\s+TABLE\s+public\."tenants"\s+DROP/iu);
+  assert.doesNotMatch(sql, /terms[_ ]?re[- ]?issue|acceptance[_ ]?recapture|active[_-]case/iu);
+});
+
+test('T-504 migration adds compatibility view, aggregate proof, and repair posture', () => {
+  const sql = migrationSql();
+
+  assert.match(sql, /CREATE OR REPLACE VIEW public\."tenant_entity_boundaries"/u);
+  assert.match(sql, /LEFT JOIN public\."legal_entities" le ON le\."id" = dbl\."legal_entity_id"/u);
+  assert.match(
+    sql,
+    /WHERE t\."id" = \(select current_setting\('app\.current_tenant_id', true\)\)::text/u
+  );
+  assert.match(
+    sql,
+    /ALTER VIEW public\."tenant_entity_boundaries"\s+SET \(security_invoker = true\)/u
+  );
+  assert.match(sql, /Rollback\/data-repair plan:/u);
+  assert.match(sql, /T-504 unresolved references legal=%/u);
+  assert.match(sql, /unmapped_subscriptions=%/u);
+  assert.match(sql, /T-504 entity decomposition backfill legal_entities=%/u);
+});

--- a/packages/database/test/tenant-entity-decomposition-migration.test.ts
+++ b/packages/database/test/tenant-entity-decomposition-migration.test.ts
@@ -53,10 +53,17 @@ test('T-504 migration adds compatibility view, aggregate proof, and repair postu
   const sql = migrationSql();
 
   assert.match(sql, /CREATE OR REPLACE VIEW public\."tenant_entity_boundaries"/u);
+  assert.match(sql, /SELECT dbl\."tenant_id" AS "home_tenant_id"/u);
+  assert.match(sql, /FROM public\."default_booking_links" dbl/u);
+  assert.match(sql, /LEFT JOIN public\."tenants" t ON t\."id" = dbl\."tenant_id"/u);
   assert.match(sql, /LEFT JOIN public\."legal_entities" le ON le\."id" = dbl\."legal_entity_id"/u);
   assert.match(
     sql,
-    /WHERE t\."id" = \(select current_setting\('app\.current_tenant_id', true\)\)::text/u
+    /WHERE dbl\."tenant_id" = \(select current_setting\('app\.current_tenant_id', true\)\)::text/u
+  );
+  assert.doesNotMatch(
+    sql,
+    /FROM public\."tenants" t\s+LEFT JOIN public\."default_booking_links" dbl/u
   );
   assert.match(
     sql,

--- a/packages/database/test/tenant-entity-decomposition-rls.test.ts
+++ b/packages/database/test/tenant-entity-decomposition-rls.test.ts
@@ -6,7 +6,12 @@ import { inArray, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 
-import { defaultBookingLinks, legalEntities, marketingHosts } from '../src/schema';
+import {
+  defaultBookingLinks,
+  legalEntities,
+  marketingHosts,
+  tenantEntityBoundaries,
+} from '../src/schema';
 import {
   grantRlsTestRole,
   quoteIdentifier,
@@ -73,7 +78,11 @@ test('T-504 entity tables use home tenant RLS, not access or booking tenant hint
         $$;
       `)
     );
-    await grantRlsTestRole(adminDb, REQUIRED_RLS_TABLES);
+    await grantRlsTestRole(adminDb, [
+      ...REQUIRED_RLS_TABLES,
+      'tenants',
+      'tenant_entity_boundaries',
+    ]);
 
     await adminDb
       .insert(legalEntities)
@@ -96,7 +105,7 @@ test('T-504 entity tables use home tenant RLS, not access or booking tenant hint
         sql`select set_config('app.current_access_tenant_id', ${MK_TENANT_ID}, true)`
       );
 
-      const [legalRows, hostRows, bookingRows] = await Promise.all([
+      const [legalRows, hostRows, bookingRows, boundaryRows] = await Promise.all([
         tx
           .select({ id: legalEntities.id, tenantId: legalEntities.tenantId })
           .from(legalEntities)
@@ -109,13 +118,18 @@ test('T-504 entity tables use home tenant RLS, not access or booking tenant hint
           .select({ id: defaultBookingLinks.id, tenantId: defaultBookingLinks.tenantId })
           .from(defaultBookingLinks)
           .where(inArray(defaultBookingLinks.id, [ksBookingId, mkBookingId])),
+        tx
+          .select({ homeTenantId: tenantEntityBoundaries.homeTenantId })
+          .from(tenantEntityBoundaries)
+          .where(inArray(tenantEntityBoundaries.homeTenantId, [KS_TENANT_ID, MK_TENANT_ID])),
       ]);
-      return { bookingRows, hostRows, legalRows };
+      return { bookingRows, boundaryRows, hostRows, legalRows };
     });
 
     assert.deepEqual(rows.legalRows, [{ id: ksLegalId, tenantId: KS_TENANT_ID }]);
     assert.deepEqual(rows.hostRows, [{ id: ksHostId, tenantId: KS_TENANT_ID }]);
     assert.deepEqual(rows.bookingRows, [{ id: ksBookingId, tenantId: KS_TENANT_ID }]);
+    assert.deepEqual(rows.boundaryRows, [{ homeTenantId: KS_TENANT_ID }]);
   } finally {
     await adminDb.delete(marketingHosts).where(inArray(marketingHosts.id, [ksHostId, mkHostId]));
     await adminDb.delete(legalEntities).where(inArray(legalEntities.id, [ksLegalId, mkLegalId]));

--- a/packages/database/test/tenant-entity-decomposition-rls.test.ts
+++ b/packages/database/test/tenant-entity-decomposition-rls.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+
+import { inArray, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+import { defaultBookingLinks, legalEntities, marketingHosts } from '../src/schema';
+import {
+  grantRlsTestRole,
+  quoteIdentifier,
+  requireRlsPreconditions,
+  TEST_DB_ROLE,
+} from './rls-test-connection';
+
+const KS_TENANT_ID = 'tenant_ks';
+const MK_TENANT_ID = 'tenant_mk';
+const REQUIRED_RLS_TABLES = ['legal_entities', 'marketing_hosts', 'default_booking_links'] as const;
+
+function uniqueId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${randomUUID().slice(0, 8)}`;
+}
+
+test('T-504 entity tables use home tenant RLS, not access or booking tenant hints', async t => {
+  const requireIntegration = process.env.REQUIRE_RLS_INTEGRATION === '1';
+
+  if (!process.env.DATABASE_URL) {
+    if (requireIntegration) {
+      assert.fail('T-504 RLS test requires DATABASE_URL when REQUIRE_RLS_INTEGRATION=1.');
+    }
+    t.skip('DATABASE_URL is required for T-504 RLS integration test');
+    return;
+  }
+
+  const adminSql = postgres(process.env.DATABASE_URL);
+  const adminDb = drizzle(adminSql);
+
+  await requireRlsPreconditions(adminDb, adminSql, requireIntegration, t, REQUIRED_RLS_TABLES);
+  if (t.signal.aborted) return;
+
+  const runId = uniqueId('t504');
+  const ksLegalId = `${runId}_ks_legal`;
+  const mkLegalId = `${runId}_mk_legal`;
+  const ksHostId = `${runId}_ks_host`;
+  const mkHostId = `${runId}_mk_host`;
+  const ksBookingId = `${KS_TENANT_ID}:default-booking`;
+  const mkBookingId = `${MK_TENANT_ID}:default-booking`;
+
+  try {
+    const bookingFixtures = await adminDb
+      .select({ id: defaultBookingLinks.id, tenantId: defaultBookingLinks.tenantId })
+      .from(defaultBookingLinks)
+      .where(inArray(defaultBookingLinks.id, [ksBookingId, mkBookingId]));
+    bookingFixtures.sort((a, b) => a.id.localeCompare(b.id));
+    assert.deepEqual(
+      bookingFixtures,
+      [
+        { id: ksBookingId, tenantId: KS_TENANT_ID },
+        { id: mkBookingId, tenantId: MK_TENANT_ID },
+      ],
+      'T-504 RLS test requires migrated default_booking_links fixture rows'
+    );
+
+    await adminDb.execute(
+      sql.raw(`
+        do $$
+        begin
+          create role ${quoteIdentifier(TEST_DB_ROLE)} nologin;
+        exception
+          when duplicate_object then null;
+        end
+        $$;
+      `)
+    );
+    await grantRlsTestRole(adminDb, REQUIRED_RLS_TABLES);
+
+    await adminDb
+      .insert(legalEntities)
+      .values([
+        entityRow(ksLegalId, KS_TENANT_ID, 'KS Test Entity'),
+        entityRow(mkLegalId, MK_TENANT_ID, 'MK Test Entity'),
+      ]);
+    await adminDb
+      .insert(marketingHosts)
+      .values([
+        hostRow(ksHostId, KS_TENANT_ID, `${runId}-ks.example.test`),
+        hostRow(mkHostId, MK_TENANT_ID, `${runId}-mk.example.test`),
+      ]);
+
+    const rows = await adminDb.transaction(async tx => {
+      await tx.execute(sql.raw(`set local role ${quoteIdentifier(TEST_DB_ROLE)}`));
+      await tx.execute(sql`set local row_security = on`);
+      await tx.execute(sql`select set_config('app.current_tenant_id', ${KS_TENANT_ID}, true)`);
+      await tx.execute(
+        sql`select set_config('app.current_access_tenant_id', ${MK_TENANT_ID}, true)`
+      );
+
+      const [legalRows, hostRows, bookingRows] = await Promise.all([
+        tx
+          .select({ id: legalEntities.id, tenantId: legalEntities.tenantId })
+          .from(legalEntities)
+          .where(inArray(legalEntities.id, [ksLegalId, mkLegalId])),
+        tx
+          .select({ id: marketingHosts.id, tenantId: marketingHosts.tenantId })
+          .from(marketingHosts)
+          .where(inArray(marketingHosts.id, [ksHostId, mkHostId])),
+        tx
+          .select({ id: defaultBookingLinks.id, tenantId: defaultBookingLinks.tenantId })
+          .from(defaultBookingLinks)
+          .where(inArray(defaultBookingLinks.id, [ksBookingId, mkBookingId])),
+      ]);
+      return { bookingRows, hostRows, legalRows };
+    });
+
+    assert.deepEqual(rows.legalRows, [{ id: ksLegalId, tenantId: KS_TENANT_ID }]);
+    assert.deepEqual(rows.hostRows, [{ id: ksHostId, tenantId: KS_TENANT_ID }]);
+    assert.deepEqual(rows.bookingRows, [{ id: ksBookingId, tenantId: KS_TENANT_ID }]);
+  } finally {
+    await adminDb.delete(marketingHosts).where(inArray(marketingHosts.id, [ksHostId, mkHostId]));
+    await adminDb.delete(legalEntities).where(inArray(legalEntities.id, [ksLegalId, mkLegalId]));
+    await adminSql.end({ timeout: 5 });
+  }
+});
+
+function entityRow(id: string, tenantId: string, legalName: string) {
+  return { countryCode: 'XK', currency: 'EUR', id, legalName, tenantId };
+}
+
+function hostRow(id: string, tenantId: string, host: string) {
+  return { host, id, isPrimary: false, label: id, tenantId };
+}

--- a/packages/database/test/tenant-entity-decomposition-schema.test.ts
+++ b/packages/database/test/tenant-entity-decomposition-schema.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  defaultBookingLinks,
+  legalEntities,
+  marketingHosts,
+  subscriptions,
+  tenantEntityBoundaries,
+} from '../src/schema';
+
+test('T-504 schema exports explicit legal, host, and booking boundaries', () => {
+  assert.equal(legalEntities.id.name, 'id');
+  assert.equal(legalEntities.tenantId.name, 'tenant_id');
+  assert.equal(legalEntities.legalName.name, 'legal_name');
+  assert.equal(legalEntities.governingLaw.name, 'governing_law');
+  assert.equal(legalEntities.tenantId.notNull, true);
+  assert.equal(legalEntities.governingLaw.notNull, false);
+
+  assert.equal(marketingHosts.tenantId.name, 'tenant_id');
+  assert.equal(marketingHosts.host.name, 'host');
+  assert.equal(marketingHosts.isPrimary.name, 'is_primary');
+
+  assert.equal(defaultBookingLinks.marketingHostId.name, 'marketing_host_id');
+  assert.equal(defaultBookingLinks.defaultBookingTenantId.name, 'default_booking_tenant_id');
+  assert.equal(defaultBookingLinks.legalEntityId.name, 'legal_entity_id');
+});
+
+test('T-504 keeps subscription legal entity compatibility additive and nullable', () => {
+  assert.equal(subscriptions.legalTenantId.name, 'legal_tenant_id');
+  assert.equal(subscriptions.legalEntityId.name, 'legal_entity_id');
+  assert.equal(subscriptions.legalEntityId.notNull, false);
+});
+
+test('T-504 exposes the compatibility boundary view shape', () => {
+  assert.equal(tenantEntityBoundaries.homeTenantId.name, 'home_tenant_id');
+  assert.equal(tenantEntityBoundaries.legalEntityId.name, 'legal_entity_id');
+  assert.equal(tenantEntityBoundaries.marketingHostId.name, 'marketing_host_id');
+  assert.equal(tenantEntityBoundaries.defaultBookingTenantId.name, 'default_booking_tenant_id');
+  assert.equal(tenantEntityBoundaries.marketingHost.name, 'marketing_host');
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 36993124,
-  "maxTrackedFiles": 4452,
+  "maxTrackedBytes": 37054620,
+  "maxTrackedFiles": 4458,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18075479,
-    "source/scripts": 6947585,
-    "docs/text": 5463284,
-    "tests/e2e": 4833403,
-    "config/data/messages": 1544208,
+    "large support/generated-ish": 18096259,
+    "source/scripts": 6952411,
+    "docs/text": 5489387,
+    "tests/e2e": 4843145,
+    "config/data/messages": 1544253,
     "other": 129165
   },
-  "maxLargestFileBytes": 3157031,
+  "maxLargestFileBytes": 3164893,
   "maxSourceOrTestLines": 3000
 }


### PR DESCRIPTION
## Summary

Implements the T-504 entity-decomposition foundation by mechanically splitting overloaded tenant authority into dedicated additive structures:

- `legal_entities` for tenant-owned legal/entity-of-record metadata.
- `marketing_hosts` for host/brand attribution, including primary-host uniqueness.
- `default_booking_links` for explicit home tenant -> default booking tenant -> legal entity linkage.
- `tenant_entity_boundaries` compatibility view for bounded read-side transition usage.
- Nullable `subscriptions.legal_entity_id` with named FK/index and backfill posture.

This is additive/idempotent foundation work only. It does not migrate members/entities, reissue terms, recapture acceptance, implement active-case guards, alter billing/product UI, or touch proxy/routing/auth/session behavior.

## T-504 Scope Audit

Base/start SHA: `19f8a664d2bec995cda490a0eef4074f2d52b5ed`
Head SHA: `15c012fe6e45f905e34d25e1ace1ecf5ffa113f4`
Branch: `codex/t-504-entity-decomposition-foundation`

Active-slice proof revalidated before PR creation:

- `activeSlice=T-504`
- class `implementation`
- Tier 3
- source: `docs/plans/current-tracker.md`

Forbidden-surface audit was clean. This PR does not touch:

- `apps/web/src/proxy.ts`
- README / AGENTS
- `docs/plans/*`
- auth/session/routing/proxy surfaces
- billing/product UI
- terms reissue / acceptance recapture / active-case guard / ADR-12
- Dependabot or dependency work
- broad M3/M4/M5 architecture rewrites

## Changed Files

- `packages/database/drizzle/0088_tenant_entity_decomposition.sql`
- `packages/database/drizzle/meta/_journal.json`
- `packages/database/src/schema/tenant-entity-decomposition.ts`
- `packages/database/src/schema/index.ts`
- `packages/database/src/schema/subscriptions.ts`
- `packages/database/package.json`
- `packages/database/test/tenant-entity-decomposition-schema.test.ts`
- `packages/database/test/tenant-entity-decomposition-migration.test.ts`
- `packages/database/test/tenant-entity-decomposition-rls.test.ts`
- `apps/web/src/app/[locale]/(app)/member/membership/_entity-disclosure.test.ts`
- `scripts/repo-size-budget.json`

## Migration / RLS / Rollback Posture

- Migration is additive and idempotent: creates new tables, indexes, policies, compatibility view, nullable subscription FK, and backfills without dropping or renaming legacy tenant columns.
- Referential integrity is explicit through tenant, marketing host, default booking tenant, legal entity, and subscription legal entity FKs.
- RLS is enabled on the new tenant-owned tables with tenant predicates based on `app.current_tenant_id`.
- The compatibility view is `security_invoker = true` and constrained to the current home tenant.
- Backfill includes collision-resistant marketing host derivation and validation blocks for missing legal/host/booking/subscription mappings.
- Rollback/repair posture is documented in the migration comments: because the change is additive, rollback can stop consumers, inspect/repair generated rows, and drop the compatibility view/new additive objects without destructive legacy tenant-status changes.

## Local Evidence

Focused tests and database proof:

- `pnpm --filter @interdomestik/database exec tsx --test test/tenant-entity-decomposition-schema.test.ts test/tenant-entity-decomposition-migration.test.ts test/tenant-entity-decomposition-rls.test.ts`
- `pnpm --filter @interdomestik/database type-check`
- `pnpm db:migrations:check-journal`
- `pnpm check:db-access`
- `pnpm db:rls:test:required`

Architecture / repo hygiene:

- `pnpm check:modularity-guard`
- `pnpm repo:size:check`
- `pnpm check:architecture-boundaries`
- `pnpm slice:verify`
- `git diff --cached --check` before commit

Required local Tier 3 gates:

- `pnpm security:guard` passed
- `pnpm pr:verify` passed
- `pnpm e2e:gate` passed: 136 passed / 8 skipped

## Reviewer / Security Disposition

- Sonnet Tier 3 review: final rerun clean; no remaining blockers after fixing FK/index/schema drift findings.
- Gemini Tier 3 review: clean/approved; no blockers.
- Opus escalation: not run because Sonnet and Gemini converged with no unresolved high-risk migration/design ambiguity.
- Codex Security diff scan: unavailable/manual-start friction. Workspace session `c986e778-2a6b-4cfa-a8b1-06b375aefcdd` repeatedly validated against `19f8a664...` -> `15c012fe...`, but remained `setup.submitted=false` waiting on manual Start scan. Supervisor/user explicitly waived Codex Security scan completion for PR creation based on clean local security evidence, required RLS proof, Sonnet/Gemini clean reviews, and no known security findings. This PR does not claim a completed Codex Security scan.

## Required PR Checks Pending

After PR creation, current-head GitHub checks must still be monitored and dispositioned before merge readiness, including CI, Sonar, CodeQL, gitleaks, pnpm audit, pr-finalizer, Pilot Gate, PR E2E, Copilot feedback, and PR feedback intake.

## Residual Risk / Merge Blockers

- Human approval or explicit waiver is still required before merge for schema/RLS/migration risk.
- Remote PR checks and automated feedback are pending at PR creation time.
- Do not merge until current-head checks and reviewer/security feedback are clean or explicitly classified/waived.