### PR TITLE
ci: add Mac runner smoke workflow

### DIFF
--- a/.github/workflows/mac-runner-smoke.yml
+++ b/.github/workflows/mac-runner-smoke.yml
@@ -1,0 +1,30 @@
+name: Mac Runner Smoke
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: [self-hosted, interdomestik-mac]
+    steps:
+      - name: Runner identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "runner=${RUNNER_NAME}"
+          echo "os=${RUNNER_OS}"
+          echo "arch=${RUNNER_ARCH}"
+          uname -a
+
+      - name: Tool availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v node
+          node --version
+          command -v pnpm
+          pnpm --version
+          command -v docker
+          docker version


### PR DESCRIPTION
Adds a manual-only diagnostic workflow for the Interdomestik Mac self-hosted runner.\n\nThe workflow has no deploy steps and reads no secrets; it only confirms that GitHub can schedule a job on the interdomestik-mac label and that required tools are available.