### PR TITLE
ci: stabilize release sbom and rls grants

### DIFF
--- a/.github/actions/build-attested-image/action.yml
+++ b/.github/actions/build-attested-image/action.yml
@@ -52,6 +52,8 @@ runs:
 
     - name: Generate Image SBOM
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      env:
+        SYFT_PLATFORM: linux/amd64
       with:
         image: ${{ inputs.registry }}/${{ inputs.image-name }}@${{ steps.build.outputs.digest }}
         format: spdx-json

--- a/packages/database/test/case-scoped-access-grants-rls-fixture.ts
+++ b/packages/database/test/case-scoped-access-grants-rls-fixture.ts
@@ -5,12 +5,12 @@ import { eq, sql } from 'drizzle-orm';
 import { caseScopedAccessGrants, claims, user } from '../src/schema';
 import { refreshCaseScopedGrantPolicies } from './case-scoped-access-grants-rls-policies';
 import {
-  grantRlsTestRole,
   quoteIdentifier,
   quoteSqlLiteral,
   TEST_DB_PASSWORD,
   TEST_DB_ROLE,
 } from './rls-test-connection';
+import { grantRlsTestRole } from './rls-test-grants';
 
 export const HOME_TENANT_ID = 'tenant_ks';
 export const ACCESS_TENANT_ID = 'tenant_mk';

--- a/packages/database/test/claim-transition-evidence-rls.test.ts
+++ b/packages/database/test/claim-transition-evidence-rls.test.ts
@@ -9,13 +9,13 @@ import postgres from 'postgres';
 import { claimTransitionEvidence, claims, user } from '../src/schema';
 import {
   applyRlsTestConnectionEnv,
-  grantRlsTestRole,
   quoteIdentifier,
   quoteSqlLiteral,
   requireRlsPreconditions,
   TEST_DB_PASSWORD,
   TEST_DB_ROLE,
 } from './rls-test-connection';
+import { grantRlsTestRole } from './rls-test-grants';
 
 const KS_TENANT_ID = 'tenant_ks';
 const MK_TENANT_ID = 'tenant_mk';

--- a/packages/database/test/rls-engaged.test.ts
+++ b/packages/database/test/rls-engaged.test.ts
@@ -9,7 +9,6 @@ import postgres from 'postgres';
 import { claims, crmTaskHistory, crmTasks, domainEvents, user } from '../src/schema';
 import {
   applyRlsTestConnectionEnv,
-  grantRlsTestRole,
   quoteIdentifier,
   quoteSqlLiteral,
   requireRlsPreconditions,
@@ -17,6 +16,7 @@ import {
   TEST_DB_PASSWORD,
   TEST_DB_ROLE,
 } from './rls-test-connection';
+import { grantRlsTestRole } from './rls-test-grants';
 import { assertRlsWriteBoundaries } from './rls-write-boundary-proof';
 
 const KS_TENANT_ID = 'tenant_ks';

--- a/packages/database/test/rls-test-connection.ts
+++ b/packages/database/test/rls-test-connection.ts
@@ -131,19 +131,3 @@ export async function requireRlsPreconditions(
     t.skip(`tenant-isolation policies are not present: ${missingPolicyTables.join(', ')}`);
   }
 }
-
-export async function grantRlsTestRole(
-  adminDb: ReturnType<typeof drizzle>,
-  tableNames: readonly string[]
-): Promise<void> {
-  await adminDb.execute(sql.raw(`grant usage on schema public to "${TEST_DB_ROLE}"`));
-  for (const tableName of tableNames) {
-    await adminDb.execute(
-      sql.raw(`grant select on table ${quoteIdentifier(tableName)} to "${TEST_DB_ROLE}"`)
-    );
-  }
-  const [{ currentUser }] = await adminDb.execute<{ currentUser: string }>(
-    sql`select current_user as "currentUser"`
-  );
-  await adminDb.execute(sql.raw(`grant "${TEST_DB_ROLE}" to ${quoteIdentifier(currentUser)}`));
-}

