### PR TITLE
T-501: add flagged IDA live-login cutover

### DIFF
--- a/apps/web/e2e/gate/ida-live-login-cutover.spec.ts
+++ b/apps/web/e2e/gate/ida-live-login-cutover.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+import { getLocale, getRootURL, path } from '../fixtures/routes';
+
+type CountryHostCase = {
+  label: 'ks' | 'mk' | 'al' | 'pilot';
+  defaultBookingTenantId: string;
+};
+
+const COUNTRY_HOSTS: readonly CountryHostCase[] = [
+  { label: 'ks', defaultBookingTenantId: 'tenant_ks' },
+  { label: 'mk', defaultBookingTenantId: 'tenant_mk' },
+  { label: 'al', defaultBookingTenantId: 'tenant_al' },
+  { label: 'pilot', defaultBookingTenantId: 'pilot-mk' },
+];
+
+const isLiveLoginCutoverEnabled = process.env.FEATURE_IDA_LIVE_LOGIN_CUTOVER === 'true';
+
+function countryHostCase(hostname: string): CountryHostCase | null {
+  return COUNTRY_HOSTS.find(country => hostname.startsWith(`${country.label}.`)) ?? null;
+}
+
+function idaHostnameFor(hostname: string, label: CountryHostCase['label']): string {
+  return hostname.replace(new RegExp(`^${label}\\.`), 'ida.');
+}
+
+test.describe('ida live-login cutover gate', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('country host redirects to ida with default booking hint', async ({ request }, testInfo) => {
+    const origin = getRootURL(testInfo);
+    const locale = getLocale(testInfo);
+    const hostCase = countryHostCase(new URL(origin).hostname);
+    if (!hostCase) {
+      test.skip(true, 'cutover redirect applies only to country-host projects');
+      return;
+    }
+
+    const loginUrl = new URL(path(testInfo, '/login'));
+    const nextPath = `/${locale}/member`;
+    loginUrl.searchParams.set('next', nextPath);
+    const response = await request.get(loginUrl.toString(), { maxRedirects: 0 });
+    const location = response.headers()['location'];
+
+    if (!isLiveLoginCutoverEnabled) {
+      expect(response.status()).not.toBe(301);
+      expect(location ?? '').not.toContain('default_booking_tenant_id=');
+      expect(location ?? '').not.toContain('ida.');
+      expect(response.headers()['set-cookie'] ?? '').toContain(
+        `tenantId=${hostCase.defaultBookingTenantId}`
+      );
+      return;
+    }
+
+    const redirectUrl = new URL(location ?? '');
+    expect(response.status()).toBe(301);
+    expect(redirectUrl.hostname).toBe(idaHostnameFor(new URL(origin).hostname, hostCase.label));
+    expect(redirectUrl.pathname).toBe(`/${locale}/login`);
+    expect(redirectUrl.searchParams.get('next')).toBe(nextPath);
+    expect(redirectUrl.searchParams.get('default_booking_tenant_id')).toBe(
+      hostCase.defaultBookingTenantId
+    );
+    expect(response.headers()['set-cookie'] ?? '').not.toContain('tenantId=');
+  });
+});

--- a/apps/web/src/app/api/auth/[...all]/_core.live-login-cutover.test.ts
+++ b/apps/web/src/app/api/auth/[...all]/_core.live-login-cutover.test.ts
@@ -37,6 +37,31 @@ describe('auth core ida live-login cutover', () => {
     );
   });
 
