### PR TITLE
ci: isolate CD concurrency for Mac runner test

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
 
 concurrency:
-  group: cd-${{ github.ref }}
+  group: cd-${{ github.ref }}-${{ github.run_id }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
Temporarily makes the CD concurrency group unique per run to test whether the zero-job pending CD runs are caused by the existing cd-main concurrency queue.\n\nContext:\n- Mac runner smoke workflow schedules and passes on interdomestik-mac.\n- CD workflow runs are created but stay pending with jobs: [].\n- This change isolates concurrency without changing deployment steps.