--- a/packages/database/test/rls-test-grants.ts
+++ b/packages/database/test/rls-test-grants.ts
@@ -1,0 +1,45 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { sql } from 'drizzle-orm';
+import type { drizzle } from 'drizzle-orm/postgres-js';
+
+import { quoteIdentifier, TEST_DB_ROLE } from './rls-test-connection';
+
+type TestDb = ReturnType<typeof drizzle>;
+
+function isTransientGrantRace(error: unknown): boolean {
+  const cause = (error as { cause?: { code?: string; message?: string } })?.cause;
+  return cause?.code === 'XX000' && /tuple concurrently updated/iu.test(cause.message ?? '');
+}
+
+async function executeGrantWithRetry(adminDb: TestDb, statement: string): Promise<void> {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      await adminDb.execute(sql.raw(statement));
+      return;
+    } catch (error) {
+      if (attempt === 3 || !isTransientGrantRace(error)) throw error;
+      await sleep(attempt * 50);
+    }
+  }
+}
+
+export async function grantRlsTestRole(
+  adminDb: TestDb,
+  tableNames: readonly string[]
+): Promise<void> {
+  await executeGrantWithRetry(adminDb, `grant usage on schema public to "${TEST_DB_ROLE}"`);
+  for (const tableName of tableNames) {
+    await executeGrantWithRetry(
+      adminDb,
+      `grant select on table ${quoteIdentifier(tableName)} to "${TEST_DB_ROLE}"`
+    );
+  }
+  const [{ currentUser }] = await adminDb.execute<{ currentUser: string }>(
+    sql`select current_user as "currentUser"`
+  );
+  await executeGrantWithRetry(
+    adminDb,
+    `grant "${TEST_DB_ROLE}" to ${quoteIdentifier(currentUser)}`
+  );
+}

--- a/packages/database/test/tenant-entity-decomposition-rls.test.ts
+++ b/packages/database/test/tenant-entity-decomposition-rls.test.ts
@@ -12,12 +12,8 @@ import {
   marketingHosts,
   tenantEntityBoundaries,
 } from '../src/schema';
-import {
-  grantRlsTestRole,
-  quoteIdentifier,
-  requireRlsPreconditions,
-  TEST_DB_ROLE,
-} from './rls-test-connection';
+import { quoteIdentifier, requireRlsPreconditions, TEST_DB_ROLE } from './rls-test-connection';
+import { grantRlsTestRole } from './rls-test-grants';
 
 const KS_TENANT_ID = 'tenant_ks';
 const MK_TENANT_ID = 'tenant_mk';

--- a/scripts/ci/cd-attestation-contract.test.mjs
+++ b/scripts/ci/cd-attestation-contract.test.mjs
@@ -91,6 +91,7 @@ function assertAttestedImageAction() {
   assert.ok(attestSbomStep, 'attested image action must create a signed SBOM attestation');
   assert.ok(verifyStep, 'attested image action must verify signed provenance and SBOM');
   assert.match(sbomStep.uses, /^anchore\/sbom-action@[a-f0-9]{40}$/u);
+  assert.equal(sbomStep.env.SYFT_PLATFORM, 'linux/amd64');
   assert.equal(sbomStep.with.format, 'spdx-json');
   assert.equal(sbomStep.with['output-file'], 'image.sbom.spdx.json');
   assert.equal(sbomStep.with['upload-artifact'], false);

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37507369,
-  "maxTrackedFiles": 4526,
+  "maxTrackedBytes": 37508485,
+  "maxTrackedFiles": 4527,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7001539,
+    "source/scripts": 7002448,
     "docs/text": 5705447,
-    "tests/e2e": 4924230,
-    "config/data/messages": 1546112,
+    "tests/e2e": 4924391,
+    "config/data/messages": 1546158,
     "other": 129287
   },
   "maxLargestFileBytes": 3263773,


### PR DESCRIPTION
## Summary
- pins Syft SBOM generation to linux/amd64 for the release image built by CD
- adds a CD attestation contract assertion for the SBOM platform
- isolates RLS grant setup into a small helper and retries only the transient Postgres catalog grant race

## Verification
- node --test scripts/ci/cd-attestation-contract.test.mjs
- pnpm repo:size:check
- pnpm security:guard
- pnpm db:rls:test:required
- pnpm pr:verify