### PR TITLE
ci: export Vercel env during prebuilt build

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -79,7 +79,7 @@ runs:
         if [[ "${DEPLOY_PRODUCTION}" == "true" ]]; then
           target_args=(--prod)
         fi
-        npx --yes vercel@latest build "${target_args[@]}"
+        npx --yes vercel@latest env run -e "${deploy_target}" -- npx --yes vercel@latest build "${target_args[@]}"
     - name: Write Vercel output attestation metadata
       id: artifact
       shell: bash

--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -77,7 +77,7 @@ runs:
         deploy_target="${DEPLOY_ENVIRONMENT}"; [[ "${deploy_target}" == staging ]] && deploy_target=preview
         target_args=(--target="${deploy_target}")
         if [[ "${DEPLOY_PRODUCTION}" == "true" ]]; then
-          target_args=(--prod)
+          deploy_target=production; target_args=(--prod)
         fi
         npx --yes vercel@latest env run -e "${deploy_target}" -- npx --yes vercel@latest build "${target_args[@]}"
     - name: Write Vercel output attestation metadata

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -110,7 +110,7 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(pullStep.run, /vercel_env=.*staging.*preview/u);
   assert.match(pullStep.run, /--environment="\$\{vercel_env\}"/u);
 
-  assert.match(buildStep.run, /vercel@latest build/u);
+  assert.match(buildStep.run, /vercel@latest env run -e "\$\{deploy_target\}"/u);
   assert.match(buildStep.run, /deploy_target=.*staging.*preview/u);
   assert.match(buildStep.run, /--target="\$\{deploy_target\}"/u);
 

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -111,7 +111,7 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(pullStep.run, /--environment="\$\{vercel_env\}"/u);
 
   assert.match(buildStep.run, /vercel@latest env run -e "\$\{deploy_target\}"/u);
-  assert.match(buildStep.run, /deploy_target=.*staging.*preview/u);
+  assert.match(buildStep.run, /deploy_target=.*staging.*preview[\s\S]*deploy_target=production/u);
   assert.match(buildStep.run, /--target="\$\{deploy_target\}"/u);
 
   assert.equal(renamedDigestStep.id, 'artifact');


### PR DESCRIPTION
## Summary
- wraps the Vercel prebuilt build command with `vercel env run -e <target>` so Preview/Production env vars are exported into the Next build process
- preserves logical staging metadata while using Vercel preview target from the previous fix
- keeps the workflow file untouched and both changed files at the 150-line guard limit

## Failure addressed
Main CD run 28193230247 reached `vercel build --target=preview` but failed during Next page-data collection because `DATABASE_URL` and `DATABASE_URL_RLS` were missing from the build process environment. `vercel env ls` and local `vercel pull --environment=preview` confirm those keys exist for Preview; this patch makes the build process receive them.

## Local checks
- pnpm exec prettier --check .github/actions/trigger-digest-verified-deploy/action.yml scripts/ci/cd-deploy-digest-boundary.test.mjs
- node --test scripts/ci/cd-deploy-digest-boundary.test.mjs scripts/ci/cd-attestation-contract.test.mjs scripts/ci/workflow-contracts.test.mjs
- git diff --check
- pnpm security:guard