+  it('uses a validated IDA front-door sign-in hint over stale tenant cookies', () => {
+    MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
+
+    expect(
+      resolveTenantIdForEmailSignIn(
+        new Headers({
+          host: 'ida.localhost:3000',
+          cookie: 'tenantId=tenant_ks; better-auth.session_token=stale',
+        }),
+        { additionalData: { tenantId: 'tenant_mk' } }
+      )
+    ).toBe('tenant_mk');
+  });
+
+  it('fails closed on invalid IDA front-door sign-in hints even with stale cookies', () => {
+    MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
+
+    expect(
+      resolveTenantIdForEmailSignIn(
+        new Headers({ host: 'ida.localhost:3000', cookie: 'tenantId=tenant_mk' }),
+        { additionalData: { tenantId: 'evil_tenant' } }
+      )
+    ).toBeNull();
+  });
+
   it('denies country-host sign-in when the cutover is on', async () => {
     MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
 
@@ -44,6 +69,41 @@ describe('auth core ida live-login cutover', () => {
       url: 'https://ks.localhost:3000/api/auth/sign-in/email',
       headers: new Headers({ host: 'ks.localhost:3000' }),
       body: { email: 'admin.ks@interdomestik.com' },
+      lookupUserTenantByEmail: async () => 'tenant_ks',
+    });
+
+    expect(result).toEqual({
+      decision: 'deny',
+      code: 'WRONG_TENANT_CONTEXT',
+      message: 'Wrong tenant context',
+      reason: 'missing_tenant_context',
+      resolvedTenantId: null,
+    });
+  });
+
+  it('allows fresh redirected IDA sign-in when the validated hint matches the user tenant', async () => {
+    MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
+
+    const result = await evaluateEmailSignInTenantGuard({
+      url: 'https://ida.localhost:3000/api/auth/sign-in/email',
+      headers: new Headers({
+        host: 'ida.localhost:3000',
+        cookie: 'tenantId=tenant_ks; better-auth.session_token=stale',
+      }),
+      body: { email: 'admin.mk@interdomestik.com', additionalData: { tenantId: 'tenant_mk' } },
+      lookupUserTenantByEmail: async () => 'tenant_mk',
+    });
+
+    expect(result).toEqual({ decision: 'allow' });
+  });
+
+  it('does not let body hints bypass the country-host cutover block', async () => {
+    MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
+
+    const result = await evaluateEmailSignInTenantGuard({
+      url: 'https://ks.localhost:3000/api/auth/sign-in/email',
+      headers: new Headers({ host: 'ks.localhost:3000' }),
+      body: { email: 'admin.ks@interdomestik.com', additionalData: { tenantId: 'tenant_ks' } },
       lookupUserTenantByEmail: async () => 'tenant_ks',
     });
 

--- a/apps/web/src/app/api/auth/[...all]/_core.live-login-cutover.test.ts
+++ b/apps/web/src/app/api/auth/[...all]/_core.live-login-cutover.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { evaluateEmailSignInTenantGuard, resolveTenantIdForEmailSignIn } from './_core';
+
+const ORIGINAL_CUTOVER_FLAG = process.env.FEATURE_IDA_LIVE_LOGIN_CUTOVER;
+const MUTABLE_ENV = process.env as Record<string, string | undefined>;
+
+function restoreCutoverFlag(): void {
+  MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = ORIGINAL_CUTOVER_FLAG;
+}
+
+afterEach(() => {
+  restoreCutoverFlag();
+});
+
+describe('auth core ida live-login cutover', () => {
+  it.each([
+    ['ks.localhost:3000'],
+    ['mk.localhost:3000'],
+    ['al.localhost:3000'],
+    ['pilot.localhost:3000'],
+  ])('fails closed for country-host sign-in on %s', host => {
+    MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
+
+    expect(
+      resolveTenantIdForEmailSignIn(
+        new Headers({ host, cookie: 'tenantId=tenant_mk', 'x-tenant-id': 'tenant_mk' })
+      )
+    ).toBeNull();
+  });
+
+  it('keeps country-host sign-in tenant resolution when flag is off', () => {
+    MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'false';
+
+    expect(resolveTenantIdForEmailSignIn(new Headers({ host: 'ks.localhost:3000' }))).toBe(
+      'tenant_ks'
+    );
+  });
+
+  it('denies country-host sign-in when the cutover is on', async () => {
+    MUTABLE_ENV.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
+
+    const result = await evaluateEmailSignInTenantGuard({
+      url: 'https://ks.localhost:3000/api/auth/sign-in/email',
+      headers: new Headers({ host: 'ks.localhost:3000' }),
+      body: { email: 'admin.ks@interdomestik.com' },
+      lookupUserTenantByEmail: async () => 'tenant_ks',
+    });
+
+    expect(result).toEqual({
+      decision: 'deny',
+      code: 'WRONG_TENANT_CONTEXT',
+      message: 'Wrong tenant context',
+      reason: 'missing_tenant_context',
+      resolvedTenantId: null,
+    });
+  });
+});

--- a/apps/web/src/app/api/auth/[...all]/_core.ts
+++ b/apps/web/src/app/api/auth/[...all]/_core.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 
+import { isCountryHostLiveLoginBlocked } from '@/lib/tenant/ida-live-login-cutover';
 import { isKnownIdaFrontDoorHost, normalizeTenantHost } from '@/lib/tenant/tenant-front-door';
 import {
   coerceTenantId,
@@ -10,6 +11,7 @@ import {
 } from '@/lib/tenant/tenant-hosts';
 
 export type AuthMethod = 'GET' | 'POST';
+export type AuthRateLimitConfig = { name: string; limit: number; windowSeconds: number };
 
 const EMAIL_SIGN_IN_PATH_SUFFIXES = ['/api/auth/sign-in/email', '/api/auth/sign-in/email-otp'];
 
@@ -21,14 +23,7 @@ function getAuthPathname(url: string): string | null {
   }
 }
 
-export function getAuthRateLimitConfig(
-  method: AuthMethod,
-  url: string
-): {
-  name: string;
-  limit: number;
-  windowSeconds: number;
-} {
+export function getAuthRateLimitConfig(method: AuthMethod, url: string): AuthRateLimitConfig {
   const pathname = getAuthPathname(url);
 
   if (pathname?.endsWith('/api/auth/get-session')) {
@@ -177,6 +172,10 @@ export function isEmailSignInUrl(url: string): boolean {
 }
 
 export function resolveTenantIdForEmailSignIn(headers: Headers): TenantId | null {
+  if (isCountryHostLiveLoginBlocked(getDirectRequestHost(headers))) {
+    return null;
+  }
+
   if (hasKnownDirectFrontDoorHost(headers)) {
     return resolveFrontDoorTenantHint(headers);
   }

--- a/apps/web/src/app/api/auth/[...all]/_core.ts
+++ b/apps/web/src/app/api/auth/[...all]/_core.ts
@@ -10,17 +10,15 @@ import {
   type TenantId,
 } from '@/lib/tenant/tenant-hosts';
 
+import { resolveSignInAdditionalTenantHint } from './sign-in-tenant-hint';
+
 export type AuthMethod = 'GET' | 'POST';
 export type AuthRateLimitConfig = { name: string; limit: number; windowSeconds: number };
 
 const EMAIL_SIGN_IN_PATH_SUFFIXES = ['/api/auth/sign-in/email', '/api/auth/sign-in/email-otp'];
 
 function getAuthPathname(url: string): string | null {
-  try {
-    return new URL(url).pathname;
-  } catch {
-    return null;
-  }
+  return URL.canParse(url) ? new URL(url).pathname : null;
 }
 
 export function getAuthRateLimitConfig(method: AuthMethod, url: string): AuthRateLimitConfig {
@@ -62,7 +60,7 @@ export function getAuthRateLimitKeySuffix(args: {
     return null;
   }
 
-  const tenantId = resolveTenantIdForEmailSignIn(headers);
+  const tenantId = resolveTenantIdForEmailSignIn(headers, body);
   if (!tenantId) {
     return null;
   }
@@ -126,12 +124,15 @@ function hasUnambiguousFrontDoorHost(headers: Headers): boolean {
   return normalizeTenantHost(forwardedHost) === host;
 }
 
-function resolveFrontDoorTenantHint(headers: Headers): TenantId | null {
+function resolveFrontDoorTenantHint(headers: Headers, body?: unknown): TenantId | null {
   if (!hasUnambiguousFrontDoorHost(headers)) return null;
-
+  const bodyTenant = resolveSignInAdditionalTenantHint(body);
   return (
     coerceTenantId(headers.get(TENANT_HEADER_NAME)) ??
-    coerceTenantId(parseCookieValue(headers.get('cookie'), TENANT_COOKIE_NAME))
+    (bodyTenant.kind === 'valid' ? bodyTenant.tenantId : null) ??
+    (bodyTenant.kind === 'invalid'
+      ? null
+      : coerceTenantId(parseCookieValue(headers.get('cookie'), TENANT_COOKIE_NAME)))
   );
 }
 
@@ -163,21 +164,17 @@ export function resolveTenantIdForPasswordResetAudit(
 }
 
 export function isEmailSignInUrl(url: string): boolean {
-  try {
-    const pathname = new URL(url).pathname;
-    return EMAIL_SIGN_IN_PATH_SUFFIXES.some(suffix => pathname.endsWith(suffix));
-  } catch {
-    return false;
-  }
+  const pathname = getAuthPathname(url);
+  return pathname ? EMAIL_SIGN_IN_PATH_SUFFIXES.some(suffix => pathname.endsWith(suffix)) : false;
 }
 
-export function resolveTenantIdForEmailSignIn(headers: Headers): TenantId | null {
+export function resolveTenantIdForEmailSignIn(headers: Headers, body?: unknown): TenantId | null {
   if (isCountryHostLiveLoginBlocked(getDirectRequestHost(headers))) {
     return null;
   }
 
   if (hasKnownDirectFrontDoorHost(headers)) {
-    return resolveFrontDoorTenantHint(headers);
+    return resolveFrontDoorTenantHint(headers, body);
   }
 
   return resolveTenantIdFromSources(
@@ -207,7 +204,7 @@ export async function evaluateEmailSignInTenantGuard(args: {
   const { url, headers, body, lookupUserTenantByEmail } = args;
   if (!isEmailSignInUrl(url)) return null;
 
-  const resolvedTenantId = resolveTenantIdForEmailSignIn(headers);
+  const resolvedTenantId = resolveTenantIdForEmailSignIn(headers, body);
   if (!resolvedTenantId) {
     return {
       decision: 'deny',

--- a/apps/web/src/app/api/auth/[...all]/route.live-login-cutover.test.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.live-login-cutover.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  enforceRateLimit: vi.fn(),
+  handlerPOST: vi.fn(),
+  logAuditEvent: vi.fn(),
+  lookupUserTenantByEmail: vi.fn(),
+}));
+
+vi.mock('@/lib/audit', () => ({ logAuditEvent: hoisted.logAuditEvent }));
+vi.mock('@/lib/auth', () => ({ auth: {} }));
+vi.mock('@/lib/auth/tenant-lookup', () => ({
+  lookupUserTenantByEmail: hoisted.lookupUserTenantByEmail,
+}));
+vi.mock('@/lib/rate-limit', () => ({ enforceRateLimit: hoisted.enforceRateLimit }));
+vi.mock('better-auth/next-js', () => ({
+  toNextJsHandler: () => ({ GET: vi.fn(), POST: hoisted.handlerPOST }),
+}));
+
+import { POST } from './route';
+
+function signInRequest(tenantId: string, cookieTenantId = 'tenant_ks'): Request {
+  return new Request('http://ida.localhost:3000/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: {
+      host: 'ida.localhost:3000',
+      'content-type': 'application/json',
+      cookie: `tenantId=${cookieTenantId}`,
+    },
+    body: JSON.stringify({
+      additionalData: { tenantId },
+      email: 'admin.mk@interdomestik.com',
+      password: 'not-used-in-route-test',
+    }),
+  });
+}
+
+describe('POST /api/auth/[...all] live-login cutover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.enforceRateLimit.mockResolvedValue(null);
+    hoisted.handlerPOST.mockResolvedValue(new Response('ok', { status: 200 }));
+    hoisted.lookupUserTenantByEmail.mockResolvedValue('tenant_mk');
+  });
+
+  it('uses the validated IDA booking tenant hint before delegating to better-auth', async () => {
+    const res = await POST(signInRequest('tenant_mk'));
+
+    expect(res.status).toBe(200);
+    expect(hoisted.handlerPOST).toHaveBeenCalledTimes(1);
+    expect(hoisted.enforceRateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keySuffix: expect.stringContaining('tenant:tenant_mk:email_hash:'),
+        name: 'api/auth/sign-in/email:identity',
+      })
+    );
+  });
+
+  it('rejects invalid IDA booking tenant hints before better-auth runs', async () => {
+    const res = await POST(signInRequest('evil_tenant', 'tenant_mk'));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      code: 'WRONG_TENANT_CONTEXT',
+      message: 'Wrong tenant context',
+    });
+    expect(hoisted.handlerPOST).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/auth/[...all]/sign-in-tenant-hint.ts
+++ b/apps/web/src/app/api/auth/[...all]/sign-in-tenant-hint.ts
@@ -1,0 +1,24 @@
+import { coerceTenantId, type TenantId } from '@/lib/tenant/tenant-hosts';
+
+type TenantHintResult =
+  | { kind: 'absent' }
+  | { kind: 'valid'; tenantId: TenantId }
+  | { kind: 'invalid' };
+
+function readAdditionalData(body: unknown): Record<string, unknown> | null {
+  if (!body || typeof body !== 'object') return null;
+  const additionalData = (body as { additionalData?: unknown }).additionalData;
+  if (!additionalData || typeof additionalData !== 'object') return null;
+  return additionalData as Record<string, unknown>;
+}
+
+export function resolveSignInAdditionalTenantHint(body: unknown): TenantHintResult {
+  const additionalData = readAdditionalData(body);
+  if (!additionalData) return { kind: 'absent' };
+
+  const rawTenantId = additionalData.tenantId ?? additionalData.default_booking_tenant_id;
+  if (typeof rawTenantId !== 'string') return { kind: 'invalid' };
+
+  const tenantId = coerceTenantId(rawTenantId.trim());
+  return tenantId ? { kind: 'valid', tenantId } : { kind: 'invalid' };
+}

--- a/apps/web/src/components/auth/login-form-live-login-cutover.test.tsx
+++ b/apps/web/src/components/auth/login-form-live-login-cutover.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LoginForm } from './login-form';
+
+let mockSearchParams = new URLSearchParams('');
+const mockSignInEmail = vi.fn();
+const mockGetSession = vi.fn();
+
+vi.mock('@/actions/admin-access', () => ({ canAccessAdmin: vi.fn(async () => false) }));
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    signIn: { email: (...args: unknown[]) => mockSignInEmail(...args) },
+    getSession: () => mockGetSession(),
+  },
+}));
+vi.mock('@/lib/auth-telemetry', () => ({ emitAuthTelemetryEvent: vi.fn() }));
+vi.mock('next-intl', () => ({
+  useTranslations: (namespace: string) => (key: string) =>
+    ({ 'auth.login': { email: 'Email', password: 'Password', submit: 'Sign In' } })[namespace]?.[
+      key
+    ] ?? key,
+}));
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => '/en/login',
+}));
+vi.mock('@/i18n/routing', () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+vi.mock('@interdomestik/ui', () => ({
+  Button: ({ children, type }: { children: React.ReactNode; type?: string }) => (
+    <button type={type === 'submit' ? 'submit' : 'button'}>{children}</button>
+  ),
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Checkbox: ({ id }: { id: string }) => <input type="checkbox" id={id} />,
+  Input: ({ id, name, type }: { id: string; name: string; type: string }) => (
+    <input id={id} name={name} type={type} />
+  ),
+  Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}));
+
+describe('LoginForm ida live-login cutover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams('default_booking_tenant_id=tenant_ks');
+    mockSignInEmail.mockResolvedValue({ error: null });
+    mockGetSession.mockResolvedValue({ data: { user: { role: 'user' } } });
+  });
+
+  it('submits default booking tenant hint after country-host redirect', async () => {
+    render(<LoginForm />);
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByText('Sign In'));
+
+    await waitFor(() => {
+      expect(mockSignInEmail).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password123',
+        additionalData: { tenantId: 'tenant_ks' },
+      });
+    });
+  });
+});

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { canAccessAdmin } from '@/actions/admin-access';
+import { resolveLoginTenantHint } from '@/components/auth/login-tenant-hint';
 import { Link } from '@/i18n/routing';
 import { authClient } from '@/lib/auth-client';
 import { emitAuthTelemetryEvent } from '@/lib/auth-telemetry';
