### PR TITLE
ci: load Vercel dotenv during prebuilt builds

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -27,9 +27,7 @@ runs:
         set -euo pipefail
         missing=()
         for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
-          if [[ -z "${!name:-}" ]]; then
-            missing+=("${name}")
-          fi
+          [[ -n "${!name:-}" ]] || missing+=("${name}")
         done
         if (( ${#missing[@]} > 0 )); then
           echo "::error::Missing Vercel deployment configuration: ${missing[*]}"
@@ -63,9 +61,12 @@ runs:
         set -euo pipefail
         vercel_env="${DEPLOY_ENVIRONMENT}"; [[ "${vercel_env}" == staging ]] && vercel_env=preview
         [[ "${DEPLOY_PRODUCTION}" == "true" ]] && vercel_env=production
-        npx --yes vercel@latest pull \
-          --yes \
-          --environment="${vercel_env}"
+        pull_args=(--yes --environment="${vercel_env}")
+        if [[ "${vercel_env}" == preview ]]; then
+          preview_branch="${GITHUB_REF_NAME:-main}"; [[ "${GITHUB_REF_TYPE:-}" == tag ]] && preview_branch=main
+          pull_args+=(--git-branch="${preview_branch}")
+        fi
+        npx --yes vercel@latest pull "${pull_args[@]}"
     - name: Build Vercel artifact
       shell: bash
       env:
@@ -75,11 +76,9 @@ runs:
       run: |
         set -euo pipefail
         deploy_target="${DEPLOY_ENVIRONMENT}"; [[ "${deploy_target}" == staging ]] && deploy_target=preview
-        target_args=(--target="${deploy_target}")
-        if [[ "${DEPLOY_PRODUCTION}" == "true" ]]; then
-          deploy_target=production; target_args=(--prod)
-        fi
-        npx --yes vercel@latest env run -e "${deploy_target}" -- npx --yes vercel@latest build "${target_args[@]}"
+        target_args=()
+        if [[ "${DEPLOY_PRODUCTION}" == "true" ]]; then deploy_target=production; target_args=(--prod); fi
+        node scripts/ci/run-with-vercel-env-file.mjs "${deploy_target}" "${target_args[@]}"
     - name: Write Vercel output attestation metadata
       id: artifact
       shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,14 +6,12 @@ on:
       - main
     tags:
       - 'v*'
-
 concurrency:
   group: cd-${{ github.ref }}-${{ github.run_id }}
   cancel-in-progress: false
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   build-staging:
     runs-on: [self-hosted, interdomestik-mac]
@@ -74,9 +72,6 @@ jobs:
       hostname: ${{ steps.vercel.outputs.hostname }}
     env:
       EXPECTED_COMMIT_SHA: ${{ github.sha }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
@@ -84,7 +79,12 @@ jobs:
         id: vercel
         uses: ./.github/actions/trigger-digest-verified-deploy
         env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL_RLS: ${{ secrets.DATABASE_URL_RLS }}
           ENABLE_VERCEL_DEPLOYMENTS: '1'
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
         with:
           environment: staging
           production: 'false'
@@ -110,7 +110,6 @@ jobs:
           done
           echo "::error::Staging health check failed after ${max_attempts} attempts."
           exit 1
-
       - name: Verify Staging Build Provenance
         shell: bash
         env:
@@ -220,7 +219,6 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-
       - name: Build, attest, and verify Docker image
         id: build
         uses: ./.github/actions/build-attested-image
@@ -244,19 +242,19 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
-
       - name: Deploy Production to Vercel
         id: vercel
         uses: ./.github/actions/trigger-digest-verified-deploy
         env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL_RLS: ${{ secrets.DATABASE_URL_RLS }}
           ENABLE_VERCEL_DEPLOYMENTS: '1'
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
         with:
           environment: production
           production: 'true'

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -22,12 +22,6 @@ function findStepIndex(steps, name) {
   return steps.findIndex(step => step?.name === name);
 }
 
-function assertBuildDigestOutput(jobName) {
-  const job = cdWorkflow.jobs[jobName];
-  assert.ok(job, `${jobName} must exist`);
-  assert.equal(job.outputs.image_digest, '${{ steps.build.outputs.digest }}');
-}
-
 function assertVercelDeployBoundary({
   jobName,
   buildJobName,
@@ -53,22 +47,28 @@ function assertVercelDeployBoundary({
   assert.equal(step.with['commit-sha'], '${{ github.sha }}');
   assert.equal(step.with['canonical-url'], undefined);
   assert.equal(step.env.ENABLE_VERCEL_DEPLOYMENTS, '1');
+  assert.equal(step.env.DATABASE_URL, '${{ secrets.DATABASE_URL }}');
+  assert.equal(step.env.DATABASE_URL_RLS, '${{ secrets.DATABASE_URL_RLS }}');
+  assert.match(step.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
+  assert.equal(step.env.VERCEL_ORG_ID, '${{ vars.VERCEL_ORG_ID }}');
+  assert.equal(step.env.VERCEL_PROJECT_ID, '${{ vars.VERCEL_PROJECT_ID }}');
   assert.equal(
     step.with['attested-image-digest'],
     '${{ needs.' + buildJobName + '.outputs.image_digest }}'
   );
 
-  assert.match(job.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
-  assert.equal(job.env.VERCEL_ORG_ID, '${{ vars.VERCEL_ORG_ID }}');
-  assert.equal(job.env.VERCEL_PROJECT_ID, '${{ vars.VERCEL_PROJECT_ID }}');
-  assert.equal(cdWorkflow.env.VERCEL_ORG_ID, undefined);
-  assert.equal(cdWorkflow.env.VERCEL_PROJECT_ID, undefined);
+  for (const key of [
+    'VERCEL_TOKEN',
+    'VERCEL_ORG_ID',
+    'VERCEL_PROJECT_ID',
+    'DATABASE_URL',
+    'DATABASE_URL_RLS',
+  ]) {
+    assert.equal(job.env?.[key], undefined);
+  }
 }
 
 test('CD deploy boundary uses Vercel prebuilt deployments after attested builds', () => {
-  assertBuildDigestOutput('build-staging');
-  assertBuildDigestOutput('build-production');
-
   assertVercelDeployBoundary({
     jobName: 'deploy-staging',
     buildJobName: 'build-staging',
@@ -109,10 +109,12 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(pullStep.run, /vercel@latest pull/u);
   assert.match(pullStep.run, /vercel_env=.*staging.*preview/u);
   assert.match(pullStep.run, /--environment="\$\{vercel_env\}"/u);
-
-  assert.match(buildStep.run, /vercel@latest env run -e "\$\{deploy_target\}"/u);
+  assert.match(pullStep.run, /if \[\[ "\$\{vercel_env\}" == preview \]\]; then/u);
+  assert.match(pullStep.run, /GITHUB_REF_TYPE:-.*tag[\s\S]*--git-branch="\$\{preview_branch\}"/u);
+  assert.match(buildStep.run, /run-with-vercel-env-file\.mjs "\$\{deploy_target\}"/u);
   assert.match(buildStep.run, /deploy_target=.*staging.*preview[\s\S]*deploy_target=production/u);
-  assert.match(buildStep.run, /--target="\$\{deploy_target\}"/u);
+  assert.match(buildStep.run, /target_args=\(\)/u);
+  assert.match(buildStep.run, /target_args=\(--prod\)/u);
 
   assert.equal(renamedDigestStep.id, 'artifact');
   assert.match(renamedDigestStep.run, /hash-vercel-output\.mjs/u);
@@ -142,9 +144,7 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.doesNotMatch(deployStep.run, /--token/u);
   assert.match(deployStep.run, /interdomestik-release-attestation\.json/u);
   assert.match(deployStep.run, /verify-vercel-attestation\.mjs/u);
-  assert.match(deployStep.run, /hostname=/u);
   assert.match(deployStep.run, /vercel_output_digest=/u);
-  assert.match(deployStep.run, /GITHUB_OUTPUT/u);
   assert.equal(cleanupStep.if, '${{ always() }}');
   assert.match(cleanupStep.run, /rm -rf \.vercel/u);
 });

--- a/scripts/ci/cd-deploy-env-scope.test.mjs
+++ b/scripts/ci/cd-deploy-env-scope.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const cdWorkflow = readYaml('.github/workflows/cd.yml');
+const deployAction = readYaml('.github/actions/trigger-digest-verified-deploy/action.yml');
+
+function readYaml(relativePath) {
+  return yaml.load(fs.readFileSync(path.join(rootDir, relativePath), 'utf8'));
+}
+
+test('CD build digest outputs remain wired into deploy jobs', () => {
+  for (const jobName of ['build-staging', 'build-production']) {
+    assert.equal(
+      cdWorkflow.jobs[jobName].outputs.image_digest,
+      '${{ steps.build.outputs.digest }}'
+    );
+  }
+});
+
+test('Vercel and database credentials stay out of workflow-level env', () => {
+  for (const key of [
+    'DATABASE_URL',
+    'DATABASE_URL_RLS',
+    'VERCEL_ORG_ID',
+    'VERCEL_PROJECT_ID',
+    'VERCEL_TOKEN',
+  ]) {
+    assert.equal(cdWorkflow.env[key], undefined);
+  }
+});
+
+test('Vercel deploy action still exports deployment hostname', () => {
+  const deployStep = deployAction.runs.steps.find(step => step?.name === 'Deploy Vercel artifact');
+
+  assert.ok(deployStep);
+  assert.match(deployStep.run, /hostname=/u);
+  assert.match(deployStep.run, /GITHUB_OUTPUT/u);
+});

--- a/scripts/ci/run-with-vercel-env-file.mjs
+++ b/scripts/ci/run-with-vercel-env-file.mjs
@@ -1,0 +1,97 @@
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
+
+const [target, maybeProdArg] = process.argv.slice(2);
+
+if (!target || !['preview', 'production'].includes(target)) {
+  console.error('Vercel env target must be preview or production.');
+  process.exit(2);
+}
+
+if (maybeProdArg && (target !== 'production' || maybeProdArg !== '--prod')) {
+  console.error('Only production builds may pass --prod.');
+  process.exit(2);
+}
+
+function parseEnv(contents) {
+  const parsed = {};
+  for (const rawLine of contents.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    const match = /^([A-Za-z_]\w*)=(.*)$/u.exec(line);
+    if (!match || line.startsWith('#')) continue;
+    let value = match[2].trim();
+    const quoted = /^(['"])(.*)\1$/u.exec(value);
+    if (quoted) value = quoted[2];
+    parsed[match[1]] = value;
+  }
+  return parsed;
+}
+
+function readPulledEnvFile(value) {
+  if (value === 'preview') {
+    return {
+      envPath: '.vercel/.env.preview.local',
+      parsed: parseEnv(readFileSync('.vercel/.env.preview.local', 'utf8')),
+    };
+  }
+  return {
+    envPath: '.vercel/.env.production.local',
+    parsed: parseEnv(readFileSync('.vercel/.env.production.local', 'utf8')),
+  };
+}
+
+function hasValue(value) {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+let envPath;
+let parsed;
+try {
+  ({ envPath, parsed } = readPulledEnvFile(target));
+} catch (error) {
+  if (error?.code === 'ENOENT') {
+    console.error(`Missing Vercel environment file for ${target}.`);
+    process.exit(1);
+  }
+  throw error;
+}
+
+let loadedCount = 0;
+
+for (const [key, value] of Object.entries(parsed)) {
+  if (!hasValue(process.env[key])) {
+    process.env[key] = value;
+    if (hasValue(value)) loadedCount += 1;
+  }
+}
+
+const missingRequired = ['DATABASE_URL', 'DATABASE_URL_RLS'].filter(
+  key => !hasValue(process.env[key])
+);
+
+if (missingRequired.length > 0) {
+  console.error(`Missing required Vercel build env keys: ${missingRequired.join(', ')}`);
+  process.exit(1);
+}
+
+console.log(`Loaded ${loadedCount} Vercel env keys from ${envPath}.`);
+
+const buildArgs = ['--yes', 'vercel@latest', 'build'];
+if (target === 'production') buildArgs.push('--prod');
+const npxBin = join(dirname(process.execPath), process.platform === 'win32' ? 'npx.cmd' : 'npx');
+
+const child = spawn(npxBin, buildArgs, {
+  stdio: 'inherit',
+  shell: false,
+});
+
+child.on('exit', code => {
+  process.exit(code ?? 1);
+});
+
+child.on('error', error => {
+  console.error(`Failed to run Vercel build command: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/ci/run-with-vercel-env-file.test.mjs
+++ b/scripts/ci/run-with-vercel-env-file.test.mjs
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const helper = path.join(rootDir, 'scripts/ci/run-with-vercel-env-file.mjs');
+
+function withTempRepo(callback) {
+  const repo = mkdtempSync(path.join(tmpdir(), 'vercel-env-helper-'));
+  try {
+    mkdirSync(path.join(repo, '.vercel'));
+    callback(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+}
+
+function runHelper(cwd, args, env = {}, nodePath = process.execPath) {
+  return spawnSync(nodePath, [helper, ...args], {
+    cwd,
+    env: {
+      PATH: process.env.PATH,
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+}
+
+function writePreviewEnv(repo, body) {
+  writeFileSync(path.join(repo, '.vercel/.env.preview.local'), body, 'utf8');
+}
+
+function writeProductionEnv(repo, body) {
+  writeFileSync(path.join(repo, '.vercel/.env.production.local'), body, 'utf8');
+}
+
+function writeFakeNodeBin(repo, includeNpx = true) {
+  const binDir = path.join(repo, 'bin');
+  mkdirSync(binDir);
+  const nodePath = path.join(binDir, 'node');
+  copyFileSync(process.execPath, nodePath);
+  chmodSync(nodePath, 0o755);
+  if (!includeNpx) return nodePath;
+  const npxPath = path.join(binDir, 'npx');
+  writeFileSync(
+    npxPath,
+    '#!/bin/sh\nprintf "%s\\n" "$DATABASE_URL" "$DATABASE_URL_RLS"\nprintf "args:%s\\n" "$*"\n',
+    'utf8'
+  );
+  chmodSync(npxPath, 0o755);
+  return nodePath;
+}
+
+function runWithFakeNpx(repo, args, env = {}) {
+  return runHelper(repo, args, env, writeFakeNodeBin(repo));
+}
+
+test('fails when the pulled Vercel env file is missing', () => {
+  withTempRepo(repo => {
+    const result = runHelper(repo, ['preview']);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Missing Vercel environment file/u);
+  });
+});
+
+test('fails before build when required database env keys are blank', () => {
+  withTempRepo(repo => {
+    writePreviewEnv(repo, 'DATABASE_URL="   "\nDATABASE_URL_RLS=""\n');
+
+    const result = runHelper(repo, ['preview']);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Missing required Vercel build env keys/u);
+  });
+});
+
+test('loads pulled database env values over blank inherited values', () => {
+  withTempRepo(repo => {
+    writePreviewEnv(
+      repo,
+      'DATABASE_URL="postgresql://example/redacted"\nDATABASE_URL_RLS="postgresql://example/redacted-rls"\n'
+    );
+    const result = runWithFakeNpx(repo, ['preview'], {
+      DATABASE_URL: '   ',
+      DATABASE_URL_RLS: '',
+    });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /postgresql:\/\/example\/redacted/u);
+    assert.match(result.stdout, /postgresql:\/\/example\/redacted-rls/u);
+    assert.match(result.stdout, /args:--yes vercel@latest build/u);
+  });
+});
+
+test('keeps non-empty inherited database env values', () => {
+  withTempRepo(repo => {
+    writePreviewEnv(
+      repo,
+      'DATABASE_URL="postgresql://example/vercel"\nDATABASE_URL_RLS="postgresql://example/vercel-rls"\n'
+    );
+    const result = runWithFakeNpx(repo, ['preview'], {
+      DATABASE_URL: 'postgresql://example/github',
+      DATABASE_URL_RLS: 'postgresql://example/github-rls',
+    });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /postgresql:\/\/example\/github/u);
+    assert.doesNotMatch(result.stdout, /postgresql:\/\/example\/vercel/u);
+  });
+});
+
+test('runs production builds with the Vercel production flag', () => {
+  withTempRepo(repo => {
+    writeProductionEnv(
+      repo,
+      'DATABASE_URL="postgresql://example/prod"\nDATABASE_URL_RLS="postgresql://example/prod-rls"\n'
+    );
+    const result = runWithFakeNpx(repo, ['production', '--prod']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /args:--yes vercel@latest build --prod/u);
+  });
+});
+
+test('reports a clean failure when the Vercel build command cannot start', () => {
+  withTempRepo(repo => {
+    writePreviewEnv(
+      repo,
+      'DATABASE_URL="postgresql://example/redacted"\nDATABASE_URL_RLS="postgresql://example/redacted-rls"\n'
+    );
+
+    const result = runHelper(repo, ['preview'], {}, writeFakeNodeBin(repo, false));
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Failed to run Vercel build command/u);
+  });
+});
+
+test('rejects invalid Vercel target arguments', () => {
+  withTempRepo(repo => {
+    for (const [args, message] of [
+      [['../preview'], /target must be preview or production/u],
+      [['preview', '--prod'], /Only production builds may pass --prod/u],
+    ]) {
+      const result = runHelper(repo, args);
+      assert.equal(result.status, 2);
+      assert.match(result.stderr, message);
+    }
+  });
+});

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -553,12 +553,12 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(deployStagingJob.outputs.base_url, '${{ steps.vercel.outputs.base_url }}');
   assert.equal(deployStagingJob.outputs.hostname, '${{ steps.vercel.outputs.hostname }}');
   assert.equal(deployStagingJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');
-  assert.match(deployStagingJob.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
   const vercelStagingDeployStep = findStep(deployStagingJob.steps, 'Deploy Staging to Vercel');
   assert.ok(vercelStagingDeployStep);
   assert.equal(vercelStagingDeployStep.id, 'vercel');
   assert.equal(vercelStagingDeployStep.uses, './.github/actions/trigger-digest-verified-deploy');
   assert.equal(vercelStagingDeployStep.env.ENABLE_VERCEL_DEPLOYMENTS, '1');
+  assert.match(vercelStagingDeployStep.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
   assert.equal(vercelStagingDeployStep.with.environment, 'staging');
   assert.equal(vercelStagingDeployStep.with.production, 'false');
   const stagingHealthIndex = findStepIndex(deployStagingJob.steps, 'Wait for Staging Health');
@@ -605,7 +605,6 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(stagingArtifactsStep.with['if-no-files-found'], 'error');
 
   assert.deepEqual(normalizeNeeds(deployProductionJob.needs), ['build-production']);
-  assert.match(deployProductionJob.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
   const vercelProductionDeployStep = findStep(
     deployProductionJob.steps,
     'Deploy Production to Vercel'
@@ -614,6 +613,7 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(vercelProductionDeployStep.id, 'vercel');
   assert.equal(vercelProductionDeployStep.uses, './.github/actions/trigger-digest-verified-deploy');
   assert.equal(vercelProductionDeployStep.env.ENABLE_VERCEL_DEPLOYMENTS, '1');
+  assert.match(vercelProductionDeployStep.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
   assert.equal(vercelProductionDeployStep.with.environment, 'production');
   assert.equal(vercelProductionDeployStep.with.production, 'true');
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37515594,
-  "maxTrackedFiles": 4529,
+  "maxTrackedBytes": 37525650,
+  "maxTrackedFiles": 4532,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7005425,
+    "source/scripts": 7008099,
     "docs/text": 5705447,
-    "tests/e2e": 4926700,
-    "config/data/messages": 1548086,
+    "tests/e2e": 4933358,
+    "config/data/messages": 1548810,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,


### PR DESCRIPTION
## Summary
- load pulled Vercel dotenv values into `vercel build` with fail-fast checks for `DATABASE_URL` and `DATABASE_URL_RLS`
- pull branch-scoped Preview env for staging so staging builds use the same env scope Vercel will deploy from
- keep Vercel and optional database secrets scoped to deploy action steps, with no RLS fallback to the primary database URL
- add helper and workflow contract coverage, plus the repo size budget update for the new CI files

## Verification
- `pnpm exec prettier --check .github/actions/trigger-digest-verified-deploy/action.yml .github/workflows/cd.yml scripts/ci/cd-deploy-digest-boundary.test.mjs scripts/ci/cd-deploy-env-scope.test.mjs scripts/ci/run-with-vercel-env-file.mjs scripts/ci/run-with-vercel-env-file.test.mjs scripts/ci/workflow-contracts.test.mjs`
- `node --test scripts/ci/run-with-vercel-env-file.test.mjs scripts/ci/cd-deploy-env-scope.test.mjs scripts/ci/cd-deploy-digest-boundary.test.mjs scripts/ci/cd-attestation-contract.test.mjs scripts/ci/workflow-contracts.test.mjs`
- `pnpm repo:size:check`
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate`
- `git diff --check origin/main..HEAD`

## Review disposition
- Sonnet second-pass blockers addressed: added spawn error handling and restored deployment env/hostname contract coverage.
- Gemini precedence finding addressed: added coverage proving non-empty inherited database env values are not overwritten by pulled Vercel values.
- Gemini redacted literal mismatch was a review-packet artifact; local tests cover the real values and pass.
- Codex Security app workflow was not used because this was a terminal/chat workflow rather than the desktop app scan path; `pnpm security:guard` is green.

## Deployment note
GitHub `staging` and `production` environment secret lists currently do not show `DATABASE_URL` or `DATABASE_URL_RLS`. This patch will use those secrets if they are added, otherwise it requires the Vercel-pulled env file to contain non-empty values. If both sources are blank or missing, the deploy now fails before `vercel build` with an explicit missing-key error.
