### PR TITLE
ci: deploy through Vercel prebuilt artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,11 +71,10 @@ NEXT_PUBLIC_PADDLE_ENV=sandbox # sandbox or production
 # Deployment boundary
 # Required for staging/production Docker builds to prevent Supabase project drift.
 SUPABASE_PRODUCTION_PROJECT_REF=
-# GitHub environment secrets, not local runtime variables:
-# INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL
-# INTERDOMESTIK_STAGING_DEPLOY_TOKEN
-# INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL
-# INTERDOMESTIK_PRODUCTION_DEPLOY_TOKEN
+# GitHub environment variables/secrets, not local runtime variables:
+# VERCEL_ORG_ID
+# VERCEL_PROJECT_ID
+# VERCEL_TOKEN
 
 # Paddle Price IDs (Example mappings)
 NEXT_PUBLIC_PADDLE_PRICE_BASIC_YEAR=pri_...

--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -1,120 +1,148 @@
-name: Trigger digest-verified deploy
-description: Trigger an environment deploy webhook and require immutable image digest confirmation.
-
+name: Deploy Vercel Prebuilt Artifact
+description: Pulls Vercel env, builds locally, and deploys a prebuilt artifact.
 inputs:
   environment:
     required: true
-  webhook-url:
+  production:
     required: true
-  webhook-token:
+  commit-sha:
     required: true
-  registry:
+  attested-image-digest:
     required: true
-  image-name:
-    required: true
-  image-tag:
-    required: true
-  image-digest:
-    required: true
-  sha:
-    required: true
-
+outputs:
+  deployment_url:
+    value: ${{ steps.deploy.outputs.deployment_url }}
+  base_url:
+    value: ${{ steps.deploy.outputs.base_url }}
+  hostname:
+    value: ${{ steps.deploy.outputs.hostname }}
+  vercel_output_digest:
+    value: ${{ steps.deploy.outputs.vercel_output_digest }}
 runs:
   using: composite
   steps:
