### PR TITLE
ci: unblock Docker build DB env placeholders

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -37,7 +37,9 @@ ENV NEXT_IGNORE_ESLINT 1
 ENV INTERDOMESTIK_BUILDING 1
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
-RUN pnpm --filter @interdomestik/web build
+RUN DATABASE_URL="postgres://p:p@127.0.0.1:54322/postgres" \
+  DATABASE_URL_RLS="postgres://p:p@127.0.0.1:54322/postgres" \
+  pnpm --filter @interdomestik/web build
 
 FROM base AS runner
 WORKDIR /app

--- a/packages/database/test/case-scoped-access-grants-rls-fixture.ts
+++ b/packages/database/test/case-scoped-access-grants-rls-fixture.ts
@@ -29,7 +29,7 @@ export async function allowRlsGrantTableAccess(adminDb: {
       begin
         create role ${quoteIdentifier(TEST_DB_ROLE)} login password ${quoteSqlLiteral(TEST_DB_PASSWORD)};
       exception
-        when duplicate_object then
+        when duplicate_object or unique_violation then
           alter role ${quoteIdentifier(TEST_DB_ROLE)} with login password ${quoteSqlLiteral(TEST_DB_PASSWORD)};
       end
       $$;

--- a/packages/database/test/claim-transition-evidence-rls.test.ts
+++ b/packages/database/test/claim-transition-evidence-rls.test.ts
@@ -48,7 +48,7 @@ test('claim_transition_evidence RLS scopes reads by access tenant and writes by 
     do $$
     begin
       create role ${quoteIdentifier(TEST_DB_ROLE)} login password ${quoteSqlLiteral(TEST_DB_PASSWORD)};
-    exception when duplicate_object then
+    exception when duplicate_object or unique_violation then
       alter role ${quoteIdentifier(TEST_DB_ROLE)} with login password ${quoteSqlLiteral(TEST_DB_PASSWORD)};
     end
     $$;

--- a/packages/database/test/rls-engaged.test.ts
+++ b/packages/database/test/rls-engaged.test.ts
@@ -88,7 +88,7 @@ test('RLS is actively enforced across tenant context boundaries', async t => {
       begin
         create role ${quoteIdentifier(TEST_DB_ROLE)} login password ${quoteSqlLiteral(TEST_DB_PASSWORD)};
       exception
-        when duplicate_object then
+        when duplicate_object or unique_violation then
           alter role ${quoteIdentifier(TEST_DB_ROLE)} with login password ${quoteSqlLiteral(TEST_DB_PASSWORD)};
       end
       $$;

--- a/packages/database/test/tenant-entity-decomposition-rls.test.ts
+++ b/packages/database/test/tenant-entity-decomposition-rls.test.ts
@@ -73,7 +73,7 @@ test('T-504 entity tables use home tenant RLS, not access or booking tenant hint
         begin
           create role ${quoteIdentifier(TEST_DB_ROLE)} nologin;
         exception
-          when duplicate_object then null;
+          when duplicate_object or unique_violation then null;
         end
         $$;
       `)

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37505855,
-  "maxTrackedFiles": 4525,
+  "maxTrackedBytes": 37507369,
+  "maxTrackedFiles": 4526,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7001519,
+    "source/scripts": 7001539,
     "docs/text": 5705447,
-    "tests/e2e": 4924170,
-    "config/data/messages": 1544800,
-    "other": 129165
+    "tests/e2e": 4924230,
+    "config/data/messages": 1546112,
+    "other": 129287
   },
   "maxLargestFileBytes": 3263773,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- provide local-only DATABASE_URL and DATABASE_URL_RLS placeholders for the Docker builder stage build command
- keep placeholder DB URLs scoped to the single build RUN step, not image runtime ENV
- refresh repo-size budget to match the current main snapshot

## Verification
- pnpm security:guard
- pnpm pr:verify
