### PR TITLE
ci: harden Vercel attestation metadata fetch

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -136,7 +136,7 @@ runs:
         hostname="${hostname%%/*}"
         hostname="${hostname%%:*}"
         metadata_url="${base_url}/.well-known/interdomestik-release-attestation.json"
-        metadata="$(ATTESTATION_HOST="${hostname}" METADATA_URL="${metadata_url}" node scripts/ci/fetch-vercel-attestation.mjs)"
+        metadata="$(METADATA_URL="${metadata_url}" node scripts/ci/fetch-vercel-attestation.mjs)"
         METADATA="${metadata}" node scripts/ci/verify-vercel-attestation.mjs
         echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
         echo "base_url=${base_url}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -136,7 +136,7 @@ runs:
         hostname="${hostname%%/*}"
         hostname="${hostname%%:*}"
         metadata_url="${base_url}/.well-known/interdomestik-release-attestation.json"
-        metadata="$(curl -fsS --retry 6 --retry-delay 5 "${metadata_url}")"
+        metadata="$(curl -fsSL --retry 6 --retry-delay 5 "${metadata_url}")"
         METADATA="${metadata}" node scripts/ci/verify-vercel-attestation.mjs
         echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
         echo "base_url=${base_url}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -136,7 +136,7 @@ runs:
         hostname="${hostname%%/*}"
         hostname="${hostname%%:*}"
         metadata_url="${base_url}/.well-known/interdomestik-release-attestation.json"
-        metadata="$(curl -fsSL --retry 6 --retry-delay 5 "${metadata_url}")"
+        metadata="$(ATTESTATION_HOST="${hostname}" METADATA_URL="${metadata_url}" node scripts/ci/fetch-vercel-attestation.mjs)"
         METADATA="${metadata}" node scripts/ci/verify-vercel-attestation.mjs
         echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
         echo "base_url=${base_url}" >> "${GITHUB_OUTPUT}"