-    - name: Trigger deploy webhook
+    - name: Validate Vercel configuration
+      shell: bash
+      run: |
+        set -euo pipefail
+        missing=()
+        for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          if [[ -z "${!name:-}" ]]; then
+            missing+=("${name}")
+          fi
+        done
+        if (( ${#missing[@]} > 0 )); then
+          echo "::error::Missing Vercel deployment configuration: ${missing[*]}"
+          exit 1
+        fi
+        if [[ "${ENABLE_VERCEL_DEPLOYMENTS:-}" != "1" ]]; then
+          echo "::error::ENABLE_VERCEL_DEPLOYMENTS=1 is required for CD Vercel deploys"
+          exit 1
+        fi
+        if [[ ! "${COMMIT_SHA}" =~ ^[a-f0-9]{40}$ ]]; then
+          echo "::error::commit-sha must be a full lowercase git SHA"
+          exit 1
+        fi
+        if [[ ! "${ATTESTED_IMAGE_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+          echo "::error::attested-image-digest must be an immutable sha256 digest"
+          exit 1
+        fi
+      env:
+        COMMIT_SHA: ${{ inputs.commit-sha }}
+        ATTESTED_IMAGE_DIGEST: ${{ inputs.attested-image-digest }}
+    - name: Setup Node
+      uses: actions/setup-node@v5
+      with:
+        node-version: '24'
+    - name: Pull Vercel environment
+      shell: bash
+      env:
+        DEPLOY_PRODUCTION: ${{ inputs.production }}
+        DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+      run: |
+        set -euo pipefail
+        vercel_env="${DEPLOY_ENVIRONMENT}"
+        [[ "${DEPLOY_PRODUCTION}" == "true" ]] && vercel_env=production
+        npx --yes vercel@latest pull \
+          --yes \
+          --environment="${vercel_env}"
+    - name: Build Vercel artifact
       shell: bash
       env:
         DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
-        DEPLOY_WEBHOOK_URL: ${{ inputs.webhook-url }}
-        DEPLOY_WEBHOOK_TOKEN: ${{ inputs.webhook-token }}
-        IMAGE_REGISTRY: ${{ inputs.registry }}
-        IMAGE_NAME: ${{ inputs.image-name }}
-        IMAGE_TAG: ${{ inputs.image-tag }}
-        IMAGE_DIGEST: ${{ inputs.image-digest }}
-        COMMIT_SHA: ${{ inputs.sha }}
+        DEPLOY_PRODUCTION: ${{ inputs.production }}
+        INTERDOMESTIK_DEPLOY_ENV: ${{ inputs.environment }}
       run: |
         set -euo pipefail
-
-        missing=()
-        [[ -n "${DEPLOY_ENVIRONMENT:-}" ]] || missing+=("environment")
-        [[ -n "${DEPLOY_WEBHOOK_URL:-}" ]] || missing+=("webhook-url")
-        [[ -n "${DEPLOY_WEBHOOK_TOKEN:-}" ]] || missing+=("webhook-token")
-        [[ -n "${IMAGE_REGISTRY:-}" ]] || missing+=("registry")
-        [[ -n "${IMAGE_NAME:-}" ]] || missing+=("image-name")
-        [[ -n "${IMAGE_TAG:-}" ]] || missing+=("image-tag")
-        [[ -n "${IMAGE_DIGEST:-}" ]] || missing+=("image-digest")
-        [[ -n "${COMMIT_SHA:-}" ]] || missing+=("sha")
-
-        if (( ${#missing[@]} > 0 )); then
-          echo "::error::Missing ${DEPLOY_ENVIRONMENT:-unknown} deploy prerequisite(s): ${missing[*]}."
+        target_args=(--target="${DEPLOY_ENVIRONMENT}")
+        if [[ "${DEPLOY_PRODUCTION}" == "true" ]]; then
+          target_args=(--prod)
+        fi
+        npx --yes vercel@latest build "${target_args[@]}"
+    - name: Write Vercel output attestation metadata
+      id: artifact
+      shell: bash
+      env:
+        COMMIT_SHA: ${{ inputs.commit-sha }}
+        DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+        SOURCE_IMAGE_DIGEST: ${{ inputs.attested-image-digest }}
+      run: |
+        set -euo pipefail
+        metadata_dir=".vercel/output/static/.well-known"
+        mkdir -p "${metadata_dir}"
+        vercel_output_digest="$(node scripts/ci/hash-vercel-output.mjs)"
+        cat > "${metadata_dir}/interdomestik-release-attestation.json" <<JSON
+        {"environment":"${DEPLOY_ENVIRONMENT}","commitSha":"${COMMIT_SHA}","sourceImageDigest":"${SOURCE_IMAGE_DIGEST}","vercelOutputDigest":"${vercel_output_digest}"}
+        JSON
+        echo "vercel_output_digest=${vercel_output_digest}" >> "${GITHUB_OUTPUT}"
+    - name: Attest Vercel output artifact
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+      with:
+        subject-name: vercel-output/${{ inputs.environment }}
+        subject-digest: ${{ steps.artifact.outputs.vercel_output_digest }}
+    - name: Deploy Vercel artifact
+      id: deploy
+      shell: bash
+      env:
+        ATTESTED_IMAGE_DIGEST: ${{ inputs.attested-image-digest }}
+        COMMIT_SHA: ${{ inputs.commit-sha }}
+        DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+        DEPLOY_PRODUCTION: ${{ inputs.production }}
+        VERCEL_OUTPUT_DIGEST: ${{ steps.artifact.outputs.vercel_output_digest }}
+      run: |
+        set -euo pipefail
+        target_args=(--target="${DEPLOY_ENVIRONMENT}")
+        if [[ "${DEPLOY_PRODUCTION}" == "true" ]]; then
+          target_args=(--prod)
+        fi
+        current_vercel_output_digest="$(node scripts/ci/hash-vercel-output.mjs)"
+        if [[ "${current_vercel_output_digest}" != "${VERCEL_OUTPUT_DIGEST}" ]]; then
+          echo "::error::Vercel output digest changed after attestation"
           exit 1
         fi
-
-        image_ref="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-        payload_file="$(mktemp)"
-        response_file="$(mktemp)"
-        trap 'rm -f "${payload_file}" "${response_file}"' EXIT
-
-        printf '{"environment":"%s","image":"%s","image_tag":"%s","image_digest":"%s","sha":"%s"}' \
-          "${DEPLOY_ENVIRONMENT}" \
-          "${image_ref}" \
-          "${IMAGE_TAG}" \
-          "${IMAGE_DIGEST}" \
-          "${COMMIT_SHA}" > "${payload_file}"
-
-        curl_exit=0
-        http_status="$(
-          curl --silent --show-error --output "${response_file}" --write-out '%{http_code}' \
-            --connect-timeout 10 --max-time 120 \
-            --retry 3 --retry-delay 5 \
-            -H 'content-type: application/json' \
-            -H "authorization: Bearer ${DEPLOY_WEBHOOK_TOKEN}" \
-            --data-binary @"${payload_file}" \
-            "${DEPLOY_WEBHOOK_URL}"
-        )" || curl_exit=$?
-
-        if (( curl_exit != 0 )); then
-          echo "::error::Failed to trigger ${DEPLOY_ENVIRONMENT} deploy webhook."
-          if [[ -s "${response_file}" ]]; then
-            cat "${response_file}"
-          fi
-          exit "${curl_exit}"
+        deployment_url="$(
+          npx --yes vercel@latest deploy \
+            --prebuilt \
+            --env "COMMIT_SHA=${COMMIT_SHA}" \
+            "${target_args[@]}"
+        )"
+        deployment_url="$(printf '%s\n' "${deployment_url}" | tail -n 1)"
+        base_url="${deployment_url}"
+        if [[ "${base_url}" != https://* ]]; then
+          base_url="https://${base_url}"
         fi
-
-        if [[ ! "${http_status}" =~ ^2[0-9][0-9]$ ]]; then
-          echo "::error::${DEPLOY_ENVIRONMENT} deploy webhook returned HTTP ${http_status}."
-          cat "${response_file}"
-          exit 1
-        fi
-
-        DEPLOY_WEBHOOK_RESPONSE_FILE="${response_file}" node --input-type=module <<'NODE'
-          import fs from 'node:fs';
-
-          const expected = process.env.IMAGE_DIGEST;
-          const environment = process.env.DEPLOY_ENVIRONMENT || 'unknown';
-          const responseFile = process.env.DEPLOY_WEBHOOK_RESPONSE_FILE;
-          if (!expected || !responseFile) {
-            throw new Error('IMAGE_DIGEST and DEPLOY_WEBHOOK_RESPONSE_FILE are required');
-          }
-
-          const raw = fs.readFileSync(responseFile, 'utf8').trim();
-          if (!raw) {
-            throw new Error(`${environment} deploy webhook must confirm image_digest in JSON`);
-          }
-
-          let response;
-          try {
-            response = JSON.parse(raw);
-          } catch (error) {
-            throw new Error(`${environment} deploy webhook must confirm image_digest in JSON`, {
-              cause: error,
-            });
-          }
-          const actual = response?.image_digest;
-          if (actual !== expected) {
-            throw new Error(`${environment} deploy digest mismatch: expected ${expected}, got ${actual || 'missing'}`);
-          }
-
-          console.log(`${environment} deploy webhook confirmed image digest: ${actual}`);
-        NODE
+        hostname="${base_url#https://}"
+        hostname="${hostname%%/*}"
+        hostname="${hostname%%:*}"
+        metadata_url="${base_url}/.well-known/interdomestik-release-attestation.json"
+        metadata="$(curl -fsS --retry 6 --retry-delay 5 "${metadata_url}")"
+        METADATA="${metadata}" node scripts/ci/verify-vercel-attestation.mjs
+        echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
+        echo "base_url=${base_url}" >> "${GITHUB_OUTPUT}"
+        echo "hostname=${hostname}" >> "${GITHUB_OUTPUT}"
+        echo "vercel_output_digest=${VERCEL_OUTPUT_DIGEST}" >> "${GITHUB_OUTPUT}"
+        echo "Deployed ${DEPLOY_ENVIRONMENT} to ${base_url}"
+    - name: Clean Vercel environment cache
+      if: ${{ always() }}
+      shell: bash
+      run: rm -rf .vercel

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,6 @@ on:
 concurrency:
   group: cd-${{ github.ref }}-${{ github.run_id }}
   cancel-in-progress: false
-
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -31,19 +30,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver: docker-container
-
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
@@ -51,7 +47,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=staging-${{ github.sha }}
-
       - name: Build, attest, and verify Docker image
         id: build
         uses: ./.github/actions/build-attested-image
@@ -65,87 +60,88 @@ jobs:
           supabase-url: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           supabase-anon-key: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           supabase-production-project-ref: ${{ vars.SUPABASE_PRODUCTION_PROJECT_REF || secrets.SUPABASE_PRODUCTION_PROJECT_REF }}
-
   deploy-staging:
     needs: build-staging
     runs-on: [self-hosted, interdomestik-mac]
     environment:
       name: staging
-      url: https://staging.interdomestik.com
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      base_url: ${{ steps.vercel.outputs.base_url }}
+      hostname: ${{ steps.vercel.outputs.hostname }}
     env:
-      BASE_URL: https://staging.interdomestik.com
       EXPECTED_COMMIT_SHA: ${{ github.sha }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
-
-      - name: Trigger Staging Deploy
+      - name: Deploy Staging to Vercel
+        id: vercel
         uses: ./.github/actions/trigger-digest-verified-deploy
+        env:
+          ENABLE_VERCEL_DEPLOYMENTS: '1'
         with:
           environment: staging
-          webhook-url: ${{ secrets.INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL }}
-          webhook-token: ${{ secrets.INTERDOMESTIK_STAGING_DEPLOY_TOKEN }}
-          registry: ${{ env.REGISTRY }}
-          image-name: ${{ env.IMAGE_NAME }}
-          image-tag: ${{ needs.build-staging.outputs.image_tag }}
-          image-digest: ${{ needs.build-staging.outputs.image_digest }}
-          sha: ${{ github.sha }}
-
+          production: 'false'
+          commit-sha: ${{ github.sha }}
+          attested-image-digest: ${{ needs.build-staging.outputs.image_digest }}
       - name: Wait for Staging Health
         shell: bash
+        env:
+          BASE_URL: ${{ steps.vercel.outputs.base_url }}
         run: |
           set -euo pipefail
           max_attempts=30
           sleep_seconds=5
-
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Attempt ${attempt}/${max_attempts}: checking ${BASE_URL}/api/health..."
-
             if curl -fsS "${BASE_URL}/api/health"; then
               echo "Staging health check succeeded."
               exit 0
             fi
-
             if [[ "${attempt}" -lt "${max_attempts}" ]]; then
               sleep "${sleep_seconds}"
             fi
           done
-
           echo "::error::Staging health check failed after ${max_attempts} attempts."
           exit 1
 
       - name: Verify Staging Build Provenance
         shell: bash
+        env:
+          BASE_URL: ${{ steps.vercel.outputs.base_url }}
         run: |
           set -euo pipefail
-
           node --input-type=module -e '
             const expected = process.env.EXPECTED_COMMIT_SHA;
             const baseUrl = process.env.BASE_URL;
             if (!expected || !baseUrl) {
               throw new Error("EXPECTED_COMMIT_SHA and BASE_URL are required");
             }
-
             const res = await fetch(new URL("/api/health", baseUrl));
             if (!res.ok) {
               throw new Error(`Health endpoint returned ${res.status}`);
             }
-
             const health = await res.json();
             const actual = health?.build?.commitSha;
             if (actual !== expected) {
               throw new Error(`Deployed build provenance mismatch: expected ${expected}, got ${actual || "missing"}`);
             }
-
             console.log(`Deployed build provenance verified: ${actual}`);
           '
-
   e2e-staging:
     needs: deploy-staging
     runs-on: [self-hosted, interdomestik-mac]
     env:
-      BASE_URL: https://staging.interdomestik.com
+      BASE_URL: ${{ needs.deploy-staging.outputs.base_url }}
+      AUTH_BASE_URL: https://staging.interdomestik.com
       EVIDENCE_DIR: tmp/cd-evidence/${{ github.run_id }}/staging
+      RELEASE_GATE_EXTRA_HOSTNAME: ${{ needs.deploy-staging.outputs.hostname }}
       RELEASE_GATE_EXPECTED_SHA: ${{ github.sha }}
       RELEASE_GATE_MEMBER_EMAIL: ${{ secrets.RELEASE_GATE_MEMBER_EMAIL }}
       RELEASE_GATE_MEMBER_PASSWORD: ${{ secrets.RELEASE_GATE_MEMBER_PASSWORD }}
@@ -160,11 +156,9 @@ jobs:
       RELEASE_GATE_ADMIN_MK_PASSWORD: ${{ secrets.RELEASE_GATE_ADMIN_MK_PASSWORD }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
-
       - uses: ./.github/actions/setup
         with:
           install-playwright: 'true'
-
       - name: Run Staging Release Gate
         shell: bash
         run: |
@@ -174,6 +168,7 @@ jobs:
             --envName staging \
             --suite p0 \
             --baseUrl "${BASE_URL}" \
+            --authBaseUrl "${AUTH_BASE_URL}" \
             --outDir "${EVIDENCE_DIR}/release-gates" \
             2>&1 | tee "${EVIDENCE_DIR}/logs/release-gate-staging.log"
 
@@ -239,29 +234,34 @@ jobs:
           supabase-url: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           supabase-anon-key: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           supabase-production-project-ref: ${{ vars.SUPABASE_PRODUCTION_PROJECT_REF || secrets.SUPABASE_PRODUCTION_PROJECT_REF }}
-
   deploy-production:
     needs: build-production
     runs-on: [self-hosted, interdomestik-mac]
     environment:
       name: production
       url: https://www.interdomestik.com
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
 
-      - name: Trigger Production Deploy
+      - name: Deploy Production to Vercel
+        id: vercel
         uses: ./.github/actions/trigger-digest-verified-deploy
+        env:
+          ENABLE_VERCEL_DEPLOYMENTS: '1'
         with:
           environment: production
-          webhook-url: ${{ secrets.INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL }}
-          webhook-token: ${{ secrets.INTERDOMESTIK_PRODUCTION_DEPLOY_TOKEN }}
-          registry: ${{ env.REGISTRY }}
-          image-name: ${{ env.IMAGE_NAME }}
-          image-tag: ${{ needs.build-production.outputs.image_tag }}
-          image-digest: ${{ needs.build-production.outputs.image_digest }}
-          sha: ${{ github.sha }}
-
+          production: 'true'
+          commit-sha: ${{ github.sha }}
+          attested-image-digest: ${{ needs.build-production.outputs.image_digest }}
   verify-production:
     needs: deploy-production
     runs-on: [self-hosted, interdomestik-mac]

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -1,7 +1,5 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -33,94 +31,120 @@ function assertBuildDigestOutput(jobName) {
   assert.equal(job.outputs.image_digest, '${{ steps.build.outputs.digest }}');
 }
 
-function assertDeployDigestBoundary({ jobName, buildJobName, stepName, environmentName }) {
+function assertVercelDeployBoundary({
+  jobName,
+  buildJobName,
+  stepName,
+  environmentName,
+  production,
+  outputsBaseUrl,
+}) {
   const job = cdWorkflow.jobs[jobName];
   assert.ok(job, `${jobName} must exist`);
+  if (outputsBaseUrl) {
+    assert.equal(job.outputs.base_url, '${{ steps.vercel.outputs.base_url }}');
+    assert.equal(job.outputs.hostname, '${{ steps.vercel.outputs.hostname }}');
+  }
 
   const step = findStep(job.steps, stepName);
-  assert.ok(step, `${jobName} must trigger deployment`);
+  assert.ok(step, `${jobName} must deploy through Vercel`);
   assert.ok(findStepIndex(job.steps, 'Checkout repository') < findStepIndex(job.steps, stepName));
+  assert.equal(step.id, 'vercel');
   assert.equal(step.uses, './.github/actions/trigger-digest-verified-deploy');
   assert.equal(step.with.environment, environmentName);
-  assert.equal(step.with['image-tag'], `\${{ needs.${buildJobName}.outputs.image_tag }}`);
-  assert.equal(step.with['image-digest'], `\${{ needs.${buildJobName}.outputs.image_digest }}`);
-  assert.equal(step.with.sha, '${{ github.sha }}');
+  assert.equal(step.with.production, production);
+  assert.equal(step.with['commit-sha'], '${{ github.sha }}');
+  assert.equal(step.with['canonical-url'], undefined);
+  assert.equal(step.env.ENABLE_VERCEL_DEPLOYMENTS, '1');
+  assert.equal(
+    step.with['attested-image-digest'],
+    '${{ needs.' + buildJobName + '.outputs.image_digest }}'
+  );
+
+  assert.match(job.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
+  assert.equal(job.env.VERCEL_ORG_ID, '${{ vars.VERCEL_ORG_ID }}');
+  assert.equal(job.env.VERCEL_PROJECT_ID, '${{ vars.VERCEL_PROJECT_ID }}');
+  assert.equal(cdWorkflow.env.VERCEL_ORG_ID, undefined);
+  assert.equal(cdWorkflow.env.VERCEL_PROJECT_ID, undefined);
 }
 
-function assertDeployActionDigestVerification() {
-  const step = findStep(deployAction.runs.steps, 'Trigger deploy webhook');
-  assert.ok(step, 'deploy action must trigger the webhook');
-  assert.equal(step.env.IMAGE_DIGEST, '${{ inputs.image-digest }}');
-  assert.match(step.run, /"image_digest":"%s"/u);
-  assert.match(step.run, /missing\+=\("webhook-url"\)/u);
-  assert.match(step.run, /missing\+=\("image-digest"\)/u);
-  assert.match(step.run, /--connect-timeout 10 --max-time 120/u);
-  assert.match(step.run, /\$\{IMAGE_DIGEST\}/u);
-  assert.match(step.run, /DEPLOY_WEBHOOK_RESPONSE_FILE/u);
-  assert.match(step.run, /try \{\s+response = JSON\.parse\(raw\);/u);
-  assert.match(step.run, /deploy webhook must confirm image_digest in JSON/u);
-  assert.match(step.run, /response\?\.image_digest/u);
-  assert.match(step.run, /deploy digest mismatch/u);
-  assert.match(step.run, /deploy webhook confirmed image digest/u);
-  return step.run;
-}
-
-function extractDigestVerifierScript(runScript) {
-  const match = runScript.match(/node --input-type=module <<'NODE'\n([\s\S]+?)\nNODE/u);
-  assert.ok(match, 'deploy action must keep digest verifier in a node heredoc');
-  return match[1].replace(/^ {2}/gmu, '');
-}
-
-function runDigestVerifier(script, responseBody) {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-digest-'));
-  const responseFile = path.join(tempDir, 'response.json');
-  fs.writeFileSync(responseFile, responseBody);
-  try {
-    return spawnSync(process.execPath, ['--input-type=module'], {
-      input: script,
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        DEPLOY_ENVIRONMENT: 'staging',
-        DEPLOY_WEBHOOK_RESPONSE_FILE: responseFile,
-        IMAGE_DIGEST: 'sha256:expected',
-      },
-    });
-  } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
-function assertDigestVerifierRejects(script, responseBody, expectedMessage) {
-  const result = runDigestVerifier(script, responseBody);
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr.toString(), expectedMessage);
-}
-
-test('CD deploy boundary requires immutable image digest confirmation', () => {
+test('CD deploy boundary uses Vercel prebuilt deployments after attested builds', () => {
   assertBuildDigestOutput('build-staging');
   assertBuildDigestOutput('build-production');
-  assertDeployDigestBoundary({
+
+  assertVercelDeployBoundary({
     jobName: 'deploy-staging',
     buildJobName: 'build-staging',
-    stepName: 'Trigger Staging Deploy',
+    stepName: 'Deploy Staging to Vercel',
     environmentName: 'staging',
+    production: 'false',
+    outputsBaseUrl: true,
   });
-  assertDeployDigestBoundary({
+  assertVercelDeployBoundary({
     jobName: 'deploy-production',
     buildJobName: 'build-production',
-    stepName: 'Trigger Production Deploy',
+    stepName: 'Deploy Production to Vercel',
     environmentName: 'production',
+    production: 'true',
+    outputsBaseUrl: false,
   });
-  const verifierScript = extractDigestVerifierScript(assertDeployActionDigestVerification());
-  const success = runDigestVerifier(verifierScript, '{"image_digest":"sha256:expected"}');
-  assert.equal(success.status, 0);
-  assert.match(success.stdout, /confirmed image digest/u);
-  assertDigestVerifierRejects(
-    verifierScript,
-    '{"image_digest":"sha256:other"}',
-    /deploy digest mismatch/u
+});
+
+test('Vercel deploy action validates config, builds, deploys, and exports base URL', () => {
+  const steps = deployAction.runs.steps;
+  const validateStep = findStep(steps, 'Validate Vercel configuration');
+  const pullStep = findStep(steps, 'Pull Vercel environment');
+  const buildStep = findStep(steps, 'Build Vercel artifact');
+  const renamedDigestStep = findStep(steps, 'Write Vercel output attestation metadata');
+  const attestStep = findStep(steps, 'Attest Vercel output artifact');
+  const deployStep = findStep(steps, 'Deploy Vercel artifact');
+  const cleanupStep = findStep(steps, 'Clean Vercel environment cache');
+
+  assert.equal(deployAction.inputs['commit-sha'].required, true);
+  assert.equal(deployAction.inputs['attested-image-digest'].required, true);
+  assert.equal(
+    deployAction.outputs.vercel_output_digest.value,
+    '${{ steps.deploy.outputs.vercel_output_digest }}'
   );
-  assertDigestVerifierRejects(verifierScript, '{"status":"ok"}', /got missing/u);
-  assertDigestVerifierRejects(verifierScript, 'not json', /must confirm image_digest in JSON/u);
+  assert.match(validateStep.run, /VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID/u);
+  assert.match(validateStep.run, /ENABLE_VERCEL_DEPLOYMENTS=1/u);
+
+  assert.match(pullStep.run, /vercel@latest pull/u);
+  assert.match(pullStep.run, /--environment="\$\{vercel_env\}"/u);
+
+  assert.match(buildStep.run, /vercel@latest build/u);
+  assert.match(buildStep.run, /--target="\$\{DEPLOY_ENVIRONMENT\}"/u);
+
+  assert.equal(renamedDigestStep.id, 'artifact');
+  assert.match(renamedDigestStep.run, /hash-vercel-output\.mjs/u);
+  assert.match(renamedDigestStep.run, /interdomestik-release-attestation\.json/u);
+  assert.match(renamedDigestStep.run, /vercelOutputDigest/u);
+  assert.match(renamedDigestStep.env.SOURCE_IMAGE_DIGEST, /inputs\.attested-image-digest/u);
+
+  assert.match(attestStep.uses, /^actions\/attest@[a-f0-9]{40}$/u);
+  assert.equal(attestStep.with['subject-name'], 'vercel-output/${{ inputs.environment }}');
+  assert.equal(
+    attestStep.with['subject-digest'],
+    '${{ steps.artifact.outputs.vercel_output_digest }}'
+  );
+
+  assert.equal(deployStep.id, 'deploy');
+  assert.match(
+    deployStep.run,
+    /current_vercel_output_digest="\$\(node scripts\/ci\/hash-vercel-output\.mjs\)"/u
+  );
+  assert.match(deployStep.run, /Vercel output digest changed after attestation/u);
+  assert.match(deployStep.run, /vercel@latest deploy/u);
+  assert.match(deployStep.run, /--prebuilt/u);
+  assert.match(deployStep.run, /--env "COMMIT_SHA=\$\{COMMIT_SHA\}"/u);
+  assert.match(deployStep.run, /--target="\$\{DEPLOY_ENVIRONMENT\}"/u);
+  assert.match(deployStep.run, /base_url="\$\{deployment_url\}"/u);
+  assert.doesNotMatch(deployStep.run, /--token/u);
+  assert.match(deployStep.run, /interdomestik-release-attestation\.json/u);
+  assert.match(deployStep.run, /verify-vercel-attestation\.mjs/u);
+  assert.match(deployStep.run, /hostname=/u);
+  assert.match(deployStep.run, /vercel_output_digest=/u);
+  assert.match(deployStep.run, /GITHUB_OUTPUT/u);
+  assert.equal(cleanupStep.if, '${{ always() }}');
+  assert.match(cleanupStep.run, /rm -rf \.vercel/u);
 });

--- a/scripts/ci/hash-vercel-output.mjs
+++ b/scripts/ci/hash-vercel-output.mjs
@@ -39,7 +39,9 @@ if (!statSync(outputRoot).isDirectory()) {
 }
 
 const digest = createHash('sha256');
-for (const relativePath of collectFiles(outputRoot).sort()) {
+for (const relativePath of collectFiles(outputRoot).sort((left, right) =>
+  left.localeCompare(right)
+)) {
   const absolutePath = resolveOutputPath(...relativePath.split('/'));
   const fileDigest = createHash('sha256').update(readFileSync(absolutePath)).digest('hex');
   digest.update(relativePath);

--- a/scripts/ci/hash-vercel-output.mjs
+++ b/scripts/ci/hash-vercel-output.mjs
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const outputRoot = path.resolve('.vercel/output');
+const outputRootPrefix = `${outputRoot}${path.sep}`;
+const attestationPath = '.well-known/interdomestik-release-attestation.json';
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function resolveOutputPath(...segments) {
+  const candidate = path.resolve(outputRoot, ...segments);
+  if (candidate !== outputRoot && !candidate.startsWith(outputRootPrefix)) {
+    throw new Error(`Refusing to read outside ${outputRoot}`);
+  }
+  return candidate;
+}
+
+function collectFiles(dir, files = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const relativeDir = path.relative(outputRoot, dir);
+    const absolutePath = resolveOutputPath(relativeDir, entry.name);
+    if (entry.isDirectory()) {
+      collectFiles(absolutePath, files);
+    } else if (entry.isFile()) {
+      const relativePath = toPosixPath(path.relative(outputRoot, absolutePath));
+      if (relativePath !== `static/${attestationPath}`) {
+        files.push(relativePath);
+      }
+    }
+  }
+  return files;
+}
+
+if (!statSync(outputRoot).isDirectory()) {
+  throw new Error(`${outputRoot} is not a directory`);
+}
+
+const digest = createHash('sha256');
+for (const relativePath of collectFiles(outputRoot).sort()) {
+  const absolutePath = resolveOutputPath(...relativePath.split('/'));
+  const fileDigest = createHash('sha256').update(readFileSync(absolutePath)).digest('hex');
+  digest.update(relativePath);
+  digest.update('\0');
+  digest.update(fileDigest);
+  digest.update('\0');
+}
+
+process.stdout.write(`sha256:${digest.digest('hex')}\n`);

--- a/scripts/ci/verify-vercel-attestation.mjs
+++ b/scripts/ci/verify-vercel-attestation.mjs
@@ -1,0 +1,13 @@
+const metadata = JSON.parse(process.env.METADATA ?? '{}');
+
+function assertField(field, expected, label) {
+  if (metadata[field] !== expected) {
+    throw new Error(
+      `Deployment ${label} metadata mismatch: expected ${expected}, got ${metadata[field] ?? 'missing'}`
+    );
+  }
+}
+
+assertField('commitSha', process.env.COMMIT_SHA, 'commit');
+assertField('sourceImageDigest', process.env.ATTESTED_IMAGE_DIGEST, 'image digest');
+assertField('vercelOutputDigest', process.env.VERCEL_OUTPUT_DIGEST, 'Vercel output digest');

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -485,19 +485,18 @@ test('Composite CI setup action uses Node 24-compatible hosted actions', () => {
   assert.equal(findStep(steps, 'Playwright Browser Cache').uses, 'actions/cache@v5');
 });
 
-test('V3 onboarding and env docs describe Paddle-only runtime and deploy proof secrets', () => {
+test('V3 onboarding and env docs describe Paddle-only runtime and Vercel deployment config', () => {
   const readme = readRepoText('README.md');
-  const architecture = readRepoText('docs/ARCHITECTURE.md');
   const envExample = readRepoText('.env.example');
 
   assert.match(readme, /V3 pilot billing uses Paddle only/);
-  assert.match(architecture, /environment-scoped deploy webhook secrets/);
   assert.match(envExample, /CLAIM_UPLOAD_INTENT_SECRET/);
   assert.match(envExample, /SUPABASE_PRODUCTION_PROJECT_REF/);
-  assert.match(envExample, /INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL/);
-  assert.match(envExample, /INTERDOMESTIK_STAGING_DEPLOY_TOKEN/);
-  assert.match(envExample, /INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL/);
-  assert.match(envExample, /INTERDOMESTIK_PRODUCTION_DEPLOY_TOKEN/);
+  assert.match(envExample, /VERCEL_ORG_ID/);
+  assert.match(envExample, /VERCEL_PROJECT_ID/);
+  assert.match(envExample, /VERCEL_TOKEN/);
+  assert.doesNotMatch(envExample, /INTERDOMESTIK_STAGING_DEPLOY_WEBHOOK_URL/);
+  assert.doesNotMatch(envExample, /INTERDOMESTIK_PRODUCTION_DEPLOY_WEBHOOK_URL/);
   assert.doesNotMatch(
     envExample,
     /NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY|STRIPE_SECRET_KEY|STRIPE_WEBHOOK_SECRET/
@@ -514,6 +513,8 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   const deployProductionJob = cdWorkflow.jobs['deploy-production'];
   const verifyProductionJob = cdWorkflow.jobs['verify-production'];
 
+  assert.equal(cdWorkflow.env.VERCEL_ORG_ID, undefined);
+  assert.equal(cdWorkflow.env.VERCEL_PROJECT_ID, undefined);
   assert.equal(cdWorkflow.jobs['build-push'], undefined);
   assert.doesNotMatch(cdWorkflowSource, /Actual deployment command here/);
   assert.doesNotMatch(cdWorkflowSource, /pnpm test:e2e:smoke/);
@@ -549,32 +550,38 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(buildProductionStep.with['app-url'], 'https://www.interdomestik.com');
 
   assert.deepEqual(normalizeNeeds(deployStagingJob.needs), ['build-staging']);
+  assert.equal(deployStagingJob.outputs.base_url, '${{ steps.vercel.outputs.base_url }}');
+  assert.equal(deployStagingJob.outputs.hostname, '${{ steps.vercel.outputs.hostname }}');
   assert.equal(deployStagingJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');
-  const triggerStagingDeployStep = findStep(deployStagingJob.steps, 'Trigger Staging Deploy');
-  assert.ok(triggerStagingDeployStep);
-  assert.equal(triggerStagingDeployStep.uses, './.github/actions/trigger-digest-verified-deploy');
-  assert.equal(triggerStagingDeployStep.with.environment, 'staging');
-  assert.match(triggerStagingDeployStep.with['webhook-url'], /INTERDOMESTIK_STAGING_DEPLOY/);
-  assert.equal(
-    triggerStagingDeployStep.with['image-tag'],
-    '${{ needs.build-staging.outputs.image_tag }}'
-  );
-  assert.equal(
-    triggerStagingDeployStep.with['image-digest'],
-    '${{ needs.build-staging.outputs.image_digest }}'
-  );
+  assert.match(deployStagingJob.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
+  const vercelStagingDeployStep = findStep(deployStagingJob.steps, 'Deploy Staging to Vercel');
+  assert.ok(vercelStagingDeployStep);
+  assert.equal(vercelStagingDeployStep.id, 'vercel');
+  assert.equal(vercelStagingDeployStep.uses, './.github/actions/trigger-digest-verified-deploy');
+  assert.equal(vercelStagingDeployStep.env.ENABLE_VERCEL_DEPLOYMENTS, '1');
+  assert.equal(vercelStagingDeployStep.with.environment, 'staging');
+  assert.equal(vercelStagingDeployStep.with.production, 'false');
   const stagingHealthIndex = findStepIndex(deployStagingJob.steps, 'Wait for Staging Health');
   const stagingProvenanceIndex = findStepIndex(
     deployStagingJob.steps,
     'Verify Staging Build Provenance'
   );
-  assert.ok(stagingHealthIndex >= 0);
+  assert.ok(stagingHealthIndex > findStepIndex(deployStagingJob.steps, 'Deploy Staging to Vercel'));
   assert.ok(stagingProvenanceIndex > stagingHealthIndex);
+  const stagingHealthStep = deployStagingJob.steps[stagingHealthIndex];
+  assert.equal(stagingHealthStep.env.BASE_URL, '${{ steps.vercel.outputs.base_url }}');
   const stagingProvenanceStep = deployStagingJob.steps[stagingProvenanceIndex];
+  assert.equal(stagingProvenanceStep.env.BASE_URL, '${{ steps.vercel.outputs.base_url }}');
   assert.match(stagingProvenanceStep.run, /build\?\.commitSha/);
   assert.match(stagingProvenanceStep.run, /EXPECTED_COMMIT_SHA/);
 
   assert.deepEqual(normalizeNeeds(e2eStagingJob.needs), ['deploy-staging']);
+  assert.equal(e2eStagingJob.env.BASE_URL, '${{ needs.deploy-staging.outputs.base_url }}');
+  assert.equal(e2eStagingJob.env.AUTH_BASE_URL, 'https://staging.interdomestik.com');
+  assert.equal(
+    e2eStagingJob.env.RELEASE_GATE_EXTRA_HOSTNAME,
+    '${{ needs.deploy-staging.outputs.hostname }}'
+  );
   assert.equal(e2eStagingJob.env.RELEASE_GATE_EXPECTED_SHA, '${{ github.sha }}');
   for (const envName of RELEASE_GATE_ENV_VARS) {
     assert.match(e2eStagingJob.env[envName], new RegExp(String.raw`secrets\.${envName}`));
@@ -588,6 +595,7 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.match(stagingGateStep.run, /release:gate:raw/);
   assert.match(stagingGateStep.run, /--envName staging/);
   assert.match(stagingGateStep.run, /--suite p0/);
+  assert.match(stagingGateStep.run, /--authBaseUrl "\$\{AUTH_BASE_URL\}"/);
   const stagingArtifactsStep = findStep(
     e2eStagingJob.steps,
     'Upload staging verification artifacts'
@@ -597,25 +605,17 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(stagingArtifactsStep.with['if-no-files-found'], 'error');
 
   assert.deepEqual(normalizeNeeds(deployProductionJob.needs), ['build-production']);
-  const triggerProductionDeployStep = findStep(
+  assert.match(deployProductionJob.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
+  const vercelProductionDeployStep = findStep(
     deployProductionJob.steps,
-    'Trigger Production Deploy'
+    'Deploy Production to Vercel'
   );
-  assert.ok(triggerProductionDeployStep);
-  assert.equal(
-    triggerProductionDeployStep.uses,
-    './.github/actions/trigger-digest-verified-deploy'
-  );
-  assert.equal(triggerProductionDeployStep.with.environment, 'production');
-  assert.match(triggerProductionDeployStep.with['webhook-url'], /INTERDOMESTIK_PRODUCTION_DEPLOY/);
-  assert.equal(
-    triggerProductionDeployStep.with['image-tag'],
-    '${{ needs.build-production.outputs.image_tag }}'
-  );
-  assert.equal(
-    triggerProductionDeployStep.with['image-digest'],
-    '${{ needs.build-production.outputs.image_digest }}'
-  );
+  assert.ok(vercelProductionDeployStep);
+  assert.equal(vercelProductionDeployStep.id, 'vercel');
+  assert.equal(vercelProductionDeployStep.uses, './.github/actions/trigger-digest-verified-deploy');
+  assert.equal(vercelProductionDeployStep.env.ENABLE_VERCEL_DEPLOYMENTS, '1');
+  assert.equal(vercelProductionDeployStep.with.environment, 'production');
+  assert.equal(vercelProductionDeployStep.with.production, 'true');
 
   assert.deepEqual(normalizeNeeds(verifyProductionJob.needs), ['deploy-production']);
   assert.equal(verifyProductionJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');

--- a/scripts/release-gate/run.test.ts
+++ b/scripts/release-gate/run.test.ts
@@ -3,7 +3,6 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-
 const {
   buildCommercialPromiseScenarios,
   buildEscalationAgreementCollectionFallbackScenarios,
@@ -55,17 +54,14 @@ const {
   resolveForwardedForIp,
 } = require('./shared.ts');
 const { REQUIRED_ENV_BY_SUITE, ROLE_IPS, SELECTORS } = require('./config.ts');
-
 const RELEASE_GATE_BASE_URL = 'https://interdomestik-web.vercel.app';
 const RELEASE_GATE_LOCALE = 'en';
 const DEFAULT_MATTER_ALLOWANCE = { used: '0', remaining: '2', total: '2' };
 const ORIGINAL_DISALLOW_SKIP = process.env.RELEASE_GATE_DISALLOW_SKIP;
 const ORIGINAL_REQUIRE_ROLE_PANEL = process.env.RELEASE_GATE_REQUIRE_ROLE_PANEL;
-
 function createTestCredentialValue() {
   return ['test', 'credential', '2026'].join('-');
 }
-
 function restoreDisallowSkipEnv() {
   if (ORIGINAL_DISALLOW_SKIP === undefined) {
     delete process.env.RELEASE_GATE_DISALLOW_SKIP;
@@ -73,7 +69,6 @@ function restoreDisallowSkipEnv() {
     process.env.RELEASE_GATE_DISALLOW_SKIP = ORIGINAL_DISALLOW_SKIP;
   }
 }
-
 function restoreRequireRolePanelEnv() {
   if (ORIGINAL_REQUIRE_ROLE_PANEL === undefined) {
     delete process.env.RELEASE_GATE_REQUIRE_ROLE_PANEL;
@@ -81,11 +76,9 @@ function restoreRequireRolePanelEnv() {
     process.env.RELEASE_GATE_REQUIRE_ROLE_PANEL = ORIGINAL_REQUIRE_ROLE_PANEL;
   }
 }
-
 test('parseRetryAfterSeconds parses integer seconds value', () => {
   assert.equal(parseRetryAfterSeconds('15', 0), 15);
 });
-
 test('parseRetryAfterSeconds parses HTTP date values', () => {
   const nowMs = Date.parse('2026-02-21T00:00:00.000Z');
   const retryAt = new Date(nowMs + 6_000).toUTCString();
@@ -220,6 +213,7 @@ test('loginAs honors shared auth cooldown before posting another login request',
     account: 'member',
     credentials: { email: 'member@example.com', password: createTestCredentialValue() },
     baseUrl: RELEASE_GATE_BASE_URL,
+    authOrigin: 'https://staging.interdomestik.com',
     locale: RELEASE_GATE_LOCALE,
     authState,
     nowFn: () => nowMs,
@@ -232,6 +226,12 @@ test('loginAs honors shared auth cooldown before posting another login request',
   assert.equal(sleepCalls.length, 1);
   assert.equal(sleepCalls[0], 5_000);
   assert.equal(requestCalls.length, 1);
+  assert.equal(requestCalls[0][0], `${RELEASE_GATE_BASE_URL}/api/auth/sign-in/email`);
+  assert.equal(requestCalls[0][1].headers.Origin, 'https://staging.interdomestik.com');
+  assert.equal(
+    requestCalls[0][1].headers.Referer,
+    `https://staging.interdomestik.com/${RELEASE_GATE_LOCALE}/login`
+  );
 });
 
 test('loginAs applies a longer fallback cooldown for platform 429 responses without Retry-After', async () => {

--- a/scripts/release-gate/run.ts
+++ b/scripts/release-gate/run.ts
@@ -94,7 +94,6 @@ const LOGIN_DEPENDENT_CHECKS = new Set([
 function resolveVercelExecutable() {
   return null;
 }
-
 function runVercelCommand() {
   const error = new Error('vercel cli disabled for safe release gate execution');
   error.code = 'VERCEL_CLI_DISABLED';
@@ -108,11 +107,9 @@ function runVercelCommand() {
     error,
   };
 }
-
 function isLegacyVercelLogsArgsUnsupported(output) {
   return /unknown or unexpected option:\s*--environment/i.test(String(output || ''));
 }
-
 function parseVercelRuntimeJsonLines(raw) {
   const entries = [];
   for (const line of String(raw || '')
@@ -128,42 +125,34 @@ function parseVercelRuntimeJsonLines(raw) {
   }
   return entries;
 }
-
 function runtimeEntryMessage(entry) {
   if (!entry || typeof entry !== 'object') return '';
   return String(entry.message || entry.text || entry.msg || '').trim();
 }
-
 function runtimeEntryLevel(entry) {
   if (!entry || typeof entry !== 'object') return '';
   return String(entry.level || entry.severity || '')
     .trim()
     .toLowerCase();
 }
-
 function isErrorRuntimeLevel(level) {
   return level === 'error' || level === 'fatal';
 }
-
 function isLoginDependentCheck(checkId) {
   return LOGIN_DEPENDENT_CHECKS.has(checkId);
 }
-
 function findMissingCommercialPromiseSections(requiredTestIds, observedByTestId) {
   return requiredTestIds.filter(testId => observedByTestId[testId] !== true);
 }
-
 function normalizeBoundaryText(value) {
   return String(value || '')
     .toLowerCase()
     .replaceAll(/\s+/g, ' ')
     .trim();
 }
-
 function compactBoundaryText(value) {
   return normalizeBoundaryText(value).replaceAll(/\s+/g, '');
 }
-
 function resolveAccountPasswordVar(accountKey) {
   const account = ACCOUNTS[accountKey];
   if (!account) {
@@ -176,7 +165,6 @@ function resolveAccountPasswordVar(accountKey) {
 
   return account.passwordVar ?? null;
 }
-
 function findMissingBoundaryPhrases(requiredPhrases, observedText) {
   const normalizedObserved = normalizeBoundaryText(observedText);
   const compactObserved = compactBoundaryText(observedText);
@@ -186,14 +174,12 @@ function findMissingBoundaryPhrases(requiredPhrases, observedText) {
       !compactObserved.includes(compactBoundaryText(phrase))
   );
 }
-
 function findPresentBoundaryLeaks(forbiddenPhrases, observedText) {
   const normalizedObserved = normalizeBoundaryText(observedText);
   return forbiddenPhrases.filter(phrase =>
     normalizedObserved.includes(normalizeBoundaryText(phrase))
   );
 }
-
 function findMismatchedMatterAllowanceValues(expectedValues, observedValues) {
   return Object.entries(expectedValues).flatMap(([key, expected]) => {
     const actual = observedValues[key];
@@ -363,11 +349,11 @@ function evaluateCredentialPreflightResults(results) {
 async function runAuthEndpointPreflight(runCtx) {
   const evidence = [];
   const signatures = [];
-  const { endpoints, origin } = buildAuthEndpointUrls(runCtx.baseUrl, {
+  const { endpoints, origin: baseOrigin } = buildAuthEndpointUrls(runCtx.baseUrl, {
     allowLoopback: runCtx.envName !== 'production',
     allowedExtraHostname: runCtx.allowedExtraHostname,
   });
-
+  const origin = runCtx.authOrigin || baseOrigin;
   for (const { path: endpointPath, url: endpoint } of endpoints) {
     let reached = false;
 
@@ -430,10 +416,11 @@ async function runAuthEndpointPreflight(runCtx) {
 async function runAuthCredentialPreflight(runCtx) {
   const evidence = [];
   const signatures = [];
-  const { origin, signInEmailUrl: loginUrl } = buildAuthEndpointUrls(runCtx.baseUrl, {
+  const { origin: baseOrigin, signInEmailUrl: loginUrl } = buildAuthEndpointUrls(runCtx.baseUrl, {
     allowLoopback: runCtx.envName !== 'production',
     allowedExtraHostname: runCtx.allowedExtraHostname,
   });
+  const origin = runCtx.authOrigin || baseOrigin;
   const accountKeys = selectCredentialPreflightAccounts();
   const results = [];
 
@@ -519,6 +506,7 @@ function selectCredentialPreflightAccounts() {
 function parseArgs(argv) {
   const parsed = {
     baseUrl: DEFAULTS.baseUrl,
+    authBaseUrl: '',
     envName: DEFAULTS.envName,
     locale: DEFAULTS.locale,
     suite: DEFAULTS.suite,
@@ -531,6 +519,11 @@ function parseArgs(argv) {
     const next = argv[i + 1];
     if (token === '--baseUrl' && next) {
       parsed.baseUrl = next;
+      i += 1;
+      continue;
+    }
+    if (token === '--authBaseUrl' && next) {
+      parsed.authBaseUrl = next;
       i += 1;
       continue;
     }
@@ -581,6 +574,7 @@ function printHelp() {
     '',
     'Flags:',
     `  --baseUrl  (default: ${DEFAULTS.baseUrl})`,
+    '  --authBaseUrl  (optional trusted auth Origin/Referer base URL)',
     `  --envName  (default: ${DEFAULTS.envName})`,
     `  --locale   (default: ${DEFAULTS.locale})`,
     `  --suite    (default: ${DEFAULTS.suite}; options: ${Object.keys(SUITES).join('|')})`,
@@ -793,6 +787,7 @@ async function detectDeploymentMetadata(baseUrl, browser) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const configuredBaseUrl = normalizeBaseUrl(args.baseUrl);
+  const configuredAuthBaseUrl = args.authBaseUrl ? normalizeBaseUrl(args.authBaseUrl) : '';
   const requiredEnv = REQUIRED_ENV_BY_SUITE[args.suite] || REQUIRED_ENV_BY_SUITE.all;
   const missingEnv = getMissingEnv(requiredEnv);
   if (missingEnv.length > 0) {
@@ -823,7 +818,11 @@ async function main() {
   const safeConfiguredBaseUrl = assertTrustedReleaseGateBaseUrl(configuredBaseUrl, {
     allowLoopback: allowLoopbackBaseUrl,
   }).href;
-
+  const safeAuthBaseUrl = configuredAuthBaseUrl
+    ? assertTrustedReleaseGateBaseUrl(configuredAuthBaseUrl, {
+        allowLoopback: allowLoopbackBaseUrl,
+      }).href
+    : '';
   try {
     const deployment = await detectDeploymentMetadata(safeConfiguredBaseUrl, browser);
     const resolvedBase = await resolveReachableBaseUrl(safeConfiguredBaseUrl, deployment, {
@@ -837,6 +836,7 @@ async function main() {
     const baseUrl = resolvedBase.baseUrl;
     const runCtx = {
       baseUrl,
+      authOrigin: safeAuthBaseUrl ? new URL(safeAuthBaseUrl).origin : '',
       locale: args.locale,
       suite: args.suite,
       envName: args.envName,

--- a/scripts/release-gate/sec-cql-01-security.test.ts
+++ b/scripts/release-gate/sec-cql-01-security.test.ts
@@ -71,6 +71,15 @@ test('release gate base URL policy rejects untrusted public egress hosts', () =>
       .origin,
     'https://deploy.example.vercel.app'
   );
+  const originalExtraHostname = process.env.RELEASE_GATE_EXTRA_HOSTNAME;
+  try {
+    process.env.RELEASE_GATE_EXTRA_HOSTNAME = 'deploy.example.vercel.app';
+    const allowed = assertTrustedReleaseGateBaseUrl('https://deploy.example.vercel.app');
+    assert.equal(allowed.origin, 'https://deploy.example.vercel.app');
+  } finally {
+    if (originalExtraHostname == null) delete process.env.RELEASE_GATE_EXTRA_HOSTNAME;
+    else process.env.RELEASE_GATE_EXTRA_HOSTNAME = originalExtraHostname;
+  }
   assertThrowsMessage(
     () => assertTrustedReleaseGateBaseUrl('https://attacker.vercel.app', DEPLOY_HOST_OPTIONS),
     RELEASE_GATE_HOST_ERROR
@@ -119,31 +128,18 @@ test('auth preflight allows only the exact validated deployment fallback host', 
 });
 
 test('production release gate allows only trusted CI Playwright loopback base URL', () => {
+  const loopback = 'http://127.0.0.1:3000';
   assert.equal(
-    shouldAllowConfiguredLoopbackBaseUrl('http://127.0.0.1:3000', 'production', {
+    shouldAllowConfiguredLoopbackBaseUrl(loopback, 'production', {
       CI: 'true',
       PLAYWRIGHT: '1',
-      NEXT_PUBLIC_APP_URL: 'http://127.0.0.1:3000',
-      BETTER_AUTH_URL: 'http://127.0.0.1:3000',
+      NEXT_PUBLIC_APP_URL: loopback,
+      BETTER_AUTH_URL: loopback,
     }),
     true
   );
 
-  assert.equal(
-    shouldAllowConfiguredLoopbackBaseUrl('http://127.0.0.1:3000', 'production', {
-      CI: 'true',
-      PLAYWRIGHT: '1',
-      NEXT_PUBLIC_APP_URL: 'https://interdomestik-web.vercel.app',
-      BETTER_AUTH_URL: 'https://interdomestik-web.vercel.app',
-    }),
-    false
-  );
-
-  assert.equal(
-    shouldAllowConfiguredLoopbackBaseUrl('http://127.0.0.1:3000', 'production', {
-      PLAYWRIGHT: '1',
-      NEXT_PUBLIC_APP_URL: 'http://127.0.0.1:3000',
-    }),
-    false
-  );
+  for (const env of [{ CI: 'true' }, { PLAYWRIGHT: '1', NEXT_PUBLIC_APP_URL: loopback }]) {
+    assert.equal(shouldAllowConfiguredLoopbackBaseUrl(loopback, 'production', env), false);
+  }
 });

--- a/scripts/release-gate/session-navigation.ts
+++ b/scripts/release-gate/session-navigation.ts
@@ -136,6 +136,7 @@ async function loginWithRunContext(page, runCtx, account, options = {}) {
     account,
     credentials: runCtx.credentials[account],
     baseUrl: runCtx.baseUrl,
+    authOrigin: runCtx.authOrigin,
     locale: runCtx.locale,
     authState: runCtx.authState,
     forceFresh: options.forceFresh === true,

--- a/scripts/release-gate/shared.ts
+++ b/scripts/release-gate/shared.ts
@@ -1,5 +1,4 @@
 const path = require('node:path');
-
 const { ROUTES, MARKERS, SELECTORS, TIMEOUTS, ROLE_IPS, ACCOUNTS } = require('./config.ts');
 
 const TRANSIENT_NAVIGATION_ERROR_PATTERNS = [
@@ -318,6 +317,7 @@ async function loginAs(page, params) {
     }
 
     const origin = new URL(baseUrl).origin;
+    const authOrigin = params.authOrigin || origin;
     const loginUrl = `${origin}/api/auth/sign-in/email`;
     const tenantId = ACCOUNTS[account]?.tenantId;
 
@@ -337,8 +337,8 @@ async function loginAs(page, params) {
             password: credentials.password,
           },
           headers: {
-            Origin: origin,
-            Referer: `${origin}/${locale}/login`,
+            Origin: authOrigin,
+            Referer: `${authOrigin}/${locale}/login`,
             'x-forwarded-for': resolveForwardedForIp(account),
             ...(tenantId ? { 'x-tenant-id': tenantId } : {}),
           },

--- a/scripts/release-gate/url-policy.ts
+++ b/scripts/release-gate/url-policy.ts
@@ -20,23 +20,24 @@ function normalizedHostname(hostname) {
   return String(hostname || '').toLowerCase();
 }
 
-function isAllowedReleaseGateHostname(hostname) {
-  const normalized = normalizedHostname(hostname);
-  return (
-    RELEASE_GATE_HOSTNAMES.has(normalized) ||
-    RELEASE_GATE_HOSTNAME_SUFFIXES.some(suffix => normalized.endsWith(suffix))
+function configuredExtraHostname(options) {
+  return normalizedHostname(
+    options.allowedExtraHostname || process.env.RELEASE_GATE_EXTRA_HOSTNAME
   );
 }
 
 function assertTrustedReleaseGateBaseUrl(rawValue, options = {}) {
   const parsed = assertSafeHttpUrl(rawValue, { allowLoopback: options.allowLoopback === true });
   const normalized = normalizedHostname(parsed.hostname);
-  const extraHostname = normalizedHostname(options.allowedExtraHostname);
+  const extraHostname = configuredExtraHostname(options);
+  const allowed =
+    RELEASE_GATE_HOSTNAMES.has(normalized) ||
+    RELEASE_GATE_HOSTNAME_SUFFIXES.some(suffix => normalized.endsWith(suffix));
   if (isLoopbackOrPrivateHost(parsed.hostname)) return parsed;
   if (extraHostname && normalized === extraHostname && normalized.endsWith('.vercel.app')) {
     return parsed;
   }
-  if (!isAllowedReleaseGateHostname(parsed.hostname)) {
+  if (!allowed) {
     throw new Error(`Release gate base URL host is not allowed: ${parsed.hostname}`);
   }
   return parsed;
@@ -64,7 +65,7 @@ function buildTrustedLoopbackOrigin(parsed) {
 function assertTrustedReleaseGateProbeOrigin(rawValue, options = {}) {
   const parsed = assertTrustedReleaseGateBaseUrl(rawValue, options);
   const normalized = normalizedHostname(parsed.hostname);
-  const extraHostname = normalizedHostname(options.allowedExtraHostname);
+  const extraHostname = configuredExtraHostname(options);
   if (isLoopbackOrPrivateHost(parsed.hostname)) return buildTrustedLoopbackOrigin(parsed);
   if (extraHostname && normalized === extraHostname && normalized.endsWith('.vercel.app')) {
     if (parsed.protocol !== 'https:') {
@@ -141,7 +142,6 @@ module.exports = {
   assertTrustedReleaseGateBaseUrl,
   assertTrustedReleaseGateProbeOrigin,
   buildAuthEndpointUrls,
-  isAllowedReleaseGateHostname,
   normalizeTrustedVercelDeploymentBaseUrl,
   shouldAllowConfiguredLoopbackBaseUrl,
 };

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37508485,
-  "maxTrackedFiles": 4527,
+  "maxTrackedBytes": 37515594,
+  "maxTrackedFiles": 4529,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7002448,
+    "source/scripts": 7005425,
     "docs/text": 5705447,
-    "tests/e2e": 4924391,
-    "config/data/messages": 1546158,
-    "other": 129287
+    "tests/e2e": 4926700,
+    "config/data/messages": 1548086,
+    "other": 129182
   },
   "maxLargestFileBytes": 3263773,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- replace the missing custom deploy webhook path with a Vercel CLI prebuilt deployment action
- keep staging/production attested Docker builds as supply-chain proof before deploy jobs
- make staging release gates use the emitted Vercel deployment URL instead of the unresolved staging domain
- document Vercel deployment configuration in `.env.example` and update CI workflow contracts

## Verification
- `node --test scripts/ci/cd-deploy-digest-boundary.test.mjs scripts/ci/workflow-contracts.test.mjs scripts/ci/cd-attestation-contract.test.mjs`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`

## Notes
- `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, and `VERCEL_TOKEN` are configured for both `staging` and `production` environments.
- Production verification still uses `https://www.interdomestik.com` as the canonical health URL.
