### PR TITLE
ci: test CD on mac self-hosted runner

### DIFF
--- a/.github/actions/build-attested-image/action.yml
+++ b/.github/actions/build-attested-image/action.yml
@@ -34,6 +34,7 @@ runs:
       with:
         context: .
         file: apps/web/Dockerfile
+        platforms: linux/amd64
         push: true
         provenance: mode=max
         sbom: true

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,13 +28,29 @@ runs:
           exit 0
         fi
 
-        apt_cmd="apt-get"
-        if command -v sudo >/dev/null 2>&1; then
-          apt_cmd="sudo apt-get"
-        fi
+        case "${RUNNER_OS}" in
+          Linux)
+            apt_cmd="apt-get"
+            if command -v sudo >/dev/null 2>&1; then
+              apt_cmd="sudo apt-get"
+            fi
 
-        ${apt_cmd} update
-        ${apt_cmd} install -y ripgrep
+            ${apt_cmd} update
+            ${apt_cmd} install -y ripgrep
+            ;;
+          macOS)
+            if command -v brew >/dev/null 2>&1; then
+              brew install ripgrep
+            else
+              echo "::error::ripgrep is missing and Homebrew is not available on macOS runner."
+              exit 1
+            fi
+            ;;
+          *)
+            echo "::error::ripgrep is missing and automatic install is not supported on ${RUNNER_OS}."
+            exit 1
+            ;;
+        esac
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile --prefer-offline
@@ -57,7 +73,7 @@ runs:
         set -euo pipefail
 
         # Most CI paths only run Chromium projects; avoid downloading unused engines.
-        if [[ "${{ steps.playwright-cache.outputs.cache-hit }}" == "true" ]]; then
+        if [[ "${{ steps.playwright-cache.outputs.cache-hit }}" == "true" || "${RUNNER_OS}" != "Linux" ]]; then
           pnpm --filter @interdomestik/web exec playwright install chromium
         else
           pnpm --filter @interdomestik/web exec playwright install --with-deps chromium

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-staging:
-    runs-on: [self-hosted, interdomestik-linux]
+    runs-on: [self-hosted, interdomestik-mac]
     environment:
       name: staging
     permissions:
@@ -68,7 +68,7 @@ jobs:
 
   deploy-staging:
     needs: build-staging
-    runs-on: [self-hosted, interdomestik-linux]
+    runs-on: [self-hosted, interdomestik-mac]
     environment:
       name: staging
       url: https://staging.interdomestik.com
@@ -142,7 +142,7 @@ jobs:
 
   e2e-staging:
     needs: deploy-staging
-    runs-on: [self-hosted, interdomestik-linux]
+    runs-on: [self-hosted, interdomestik-mac]
     env:
       BASE_URL: https://staging.interdomestik.com
       EVIDENCE_DIR: tmp/cd-evidence/${{ github.run_id }}/staging
@@ -188,7 +188,7 @@ jobs:
 
   build-production:
     needs: e2e-staging
-    runs-on: [self-hosted, interdomestik-linux]
+    runs-on: [self-hosted, interdomestik-mac]
     environment:
       name: production
     permissions:
@@ -242,7 +242,7 @@ jobs:
 
   deploy-production:
     needs: build-production
-    runs-on: [self-hosted, interdomestik-linux]
+    runs-on: [self-hosted, interdomestik-mac]
     environment:
       name: production
       url: https://www.interdomestik.com
@@ -264,7 +264,7 @@ jobs:
 
   verify-production:
     needs: deploy-production
-    runs-on: [self-hosted, interdomestik-linux]
+    runs-on: [self-hosted, interdomestik-mac]
     timeout-minutes: 20
     env:
       BASE_URL: https://www.interdomestik.com


### PR DESCRIPTION
## Summary
- Switch CD jobs from the unavailable `interdomestik-linux` self-hosted label to the online `interdomestik-mac` self-hosted runner for a deployment test.
- Pin attested Docker image builds to `linux/amd64` so the ARM Mac runner does not accidentally publish an ARM-only image.
- Make the shared setup action macOS-safe for ripgrep and Playwright browser install while preserving Linux behavior.

## Verification
- `ruby -e 'require \"yaml\"; ARGV.each { |f| YAML.load_file(f); puts \"#{f}: yaml ok\" }' .github/workflows/cd.yml .github/actions/build-attested-image/action.yml .github/actions/setup/action.yml`
- `git diff --check HEAD~1..HEAD`
- Confirmed runner online via GitHub API: `interdomestik-mac-Arbens-Mac-mini` labels `self-hosted, macOS, ARM64, interdomestik-mac`.
- Confirmed Docker Desktop is available on the Mac host: Docker server `29.5.2 linux/arm64`.

## Risk / rollback
- This is a temporary CD runner-capacity workaround for testing deployment on the authorized Mac self-hosted runner.
- Production target remains `https://www.interdomestik.com`.
- Roll back by reverting this PR or restoring CD `runs-on: [self-hosted, interdomestik-linux]` after Linux runner capacity is restored.