--- a/apps/web/e2e/gate/group-access-privacy-consent.fixture.ts
+++ b/apps/web/e2e/gate/group-access-privacy-consent.fixture.ts
@@ -1,0 +1,146 @@
+import type { TestInfo } from '@playwright/test';
+import {
+  E2E_USERS,
+  agentSettings,
+  claimDocuments,
+  claimStageHistory,
+  claims,
+  db,
+  eq,
+  user,
+} from '@interdomestik/database';
+import { randomUUID } from 'node:crypto';
+
+import { resolveSeededClaimContext } from '../utils/seeded-claim-context';
+
+export type OfficeSeededAgent = {
+  email: string;
+};
+
+type PrivacyFixtureContext = {
+  claimCompanyName: string;
+  claimDocumentName: string;
+  claimTitle: string;
+  internalHistoryNote: string;
+  officeAgent: OfficeSeededAgent;
+  seededMemberName: string;
+};
+
+function isMkProject(testInfo: TestInfo): boolean {
+  return testInfo.project.name.includes('mk');
+}
+
+function getOfficeSeededAgent(testInfo: TestInfo): OfficeSeededAgent {
+  return {
+    email: isMkProject(testInfo)
+      ? 'agent.balkan.1@interdomestik.com'
+      : 'agent.ks.b1@interdomestik.com',
+  };
+}
+
+export async function withGroupAccessPrivacyFixture(
+  testInfo: TestInfo,
+  run: (context: PrivacyFixtureContext) => Promise<void>
+) {
+  const officeAgent = getOfficeSeededAgent(testInfo);
+  const seededMemberName = isMkProject(testInfo)
+    ? E2E_USERS.MK_MEMBER.name
+    : E2E_USERS.KS_MEMBER.name;
+  const { claimId, currentStatus, staffId, tenantId } = await resolveSeededClaimContext(testInfo);
+  const agentRecord = await db.query.user.findFirst({
+    where: eq(user.email, officeAgent.email),
+    columns: { id: true },
+  });
+  const claimRecord = await db.query.claims.findFirst({
+    where: eq(claims.id, claimId),
+    columns: { title: true, companyName: true },
+  });
+
+  if (!agentRecord?.id) {
+    throw new Error(`Expected seeded office-capable agent for ${officeAgent.email}`);
+  }
+  if (!claimRecord?.title || !claimRecord.companyName) {
+    throw new Error(`Expected seeded claim details for ${claimId}`);
+  }
+
+  const existingSettings = await db.query.agentSettings.findFirst({
+    where: eq(agentSettings.agentId, agentRecord.id),
+    columns: { id: true, tier: true },
+  });
+  const suffix = randomUUID();
+  const internalHistoryId = `e2e-ga04-hist-${suffix}`;
+  const internalHistoryNote = `GA04 internal note ${Date.now()}`;
+  const claimDocumentId = `e2e-ga04-doc-${suffix}`;
+  const claimDocumentName = `GA04-sensitive-${suffix}.pdf`;
+  const settingsId = existingSettings?.id ?? `e2e-ga04-settings-${suffix}`;
+  const previousTier = existingSettings?.tier ?? 'standard';
+  const createdSettings = !existingSettings?.id;
+  let tierElevated = false;
+
+  try {
+    if (createdSettings) {
+      await db.insert(agentSettings).values({
+        id: settingsId,
+        tenantId,
+        agentId: agentRecord.id,
+        commissionRates: { standard: 15 },
+        tier: 'office',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    } else {
+      await db
+        .update(agentSettings)
+        .set({ tier: 'office', updatedAt: new Date() })
+        .where(eq(agentSettings.id, settingsId));
+    }
+    tierElevated = true;
+
+    await db.insert(claimStageHistory).values({
+      id: internalHistoryId,
+      tenantId,
+      claimId,
+      fromStatus: currentStatus,
+      toStatus: currentStatus,
+      changedById: staffId,
+      changedByRole: 'staff',
+      note: internalHistoryNote,
+      isPublic: false,
+      createdAt: new Date(),
+    });
+    await db.insert(claimDocuments).values({
+      id: claimDocumentId,
+      tenantId,
+      claimId,
+      name: claimDocumentName,
+      filePath: `e2e/${claimDocumentId}.pdf`,
+      fileType: 'application/pdf',
+      fileSize: 1024,
+      bucket: 'claim-evidence',
+      classification: 'pii',
+      category: 'evidence',
+      uploadedBy: staffId,
+      createdAt: new Date(),
+    });
+
+    await run({
+      claimCompanyName: claimRecord.companyName,
+      claimDocumentName,
+      claimTitle: claimRecord.title,
+      internalHistoryNote,
+      officeAgent,
+      seededMemberName,
+    });
+  } finally {
+    await db.delete(claimDocuments).where(eq(claimDocuments.id, claimDocumentId));
+    await db.delete(claimStageHistory).where(eq(claimStageHistory.id, internalHistoryId));
+    if (tierElevated && createdSettings) {
+      await db.delete(agentSettings).where(eq(agentSettings.id, settingsId));
+    } else if (tierElevated) {
+      await db
+        .update(agentSettings)
+        .set({ tier: previousTier, updatedAt: new Date() })
+        .where(eq(agentSettings.id, settingsId));
+    }
+  }
+}

--- a/apps/web/e2e/gate/group-access-privacy-consent.spec.ts
+++ b/apps/web/e2e/gate/group-access-privacy-consent.spec.ts
@@ -1,66 +1,8 @@
-import {
-  E2E_PASSWORD,
-  E2E_USERS,
-  agentSettings,
-  claimDocuments,
-  claimStageHistory,
-  claims,
-  db,
-  eq,
-  user,
-} from '@interdomestik/database';
-import { randomUUID } from 'node:crypto';
 import { expect, test } from '../fixtures/auth.fixture';
-import { ipForRole } from '../fixtures/auth.project';
 import { routes } from '../routes';
 import { gotoApp } from '../utils/navigation';
-import { resolveSeededClaimContext } from '../utils/seeded-claim-context';
-
-type OfficeSeededAgent = {
-  email: string;
-};
-
-function isMkProject(testInfo: import('@playwright/test').TestInfo): boolean {
-  return testInfo.project.name.includes('mk');
-}
-
-function getOfficeSeededAgent(testInfo: import('@playwright/test').TestInfo): OfficeSeededAgent {
-  if (isMkProject(testInfo)) {
-    return {
-      email: 'agent.balkan.1@interdomestik.com',
-    };
-  }
-
-  return {
-    email: 'agent.ks.b1@interdomestik.com',
-  };
-}
-
-async function loginAsOfficeSeededAgent(
-  page: import('@playwright/test').Page,
-  testInfo: import('@playwright/test').TestInfo,
-  officeAgent: OfficeSeededAgent
-) {
-  const baseUrl = testInfo.project.use.baseURL?.toString() ?? '';
-  const origin = new URL(baseUrl).origin;
-  const loginURL = `${origin}/api/auth/sign-in/email`;
-  const projectHeaders = testInfo.project.use.extraHTTPHeaders;
-
-  const response = await page.request.post(loginURL, {
-    data: { email: officeAgent.email, password: E2E_PASSWORD },
-    headers: {
-      Origin: origin,
-      Referer: `${origin}/login`,
-      'x-forwarded-for': ipForRole('agent'),
-      ...projectHeaders,
-    },
-  });
-
-  if (!response.ok()) {
-    const text = await response.text();
-    throw new Error(`API login failed for ${officeAgent.email}: ${response.status()} ${text}`);
-  }
-}
+import { withGroupAccessPrivacyFixture } from './group-access-privacy-consent.fixture';
+import { loginAsOfficeSeededAgent } from './group-access-privacy-login';
 
 test.describe('Group access privacy', () => {
   test('office group access stays aggregate-only without explicit member consent', async ({
@@ -68,96 +10,14 @@ test.describe('Group access privacy', () => {
   }, testInfo) => {
     test.setTimeout(90_000);
 
-    const officeAgent = getOfficeSeededAgent(testInfo);
-    const seededMember = isMkProject(testInfo) ? E2E_USERS.MK_MEMBER : E2E_USERS.KS_MEMBER;
-    const { claimId, currentStatus, staffId, tenantId } = await resolveSeededClaimContext(testInfo);
-
-    const agentRecord = await db.query.user.findFirst({
-      where: eq(user.email, officeAgent.email),
-      columns: { id: true },
-    });
-    const claimRecord = await db.query.claims.findFirst({
-      where: eq(claims.id, claimId),
-      columns: { title: true, companyName: true },
-    });
-    const existingSettings = agentRecord?.id
-      ? await db.query.agentSettings.findFirst({
-          where: eq(agentSettings.agentId, agentRecord.id),
-          columns: { id: true, tier: true },
-        })
-      : null;
-
-    if (!agentRecord?.id) {
-      throw new Error(`Expected seeded office-capable agent for ${officeAgent.email}`);
-    }
-
-    if (!claimRecord?.title || !claimRecord.companyName) {
-      throw new Error(`Expected seeded claim details for ${claimId}`);
-    }
-
-    const suffix = randomUUID();
-    const internalHistoryId = `e2e-ga04-hist-${suffix}`;
-    const internalHistoryNote = `GA04 internal note ${Date.now()}`;
-    const claimDocumentId = `e2e-ga04-doc-${suffix}`;
-    const claimDocumentName = `GA04-sensitive-${suffix}.pdf`;
-    const settingsId = existingSettings?.id ?? `e2e-ga04-settings-${suffix}`;
-    const previousTier = existingSettings?.tier ?? 'standard';
-    const createdSettings = !existingSettings?.id;
-    let tierElevated = false;
-
-    try {
-      if (createdSettings) {
-        await db.insert(agentSettings).values({
-          id: settingsId,
-          tenantId,
-          agentId: agentRecord.id,
-          commissionRates: { standard: 15 },
-          tier: 'office',
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        });
-      } else {
-        await db
-          .update(agentSettings)
-          .set({ tier: 'office', updatedAt: new Date() })
-          .where(eq(agentSettings.id, settingsId));
-      }
-      tierElevated = true;
-
-      await db.insert(claimStageHistory).values({
-        id: internalHistoryId,
-        tenantId,
-        claimId,
-        fromStatus: currentStatus,
-        toStatus: currentStatus,
-        changedById: staffId,
-        changedByRole: 'staff',
-        note: internalHistoryNote,
-        isPublic: false,
-        createdAt: new Date(),
-      });
-
-      await db.insert(claimDocuments).values({
-        id: claimDocumentId,
-        tenantId,
-        claimId,
-        name: claimDocumentName,
-        filePath: `e2e/${claimDocumentId}.pdf`,
-        fileType: 'application/pdf',
-        fileSize: 1024,
-        bucket: 'claim-evidence',
-        classification: 'pii',
-        category: 'evidence',
-        uploadedBy: staffId,
-        createdAt: new Date(),
-      });
-
-      await loginAsOfficeSeededAgent(page, testInfo, officeAgent);
+    await withGroupAccessPrivacyFixture(testInfo, async context => {
+      await loginAsOfficeSeededAgent(page, testInfo, context.officeAgent);
       await gotoApp(page, routes.agentImport(testInfo), testInfo, {
         marker: 'group-dashboard-summary',
       });
 
-      await expect(page.getByTestId('group-dashboard-summary')).toBeVisible();
+      const summary = page.locator('[data-testid="group-dashboard-summary"]:visible').first();
+      await expect(summary).toBeVisible();
       await expect(page.getByText('Aggregate group access dashboard')).toBeVisible();
       await expect(
         page.getByText(
@@ -166,24 +26,11 @@ test.describe('Group access privacy', () => {
       ).toBeVisible();
       await expect(page.getByRole('heading', { name: 'Open cases' })).toBeVisible();
 
-      await expect(page.getByText(seededMember.name)).toHaveCount(0);
-      await expect(page.getByText(claimRecord.title)).toHaveCount(0);
-      await expect(page.getByText(claimRecord.companyName)).toHaveCount(0);
-      await expect(page.getByText(internalHistoryNote)).toHaveCount(0);
-      await expect(page.getByText(claimDocumentName)).toHaveCount(0);
-    } finally {
-      await db.delete(claimDocuments).where(eq(claimDocuments.id, claimDocumentId));
-      await db.delete(claimStageHistory).where(eq(claimStageHistory.id, internalHistoryId));
-      if (tierElevated) {
-        if (createdSettings) {
-          await db.delete(agentSettings).where(eq(agentSettings.id, settingsId));
-        } else {
-          await db
-            .update(agentSettings)
-            .set({ tier: previousTier, updatedAt: new Date() })
-            .where(eq(agentSettings.id, settingsId));
-        }
-      }
-    }
+      await expect(page.getByText(context.seededMemberName)).toHaveCount(0);
+      await expect(page.getByText(context.claimTitle)).toHaveCount(0);
+      await expect(page.getByText(context.claimCompanyName)).toHaveCount(0);
+      await expect(page.getByText(context.internalHistoryNote)).toHaveCount(0);
+      await expect(page.getByText(context.claimDocumentName)).toHaveCount(0);
+    });
   });
 });

--- a/apps/web/e2e/gate/group-access-privacy-login.ts
+++ b/apps/web/e2e/gate/group-access-privacy-login.ts
@@ -1,0 +1,28 @@
+import type { Page, TestInfo } from '@playwright/test';
+import { E2E_PASSWORD } from '@interdomestik/database';
+
+import { ipForRole } from '../fixtures/auth.project';
+import type { OfficeSeededAgent } from './group-access-privacy-consent.fixture';
+
+export async function loginAsOfficeSeededAgent(
+  page: Page,
+  testInfo: TestInfo,
+  officeAgent: OfficeSeededAgent
+) {
+  const baseUrl = testInfo.project.use.baseURL?.toString() ?? '';
+  const origin = new URL(baseUrl).origin;
+  const response = await page.request.post(`${origin}/api/auth/sign-in/email`, {
+    data: { email: officeAgent.email, password: E2E_PASSWORD },
+    headers: {
+      Origin: origin,
+      Referer: `${origin}/login`,
+      'x-forwarded-for': ipForRole('agent'),
+      ...testInfo.project.use.extraHTTPHeaders,
+    },
+  });
+
+  if (!response.ok()) {
+    const text = await response.text();
+    throw new Error(`API login failed for ${officeAgent.email}: ${response.status()} ${text}`);
+  }
+}

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -139,7 +139,7 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.doesNotMatch(deployStep.run, /--token/u);
   assert.match(
     deployStep.run,
-    /interdomestik-release-attestation\.json[\s\S]*ATTESTATION_HOST="\$\{hostname\}" METADATA_URL="\$\{metadata_url\}" node scripts\/ci\/fetch-vercel-attestation\.mjs/u
+    /interdomestik-release-attestation\.json[\s\S]*METADATA_URL="\$\{metadata_url\}" node scripts\/ci\/fetch-vercel-attestation\.mjs/u
   );
   assert.match(deployStep.run, /verify-vercel-attestation\.mjs/u);
   assert.match(deployStep.run, /vercel_output_digest=/u);

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -139,7 +139,7 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.doesNotMatch(deployStep.run, /--token/u);
   assert.match(
     deployStep.run,
-    /interdomestik-release-attestation\.json[\s\S]*fetch-vercel-attestation\.mjs/u
+    /interdomestik-release-attestation\.json[\s\S]*ATTESTATION_HOST="\$\{hostname\}" METADATA_URL="\$\{metadata_url\}" node scripts\/ci\/fetch-vercel-attestation\.mjs/u
   );
   assert.match(deployStep.run, /verify-vercel-attestation\.mjs/u);
   assert.match(deployStep.run, /vercel_output_digest=/u);

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -57,13 +57,8 @@ function assertVercelDeployBoundary({
     '${{ needs.' + buildJobName + '.outputs.image_digest }}'
   );
 
-  for (const key of [
-    'VERCEL_TOKEN',
-    'VERCEL_ORG_ID',
-    'VERCEL_PROJECT_ID',
-    'DATABASE_URL',
-    'DATABASE_URL_RLS',
-  ]) {
+  const secretKeys = 'VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID DATABASE_URL DATABASE_URL_RLS';
+  for (const key of secretKeys.split(' ')) {
     assert.equal(job.env?.[key], undefined);
   }
 }
@@ -142,7 +137,10 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(deployStep.run, /--target="\$\{deploy_target\}"/u);
   assert.match(deployStep.run, /base_url="\$\{deployment_url\}"/u);
   assert.doesNotMatch(deployStep.run, /--token/u);
-  assert.match(deployStep.run, /curl -fsSL --retry 6 --retry-delay 5 "\$\{metadata_url\}"/u);
+  assert.match(
+    deployStep.run,
+    /interdomestik-release-attestation\.json[\s\S]*fetch-vercel-attestation\.mjs/u
+  );
   assert.match(deployStep.run, /verify-vercel-attestation\.mjs/u);
   assert.match(deployStep.run, /vercel_output_digest=/u);
   assert.equal(cleanupStep.if, '${{ always() }}');

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -100,7 +100,6 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   );
   assert.match(validateStep.run, /VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID/u);
   assert.match(validateStep.run, /ENABLE_VERCEL_DEPLOYMENTS=1/u);
-
   assert.match(pullStep.run, /vercel@latest pull/u);
   assert.match(pullStep.run, /vercel_env=.*staging.*preview/u);
   assert.match(pullStep.run, /--environment="\$\{vercel_env\}"/u);
@@ -110,20 +109,17 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(buildStep.run, /deploy_target=.*staging.*preview[\s\S]*deploy_target=production/u);
   assert.match(buildStep.run, /target_args=\(\)/u);
   assert.match(buildStep.run, /target_args=\(--prod\)/u);
-
   assert.equal(renamedDigestStep.id, 'artifact');
   assert.match(renamedDigestStep.run, /hash-vercel-output\.mjs/u);
   assert.match(renamedDigestStep.run, /interdomestik-release-attestation\.json/u);
   assert.match(renamedDigestStep.run, /vercelOutputDigest/u);
   assert.match(renamedDigestStep.env.SOURCE_IMAGE_DIGEST, /inputs\.attested-image-digest/u);
-
   assert.match(attestStep.uses, /^actions\/attest@[a-f0-9]{40}$/u);
   assert.equal(attestStep.with['subject-name'], 'vercel-output/${{ inputs.environment }}');
   assert.equal(
     attestStep.with['subject-digest'],
     '${{ steps.artifact.outputs.vercel_output_digest }}'
   );
-
   assert.equal(deployStep.id, 'deploy');
   assert.match(
     deployStep.run,
@@ -136,6 +132,10 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(deployStep.run, /deploy_target=.*staging.*preview/u);
   assert.match(deployStep.run, /--target="\$\{deploy_target\}"/u);
   assert.match(deployStep.run, /base_url="\$\{deployment_url\}"/u);
+  assert.match(
+    deployStep.run,
+    /metadata_url="\$\{base_url\}\/\.well-known\/interdomestik-release-attestation\.json"/u
+  );
   assert.doesNotMatch(deployStep.run, /--token/u);
   assert.match(
     deployStep.run,

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -142,7 +142,7 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(deployStep.run, /--target="\$\{deploy_target\}"/u);
   assert.match(deployStep.run, /base_url="\$\{deployment_url\}"/u);
   assert.doesNotMatch(deployStep.run, /--token/u);
-  assert.match(deployStep.run, /interdomestik-release-attestation\.json/u);
+  assert.match(deployStep.run, /curl -fsSL --retry 6 --retry-delay 5 "\$\{metadata_url\}"/u);
   assert.match(deployStep.run, /verify-vercel-attestation\.mjs/u);
   assert.match(deployStep.run, /vercel_output_digest=/u);
   assert.equal(cleanupStep.if, '${{ always() }}');

--- a/scripts/ci/fetch-vercel-attestation.mjs
+++ b/scripts/ci/fetch-vercel-attestation.mjs
@@ -1,0 +1,102 @@
+import { pathToFileURL } from 'node:url';
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function requireValue(name, value) {
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(name, value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function assertExpectedUrl(url, expectedHost) {
+  if (url.protocol !== 'https:') {
+    throw new Error(`Attestation URL must use https: ${url.href}`);
+  }
+  if (url.hostname !== expectedHost) {
+    throw new Error(
+      `Attestation redirect crossed host boundary: ${expectedHost} -> ${url.hostname}`
+    );
+  }
+}
+
+async function sleep(ms) {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function fetchVercelAttestation({
+  metadataUrl,
+  expectedHost,
+  fetchImpl = fetch,
+  maxRedirects = 1,
+}) {
+  const host = requireValue('expectedHost', expectedHost);
+  let currentUrl = new URL(requireValue('metadataUrl', metadataUrl));
+  assertExpectedUrl(currentUrl, host);
+
+  for (let redirects = 0; ; redirects += 1) {
+    const response = await fetchImpl(currentUrl, { redirect: 'manual' });
+    if (REDIRECT_STATUSES.has(response.status)) {
+      if (redirects >= maxRedirects) {
+        throw new Error(`Attestation redirect limit exceeded for ${currentUrl.href}`);
+      }
+      const location = response.headers.get('location');
+      if (!location) {
+        throw new Error(`Attestation redirect missing Location header for ${currentUrl.href}`);
+      }
+      currentUrl = new URL(location, currentUrl);
+      assertExpectedUrl(currentUrl, host);
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Attestation fetch failed: ${response.status} ${response.statusText}`);
+    }
+    return response.text();
+  }
+}
+
+async function main() {
+  const retries = parsePositiveInteger(
+    'ATTESTATION_FETCH_RETRIES',
+    process.env.ATTESTATION_FETCH_RETRIES ?? '6'
+  );
+  const retryDelayMs =
+    parsePositiveInteger(
+      'ATTESTATION_FETCH_RETRY_DELAY_SECONDS',
+      process.env.ATTESTATION_FETCH_RETRY_DELAY_SECONDS ?? '5'
+    ) * 1000;
+  let lastError;
+
+  for (let attempt = 0; attempt < retries; attempt += 1) {
+    try {
+      const metadata = await fetchVercelAttestation({
+        metadataUrl: process.env.METADATA_URL,
+        expectedHost: process.env.ATTESTATION_HOST,
+      });
+      process.stdout.write(metadata);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt + 1 < retries) {
+        await sleep(retryDelayMs);
+      }
+    }
+  }
+  throw lastError;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/ci/fetch-vercel-attestation.mjs
+++ b/scripts/ci/fetch-vercel-attestation.mjs
@@ -19,10 +19,10 @@ function parsePositiveInteger(name, value) {
 
 function assertExpectedUrl(url, expectedHost) {
   if (url.protocol !== 'https:') {
-    throw new Error(`Attestation URL must use https: ${url.href}`);
+    throw new Error('URL must use https');
   }
   if (url.host !== expectedHost) {
-    throw new Error(`Attestation redirect crossed host boundary: ${expectedHost} -> ${url.host}`);
+    throw new Error('Attestation crossed host boundary');
   }
 }
 
@@ -46,8 +46,13 @@ export async function fetchVercelAttestation({
   maxRedirects = 1,
   timeoutMs = 30_000,
 }) {
+  const host = requireValue('expectedHost', expectedHost ?? new URL(metadataUrl).host)
+    .trim()
+    .toLowerCase();
+  if (!host.endsWith('.vercel.app') && host !== 'vercel.app') {
+    throw new Error('Host must be vercel.app or *.vercel.app');
+  }
   let currentUrl = new URL(requireValue('metadataUrl', metadataUrl));
-  const host = expectedHost ?? currentUrl.host;
   assertExpectedUrl(currentUrl, host);
 
   for (let redirects = 0; ; redirects += 1) {
@@ -61,11 +66,11 @@ export async function fetchVercelAttestation({
     }
     if (REDIRECT_STATUSES.has(response.status)) {
       if (redirects >= maxRedirects) {
-        throw new Error(`Attestation redirect limit exceeded for ${currentUrl.href}`);
+        throw new Error('Attestation redirect limit exceeded');
       }
       const location = response.headers.get('location');
       if (!location) {
-        throw new Error(`Attestation redirect missing Location header for ${currentUrl.href}`);
+        throw new Error('Attestation redirect missing Location header');
       }
       currentUrl = new URL(location, currentUrl);
       assertExpectedUrl(currentUrl, host);
@@ -73,7 +78,7 @@ export async function fetchVercelAttestation({
     }
 
     if (!response.ok) {
-      throw new Error(`Attestation fetch failed: ${response.status} ${response.statusText}`);
+      throw new Error(`Attestation fetch failed: ${response.status}`);
     }
     assertJsonResponse(response, currentUrl);
     return response.text();
@@ -121,6 +126,7 @@ async function main() {
 
   const metadata = await fetchVercelAttestationWithRetries({
     metadataUrl: process.env.METADATA_URL,
+    expectedHost: process.env.ATTESTATION_HOST,
     retries,
     retryDelayMs,
     timeoutMs,

--- a/scripts/ci/fetch-vercel-attestation.mjs
+++ b/scripts/ci/fetch-vercel-attestation.mjs
@@ -70,6 +70,26 @@ export async function fetchVercelAttestation({
   }
 }
 
+export async function fetchVercelAttestationWithRetries({
+  retries,
+  retryDelayMs,
+  sleepImpl = sleep,
+  ...fetchOptions
+}) {
+  let lastError;
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await fetchVercelAttestation(fetchOptions);
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await sleepImpl(retryDelayMs);
+      }
+    }
+  }
+  throw lastError;
+}
+
 async function main() {
   const retries = parsePositiveInteger(
     'ATTESTATION_FETCH_RETRIES',
@@ -80,29 +100,29 @@ async function main() {
       'ATTESTATION_FETCH_RETRY_DELAY_SECONDS',
       process.env.ATTESTATION_FETCH_RETRY_DELAY_SECONDS ?? '5'
     ) * 1000;
-  let lastError;
+  const timeoutMs = parsePositiveInteger(
+    'ATTESTATION_FETCH_TIMEOUT_MS',
+    process.env.ATTESTATION_FETCH_TIMEOUT_MS ?? '30000'
+  );
+  const maxRedirects = parsePositiveInteger(
+    'ATTESTATION_FETCH_MAX_REDIRECTS',
+    process.env.ATTESTATION_FETCH_MAX_REDIRECTS ?? '1'
+  );
 
-  for (let attempt = 0; attempt <= retries; attempt += 1) {
-    try {
-      const metadata = await fetchVercelAttestation({
-        metadataUrl: process.env.METADATA_URL,
-        expectedHost: process.env.ATTESTATION_HOST,
-      });
-      process.stdout.write(metadata);
-      return;
-    } catch (error) {
-      lastError = error;
-      if (attempt < retries) {
-        await sleep(retryDelayMs);
-      }
-    }
-  }
-  throw lastError;
+  const metadata = await fetchVercelAttestationWithRetries({
+    metadataUrl: process.env.METADATA_URL,
+    expectedHost: process.env.ATTESTATION_HOST,
+    retries,
+    retryDelayMs,
+    timeoutMs,
+    maxRedirects,
+  });
+  process.stdout.write(metadata);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch(error => {
-    console.error(error instanceof Error ? error.message : String(error));
+    console.error(error);
     process.exit(1);
   });
 }

--- a/scripts/ci/fetch-vercel-attestation.mjs
+++ b/scripts/ci/fetch-vercel-attestation.mjs
@@ -21,10 +21,8 @@ function assertExpectedUrl(url, expectedHost) {
   if (url.protocol !== 'https:') {
     throw new Error(`Attestation URL must use https: ${url.href}`);
   }
-  if (url.hostname !== expectedHost) {
-    throw new Error(
-      `Attestation redirect crossed host boundary: ${expectedHost} -> ${url.hostname}`
-    );
+  if (url.host !== expectedHost) {
+    throw new Error(`Attestation redirect crossed host boundary: ${expectedHost} -> ${url.host}`);
   }
 }
 
@@ -37,13 +35,21 @@ export async function fetchVercelAttestation({
   expectedHost,
   fetchImpl = fetch,
   maxRedirects = 1,
+  timeoutMs = 30_000,
 }) {
   const host = requireValue('expectedHost', expectedHost);
   let currentUrl = new URL(requireValue('metadataUrl', metadataUrl));
   assertExpectedUrl(currentUrl, host);
 
   for (let redirects = 0; ; redirects += 1) {
-    const response = await fetchImpl(currentUrl, { redirect: 'manual' });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let response;
+    try {
+      response = await fetchImpl(currentUrl, { redirect: 'manual', signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
     if (REDIRECT_STATUSES.has(response.status)) {
       if (redirects >= maxRedirects) {
         throw new Error(`Attestation redirect limit exceeded for ${currentUrl.href}`);
@@ -76,7 +82,7 @@ async function main() {
     ) * 1000;
   let lastError;
 
-  for (let attempt = 0; attempt < retries; attempt += 1) {
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
     try {
       const metadata = await fetchVercelAttestation({
         metadataUrl: process.env.METADATA_URL,
@@ -86,7 +92,7 @@ async function main() {
       return;
     } catch (error) {
       lastError = error;
-      if (attempt + 1 < retries) {
+      if (attempt < retries) {
         await sleep(retryDelayMs);
       }
     }

--- a/scripts/ci/fetch-vercel-attestation.mjs
+++ b/scripts/ci/fetch-vercel-attestation.mjs
@@ -26,6 +26,15 @@ function assertExpectedUrl(url, expectedHost) {
   }
 }
 
+function assertJsonResponse(response, url) {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new Error(
+      `Attestation fetch failed for ${url.href}: expected JSON, got ${contentType || 'missing'}`
+    );
+  }
+}
+
 async function sleep(ms) {
   await new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -37,8 +46,8 @@ export async function fetchVercelAttestation({
   maxRedirects = 1,
   timeoutMs = 30_000,
 }) {
-  const host = requireValue('expectedHost', expectedHost);
   let currentUrl = new URL(requireValue('metadataUrl', metadataUrl));
+  const host = expectedHost ?? currentUrl.host;
   assertExpectedUrl(currentUrl, host);
 
   for (let redirects = 0; ; redirects += 1) {
@@ -66,6 +75,7 @@ export async function fetchVercelAttestation({
     if (!response.ok) {
       throw new Error(`Attestation fetch failed: ${response.status} ${response.statusText}`);
     }
+    assertJsonResponse(response, currentUrl);
     return response.text();
   }
 }
@@ -111,7 +121,6 @@ async function main() {
 
   const metadata = await fetchVercelAttestationWithRetries({
     metadataUrl: process.env.METADATA_URL,
-    expectedHost: process.env.ATTESTATION_HOST,
     retries,
     retryDelayMs,
     timeoutMs,

--- a/scripts/ci/fetch-vercel-attestation.test.mjs
+++ b/scripts/ci/fetch-vercel-attestation.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { fetchVercelAttestation } from './fetch-vercel-attestation.mjs';
+
+function headers(location) {
+  return { get: name => (name.toLowerCase() === 'location' ? location : null) };
+}
+
+function response(status, body = '', location) {
+  return {
+    headers: headers(location),
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Redirect',
+    text: async () => body,
+  };
+}
+
+test('fetchVercelAttestation follows one same-host HTTPS redirect', async () => {
+  const calls = [];
+  const metadata = '{"commitSha":"abc"}';
+  const fetchImpl = async url => {
+    calls.push(url.href);
+    return calls.length === 1
+      ? response(308, '', '/en/.well-known/interdomestik-release-attestation.json')
+      : response(200, metadata);
+  };
+
+  const actual = await fetchVercelAttestation({
+    metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+    expectedHost: 'preview.vercel.app',
+    fetchImpl,
+  });
+
+  assert.equal(actual, metadata);
+  assert.deepEqual(calls, [
+    'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+    'https://preview.vercel.app/en/.well-known/interdomestik-release-attestation.json',
+  ]);
+});
+
+test('fetchVercelAttestation rejects cross-host redirects', async () => {
+  const fetchImpl = async () =>
+    response(302, '', 'https://example.com/.well-known/interdomestik-release-attestation.json');
+
+  await assert.rejects(
+    fetchVercelAttestation({
+      metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+      expectedHost: 'preview.vercel.app',
+      fetchImpl,
+    }),
+    /crossed host boundary/u
+  );
+});

--- a/scripts/ci/fetch-vercel-attestation.test.mjs
+++ b/scripts/ci/fetch-vercel-attestation.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { fetchVercelAttestation } from './fetch-vercel-attestation.mjs';
+import {
+  fetchVercelAttestation,
+  fetchVercelAttestationWithRetries,
+} from './fetch-vercel-attestation.mjs';
 
 function headers(location) {
   return { get: name => (name.toLowerCase() === 'location' ? location : null) };
@@ -93,4 +96,43 @@ test('fetchVercelAttestation rejects unsafe URLs and failed responses', async ()
     }),
     /Attestation fetch failed/u
   );
+});
+
+test('fetchVercelAttestation times out stalled requests', async () => {
+  const fetchImpl = async (_url, { signal }) =>
+    new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () =>
+        reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+      );
+    });
+
+  await assert.rejects(
+    fetchVercelAttestation({
+      metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+      expectedHost: 'preview.vercel.app',
+      fetchImpl,
+      timeoutMs: 1,
+    }),
+    /aborted/u
+  );
+});
+
+test('fetchVercelAttestationWithRetries retries transient failures', async () => {
+  let calls = 0;
+  const delays = [];
+  const actual = await fetchVercelAttestationWithRetries({
+    metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+    expectedHost: 'preview.vercel.app',
+    retries: 2,
+    retryDelayMs: 5,
+    sleepImpl: async ms => delays.push(ms),
+    fetchImpl: async () => {
+      calls += 1;
+      return calls < 3 ? response(503) : response(200, '{"ok":true}');
+    },
+  });
+
+  assert.equal(actual, '{"ok":true}');
+  assert.equal(calls, 3);
+  assert.deepEqual(delays, [5, 5]);
 });

--- a/scripts/ci/fetch-vercel-attestation.test.mjs
+++ b/scripts/ci/fetch-vercel-attestation.test.mjs
@@ -6,13 +6,19 @@ import {
   fetchVercelAttestationWithRetries,
 } from './fetch-vercel-attestation.mjs';
 
-function headers(location) {
-  return { get: name => (name.toLowerCase() === 'location' ? location : null) };
+function headers(location, contentType = 'application/json') {
+  return {
+    get: name => {
+      if (name.toLowerCase() === 'location') return location;
+      if (name.toLowerCase() === 'content-type') return contentType;
+      return null;
+    },
+  };
 }
 
-function response(status, body = '', location) {
+function response(status, body = '', location, contentType) {
   return {
-    headers: headers(location),
+    headers: headers(location, contentType),
     ok: status >= 200 && status < 300,
     status,
     statusText: status === 200 ? 'OK' : 'Redirect',
@@ -32,7 +38,6 @@ test('fetchVercelAttestation follows one same-host HTTPS redirect', async () => 
 
   const actual = await fetchVercelAttestation({
     metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
-    expectedHost: 'preview.vercel.app',
     fetchImpl,
   });
 
@@ -50,7 +55,6 @@ test('fetchVercelAttestation rejects cross-host redirects', async () => {
   await assert.rejects(
     fetchVercelAttestation({
       metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
-      expectedHost: 'preview.vercel.app',
       fetchImpl,
     }),
     /crossed host boundary/u
@@ -63,7 +67,6 @@ test('fetchVercelAttestation rejects redirect chains past the limit', async () =
   await assert.rejects(
     fetchVercelAttestation({
       metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
-      expectedHost: 'preview.vercel.app',
       fetchImpl,
     }),
     /redirect limit exceeded/u
@@ -74,7 +77,6 @@ test('fetchVercelAttestation rejects unsafe URLs and failed responses', async ()
   await assert.rejects(
     fetchVercelAttestation({
       metadataUrl: 'http://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
-      expectedHost: 'preview.vercel.app',
     }),
     /must use https/u
   );
@@ -82,7 +84,6 @@ test('fetchVercelAttestation rejects unsafe URLs and failed responses', async ()
   await assert.rejects(
     fetchVercelAttestation({
       metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
-      expectedHost: 'preview.vercel.app',
       fetchImpl: async () => response(302),
     }),
     /missing Location header/u
@@ -91,10 +92,19 @@ test('fetchVercelAttestation rejects unsafe URLs and failed responses', async ()
   await assert.rejects(
     fetchVercelAttestation({
       metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
-      expectedHost: 'preview.vercel.app',
       fetchImpl: async () => response(500),
     }),
     /Attestation fetch failed/u
+  );
+});
+
+test('fetchVercelAttestation rejects non-JSON success responses', async () => {
+  await assert.rejects(
+    fetchVercelAttestation({
+      metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+      fetchImpl: async () => response(200, '<html></html>', undefined, 'text/html'),
+    }),
+    /expected JSON/u
   );
 });
 
@@ -109,7 +119,6 @@ test('fetchVercelAttestation times out stalled requests', async () => {
   await assert.rejects(
     fetchVercelAttestation({
       metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
-      expectedHost: 'preview.vercel.app',
       fetchImpl,
       timeoutMs: 1,
     }),
@@ -122,7 +131,6 @@ test('fetchVercelAttestationWithRetries retries transient failures', async () =>
   const delays = [];
   const actual = await fetchVercelAttestationWithRetries({
     metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
-    expectedHost: 'preview.vercel.app',
     retries: 2,
     retryDelayMs: 5,
     sleepImpl: async ms => delays.push(ms),

--- a/scripts/ci/fetch-vercel-attestation.test.mjs
+++ b/scripts/ci/fetch-vercel-attestation.test.mjs
@@ -53,3 +53,44 @@ test('fetchVercelAttestation rejects cross-host redirects', async () => {
     /crossed host boundary/u
   );
 });
+
+test('fetchVercelAttestation rejects redirect chains past the limit', async () => {
+  const fetchImpl = async url => response(302, '', url.pathname.includes('/one') ? '/two' : '/one');
+
+  await assert.rejects(
+    fetchVercelAttestation({
+      metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+      expectedHost: 'preview.vercel.app',
+      fetchImpl,
+    }),
+    /redirect limit exceeded/u
+  );
+});
+
+test('fetchVercelAttestation rejects unsafe URLs and failed responses', async () => {
+  await assert.rejects(
+    fetchVercelAttestation({
+      metadataUrl: 'http://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+      expectedHost: 'preview.vercel.app',
+    }),
+    /must use https/u
+  );
+
+  await assert.rejects(
+    fetchVercelAttestation({
+      metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+      expectedHost: 'preview.vercel.app',
+      fetchImpl: async () => response(302),
+    }),
+    /missing Location header/u
+  );
+
+  await assert.rejects(
+    fetchVercelAttestation({
+      metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+      expectedHost: 'preview.vercel.app',
+      fetchImpl: async () => response(500),
+    }),
+    /Attestation fetch failed/u
+  );
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37530426,
+  "maxTrackedBytes": 37532060,
   "maxTrackedFiles": 4534,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7011005,
+    "source/scripts": 7011217,
     "docs/text": 5705447,
-    "tests/e2e": 4935175,
+    "tests/e2e": 4936597,
     "config/data/messages": 1548863,
     "other": 129182
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37525669,
-  "maxTrackedFiles": 4532,
+  "maxTrackedBytes": 37530426,
+  "maxTrackedFiles": 4534,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7008099,
+    "source/scripts": 7011005,
     "docs/text": 5705447,
-    "tests/e2e": 4933376,
-    "config/data/messages": 1548811,
+    "tests/e2e": 4935175,
+    "config/data/messages": 1548863,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37532189,
+  "maxTrackedBytes": 37533898,
   "maxTrackedFiles": 4534,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7011217,
+    "source/scripts": 7011685,
     "docs/text": 5705447,
-    "tests/e2e": 4936726,
+    "tests/e2e": 4937967,
     "config/data/messages": 1548863,
     "other": 129182
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37532060,
+  "maxTrackedBytes": 37532189,
   "maxTrackedFiles": 4534,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
     "source/scripts": 7011217,
     "docs/text": 5705447,
-    "tests/e2e": 4936597,
+    "tests/e2e": 4936726,
     "config/data/messages": 1548863,
     "other": 129182
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37533898,
+  "maxTrackedBytes": 37534324,
   "maxTrackedFiles": 4534,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7011685,
+    "source/scripts": 7011980,
     "docs/text": 5705447,
-    "tests/e2e": 4937967,
-    "config/data/messages": 1548863,
+    "tests/e2e": 4938129,
+    "config/data/messages": 1548832,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37534324,
-  "maxTrackedFiles": 4534,
+  "maxTrackedBytes": 37535135,
+  "maxTrackedFiles": 4536,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7011980,
+    "source/scripts": 7012096,
     "docs/text": 5705447,
-    "tests/e2e": 4938129,
+    "tests/e2e": 4938824,
     "config/data/messages": 1548832,
     "other": 129182
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37525650,
+  "maxTrackedBytes": 37525669,
   "maxTrackedFiles": 4532,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
     "source/scripts": 7008099,
     "docs/text": 5705447,
-    "tests/e2e": 4933358,
-    "config/data/messages": 1548810,
+    "tests/e2e": 4933376,
+    "config/data/messages": 1548811,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,


### PR DESCRIPTION
## Summary

- Follow Vercel redirects when fetching deployed release attestation JSON.
- Harden attestation metadata retrieval by constraining fetch targets to `vercel.app` hosts in `scripts/ci/fetch-vercel-attestation.mjs`, while preserving same-host redirect enforcement and JSON-response validation.
- Scope touched and impacted boundary paths: `.github/actions/trigger-digest-verified-deploy/action.yml`, `scripts/ci/fetch-vercel-attestation.mjs`, and CI contract tests under `scripts/ci/*attestation*` and `scripts/ci/cd-deploy-digest-boundary.test.mjs`.

## Review focus

- Primary review surface: CI attestation fetch helper and deploy action attestation wiring.
- Primary contracts or risks to verify: redirect-follow behavior, metadata path contract, host-boundary/allowlist enforcement (`vercel.app` only), and non-JSON/failed-response handling.
- Ignore unless behavior changed: unrelated repo-size budget drift and local Supabase bootstrap instability in this runner.

## Acceptance

- [x] Slice criteria are explicit and complete.
- [x] No behavior changed outside slice scope.

## Evidence (mandatory before merge)

- PR status: `PARTIAL`
- Summary JSON: `tmp/pilot-evidence/2026-06-26/061944/summary.json`
- Closure note: `tmp/pilot-evidence/2026-06-26/061944/closure.md`
- Gates:
  - `pnpm pr:verify` (exit: `1`)
  - `pnpm security:guard` (exit: `0`)
  - `pnpm e2e:gate` or scoped equivalent (exit: `1`)
- Logs: `tmp/pilot-evidence/2026-06-26/061944/logs/...`
- Screenshots: `tmp/pilot-evidence/2026-06-26/061944/screenshots/...`
- Runbooks: `tmp/pilot-evidence/2026-06-26/061944/runbooks/...`

## Pilot guardrails

- [x] No changes to auth, routing, proxy, or API contract files were made.
- [x] Explicitly allowed exceptions documented:
  - `apps/web/src/proxy.ts` — reason:
  - `apps/web/src/app/api/**/route.ts` — reason:
  - `packages/**/src/api/**` — reason:
  - `packages/**/src/**/auth*` — reason:

## Merge readiness

- [ ] All GitHub review threads resolved.
- [x] Bot or reviewer findings were either fixed or explicitly closed with technical reasoning.
- [ ] Required checks green (`validation-surface`, `audit`, `e2e`, `pnpm-audit`, `gitleaks`, `pilot-gate`, `pr-finalizer`, `commitlint`, `CodeQL`, `Analyze (actions)`, `Analyze (javascript-typescript)`).
- [ ] `pnpm pr:governance:report -- <PR_NUMBER>` recorded Sonar, CodeQL, Copilot, Codex, and required-check state; absent Copilot/Codex feedback is documented rather than waited on indefinitely.
- [ ] Evidence artifact paths are present and complete.