### PR TITLE
feat: add T-108 ida neutral host foundation

### DIFF
--- a/apps/web/src/app/[locale]/(auth)/login/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/_core.entry.test.tsx
@@ -3,12 +3,20 @@ import { join } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+type MockTenantContext =
+  | { kind: 'tenant'; tenantId: string; source: string }
+  | { kind: 'public'; tenantId: null; source: string };
+
 const hoisted = vi.hoisted(() => ({
   getSessionSafeMock: vi.fn(async () => null),
   loadTenantOptionsMock: vi.fn(async () => [{ id: 'tenant_ks', name: 'KS', countryCode: 'XK' }]),
   loginFormMock: vi.fn((_: unknown) => <div>login-form</div>),
   redirectMock: vi.fn(),
-  resolveTenantIdFromRequestMock: vi.fn<() => Promise<string | null>>(async () => 'tenant_ks'),
+  resolveTenantContextFromRequestMock: vi.fn<() => Promise<MockTenantContext>>(async () => ({
+    kind: 'tenant',
+    tenantId: 'tenant_ks',
+    source: 'compatibility_alias',
+  })),
   setRequestLocaleMock: vi.fn(),
   tenantSelectorMock: vi.fn((_: unknown) => <div>tenant-selector</div>),
 }));
@@ -39,7 +47,7 @@ vi.mock('@/lib/canonical-routes', () => ({
 }));
 
 vi.mock('@/lib/tenant/tenant-request', () => ({
-  resolveTenantIdFromRequest: hoisted.resolveTenantIdFromRequestMock,
+  resolveTenantContextFromRequest: hoisted.resolveTenantContextFromRequestMock,
 }));
 
 vi.mock('./_core', () => ({
@@ -56,7 +64,11 @@ describe('LoginPage tenant selection', () => {
     hoisted.loadTenantOptionsMock.mockResolvedValue([
       { id: 'tenant_ks', name: 'KS', countryCode: 'XK' },
     ]);
-    hoisted.resolveTenantIdFromRequestMock.mockResolvedValue('tenant_ks');
+    hoisted.resolveTenantContextFromRequestMock.mockResolvedValue({
+      kind: 'tenant',
+      tenantId: 'tenant_ks',
+      source: 'compatibility_alias',
+    });
   });
 
   it('renders the portal shell and resolves tenant context without rendering the chooser', async () => {
@@ -79,8 +91,12 @@ describe('LoginPage tenant selection', () => {
     );
   });
 
-  it('renders the tenant chooser inside the portal form region when no tenant is resolved', async () => {
-    hoisted.resolveTenantIdFromRequestMock.mockResolvedValueOnce(null);
+  it('renders the tenant chooser inside the portal form region for public ida context', async () => {
+    hoisted.resolveTenantContextFromRequestMock.mockResolvedValueOnce({
+      kind: 'public',
+      tenantId: null,
+      source: 'ida_front_door',
+    });
 
     const tree = await LoginPage({
       params: Promise.resolve({ locale: 'en' }),

--- a/apps/web/src/app/[locale]/(auth)/login/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/(auth)/login/_core.entry.tsx
@@ -4,7 +4,7 @@ import { TenantSelector, type TenantOption } from '@/components/auth/tenant-sele
 import { getCanonicalRouteForRole } from '@/lib/canonical-routes';
 import { hasGitHubOAuthCredentials } from '@/lib/auth/social-providers';
 import { coerceTenantId } from '@/lib/tenant/tenant-hosts';
-import { resolveTenantIdFromRequest } from '@/lib/tenant/tenant-request';
+import { resolveTenantContextFromRequest } from '@/lib/tenant/tenant-request';
 import { FileText, Globe2, LockKeyhole, ShieldCheck } from 'lucide-react';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { redirect } from 'next/navigation';
@@ -93,7 +93,8 @@ export default async function LoginPage({ params, searchParams }: Props) {
   }
 
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
-  const tenantIdFromContext = await resolveTenantIdFromRequest();
+  const tenantContext = await resolveTenantContextFromRequest();
+  const tenantIdFromContext = tenantContext.kind === 'tenant' ? tenantContext.tenantId : null;
   const bootstrapRedirect = getLoginTenantBootstrapRedirect({
     locale,
     tenantIdFromQuery: resolvedSearchParams?.tenantId ?? null,
@@ -171,5 +172,4 @@ export default async function LoginPage({ params, searchParams }: Props) {
     </main>
   );
 }
-
 export { generateMetadata, generateViewport } from '@/app/_segment-exports';

--- a/apps/web/src/lib/tenant/tenant-context-concepts.test.ts
+++ b/apps/web/src/lib/tenant/tenant-context-concepts.test.ts
@@ -64,10 +64,10 @@ describe('resolveTenantContext tenant concept separation', () => {
 
     expect(result).toMatchObject({
       status: 'missing_session_tenant',
-      booking_tenant_id: 'tenant_mk',
+      booking_tenant_id: null,
       access_tenant_id: null,
       legal_tenant_id: null,
-      source: 'cookie',
+      source: 'ida_front_door',
     });
   });
 });

--- a/apps/web/src/lib/tenant/tenant-context-session-precedence.test.ts
+++ b/apps/web/src/lib/tenant/tenant-context-session-precedence.test.ts
@@ -89,17 +89,17 @@ describe('resolveTenantContext session precedence', () => {
     const result = resolveTenantContext(
       request('https://ida.localhost/member', {
         cookie: 'tenantId=tenant_mk',
-        host: 'localhost:3000',
+        host: 'ida.localhost:3000',
       }),
       { user: { tenantId: 'tenant_unknown' } }
     );
 
     expect(result).toMatchObject({
       status: 'missing_session_tenant',
-      booking_tenant_id: 'tenant_mk',
+      booking_tenant_id: null,
       access_tenant_id: null,
       legal_tenant_id: null,
-      source: 'cookie',
+      source: 'ida_front_door',
     });
   });
 });

--- a/apps/web/src/lib/tenant/tenant-context.test.ts
+++ b/apps/web/src/lib/tenant/tenant-context.test.ts
@@ -97,10 +97,10 @@ describe('resolveTenantContext', () => {
     expect(result).toEqual({
       status: 'missing_session_tenant',
       host_id: null,
-      booking_tenant_id: 'tenant_ks',
+      booking_tenant_id: null,
       access_tenant_id: null,
       legal_tenant_id: null,
-      source: 'default_public',
+      source: 'ida_front_door',
     });
   });
 });

--- a/apps/web/src/lib/tenant/tenant-context.ts
+++ b/apps/web/src/lib/tenant/tenant-context.ts
@@ -16,7 +16,7 @@ type RequestLike = {
 
 type TenantContextBase = {
   host_id: TenantId | null;
-  booking_tenant_id: TenantId;
+  booking_tenant_id: TenantId | null;
   source: TenantResolutionSource;
 };
 
@@ -89,9 +89,15 @@ export function resolveTenantContext(
     },
     options
   );
-  const hostId = requestContext.source === 'compatibility_alias' ? requestContext.tenantId : null;
+  const hostId =
+    requestContext.kind === 'tenant' && requestContext.source === 'compatibility_alias'
+      ? requestContext.tenantId
+      : null;
   const { accessTenantId, bookingTenantId, legalTenantId } = resolveSessionTenantConcepts(session);
-  const requestBookingTenantId = requestContext.defaultBookingTenantId ?? requestContext.tenantId;
+  const requestBookingTenantId =
+    requestContext.kind === 'tenant'
+      ? (requestContext.defaultBookingTenantId ?? requestContext.tenantId)
+      : null;
   const requestBase = {
     host_id: hostId,
     booking_tenant_id: requestBookingTenantId,

--- a/apps/web/src/lib/tenant/tenant-front-door.ts
+++ b/apps/web/src/lib/tenant/tenant-front-door.ts
@@ -50,6 +50,7 @@ export function isKnownIdaFrontDoorHost(host: string | null | undefined): boolea
   const configuredIdaHost = normalizeTenantHost(process.env.IDA_HOST);
 
   return (
+    normalized.startsWith('ida.') ||
     DEFAULT_IDA_FRONT_DOOR_HOSTS.has(normalized) ||
     (configuredIdaHost.length > 0 && normalized === configuredIdaHost)
   );

--- a/apps/web/src/lib/tenant/tenant-host-aliases.test.ts
+++ b/apps/web/src/lib/tenant/tenant-host-aliases.test.ts
@@ -66,6 +66,7 @@ describe('tenant host compatibility aliases', () => {
         queryTenantId: 'tenant_mk',
       })
     ).toEqual({
+      kind: 'tenant',
       tenantId: 'tenant_ks',
       source: 'compatibility_alias',
       defaultBookingTenantId: 'tenant_ks',

--- a/apps/web/src/lib/tenant/tenant-hosts-public-context.test.ts
+++ b/apps/web/src/lib/tenant/tenant-hosts-public-context.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveTenantContextFromSources, resolveTenantIdFromSources } from './tenant-hosts';
+
+describe('tenant-hosts public context', () => {
+  const mutableEnv = process.env as Record<string, string | undefined>;
+  const originalDefaultPublicTenantId = process.env.DEFAULT_PUBLIC_TENANT_ID;
+
+  afterEach(() => {
+    if (originalDefaultPublicTenantId === undefined) {
+      delete mutableEnv.DEFAULT_PUBLIC_TENANT_ID;
+      return;
+    }
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = originalDefaultPublicTenantId;
+  });
+
+  it('returns public context instead of tenant for ida front-door hosts', () => {
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
+
+    expect(
+      resolveTenantContextFromSources({
+        host: 'ida.localhost:3000',
+        cookieTenantId: 'tenant_mk',
+        headerTenantId: 'tenant_al',
+        queryTenantId: 'pilot-mk',
+      })
+    ).toEqual({
+      kind: 'public',
+      tenantId: null,
+      source: 'ida_front_door',
+    });
+  });
+
+  it('keeps neutral fallback on the legacy default tenant path', () => {
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
+
+    const sources = { host: 'example.test' };
+
+    expect(resolveTenantContextFromSources(sources)).toEqual({
+      kind: 'tenant',
+      tenantId: 'tenant_ks',
+      source: 'default_public',
+    });
+    expect(resolveTenantIdFromSources(sources)).toBe('tenant_ks');
+  });
+
+  it('keeps host alias compatibility as tenant context when other hints conflict', () => {
+    expect(
+      resolveTenantContextFromSources({
+        host: 'ks.localhost:3000',
+        cookieTenantId: 'tenant_mk',
+        headerTenantId: 'tenant_mk',
+        queryTenantId: 'tenant_mk',
+      })
+    ).toMatchObject({
+      kind: 'tenant',
+      tenantId: 'tenant_ks',
+      source: 'compatibility_alias',
+    });
+  });
+});

--- a/apps/web/src/lib/tenant/tenant-hosts-public-context.test.ts
+++ b/apps/web/src/lib/tenant/tenant-hosts-public-context.test.ts
@@ -31,6 +31,23 @@ describe('tenant-hosts public context', () => {
     });
   });
 
+  it('returns public context for arbitrary ida subdomains despite stale tenant hints', () => {
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
+
+    expect(
+      resolveTenantContextFromSources({
+        host: 'ida.staging.interdomestik.com:443',
+        cookieTenantId: 'tenant_mk',
+        headerTenantId: 'tenant_al',
+        queryTenantId: 'pilot-mk',
+      })
+    ).toEqual({
+      kind: 'public',
+      tenantId: null,
+      source: 'ida_front_door',
+    });
+  });
+
   it('keeps neutral fallback on the legacy default tenant path', () => {
     mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
 

--- a/apps/web/src/lib/tenant/tenant-hosts.ts
+++ b/apps/web/src/lib/tenant/tenant-hosts.ts
@@ -3,11 +3,13 @@ import {
   envHostForTenant,
   localHostForTenant,
   resolveCountryHostCompatibilityAlias,
-  type CountryHostAliasLabel,
   type TenantId,
 } from './tenant-host-aliases';
+import { isKnownIdaFrontDoorHost } from './tenant-front-door';
+import type { TenantResolutionResult } from './tenant-resolution-types';
 
 export type { TenantId } from './tenant-host-aliases';
+export type { TenantResolutionResult, TenantResolutionSource } from './tenant-resolution-types';
 export type TenantLocale = 'sq' | 'en' | 'sr' | 'mk';
 
 export const TENANT_COOKIE_NAME = 'tenantId';
@@ -25,23 +27,8 @@ export type TenantResolutionOptions = {
   allowLoopbackFallback?: boolean;
 };
 
-export type TenantResolutionSource =
-  | 'compatibility_alias'
-  | 'cookie'
-  | 'header'
-  | 'query'
-  | 'default_public';
-
-export type TenantResolutionResult = {
-  tenantId: TenantId;
-  source: TenantResolutionSource;
-  defaultBookingTenantId?: TenantId;
-  hostAlias?: CountryHostAliasLabel;
-};
-
 export function resolveDefaultPublicTenantId(): TenantId {
-  const configured = coerceTenantId(process.env.DEFAULT_PUBLIC_TENANT_ID);
-  return configured ?? 'tenant_ks';
+  return coerceTenantId(process.env.DEFAULT_PUBLIC_TENANT_ID) ?? 'tenant_ks';
 }
 
 function normalizeHost(host: string): string {
@@ -99,11 +86,18 @@ function isLoopbackHost(host: string | null | undefined): boolean {
   return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1';
 }
 
+const publicContext = (): TenantResolutionResult => ({
+  kind: 'public',
+  tenantId: null,
+  source: 'ida_front_door',
+});
+
 export function resolveTenantIdFromSources(
   sources: TenantResolutionSources,
   options: TenantResolutionOptions = {}
 ): TenantId {
-  return resolveTenantContextFromSources(sources, options).tenantId;
+  const context = resolveTenantContextFromSources(sources, options);
+  return context.kind === 'tenant' ? context.tenantId : resolveDefaultPublicTenantId();
 }
 
 export function resolveTenantContextFromSources(
@@ -113,12 +107,15 @@ export function resolveTenantContextFromSources(
   const hostAlias = resolveCountryHostCompatibilityAlias(sources.host ?? '');
   if (hostAlias) {
     return {
+      kind: 'tenant',
       tenantId: hostAlias.tenantId,
       source: 'compatibility_alias',
       defaultBookingTenantId: hostAlias.defaultBookingTenantId,
       hostAlias: hostAlias.label,
     };
   }
+
+  if (isKnownIdaFrontDoorHost(sources.host)) return publicContext();
 
   const productionSensitive = options.productionSensitive ?? true;
   const isLocalLoopbackFallbackAllowed =
@@ -127,16 +124,16 @@ export function resolveTenantContextFromSources(
     isLocalLoopbackFallbackAllowed || !(productionSensitive && isProductionLikeEnvironment());
   if (allowUserControlledFallback) {
     const cookieTenant = coerceTenantId(sources.cookieTenantId);
-    if (cookieTenant) return { tenantId: cookieTenant, source: 'cookie' };
+    if (cookieTenant) return { kind: 'tenant', tenantId: cookieTenant, source: 'cookie' };
 
     const headerTenant = coerceTenantId(sources.headerTenantId);
-    if (headerTenant) return { tenantId: headerTenant, source: 'header' };
+    if (headerTenant) return { kind: 'tenant', tenantId: headerTenant, source: 'header' };
 
     const queryTenant = coerceTenantId(sources.queryTenantId);
-    if (queryTenant) return { tenantId: queryTenant, source: 'query' };
+    if (queryTenant) return { kind: 'tenant', tenantId: queryTenant, source: 'query' };
   }
 
-  return { tenantId: resolveDefaultPublicTenantId(), source: 'default_public' };
+  return { kind: 'tenant', tenantId: resolveDefaultPublicTenantId(), source: 'default_public' };
 }
 
 export function hasHostSessionTenantMismatch(

--- a/apps/web/src/lib/tenant/tenant-request-public-context.test.ts
+++ b/apps/web/src/lib/tenant/tenant-request-public-context.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  headers: vi.fn<() => Promise<Headers>>(),
+  cookieGet: vi.fn<(name: string) => { value: string } | undefined>(),
+}));
+
+vi.mock('next/headers', () => ({
+  headers: async () => mocks.headers(),
+  cookies: async () => ({
+    get: (name: string) => mocks.cookieGet(name),
+  }),
+}));
+
+import { resolveTenantContextFromRequest, resolveTenantIdFromRequest } from './tenant-request';
+
+describe('tenant-request public context', () => {
+  const mutableEnv = process.env as Record<string, string | undefined>;
+  const originalDefaultPublicTenantId = process.env.DEFAULT_PUBLIC_TENANT_ID;
+  const originalIdaHost = process.env.IDA_HOST;
+
+  const restoreEnv = (key: string, value: string | undefined): void => {
+    if (value === undefined) {
+      delete mutableEnv[key];
+      return;
+    }
+    mutableEnv[key] = value;
+  };
+
+  beforeEach(() => {
+    mocks.headers.mockReset();
+    mocks.cookieGet.mockReset();
+  });
+
+  afterEach(() => {
+    restoreEnv('DEFAULT_PUBLIC_TENANT_ID', originalDefaultPublicTenantId);
+    restoreEnv('IDA_HOST', originalIdaHost);
+  });
+
+  it('returns public no-tenant context for ida.localhost even with stale hints', async () => {
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
+    mocks.headers.mockResolvedValue(
+      new Headers({ host: 'ida.localhost:3000', 'x-tenant-id': 'tenant_mk' })
+    );
+    mocks.cookieGet.mockReturnValue({ value: 'tenant_al' });
+
+    await expect(
+      resolveTenantContextFromRequest({ tenantIdFromQuery: 'pilot-mk' })
+    ).resolves.toEqual({
+      kind: 'public',
+      tenantId: null,
+      source: 'ida_front_door',
+    });
+    await expect(resolveTenantIdFromRequest({ tenantIdFromQuery: 'pilot-mk' })).resolves.toBe(
+      'tenant_ks'
+    );
+  });
+
+  it('supports configured IDA_HOST as a public no-tenant context', async () => {
+    mutableEnv.IDA_HOST = 'front-door.localhost:3000';
+    mocks.headers.mockResolvedValue(new Headers({ host: 'front-door.localhost:3000' }));
+    mocks.cookieGet.mockReturnValue(undefined);
+
+    await expect(resolveTenantContextFromRequest()).resolves.toEqual({
+      kind: 'public',
+      tenantId: null,
+      source: 'ida_front_door',
+    });
+  });
+});

--- a/apps/web/src/lib/tenant/tenant-request-public-context.test.ts
+++ b/apps/web/src/lib/tenant/tenant-request-public-context.test.ts
@@ -56,6 +56,22 @@ describe('tenant-request public context', () => {
     );
   });
 
+  it('returns public no-tenant context for arbitrary ida subdomains with stale hints', async () => {
+    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = 'tenant_ks';
+    mocks.headers.mockResolvedValue(
+      new Headers({ host: 'ida.staging.interdomestik.com:443', 'x-tenant-id': 'tenant_mk' })
+    );
+    mocks.cookieGet.mockReturnValue({ value: 'tenant_al' });
+
+    await expect(
+      resolveTenantContextFromRequest({ tenantIdFromQuery: 'pilot-mk' })
+    ).resolves.toEqual({
+      kind: 'public',
+      tenantId: null,
+      source: 'ida_front_door',
+    });
+  });
+
   it('supports configured IDA_HOST as a public no-tenant context', async () => {
     mutableEnv.IDA_HOST = 'front-door.localhost:3000';
     mocks.headers.mockResolvedValue(new Headers({ host: 'front-door.localhost:3000' }));

--- a/apps/web/src/lib/tenant/tenant-request.test.ts
+++ b/apps/web/src/lib/tenant/tenant-request.test.ts
@@ -19,6 +19,13 @@ describe('tenant-request', () => {
   const originalNodeEnv = process.env.NODE_ENV;
   const originalVercelEnv = process.env.VERCEL_ENV;
   const originalDefaultPublicTenantId = process.env.DEFAULT_PUBLIC_TENANT_ID;
+  const restoreEnv = (key: string, value: string | undefined): void => {
+    if (value === undefined) {
+      delete mutableEnv[key];
+      return;
+    }
+    mutableEnv[key] = value;
+  };
 
   beforeEach(() => {
     mocks.headers.mockReset();
@@ -26,9 +33,9 @@ describe('tenant-request', () => {
   });
 
   afterEach(() => {
-    mutableEnv.NODE_ENV = originalNodeEnv;
-    mutableEnv.VERCEL_ENV = originalVercelEnv;
-    mutableEnv.DEFAULT_PUBLIC_TENANT_ID = originalDefaultPublicTenantId;
+    restoreEnv('NODE_ENV', originalNodeEnv);
+    restoreEnv('VERCEL_ENV', originalVercelEnv);
+    restoreEnv('DEFAULT_PUBLIC_TENANT_ID', originalDefaultPublicTenantId);
   });
 
   it('Host wins over cookie/header/query', async () => {

--- a/apps/web/src/lib/tenant/tenant-request.ts
+++ b/apps/web/src/lib/tenant/tenant-request.ts
@@ -1,6 +1,7 @@
 import { cookies, headers } from 'next/headers';
 import {
   resolveTenantContextFromSources,
+  resolveDefaultPublicTenantId,
   TENANT_COOKIE_NAME,
   TENANT_HEADER_NAME,
   type TenantId,
@@ -21,6 +22,7 @@ function getRequestHost(h: Headers): string {
  * 2) Cookie `tenantId`
  * 3) Header `x-tenant-id`
  * 4) Query param `tenantId` (back-compat)
+ * 5) Public no-tenant context for ida/front-door hosts or neutral fallbacks
  *
  * This helper uses the production-sensitive resolver default. In production-like
  * environments, user-controlled cookie/header/query hints are ignored on neutral
@@ -30,7 +32,7 @@ export async function resolveTenantIdFromRequest(
   options: ResolveTenantOptions = {}
 ): Promise<TenantId> {
   const context = await resolveTenantContextFromRequest(options);
-  return context.tenantId;
+  return context.kind === 'tenant' ? context.tenantId : resolveDefaultPublicTenantId();
 }
 
 export async function resolveTenantContextFromRequest(

--- a/apps/web/src/lib/tenant/tenant-resolution-types.ts
+++ b/apps/web/src/lib/tenant/tenant-resolution-types.ts
@@ -1,0 +1,23 @@
+import type { CountryHostAliasLabel, TenantId } from './tenant-host-aliases';
+
+export type TenantResolutionSource =
+  | 'compatibility_alias'
+  | 'cookie'
+  | 'header'
+  | 'query'
+  | 'default_public'
+  | 'ida_front_door';
+
+export type TenantResolutionResult =
+  | {
+      kind: 'tenant';
+      tenantId: TenantId;
+      source: Exclude<TenantResolutionSource, 'ida_front_door'>;
+      defaultBookingTenantId?: TenantId;
+      hostAlias?: CountryHostAliasLabel;
+    }
+  | {
+      kind: 'public';
+      tenantId: null;
+      source: 'ida_front_door';
+    };

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37179549,
-  "maxTrackedFiles": 4481,
+  "maxTrackedBytes": 37186688,
+  "maxTrackedFiles": 4484,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18117090,
-    "source/scripts": 6984983,
-    "docs/text": 5531838,
-    "tests/e2e": 4872078,
+    "large support/generated-ish": 18117124,
+    "source/scripts": 6986192,
+    "docs/text": 5532978,
+    "tests/e2e": 4876834,
     "config/data/messages": 1544395,
     "other": 129165
   },
-  "maxLargestFileBytes": 3185679,
+  "maxLargestFileBytes": 3185713,
   "maxSourceOrTestLines": 3000
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37186688,
+  "maxTrackedBytes": 37187729,
   "maxTrackedFiles": 4484,
   "maxCategoryBytes": {
     "large support/generated-ish": 18117124,
-    "source/scripts": 6986192,
+    "source/scripts": 6986205,
     "docs/text": 5532978,
-    "tests/e2e": 4876834,
+    "tests/e2e": 4877862,
     "config/data/messages": 1544395,
     "other": 129165
   },


### PR DESCRIPTION
## Summary
- Implements T-108 IDA neutral-host foundation with a discriminated tenant resolution result.
- Makes `ida.*`, `IDA_HOST`, and `ida.localhost` resolve as real no-tenant public context.
- Keeps non-IDA neutral hosts on existing `default_public` tenant fallback for compatibility.
- Updates login and tenant-context helpers/tests so IDA ignores stale tenant cookie/header/query hints until a valid session resolves.

## T-108 Scope Audit
- Scope: host/public-context/config/helper/page/test surfaces for IDA neutral-host behavior.
- No `apps/web/src/proxy.ts` diff.
- No schema/RLS/migration changes.
- No proxy/auth/session routing changes beyond tenant-context/login helper reads.
- No billing/product UI, dependency, README/AGENTS, OP Brain, T-501/T-502/T-503/T-505, or broad M3/M4/M5 work.

## Changed Files
- `apps/web/src/app/[locale]/(auth)/login/_core.entry.test.tsx`
- `apps/web/src/app/[locale]/(auth)/login/_core.entry.tsx`
- `apps/web/src/lib/tenant/tenant-context-concepts.test.ts`
- `apps/web/src/lib/tenant/tenant-context-session-precedence.test.ts`
- `apps/web/src/lib/tenant/tenant-context.test.ts`
- `apps/web/src/lib/tenant/tenant-context.ts`
- `apps/web/src/lib/tenant/tenant-host-aliases.test.ts`
- `apps/web/src/lib/tenant/tenant-hosts-public-context.test.ts`
- `apps/web/src/lib/tenant/tenant-hosts.ts`
- `apps/web/src/lib/tenant/tenant-request-public-context.test.ts`
- `apps/web/src/lib/tenant/tenant-request.test.ts`
- `apps/web/src/lib/tenant/tenant-request.ts`
- `apps/web/src/lib/tenant/tenant-resolution-types.ts`
- `scripts/repo-size-budget.json`

## Start / Head
- Start/base SHA: `e97fbce410dbe5ecc9963ee0ca8406501592129d`
- Head SHA: `ea1678fb2a88b2761d3717b96e69e03f22e0af82`
- Branch: `codex/t-108-ida-neutral-host-foundation`

## Local Evidence
- `node /Users/arbenlila/.codex/skills/interdomestik-slice-runner/scripts/next-slice.mjs .`: `activeSlice=T-108`, class `implementation`, Tier 3.
- Focused tenant/login/proxy unit tests: 78 passed.
- `pnpm --filter @interdomestik/web type-check`: passed.
- `pnpm check:modularity-guard`: passed.
- `pnpm repo:size:check`: passed.
- `pnpm check:architecture-boundaries`: passed.
- `pnpm check:db-access`: passed.
- `pnpm db:rls:test:required`: passed.
- `pnpm security:guard`: passed.
- `pnpm pr:verify`: passed.
- `pnpm e2e:gate`: passed on rerun, 136 passed / 8 skipped. First standalone run had an unrelated transient support-handoff strict locator failure; rerun passed the same area.
- `git diff --check`: passed.

## Security / Review Disposition
- Codex Security diff scan is blocked/pending manual Start scan. Session `211f425a-78f2-465a-b625-695221ff6dd3` opened with valid setup, `setup.submitted=false`; `await_codex_security_scan_start` timed out.
- This PR does not claim Codex Security passed.
- Merge remains blocked until Codex Security completes cleanly or an explicit waiver is granted.
- Bounded Sonnet/Gemini Tier 3 reviews: pending/not yet run in this thread.
- Copilot disposition: pending PR feedback.

## Required PR Checks Pending
- GitHub current-head CI.
- Sonar Quality Gate.
- CodeQL.
- Secret Scan/gitleaks.
- Security/pnpm-audit.
- pr-finalizer.
- Pilot Gate.
- PR E2E.
- Commitlint.
- `pr-feedback-intake` after PR creation.

## Merge Blockers
- Codex Security scan completion or explicit waiver.
- Current-head GitHub checks and review feedback must be clean.
