### PR TITLE
ci: add manual CD dispatch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,6 @@
 name: CD
-
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -185,8 +185,8 @@ jobs:
           path: ${{ env.EVIDENCE_DIR }}/**
           if-no-files-found: error
           retention-days: 14
-
   build-production:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     needs: e2e-staging
     runs-on: [self-hosted, interdomestik-mac]
     environment:


### PR DESCRIPTION
Adds workflow_dispatch to the CD workflow so we can manually trigger a fresh CD run while diagnosing the Mac self-hosted runner deployment path.\n\nScope: CD workflow trigger only.