@@ -114,10 +115,9 @@ export function LoginForm({
   const common = useTranslations('common');
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const tenantIdFromQuery = searchParams.get('tenantId') || undefined;
   const planIdFromQuery = searchParams.get('plan') || undefined;
   const nextPathFromQuery = searchParams.get('next');
-  const resolvedTenantId = tenantId ?? tenantIdFromQuery;
+  const resolvedTenantId = resolveLoginTenantHint(searchParams, tenantId);
   const signupHref = getPublicMembershipEntryHref(planIdFromQuery);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -154,6 +154,7 @@ export function LoginForm({
               const { error } = await authClient.signIn.email({
                 email,
                 password,
+                ...(resolvedTenantId ? { additionalData: { tenantId: resolvedTenantId } } : {}),
               });
 
               if (error) {
@@ -184,7 +185,6 @@ export function LoginForm({
                   return;
                 }
               }
-              // V3 canonical routing standardizes branch_manager to admin overview.
               const canonical = getCanonicalRouteForRole(role, locale);
               if (!canonical) {
                 emitPostLoginFailureTelemetry(

--- a/apps/web/src/components/auth/login-tenant-hint.test.ts
+++ b/apps/web/src/components/auth/login-tenant-hint.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveLoginTenantHint } from './login-tenant-hint';
+
+describe('resolveLoginTenantHint', () => {
+  it('prefers explicit tenant over query hints', () => {
+    const params = new URLSearchParams('tenantId=tenant_mk&default_booking_tenant_id=tenant_al');
+
+    expect(resolveLoginTenantHint(params, 'tenant_ks')).toBe('tenant_ks');
+  });
+
+  it('uses default booking tenant as a neutral ida login hint', () => {
+    const params = new URLSearchParams('default_booking_tenant_id=pilot-mk');
+
+    expect(resolveLoginTenantHint(params)).toBe('pilot-mk');
+  });
+
+  it('rejects unsupported hints', () => {
+    const params = new URLSearchParams('default_booking_tenant_id=tenant_evil');
+
+    expect(resolveLoginTenantHint(params)).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/auth/login-tenant-hint.ts
+++ b/apps/web/src/components/auth/login-tenant-hint.ts
@@ -1,0 +1,18 @@
+const TENANT_IDS = new Set(['tenant_mk', 'tenant_ks', 'tenant_al', 'pilot-mk']);
+
+function coerceTenantHint(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim();
+  return TENANT_IDS.has(normalized) ? normalized : undefined;
+}
+
+export function resolveLoginTenantHint(
+  searchParams: Pick<URLSearchParams, 'get'>,
+  explicitTenantId?: string
+): string | undefined {
+  return (
+    coerceTenantHint(explicitTenantId) ??
+    coerceTenantHint(searchParams.get('tenantId')) ??
+    coerceTenantHint(searchParams.get('default_booking_tenant_id'))
+  );
+}

--- a/apps/web/src/lib/feature-flags.test.ts
+++ b/apps/web/src/lib/feature-flags.test.ts
@@ -35,3 +35,32 @@ describe('staff auth tolerant tenants flag', () => {
     expect(isStaffAuthTolerantTenant('pilot-mk')).toBe(true);
   });
 });
+
+describe('ida live login cutover flag', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('defaults to disabled', async () => {
+    delete process.env.FEATURE_IDA_LIVE_LOGIN_CUTOVER;
+
+    const { isIdaLiveLoginCutoverEnabled } = await import('./feature-flags');
+
+    expect(isIdaLiveLoginCutoverEnabled()).toBe(false);
+  });
+
+  it('enables only on explicit true', async () => {
+    process.env.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
+
+    const { isIdaLiveLoginCutoverEnabled } = await import('./feature-flags');
+
+    expect(isIdaLiveLoginCutoverEnabled()).toBe(true);
+  });
+});

--- a/apps/web/src/lib/feature-flags.ts
+++ b/apps/web/src/lib/feature-flags.ts
@@ -14,6 +14,11 @@ export function isBranchDashboardEnabled(): boolean {
 }
 
 const STAFF_AUTH_TOLERANT_TENANTS_FLAG = 'STAFF_AUTH_TOLERANT_TENANTS';
+const IDA_LIVE_LOGIN_CUTOVER_FLAG = 'FEATURE_IDA_LIVE_LOGIN_CUTOVER';
+
+export function isIdaLiveLoginCutoverEnabled(): boolean {
+  return process.env[IDA_LIVE_LOGIN_CUTOVER_FLAG] === 'true';
+}
 
 export function getStaffAuthTolerantTenants(): Set<string> {
   const rawValue = process.env[STAFF_AUTH_TOLERANT_TENANTS_FLAG];

--- a/apps/web/src/lib/proxy-live-login-cutover.test.ts
+++ b/apps/web/src/lib/proxy-live-login-cutover.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { LOCALES } from '@/i18n/locales';
+
+vi.mock('@/i18n/routing', () => ({ routing: { locales: LOCALES } }));
+vi.mock('@/lib/telemetry', () => ({ emitAuthTelemetryEvent: vi.fn() }));
+
+import { proxy } from './proxy-logic';
+
+const ORIGINAL_CUTOVER_FLAG = process.env.FEATURE_IDA_LIVE_LOGIN_CUTOVER;
+const ORIGINAL_IDA_HOST = process.env.IDA_HOST;
+
+function restoreEnv(): void {
+  if (ORIGINAL_CUTOVER_FLAG === undefined) {
+    delete process.env.FEATURE_IDA_LIVE_LOGIN_CUTOVER;
+  } else {
+    process.env.FEATURE_IDA_LIVE_LOGIN_CUTOVER = ORIGINAL_CUTOVER_FLAG;
+  }
+  if (ORIGINAL_IDA_HOST === undefined) {
+    delete process.env.IDA_HOST;
+  } else {
+    process.env.IDA_HOST = ORIGINAL_IDA_HOST;
+  }
+}
+
+function makeRequest(pathname: string, cookieHeader?: string, host = 'ks.localhost:3000') {
+  const headers = new Headers({ host });
+  if (cookieHeader) headers.set('cookie', cookieHeader);
+  return new NextRequest(`http://${host}${pathname}`, { headers });
+}
+
+describe('proxy ida live-login cutover', () => {
+  beforeEach(() => {
+    process.env.FEATURE_IDA_LIVE_LOGIN_CUTOVER = 'true';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreEnv();
+  });
+
+  it.each([
+    ['ks.localhost:3000', 'tenant_ks'],
+    ['mk.localhost:3000', 'tenant_mk'],
+    ['al.localhost:3000', 'tenant_al'],
+    ['pilot.localhost:3000', 'pilot-mk'],
+  ])(
+    '301 redirects %s to ida.localhost with default booking tenant',
+    async (host, defaultBookingTenantId) => {
+      const response = await proxy(makeRequest('/sq/login?next=%2Fsq%2Fmember', undefined, host));
+
+      expect(response.status).toBe(301);
+      expect(response.headers.get('location')).toBe(
+        `http://ida.localhost:3000/sq/login?next=%2Fsq%2Fmember&default_booking_tenant_id=${defaultBookingTenantId}`
+      );
+      expect(response.headers.get('x-ida-live-login-cutover')).toBe('country-host-redirect');
+      expect(response.headers.get('set-cookie')).toBeNull();
+    }
+  );
+
+  it('redirects protected country-host routes to ida before auth bounce logic', async () => {
+    const response = await proxy(
+      makeRequest(
+        '/sq/member',
+        'tenantId=tenant_mk; better-auth.session_token=stale',
+        'ks.localhost:3000'
+      )
+    );
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(
+      'http://ida.localhost:3000/sq/member?default_booking_tenant_id=tenant_ks'
+    );
+    expect(response.headers.get('x-auth-guard')).toBeNull();
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('uses configured IDA_HOST as the cutover redirect target', async () => {
+    process.env.IDA_HOST = 'https://login.interdomestik.test';
+
+    const response = await proxy(makeRequest('/mk/login', undefined, 'mk.localhost:3000'));
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(
+      'https://login.interdomestik.test/mk/login?default_booking_tenant_id=tenant_mk'
+    );
+  });
+
+  it('does not redirect hostile country-label lookalikes', async () => {
+    const response = await proxy(makeRequest('/sq/login', undefined, 'ks.evil.test'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-ida-live-login-cutover')).toBeNull();
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/proxy-logic.csp-nonce.test.ts
+++ b/apps/web/src/lib/proxy-logic.csp-nonce.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/i18n/routing', () => ({
 }));
 
 vi.mock('@/lib/feature-flags', () => ({
+  isIdaLiveLoginCutoverEnabled: () => false,
   isStaffAuthTolerantTenant: () => false,
 }));
 

--- a/apps/web/src/lib/proxy-logic.ts
+++ b/apps/web/src/lib/proxy-logic.ts
@@ -3,6 +3,7 @@ import { isStaffAuthTolerantTenant } from '@/lib/feature-flags';
 import { isE2EDiagnosticsEnabled, isProductionDeployment } from '@/lib/runtime-environment';
 import { emitAuthTelemetryEvent } from '@/lib/telemetry';
 import { resolveTenantHostContext } from '@/lib/tenant/tenant-front-door';
+import { buildIdaLiveLoginRedirectUrl } from '@/lib/tenant/ida-live-login-cutover';
 import { applyTenantCookie } from '@/lib/tenant/tenant-cookie';
 import { NextRequest, NextResponse } from 'next/server';
 import {
@@ -423,20 +424,20 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const host = request.headers.get('host') ?? '';
   const tenantContext = resolveTenantHostContext(host);
   const tenant = tenantContext.tenantId;
+  const securityHeaders = createSecurityHeaders(request);
+  const idaLiveLoginRedirectUrl = buildIdaLiveLoginRedirectUrl(request.nextUrl, host);
+  if (idaLiveLoginRedirectUrl) {
+    const redirectResponse = NextResponse.redirect(idaLiveLoginRedirectUrl, 301);
+    redirectResponse.headers.set('x-ida-live-login-cutover', 'country-host-redirect');
+    return applyResponseHardening(redirectResponse, request, null, securityHeaders);
+  }
 
-  // 1. Force nip.io in Dev (Optional, if env var set)
-  // Logic simplified/removed to prevent loops - rely on manual access for now
-  // or user-provided "Force Redirect" if absolutely needed.
-  // Given "restart loop" history, we are being conservative.
-
-  // 2. Auth Guard (Edge Safe)
   const segments = pathname.split('/');
   const possibleLocale = segments[1];
   const isLocale = routing.locales.includes(possibleLocale as (typeof routing.locales)[number]);
   const topLevel = isLocale ? segments[2] : segments[1];
   const locale = isLocale ? possibleLocale : 'sq';
   const surface = getTelemetrySurface(topLevel);
-  const securityHeaders = createSecurityHeaders(request);
 
   const isProtected = PROTECTED_TOP_LEVEL.has(topLevel);
   const sessionCookieValue = isProtected ? getSessionCookieValue(request) : null;
@@ -473,7 +474,6 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
     }
   }
 
-  // 3. Tenant Resolution
   const response = securityHeaders.requestHeaders
     ? NextResponse.next({ request: { headers: securityHeaders.requestHeaders } })
     : NextResponse.next();

--- a/apps/web/src/lib/tenant/ida-live-login-cutover.ts
+++ b/apps/web/src/lib/tenant/ida-live-login-cutover.ts
@@ -1,0 +1,82 @@
+import { isIdaLiveLoginCutoverEnabled } from '@/lib/feature-flags';
+
+import { normalizeTenantHost, resolveTenantHostContext } from './tenant-front-door';
+
+const CANONICAL_IDA_HOST = 'ida.interdomestik.com';
+
+type RedirectTarget = {
+  protocol: string;
+  host: string;
+};
+
+function parseConfiguredIdaHost(): Partial<RedirectTarget> | null {
+  const configured = process.env.IDA_HOST?.trim();
+  if (!configured) return null;
+
+  try {
+    const parsed = new URL(configured.includes('://') ? configured : `https://${configured}`);
+    return {
+      protocol: configured.includes('://') ? parsed.protocol : undefined,
+      host: parsed.host,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function extractPortSuffix(host: string | null | undefined): string {
+  const raw = host?.split(',')[0]?.trim() ?? '';
+  try {
+    const parsed = new URL(raw.includes('://') ? raw : `http://${raw}`);
+    return parsed.port ? `:${parsed.port}` : '';
+  } catch {
+    return '';
+  }
+}
+
+function resolveIdaRedirectTarget(
+  host: string | null | undefined,
+  protocol: string
+): RedirectTarget {
+  const configured = parseConfiguredIdaHost();
+  if (configured?.host) {
+    return { protocol: configured.protocol ?? protocol, host: configured.host };
+  }
+
+  const normalized = normalizeTenantHost(host);
+  const port = extractPortSuffix(host);
+  const nipIoMatch = normalized.match(/^[^.]+(\.\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\.nip\.io)$/);
+
+  if (normalized.endsWith('.localhost')) {
+    return { protocol, host: `ida.localhost${port}` };
+  }
+
+  if (nipIoMatch) {
+    return { protocol, host: `ida${nipIoMatch[1]}${port}` };
+  }
+
+  return { protocol: 'https:', host: CANONICAL_IDA_HOST };
+}
+
+export function isCountryHostLiveLoginBlocked(host: string | null | undefined): boolean {
+  return (
+    isIdaLiveLoginCutoverEnabled() &&
+    resolveTenantHostContext(host ?? '').kind === 'compatibility_alias'
+  );
+}
+
+export function buildIdaLiveLoginRedirectUrl(
+  requestUrl: URL,
+  host: string | null | undefined
+): URL | null {
+  if (!isIdaLiveLoginCutoverEnabled()) return null;
+
+  const context = resolveTenantHostContext(host ?? '');
+  if (context.kind !== 'compatibility_alias') return null;
+
+  const target = resolveIdaRedirectTarget(host, requestUrl.protocol);
+  const redirectUrl = new URL(`${target.protocol}//${target.host}${requestUrl.pathname}`);
+  redirectUrl.search = requestUrl.search;
+  redirectUrl.searchParams.set('default_booking_tenant_id', context.defaultBookingTenantId);
+  return redirectUrl;
+}

--- a/scripts/raw-role-array-allowlist.json
+++ b/scripts/raw-role-array-allowlist.json
@@ -34,7 +34,7 @@
     "apps/web/src/features/admin/verification/components/v2/VerificationOpsCenterPage.tsx:23:24:admin,super_admin,branch_manager,tenant_admin,staff",
     "apps/web/src/features/claims/upload/server/access.ts:13:42:admin,tenant_admin,super_admin",
     "apps/web/src/lib/canonical-routes.ts:3:29:admin,super_admin,tenant_admin,branch_manager",
-    "apps/web/src/lib/proxy-logic.ts:15:37:member,admin,staff,agent",
+    "apps/web/src/lib/proxy-logic.ts:16:37:member,admin,staff,agent",
     "apps/web/src/lib/rbac-portals.ts:1:36:admin,super_admin,tenant_admin,branch_manager",
     "apps/web/src/server/domains/claims/queries.ts:57:14:admin,tenant_admin,super_admin",
     "packages/domain-activities/src/log-lead.ts:11:31:admin,staff,agent",

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37187729,
-  "maxTrackedFiles": 4484,
+  "maxTrackedBytes": 37210244,
+  "maxTrackedFiles": 4491,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18117124,
-    "source/scripts": 6986205,
-    "docs/text": 5532978,
-    "tests/e2e": 4877862,
+    "large support/generated-ish": 18120880,
+    "source/scripts": 6989917,
+    "docs/text": 5536236,
+    "tests/e2e": 4889651,
     "config/data/messages": 1544395,
     "other": 129165
   },
-  "maxLargestFileBytes": 3185713,
+  "maxLargestFileBytes": 3189469,
   "maxSourceOrTestLines": 3000
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37210244,
-  "maxTrackedFiles": 4491,
+  "maxTrackedBytes": 37216519,
+  "maxTrackedFiles": 4493,
   "maxCategoryBytes": {
     "large support/generated-ish": 18120880,
-    "source/scripts": 6989917,
+    "source/scripts": 6991176,
     "docs/text": 5536236,
-    "tests/e2e": 4889651,
+    "tests/e2e": 4894667,
     "config/data/messages": 1544395,
     "other": 129165
   },


### PR DESCRIPTION
## Summary

Implements the T-501 flagged IDA live-login cutover foundation:

- Adds `FEATURE_IDA_LIVE_LOGIN_CUTOVER` gating for the live-login cutover.
- Redirects country/compatibility hosts to the IDA front door with `default_booking_tenant_id` preserved when the flag is enabled.
- Keeps neutral `ida.*` behavior tenant-free and avoids tenant cookie writes on redirect.
- Blocks direct country-host email sign-in when the cutover flag is enabled while preserving flag-off behavior.
- Allows the IDA login form to consume `default_booking_tenant_id` as a booking tenant hint without branding IDA as a tenant host.

No `apps/web/src/proxy.ts` diff.

## T-501 scope audit

Allowed T-501 surfaces only:

- Route/proxy helper logic under `apps/web/src/lib/proxy-logic.ts` and tenant host helper additions.
- Auth sign-in tenant resolution guard in the existing auth API core.
- Login form tenant hint plumbing for redirected country-host users.
- Focused unit and Playwright gate coverage.
- Guard metadata updates required by repo checks.

Forbidden surfaces not touched:

- No `apps/web/src/proxy.ts` edit.
- No T-502, T-503, T-505, schema/RLS/migrations, entity/member migration, billing/product UI, dependency work, README/AGENTS, OP Brain runtime/live AI, CodeQL batch work, or broad M3/M4/M5 rewrite.

## Start / head

- Start/base SHA: `7c1db68b028d1b0b8ba4e6943046858e6a08cdde`
- Head SHA: `40170889f5d578a0f72ee85e2028dfcc19dbfcbe`
- Branch: `codex/t-501-ida-live-login-cutover`
- Active-slice proof after commit: `status=ready`, `activeSlice=T-501`, class `implementation`, Tier 3.

## Changed files

- `apps/web/e2e/gate/ida-live-login-cutover.spec.ts`
- `apps/web/src/app/api/auth/[...all]/_core.live-login-cutover.test.ts`
- `apps/web/src/app/api/auth/[...all]/_core.ts`
- `apps/web/src/components/auth/login-form-live-login-cutover.test.tsx`
- `apps/web/src/components/auth/login-form.tsx`
- `apps/web/src/components/auth/login-tenant-hint.test.ts`
- `apps/web/src/components/auth/login-tenant-hint.ts`
- `apps/web/src/lib/feature-flags.test.ts`
- `apps/web/src/lib/feature-flags.ts`
- `apps/web/src/lib/proxy-live-login-cutover.test.ts`
- `apps/web/src/lib/proxy-logic.csp-nonce.test.ts`
- `apps/web/src/lib/proxy-logic.ts`
- `apps/web/src/lib/tenant/ida-live-login-cutover.ts`
- `scripts/raw-role-array-allowlist.json`
- `scripts/repo-size-budget.json`

## Local evidence

Focused tests and checks completed locally:

- `node /Users/arbenlila/.codex/skills/interdomestik-slice-runner/scripts/next-slice.mjs .` -> `activeSlice=T-501`, class `implementation`, Tier 3.
- `git diff --check` and `git diff --cached --check` passed.
- `pnpm --filter @interdomestik/web type-check` passed.
- Focused unit suite passed for proxy, auth guard, feature flag, login form, and login hint coverage.
- `pnpm --filter @interdomestik/web test:unit --run src/lib/proxy-logic.csp-nonce.test.ts` passed.
- Focused Playwright default flag-off passed for `gate-ks-sq` and `gate-mk-mk`.
- Focused Playwright flag-on passed for `gate-ks-sq` and `gate-mk-mk`.
- `pnpm check:e2e-contracts` passed.
- `pnpm check:architecture-boundaries` passed.
- `pnpm check:modularity-guard` passed.
- `pnpm repo:size:check` passed.
- `pnpm check:db-access` passed.
- `pnpm db:rls:test:required` passed; no schema/RLS changes in this PR.
- `pnpm security:guard` passed.
- `pnpm pr:verify` passed.
- `pnpm e2e:gate` passed.

## Review / security disposition

- Codex Security diff scan: unavailable/pending manual start. Session `4c4c94b3-6c81-4c4a-9edc-7644ba692bb8` opened successfully for this working-tree diff with valid setup, but `setup.submitted=false`; `await_codex_security_scan_start` timed out. Do not treat this as a completed or passing scan.
- Sonnet/Gemini bounded review: not callable in this runtime; available multi-agent tooling exposes GPT-family agents only, so no Sonnet/Gemini disposition is claimed.
- Copilot disposition: pending PR review/comment state.
- `pr-feedback-intake`: pending after PR creation.

## Merge blockers / required follow-up

- PR current-head checks must pass: CI, Sonar/Quality Gate, CodeQL, Secret Scan/gitleaks, Security/pnpm-audit, pr-finalizer, Pilot Gate, PR E2E, Commitlint as applicable.
- `pr-feedback-intake` must be clean.
- Codex Security must either complete or receive an explicit supervisor/user waiver.
- Explicit supervisor/user approval or waiver is required before merge readiness because T-501 touches routing/auth/session behavior, even though `apps/web/src/proxy.ts` itself is unchanged.
