### PR TITLE
ci: map Vercel staging deploys to preview target

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -61,7 +61,7 @@ runs:
         DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
       run: |
         set -euo pipefail
-        vercel_env="${DEPLOY_ENVIRONMENT}"
+        vercel_env="${DEPLOY_ENVIRONMENT}"; [[ "${vercel_env}" == staging ]] && vercel_env=preview
         [[ "${DEPLOY_PRODUCTION}" == "true" ]] && vercel_env=production
         npx --yes vercel@latest pull \
           --yes \
@@ -74,7 +74,8 @@ runs:
         INTERDOMESTIK_DEPLOY_ENV: ${{ inputs.environment }}
       run: |
         set -euo pipefail
-        target_args=(--target="${DEPLOY_ENVIRONMENT}")
+        deploy_target="${DEPLOY_ENVIRONMENT}"; [[ "${deploy_target}" == staging ]] && deploy_target=preview
+        target_args=(--target="${deploy_target}")
         if [[ "${DEPLOY_PRODUCTION}" == "true" ]]; then
           target_args=(--prod)
         fi
@@ -111,7 +112,8 @@ runs:
         VERCEL_OUTPUT_DIGEST: ${{ steps.artifact.outputs.vercel_output_digest }}
       run: |
         set -euo pipefail
-        target_args=(--target="${DEPLOY_ENVIRONMENT}")
+        deploy_target="${DEPLOY_ENVIRONMENT}"; [[ "${deploy_target}" == staging ]] && deploy_target=preview
+        target_args=(--target="${deploy_target}")
         if [[ "${DEPLOY_PRODUCTION}" == "true" ]]; then
           target_args=(--prod)
         fi

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -7,15 +7,12 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const cdWorkflow = yaml.load(
-  fs.readFileSync(path.join(rootDir, '.github/workflows/cd.yml'), 'utf8')
-);
-const deployAction = yaml.load(
-  fs.readFileSync(
-    path.join(rootDir, '.github/actions/trigger-digest-verified-deploy/action.yml'),
-    'utf8'
-  )
-);
+const cdWorkflow = readYaml('.github/workflows/cd.yml');
+const deployAction = readYaml('.github/actions/trigger-digest-verified-deploy/action.yml');
+
+function readYaml(relativePath) {
+  return yaml.load(fs.readFileSync(path.join(rootDir, relativePath), 'utf8'));
+}
 
 function findStep(steps, name) {
   return steps.find(step => step?.name === name);
@@ -110,10 +107,12 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(validateStep.run, /ENABLE_VERCEL_DEPLOYMENTS=1/u);
 
   assert.match(pullStep.run, /vercel@latest pull/u);
+  assert.match(pullStep.run, /vercel_env=.*staging.*preview/u);
   assert.match(pullStep.run, /--environment="\$\{vercel_env\}"/u);
 
   assert.match(buildStep.run, /vercel@latest build/u);
-  assert.match(buildStep.run, /--target="\$\{DEPLOY_ENVIRONMENT\}"/u);
+  assert.match(buildStep.run, /deploy_target=.*staging.*preview/u);
+  assert.match(buildStep.run, /--target="\$\{deploy_target\}"/u);
 
   assert.equal(renamedDigestStep.id, 'artifact');
   assert.match(renamedDigestStep.run, /hash-vercel-output\.mjs/u);
@@ -137,7 +136,8 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(deployStep.run, /vercel@latest deploy/u);
   assert.match(deployStep.run, /--prebuilt/u);
   assert.match(deployStep.run, /--env "COMMIT_SHA=\$\{COMMIT_SHA\}"/u);
-  assert.match(deployStep.run, /--target="\$\{DEPLOY_ENVIRONMENT\}"/u);
+  assert.match(deployStep.run, /deploy_target=.*staging.*preview/u);
+  assert.match(deployStep.run, /--target="\$\{deploy_target\}"/u);
   assert.match(deployStep.run, /base_url="\$\{deployment_url\}"/u);
   assert.doesNotMatch(deployStep.run, /--token/u);
   assert.match(deployStep.run, /interdomestik-release-attestation\.json/u);


### PR DESCRIPTION
## Summary
- maps logical CD staging deploys to Vercel's preview target because the Vercel project has no custom staging environment
- keeps production deploys on production and preserves IDA staging labels/artifact metadata
- sets repo Vercel variables separately: VERCEL_ORG_ID=team_zZnOjQLylAZArqxcUhLbHDHc and VERCEL_PROJECT_ID=prj_K0HT5WpYJUloEmRppA4CBfoY8KtJ

## Evidence
- VERCEL_ORG_ID=ecohub fails vercel pull with Project not found
- VERCEL_ORG_ID=team_zZnOjQLylAZArqxcUhLbHDHc resolves ecohub/interdomestik-web
- Vercel preview environment pull succeeds; staging environment pull fails because it does not exist

## Local checks
- pnpm exec prettier --check .github/actions/trigger-digest-verified-deploy/action.yml .github/workflows/cd.yml scripts/ci/cd-deploy-digest-boundary.test.mjs
- node --test scripts/ci/cd-deploy-digest-boundary.test.mjs scripts/ci/cd-attestation-contract.test.mjs scripts/ci/workflow-contracts.test.mjs
- git diff --check
- pnpm security:guard