### PR TITLE
ci: support Vercel protected preview gates

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -9,6 +9,9 @@ inputs:
     required: true
   attested-image-digest:
     required: true
+  vercel-automation-bypass-secret:
+    required: false
+    default: ''
 outputs:
   deployment_url:
     value: ${{ steps.deploy.outputs.deployment_url }}
@@ -108,6 +111,7 @@ runs:
         COMMIT_SHA: ${{ inputs.commit-sha }}
         DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
         DEPLOY_PRODUCTION: ${{ inputs.production }}
+        VERCEL_AUTOMATION_BYPASS_SECRET: ${{ inputs.vercel-automation-bypass-secret }}
         VERCEL_OUTPUT_DIGEST: ${{ steps.artifact.outputs.vercel_output_digest }}
       run: |
         set -euo pipefail
@@ -121,12 +125,7 @@ runs:
           echo "::error::Vercel output digest changed after attestation"
           exit 1
         fi
-        deployment_url="$(
-          npx --yes vercel@latest deploy \
-            --prebuilt \
-            --env "COMMIT_SHA=${COMMIT_SHA}" \
-            "${target_args[@]}"
-        )"
+        deployment_url="$(npx --yes vercel@latest deploy --prebuilt --env "COMMIT_SHA=${COMMIT_SHA}" "${target_args[@]}")"
         deployment_url="$(printf '%s\n' "${deployment_url}" | tail -n 1)"
         base_url="${deployment_url}"
         if [[ "${base_url}" != https://* ]]; then
@@ -136,7 +135,7 @@ runs:
         hostname="${hostname%%/*}"
         hostname="${hostname%%:*}"
         metadata_url="${base_url}/.well-known/interdomestik-release-attestation.json"
-        metadata="$(METADATA_URL="${metadata_url}" node scripts/ci/fetch-vercel-attestation.mjs)"
+        metadata="$(METADATA_URL="${metadata_url}" VERCEL_AUTOMATION_BYPASS_SECRET="${VERCEL_AUTOMATION_BYPASS_SECRET:-}" node scripts/ci/fetch-vercel-attestation.mjs)"
         METADATA="${metadata}" node scripts/ci/verify-vercel-attestation.mjs
         echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
         echo "base_url=${base_url}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,17 +90,19 @@ jobs:
           production: 'false'
           commit-sha: ${{ github.sha }}
           attested-image-digest: ${{ needs.build-staging.outputs.image_digest }}
+          vercel-automation-bypass-secret: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Wait for Staging Health
         shell: bash
         env:
           BASE_URL: ${{ steps.vercel.outputs.base_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           set -euo pipefail
           max_attempts=30
           sleep_seconds=5
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "Attempt ${attempt}/${max_attempts}: checking ${BASE_URL}/api/health..."
-            if curl -fsS "${BASE_URL}/api/health"; then
+            if node scripts/ci/fetch-vercel-health.mjs "${BASE_URL}/api/health"; then
               echo "Staging health check succeeded."
               exit 0
             fi
@@ -114,25 +116,10 @@ jobs:
         shell: bash
         env:
           BASE_URL: ${{ steps.vercel.outputs.base_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           set -euo pipefail
-          node --input-type=module -e '
-            const expected = process.env.EXPECTED_COMMIT_SHA;
-            const baseUrl = process.env.BASE_URL;
-            if (!expected || !baseUrl) {
-              throw new Error("EXPECTED_COMMIT_SHA and BASE_URL are required");
-            }
-            const res = await fetch(new URL("/api/health", baseUrl));
-            if (!res.ok) {
-              throw new Error(`Health endpoint returned ${res.status}`);
-            }
-            const health = await res.json();
-            const actual = health?.build?.commitSha;
-            if (actual !== expected) {
-              throw new Error(`Deployed build provenance mismatch: expected ${expected}, got ${actual || "missing"}`);
-            }
-            console.log(`Deployed build provenance verified: ${actual}`);
-          '
+          node scripts/ci/fetch-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
   e2e-staging:
     needs: deploy-staging
     runs-on: [self-hosted, interdomestik-mac]
@@ -160,6 +147,8 @@ jobs:
           install-playwright: 'true'
       - name: Run Staging Release Gate
         shell: bash
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           set -euo pipefail
           mkdir -p "${EVIDENCE_DIR}/logs" "${EVIDENCE_DIR}/release-gates"
@@ -196,7 +185,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
@@ -260,6 +248,7 @@ jobs:
           production: 'true'
           commit-sha: ${{ github.sha }}
           attested-image-digest: ${{ needs.build-production.outputs.image_digest }}
+          vercel-automation-bypass-secret: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
   verify-production:
     needs: deploy-production
     runs-on: [self-hosted, interdomestik-mac]
@@ -330,7 +319,7 @@ jobs:
           for attempt in $(seq 1 "${max_attempts}"); do
             echo "🏥 Attempt ${attempt}/${max_attempts}: checking health of ${BASE_URL}..."
 
-            if curl -fsS "${BASE_URL}/api/health"; then
+            if node scripts/ci/fetch-vercel-health.mjs "${BASE_URL}/api/health"; then
               echo "✅ Health check succeeded on attempt ${attempt}."
               exit 0
             fi
@@ -343,32 +332,11 @@ jobs:
 
           echo "❌ Health check failed after ${max_attempts} attempts."
           exit 1
-
       - name: Verify Production Build Provenance
         shell: bash
         run: |
           set -euo pipefail
-
-          node --input-type=module -e '
-            const expected = process.env.EXPECTED_COMMIT_SHA;
-            const baseUrl = process.env.BASE_URL;
-            if (!expected || !baseUrl) {
-              throw new Error("EXPECTED_COMMIT_SHA and BASE_URL are required");
-            }
-
-            const res = await fetch(new URL("/api/health", baseUrl));
-            if (!res.ok) {
-              throw new Error(`Health endpoint returned ${res.status}`);
-            }
-
-            const health = await res.json();
-            const actual = health?.build?.commitSha;
-            if (actual !== expected) {
-              throw new Error(`Deployed build provenance mismatch: expected ${expected}, got ${actual || "missing"}`);
-            }
-
-            console.log(`Deployed build provenance verified: ${actual}`);
-          '
+          node scripts/ci/fetch-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
 
       - name: Run Production Release Gate
         shell: bash

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -52,13 +52,21 @@ function assertVercelDeployBoundary({
   assert.match(step.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
   assert.equal(step.env.VERCEL_ORG_ID, '${{ vars.VERCEL_ORG_ID }}');
   assert.equal(step.env.VERCEL_PROJECT_ID, '${{ vars.VERCEL_PROJECT_ID }}');
+  assert.equal(step.env.VERCEL_AUTOMATION_BYPASS_SECRET, undefined);
+  assert.match(step.with['vercel-automation-bypass-secret'], /secrets\.VERCEL_AUTOMATION/u);
   assert.equal(
     step.with['attested-image-digest'],
     '${{ needs.' + buildJobName + '.outputs.image_digest }}'
   );
 
-  const secretKeys = 'VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID DATABASE_URL DATABASE_URL_RLS';
-  for (const key of secretKeys.split(' ')) {
+  for (const key of [
+    'VERCEL_TOKEN',
+    'VERCEL_ORG_ID',
+    'VERCEL_PROJECT_ID',
+    'DATABASE_URL',
+    'DATABASE_URL_RLS',
+    'VERCEL_AUTOMATION_BYPASS_SECRET',
+  ]) {
     assert.equal(job.env?.[key], undefined);
   }
 }
@@ -94,10 +102,8 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
 
   assert.equal(deployAction.inputs['commit-sha'].required, true);
   assert.equal(deployAction.inputs['attested-image-digest'].required, true);
-  assert.equal(
-    deployAction.outputs.vercel_output_digest.value,
-    '${{ steps.deploy.outputs.vercel_output_digest }}'
-  );
+  assert.equal(deployAction.inputs['vercel-automation-bypass-secret'].required, false);
+  assert.equal(deployAction.outputs.vercel_output_digest.value, '${{ steps.deploy.outputs.vercel_output_digest }}');
   assert.match(validateStep.run, /VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID/u);
   assert.match(validateStep.run, /ENABLE_VERCEL_DEPLOYMENTS=1/u);
   assert.match(pullStep.run, /vercel@latest pull/u);
@@ -116,15 +122,10 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(renamedDigestStep.env.SOURCE_IMAGE_DIGEST, /inputs\.attested-image-digest/u);
   assert.match(attestStep.uses, /^actions\/attest@[a-f0-9]{40}$/u);
   assert.equal(attestStep.with['subject-name'], 'vercel-output/${{ inputs.environment }}');
-  assert.equal(
-    attestStep.with['subject-digest'],
-    '${{ steps.artifact.outputs.vercel_output_digest }}'
-  );
+  assert.equal(attestStep.with['subject-digest'], '${{ steps.artifact.outputs.vercel_output_digest }}');
   assert.equal(deployStep.id, 'deploy');
-  assert.match(
-    deployStep.run,
-    /current_vercel_output_digest="\$\(node scripts\/ci\/hash-vercel-output\.mjs\)"/u
-  );
+  assert.match(deployStep.env.VERCEL_AUTOMATION_BYPASS_SECRET, /inputs\.vercel-automation-bypass-secret/u);
+  assert.match(deployStep.run, /current_vercel_output_digest="\$\(node scripts\/ci\/hash-vercel-output\.mjs\)"/u);
   assert.match(deployStep.run, /Vercel output digest changed after attestation/u);
   assert.match(deployStep.run, /vercel@latest deploy/u);
   assert.match(deployStep.run, /--prebuilt/u);
@@ -132,15 +133,9 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(deployStep.run, /deploy_target=.*staging.*preview/u);
   assert.match(deployStep.run, /--target="\$\{deploy_target\}"/u);
   assert.match(deployStep.run, /base_url="\$\{deployment_url\}"/u);
-  assert.match(
-    deployStep.run,
-    /metadata_url="\$\{base_url\}\/\.well-known\/interdomestik-release-attestation\.json"/u
-  );
+  assert.match(deployStep.run, /metadata_url="\$\{base_url\}\/\.well-known\/interdomestik-release-attestation\.json"/u);
   assert.doesNotMatch(deployStep.run, /--token/u);
-  assert.match(
-    deployStep.run,
-    /interdomestik-release-attestation\.json[\s\S]*METADATA_URL="\$\{metadata_url\}" node scripts\/ci\/fetch-vercel-attestation\.mjs/u
-  );
+  assert.match(deployStep.run, /interdomestik-release-attestation\.json[\s\S]*VERCEL_AUTOMATION_BYPASS_SECRET="\$\{VERCEL_AUTOMATION_BYPASS_SECRET:-\}" node scripts\/ci\/fetch-vercel-attestation\.mjs/u);
   assert.match(deployStep.run, /verify-vercel-attestation\.mjs/u);
   assert.match(deployStep.run, /vercel_output_digest=/u);
   assert.equal(cleanupStep.if, '${{ always() }}');

--- a/scripts/ci/fetch-vercel-attestation-bypass.test.mjs
+++ b/scripts/ci/fetch-vercel-attestation-bypass.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { fetchVercelAttestation } from './fetch-vercel-attestation.mjs';
+
+function response(status, body = '', location) {
+  return {
+    headers: {
+      get: name => {
+        if (name.toLowerCase() === 'location') return location;
+        if (name.toLowerCase() === 'content-type') return 'application/json';
+        return null;
+      },
+    },
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+  };
+}
+
+test('fetchVercelAttestation sends Vercel protection bypass header', async () => {
+  let receivedHeaders;
+  const fetchImpl = async (_url, init) => {
+    receivedHeaders = init.headers;
+    return response(200, '{"commitSha":"abc"}');
+  };
+
+  await fetchVercelAttestation({
+    metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+    bypassSecret: 'secret-123',
+    fetchImpl,
+  });
+
+  assert.equal(receivedHeaders['x-vercel-protection-bypass'], 'secret-123');
+});
+
+test('fetchVercelAttestation rejects Vercel SSO protection redirects', async () => {
+  const fetchImpl = async () =>
+    response(302, '', 'https://vercel.com/sso-api/login?url=https%3A%2F%2Fpreview.vercel.app');
+
+  await assert.rejects(
+    fetchVercelAttestation({
+      metadataUrl: 'https://preview.vercel.app/.well-known/interdomestik-release-attestation.json',
+      fetchImpl,
+    }),
+    /VERCEL_AUTOMATION_BYPASS_SECRET/u
+  );
+});

--- a/scripts/ci/fetch-vercel-attestation.mjs
+++ b/scripts/ci/fetch-vercel-attestation.mjs
@@ -42,6 +42,7 @@ async function sleep(ms) {
 export async function fetchVercelAttestation({
   metadataUrl,
   expectedHost,
+  bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
   fetchImpl = fetch,
   maxRedirects = 1,
   timeoutMs = 30_000,
@@ -49,6 +50,7 @@ export async function fetchVercelAttestation({
   const host = requireValue('expectedHost', expectedHost ?? new URL(metadataUrl).host)
     .trim()
     .toLowerCase();
+  const secret = typeof bypassSecret === 'string' ? bypassSecret.trim() : '';
   if (!host.endsWith('.vercel.app') && host !== 'vercel.app') {
     throw new Error('Host must be vercel.app or *.vercel.app');
   }
@@ -60,7 +62,9 @@ export async function fetchVercelAttestation({
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     let response;
     try {
-      response = await fetchImpl(currentUrl, { redirect: 'manual', signal: controller.signal });
+      const init = { redirect: 'manual', signal: controller.signal };
+      if (secret) init.headers = { 'x-vercel-protection-bypass': secret };
+      response = await fetchImpl(currentUrl, init);
     } finally {
       clearTimeout(timer);
     }
@@ -73,6 +77,9 @@ export async function fetchVercelAttestation({
         throw new Error('Attestation redirect missing Location header');
       }
       currentUrl = new URL(location, currentUrl);
+      if (currentUrl.hostname === 'vercel.com' && currentUrl.pathname.startsWith('/sso-api')) {
+        throw new Error('Attestation requires VERCEL_AUTOMATION_BYPASS_SECRET');
+      }
       assertExpectedUrl(currentUrl, host);
       continue;
     }

--- a/scripts/ci/fetch-vercel-attestation.mjs
+++ b/scripts/ci/fetch-vercel-attestation.mjs
@@ -17,6 +17,10 @@ function parsePositiveInteger(name, value) {
   return parsed;
 }
 
+function envInteger(name, fallback) {
+  return parsePositiveInteger(name, process.env[name] ?? fallback);
+}
+
 function assertExpectedUrl(url, expectedHost) {
   if (url.protocol !== 'https:') {
     throw new Error('URL must use https');
@@ -35,6 +39,24 @@ function assertJsonResponse(response, url) {
   }
 }
 
+function buildRequestInit(secret, controller) {
+  const init = { redirect: 'manual', signal: controller.signal };
+  if (secret) init.headers = { 'x-vercel-protection-bypass': secret };
+  return init;
+}
+
+function nextRedirectUrl(response, currentUrl, redirects, maxRedirects, host) {
+  if (!REDIRECT_STATUSES.has(response.status)) return null;
+  if (redirects >= maxRedirects) throw new Error('Attestation redirect limit exceeded');
+  const location = response.headers.get('location');
+  if (!location) throw new Error('Attestation redirect missing Location header');
+  const nextUrl = new URL(location, currentUrl);
+  if (nextUrl.hostname === 'vercel.com' && nextUrl.pathname.startsWith('/sso-api')) {
+    throw new Error('Attestation requires VERCEL_AUTOMATION_BYPASS_SECRET');
+  }
+  assertExpectedUrl(nextUrl, host);
+  return nextUrl;
+}
 async function sleep(ms) {
   await new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -62,25 +84,13 @@ export async function fetchVercelAttestation({
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     let response;
     try {
-      const init = { redirect: 'manual', signal: controller.signal };
-      if (secret) init.headers = { 'x-vercel-protection-bypass': secret };
-      response = await fetchImpl(currentUrl, init);
+      response = await fetchImpl(currentUrl, buildRequestInit(secret, controller));
     } finally {
       clearTimeout(timer);
     }
-    if (REDIRECT_STATUSES.has(response.status)) {
-      if (redirects >= maxRedirects) {
-        throw new Error('Attestation redirect limit exceeded');
-      }
-      const location = response.headers.get('location');
-      if (!location) {
-        throw new Error('Attestation redirect missing Location header');
-      }
-      currentUrl = new URL(location, currentUrl);
-      if (currentUrl.hostname === 'vercel.com' && currentUrl.pathname.startsWith('/sso-api')) {
-        throw new Error('Attestation requires VERCEL_AUTOMATION_BYPASS_SECRET');
-      }
-      assertExpectedUrl(currentUrl, host);
+    const redirectUrl = nextRedirectUrl(response, currentUrl, redirects, maxRedirects, host);
+    if (redirectUrl) {
+      currentUrl = redirectUrl;
       continue;
     }
 
@@ -113,23 +123,10 @@ export async function fetchVercelAttestationWithRetries({
 }
 
 async function main() {
-  const retries = parsePositiveInteger(
-    'ATTESTATION_FETCH_RETRIES',
-    process.env.ATTESTATION_FETCH_RETRIES ?? '6'
-  );
-  const retryDelayMs =
-    parsePositiveInteger(
-      'ATTESTATION_FETCH_RETRY_DELAY_SECONDS',
-      process.env.ATTESTATION_FETCH_RETRY_DELAY_SECONDS ?? '5'
-    ) * 1000;
-  const timeoutMs = parsePositiveInteger(
-    'ATTESTATION_FETCH_TIMEOUT_MS',
-    process.env.ATTESTATION_FETCH_TIMEOUT_MS ?? '30000'
-  );
-  const maxRedirects = parsePositiveInteger(
-    'ATTESTATION_FETCH_MAX_REDIRECTS',
-    process.env.ATTESTATION_FETCH_MAX_REDIRECTS ?? '1'
-  );
+  const retries = envInteger('ATTESTATION_FETCH_RETRIES', '6');
+  const retryDelayMs = envInteger('ATTESTATION_FETCH_RETRY_DELAY_SECONDS', '5') * 1000;
+  const timeoutMs = envInteger('ATTESTATION_FETCH_TIMEOUT_MS', '30000');
+  const maxRedirects = envInteger('ATTESTATION_FETCH_MAX_REDIRECTS', '1');
 
   const metadata = await fetchVercelAttestationWithRetries({
     metadataUrl: process.env.METADATA_URL,

--- a/scripts/ci/fetch-vercel-health.mjs
+++ b/scripts/ci/fetch-vercel-health.mjs
@@ -100,8 +100,10 @@ async function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch(error => {
+  try {
+    await main();
+  } catch (error) {
     console.error(error);
     process.exit(1);
-  });
+  }
 }

--- a/scripts/ci/fetch-vercel-health.mjs
+++ b/scripts/ci/fetch-vercel-health.mjs
@@ -1,0 +1,107 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCallback);
+const STATUS_MARKER = '\n__INTERDOMESTIK_HEALTH_STATUS__:';
+
+function requireValue(name, value) {
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function isVercelAppUrl(value) {
+  const hostname = value.hostname.toLowerCase();
+  return /^interdomestik-web(?:-[a-z0-9-]+)?-ecohub\.vercel\.app$/u.test(hostname);
+}
+
+function isAllowedHealthUrl(value) {
+  const hostname = value.hostname.toLowerCase();
+  return isVercelAppUrl(value) || hostname === 'www.interdomestik.com' || hostname === 'interdomestik.com';
+}
+
+function parseVercelHealthUrl(value) {
+  const url = new URL(requireValue('healthUrl', value));
+  if (url.protocol !== 'https:') throw new Error('Health URL must use https');
+  if (!isAllowedHealthUrl(url)) throw new Error('Health URL must use an allowed deployment host');
+  if (url.pathname.replace(/\/+/g, '/') !== '/api/health') {
+    throw new Error('Health URL must target /api/health');
+  }
+  return new URL(`https://${url.hostname.toLowerCase()}/api/health`);
+}
+
+function buildHeaders(url) {
+  const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
+  if (!secret || !isVercelAppUrl(url)) return {};
+  return { 'x-vercel-protection-bypass': secret };
+}
+
+async function requestVercelHealth(url, headers, timeoutMs, execFileImpl = execFile) {
+  const args = [
+    '--silent',
+    '--show-error',
+    '--max-time',
+    String(Math.max(1, Math.ceil(timeoutMs / 1000))),
+    '--write-out',
+    `${STATUS_MARKER}%{http_code}`,
+  ];
+  for (const [name, value] of Object.entries(headers)) {
+    args.push('--header', `${name}: ${value}`);
+  }
+  args.push('--', url.href);
+
+  const { stdout } = await execFileImpl('curl', args, {
+    encoding: 'utf8',
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  const markerIndex = stdout.lastIndexOf(STATUS_MARKER);
+  if (markerIndex < 0) throw new Error('Health endpoint response did not include status');
+  const status = Number(stdout.slice(markerIndex + STATUS_MARKER.length).trim());
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => stdout.slice(0, markerIndex),
+  };
+}
+
+export async function fetchVercelHealth({
+  healthUrl,
+  expectedCommitSha,
+  requestImpl = requestVercelHealth,
+  timeoutMs = 10_000,
+}) {
+  const url = parseVercelHealthUrl(healthUrl);
+  const response = await requestImpl(url, buildHeaders(url), timeoutMs);
+  if (response.status >= 300 && response.status < 400) {
+    throw new Error('Health endpoint redirected before returning /api/health');
+  }
+  if (!response.ok) throw new Error(`Health endpoint returned ${response.status}`);
+  const body = await response.text();
+  if (!expectedCommitSha) return body;
+  const actual = JSON.parse(body)?.build?.commitSha;
+  if (actual !== expectedCommitSha) {
+    throw new Error(
+      `Deployed build provenance mismatch: expected ${expectedCommitSha}, got ${actual || 'missing'}`
+    );
+  }
+  return body;
+}
+
+async function main() {
+  if (process.argv.length > 3 && !process.argv[3]) {
+    throw new Error('expectedCommitSha must not be empty when provided');
+  }
+  const body = await fetchVercelHealth({
+    healthUrl: process.argv[2],
+    expectedCommitSha: process.argv[3],
+  });
+  process.stdout.write(`${body}\n`);
+  if (process.argv[3]) console.log(`Deployed build provenance verified: ${process.argv[3]}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/ci/fetch-vercel-health.test.mjs
+++ b/scripts/ci/fetch-vercel-health.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { fetchVercelHealth } from './fetch-vercel-health.mjs';
+
+const PREVIEW_HEALTH_URL = 'https://interdomestik-web-git-main-ecohub.vercel.app/api/health';
+
+function response(status, body = '{}') {
+  return { ok: status >= 200 && status < 300, status, text: async () => body };
+}
+
+test('fetchVercelHealth sends bypass header for Vercel preview hosts', async () => {
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
+  let receivedHeaders;
+  await fetchVercelHealth({
+    healthUrl: PREVIEW_HEALTH_URL,
+    requestImpl: async (_url, headers) => {
+      receivedHeaders = headers;
+      return response(200);
+    },
+  });
+  assert.equal(receivedHeaders['x-vercel-protection-bypass'], 'bypass-secret');
+});
+
+test('fetchVercelHealth rejects redirects before reading health body', async () => {
+  await assert.rejects(
+    fetchVercelHealth({
+      healthUrl: PREVIEW_HEALTH_URL,
+      requestImpl: async () => response(307),
+    }),
+    /Health endpoint redirected/u
+  );
+});
+
+test('fetchVercelHealth validates the deployed commit SHA', async () => {
+  const body = JSON.stringify({ build: { commitSha: 'abc123' } });
+  await fetchVercelHealth({
+    healthUrl: PREVIEW_HEALTH_URL,
+    expectedCommitSha: 'abc123',
+    requestImpl: async () => response(200, body),
+  });
+  await assert.rejects(
+    fetchVercelHealth({
+      healthUrl: PREVIEW_HEALTH_URL,
+      expectedCommitSha: 'def456',
+      requestImpl: async () => response(200, body),
+    }),
+    /Deployed build provenance mismatch/u
+  );
+});
+
+test('fetchVercelHealth allows production host without bypass header', async () => {
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
+  let receivedHeaders;
+  await fetchVercelHealth({
+    healthUrl: 'https://www.interdomestik.com/api/health',
+    requestImpl: async (_url, headers) => {
+      receivedHeaders = headers;
+      return response(200);
+    },
+  });
+  assert.deepEqual(receivedHeaders, {});
+});
+
+test('fetchVercelHealth normalizes duplicate slashes in the health path', async () => {
+  let receivedUrl;
+  await fetchVercelHealth({
+    healthUrl: 'https://interdomestik-web-git-main-ecohub.vercel.app//api/health',
+    requestImpl: async url => {
+      receivedUrl = url;
+      return response(200);
+    },
+  });
+  assert.equal(receivedUrl.href, PREVIEW_HEALTH_URL);
+});
+
+test('fetchVercelHealth rejects non-Vercel health targets before fetch', async () => {
+  await assert.rejects(
+    fetchVercelHealth({
+      healthUrl: 'https://example.com/api/health',
+      requestImpl: async () => response(200),
+    }),
+    /Health URL must use an allowed deployment host/u
+  );
+  await assert.rejects(
+    fetchVercelHealth({
+      healthUrl: PREVIEW_HEALTH_URL.replace('https:', 'http:'),
+      requestImpl: async () => response(200),
+    }),
+    /Health URL must use https/u
+  );
+  await assert.rejects(
+    fetchVercelHealth({
+      healthUrl: PREVIEW_HEALTH_URL.replace('/api/health', '/api/status'),
+      requestImpl: async () => response(200),
+    }),
+    /Health URL must target \/api\/health/u
+  );
+});

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -555,12 +555,12 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(deployStagingJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');
   const vercelStagingDeployStep = findStep(deployStagingJob.steps, 'Deploy Staging to Vercel');
   assert.ok(vercelStagingDeployStep);
-  assert.equal(vercelStagingDeployStep.id, 'vercel');
   assert.equal(vercelStagingDeployStep.uses, './.github/actions/trigger-digest-verified-deploy');
-  assert.equal(vercelStagingDeployStep.env.ENABLE_VERCEL_DEPLOYMENTS, '1');
-  assert.match(vercelStagingDeployStep.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
-  assert.equal(vercelStagingDeployStep.with.environment, 'staging');
-  assert.equal(vercelStagingDeployStep.with.production, 'false');
+  assert.equal(vercelStagingDeployStep.env.VERCEL_AUTOMATION_BYPASS_SECRET, undefined);
+  assert.match(
+    vercelStagingDeployStep.with['vercel-automation-bypass-secret'],
+    /secrets\.VERCEL_AUTOMATION/u
+  );
   const stagingHealthIndex = findStepIndex(deployStagingJob.steps, 'Wait for Staging Health');
   const stagingProvenanceIndex = findStepIndex(
     deployStagingJob.steps,
@@ -570,10 +570,11 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.ok(stagingProvenanceIndex > stagingHealthIndex);
   const stagingHealthStep = deployStagingJob.steps[stagingHealthIndex];
   assert.equal(stagingHealthStep.env.BASE_URL, '${{ steps.vercel.outputs.base_url }}');
+  assert.match(stagingHealthStep.env.VERCEL_AUTOMATION_BYPASS_SECRET, /secrets\.VERCEL/u);
   const stagingProvenanceStep = deployStagingJob.steps[stagingProvenanceIndex];
   assert.equal(stagingProvenanceStep.env.BASE_URL, '${{ steps.vercel.outputs.base_url }}');
-  assert.match(stagingProvenanceStep.run, /build\?\.commitSha/);
-  assert.match(stagingProvenanceStep.run, /EXPECTED_COMMIT_SHA/);
+  assert.match(stagingProvenanceStep.env.VERCEL_AUTOMATION_BYPASS_SECRET, /secrets\.VERCEL/u);
+  assert.match(stagingProvenanceStep.run, /fetch-vercel-health\.mjs[\s\S]*EXPECTED_COMMIT_SHA/u);
 
   assert.deepEqual(normalizeNeeds(e2eStagingJob.needs), ['deploy-staging']);
   assert.equal(e2eStagingJob.env.BASE_URL, '${{ needs.deploy-staging.outputs.base_url }}');
@@ -583,26 +584,17 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
     '${{ needs.deploy-staging.outputs.hostname }}'
   );
   assert.equal(e2eStagingJob.env.RELEASE_GATE_EXPECTED_SHA, '${{ github.sha }}');
+  assert.equal(e2eStagingJob.env.VERCEL_AUTOMATION_BYPASS_SECRET, undefined);
   for (const envName of RELEASE_GATE_ENV_VARS) {
     assert.match(e2eStagingJob.env[envName], new RegExp(String.raw`secrets\.${envName}`));
   }
-  const stagingSetupStep = e2eStagingJob.steps.find(
-    step => step?.uses === './.github/actions/setup'
-  );
-  assert.equal(stagingSetupStep.with['install-playwright'], 'true');
   const stagingGateStep = findStep(e2eStagingJob.steps, 'Run Staging Release Gate');
   assert.ok(stagingGateStep);
+  assert.match(stagingGateStep.env.VERCEL_AUTOMATION_BYPASS_SECRET, /secrets\.VERCEL/u);
   assert.match(stagingGateStep.run, /release:gate:raw/);
   assert.match(stagingGateStep.run, /--envName staging/);
   assert.match(stagingGateStep.run, /--suite p0/);
   assert.match(stagingGateStep.run, /--authBaseUrl "\$\{AUTH_BASE_URL\}"/);
-  const stagingArtifactsStep = findStep(
-    e2eStagingJob.steps,
-    'Upload staging verification artifacts'
-  );
-  assert.ok(stagingArtifactsStep);
-  assert.equal(stagingArtifactsStep['continue-on-error'], undefined);
-  assert.equal(stagingArtifactsStep.with['if-no-files-found'], 'error');
 
   assert.deepEqual(normalizeNeeds(deployProductionJob.needs), ['build-production']);
   const vercelProductionDeployStep = findStep(
@@ -614,8 +606,13 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(vercelProductionDeployStep.uses, './.github/actions/trigger-digest-verified-deploy');
   assert.equal(vercelProductionDeployStep.env.ENABLE_VERCEL_DEPLOYMENTS, '1');
   assert.match(vercelProductionDeployStep.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/);
+  assert.equal(vercelProductionDeployStep.env.VERCEL_AUTOMATION_BYPASS_SECRET, undefined);
   assert.equal(vercelProductionDeployStep.with.environment, 'production');
   assert.equal(vercelProductionDeployStep.with.production, 'true');
+  assert.match(
+    vercelProductionDeployStep.with['vercel-automation-bypass-secret'],
+    /secrets\.VERCEL_AUTOMATION/u
+  );
 
   assert.deepEqual(normalizeNeeds(verifyProductionJob.needs), ['deploy-production']);
   assert.equal(verifyProductionJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');
@@ -639,8 +636,10 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.ok(productionHealthIndex >= 0);
   assert.ok(productionProvenanceIndex > productionHealthIndex);
   assert.ok(productionGateIndex > productionProvenanceIndex);
+  const productionHealthStep = verifyProductionJob.steps[productionHealthIndex];
+  assert.match(productionHealthStep.run, /fetch-vercel-health\.mjs/u);
   const productionProvenanceStep = verifyProductionJob.steps[productionProvenanceIndex];
-  assert.match(productionProvenanceStep.run, /build\?\.commitSha/);
+  assert.match(productionProvenanceStep.run, /fetch-vercel-health\.mjs/u);
   assert.match(productionProvenanceStep.run, /EXPECTED_COMMIT_SHA/);
   const productionGateStep = findStep(verifyProductionJob.steps, 'Run Production Release Gate');
   assert.ok(productionGateStep);

--- a/scripts/release-gate/run.ts
+++ b/scripts/release-gate/run.ts
@@ -807,10 +807,6 @@ async function main() {
       password: passwordVar ? process.env[passwordVar] || '' : '',
     };
   }
-
-  const { chromium } = resolvePlaywright();
-  const browser = await chromium.launch({ headless: true });
-  const checks = [];
   const allowLoopbackBaseUrl = shouldAllowConfiguredLoopbackBaseUrl(
     configuredBaseUrl,
     args.envName
@@ -823,6 +819,10 @@ async function main() {
         allowLoopback: allowLoopbackBaseUrl,
       }).href
     : '';
+  const { chromium } = resolvePlaywright();
+  const browser = await chromium.launch({ headless: true });
+  require('./vercel-protection.ts').installVercelProtection(safeConfiguredBaseUrl, browser);
+  const checks = [];
   try {
     const deployment = await detectDeploymentMetadata(safeConfiguredBaseUrl, browser);
     const resolvedBase = await resolveReachableBaseUrl(safeConfiguredBaseUrl, deployment, {

--- a/scripts/release-gate/vercel-protection.test.mjs
+++ b/scripts/release-gate/vercel-protection.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const {
+  buildVercelProtectionHeaders,
+  installVercelProtectionBrowser,
+  installVercelProtectionFetch,
+} = require('./vercel-protection.ts');
+
+test('buildVercelProtectionHeaders adds Vercel bypass and cookie headers for protected previews', () => {
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
+  assert.deepEqual(buildVercelProtectionHeaders('https://preview.vercel.app'), {
+    'x-vercel-protection-bypass': 'bypass-secret',
+    'x-vercel-set-bypass-cookie': 'true',
+  });
+});
+
+test('installVercelProtectionBrowser scopes bypass headers to Vercel requests', async () => {
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
+  let routeHandler;
+  const browser = {
+    async newContext(options) {
+      assert.deepEqual(options, { viewport: { width: 800, height: 600 } });
+      return {
+        async route(pattern, handler) {
+          assert.equal(pattern, '**/*');
+          routeHandler = handler;
+        },
+      };
+    },
+  };
+  installVercelProtectionBrowser('https://preview.vercel.app', browser);
+  await browser.newContext({ viewport: { width: 800, height: 600 } });
+  assert.ok(routeHandler, 'route handler was registered');
+
+  const continuations = [];
+  routeHandler({
+    request: () => ({
+      headers: () => ({ accept: 'text/html' }),
+      url: () => 'https://preview.vercel.app/member',
+    }),
+    continue: params => continuations.push(params),
+  });
+  routeHandler({
+    request: () => ({
+      headers: () => ({ accept: 'text/html' }),
+      url: () => 'https://other.vercel.app/asset.js',
+    }),
+    continue: params => continuations.push(params),
+  });
+
+  assert.equal(continuations[0].headers['x-vercel-protection-bypass'], 'bypass-secret');
+  assert.equal(continuations[0].headers['x-vercel-set-bypass-cookie'], 'true');
+  assert.equal(continuations[1], undefined);
+});
+
+test('installVercelProtectionFetch scopes bypass headers to the protected host', async () => {
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (_input, init = {}) => {
+    calls.push(init.headers);
+    return { ok: true };
+  };
+  delete globalThis.fetch.__vercelProtectionWrapped;
+  try {
+    installVercelProtectionFetch('https://preview.vercel.app');
+    await globalThis.fetch('https://preview.vercel.app/api/health');
+    await globalThis.fetch('https://other.vercel.app/api/health');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(calls[0].get('x-vercel-protection-bypass'), 'bypass-secret');
+  assert.equal(calls[1], undefined);
+});
+
+test('buildVercelProtectionHeaders ignores non-Vercel hosts and missing secrets', () => {
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
+  assert.deepEqual(buildVercelProtectionHeaders('https://www.interdomestik.com'), {});
+  delete process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  assert.deepEqual(buildVercelProtectionHeaders('https://preview.vercel.app'), {});
+});

--- a/scripts/release-gate/vercel-protection.ts
+++ b/scripts/release-gate/vercel-protection.ts
@@ -47,12 +47,13 @@ function installVercelProtectionBrowser(baseUrl, browser) {
   const protectedHost = vercelAppHost(baseUrl);
   browser.newContext = async options => {
     const context = await originalNewContext(options);
-    if (Object.keys(headers).length === 0) return context;
-    await context.route('**/*', route => {
-      const request = route.request();
-      if (vercelAppHost(request.url()) !== protectedHost) return route.continue();
-      return route.continue({ headers: { ...request.headers(), ...headers } });
-    });
+    if (Object.keys(headers).length > 0) {
+      await context.route('**/*', route => {
+        const request = route.request();
+        if (vercelAppHost(request.url()) !== protectedHost) return route.continue();
+        return route.continue({ headers: { ...request.headers(), ...headers } });
+      });
+    }
     return context;
   };
 }

--- a/scripts/release-gate/vercel-protection.ts
+++ b/scripts/release-gate/vercel-protection.ts
@@ -1,0 +1,70 @@
+function vercelAppHost(value) {
+  try {
+    const hostname = new URL(value).hostname.toLowerCase();
+    if (hostname === 'vercel.app' || hostname.endsWith('.vercel.app')) return hostname;
+  } catch {
+    return '';
+  }
+  return '';
+}
+
+function protectionSecret() {
+  const value = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function buildVercelProtectionHeaders(baseUrl) {
+  const secret = protectionSecret();
+  if (!secret || !vercelAppHost(baseUrl)) return {};
+  return {
+    'x-vercel-protection-bypass': secret,
+    'x-vercel-set-bypass-cookie': 'true',
+  };
+}
+
+function installVercelProtectionFetch(baseUrl) {
+  const headers = buildVercelProtectionHeaders(baseUrl);
+  const protectedHost = vercelAppHost(baseUrl);
+  if (Object.keys(headers).length === 0 || globalThis.fetch.__vercelProtectionWrapped) return;
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  const wrappedFetch = (input, init = {}) => {
+    const target = typeof input === 'string' || input instanceof URL ? input : input.url;
+    if (vercelAppHost(target) !== protectedHost) return originalFetch(input, init);
+    const nextHeaders = new Headers(init.headers || {});
+    for (const [name, value] of Object.entries(headers)) nextHeaders.set(name, value);
+    return originalFetch(input, {
+      ...init,
+      headers: nextHeaders,
+    });
+  };
+  wrappedFetch.__vercelProtectionWrapped = true;
+  globalThis.fetch = wrappedFetch;
+}
+
+function installVercelProtectionBrowser(baseUrl, browser) {
+  const originalNewContext = browser.newContext.bind(browser);
+  const headers = buildVercelProtectionHeaders(baseUrl);
+  const protectedHost = vercelAppHost(baseUrl);
+  browser.newContext = async options => {
+    const context = await originalNewContext(options);
+    if (Object.keys(headers).length === 0) return context;
+    await context.route('**/*', route => {
+      const request = route.request();
+      if (vercelAppHost(request.url()) !== protectedHost) return route.continue();
+      return route.continue({ headers: { ...request.headers(), ...headers } });
+    });
+    return context;
+  };
+}
+
+function installVercelProtection(baseUrl, browser) {
+  installVercelProtectionFetch(baseUrl);
+  installVercelProtectionBrowser(baseUrl, browser);
+}
+
+module.exports = {
+  buildVercelProtectionHeaders,
+  installVercelProtection,
+  installVercelProtectionBrowser,
+  installVercelProtectionFetch,
+};

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37535135,
-  "maxTrackedFiles": 4536,
+  "maxTrackedBytes": 37549188,
+  "maxTrackedFiles": 4541,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7012096,
+    "source/scripts": 7018728,
     "docs/text": 5705447,
-    "tests/e2e": 4938824,
-    "config/data/messages": 1548832,
+    "tests/e2e": 4947015,
+    "config/data/messages": 1548062,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37549188,
+  "maxTrackedBytes": 37549307,
   "maxTrackedFiles": 4541,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7018728,
+    "source/scripts": 7018847,
     "docs/text": 5705447,
     "tests/e2e": 4947015,
     "config/data/messages": 1548062,


### PR DESCRIPTION
Summary
- wire VERCEL_AUTOMATION_BYPASS_SECRET through staging/prod deploy, health, attestation, and release-gate paths
- add Vercel-protected health and release-gate bypass helpers with focused contract tests
- keep protected preview access scoped to *.vercel.app and preserve same-host attestation safety

Verification
- node --test scripts/ci/cd-deploy-digest-boundary.test.mjs scripts/ci/fetch-vercel-attestation-bypass.test.mjs scripts/ci/fetch-vercel-health.test.mjs scripts/ci/workflow-contracts.test.mjs scripts/release-gate/vercel-protection.test.mjs
- pnpm security:guard
- pnpm pr:verify
- git diff --check

Residual operational blocker
- GitHub environment secret VERCEL_AUTOMATION_BYPASS_SECRET is still required in staging and production. It must match the Vercel project Protection Bypass for Automation secret for ecohub/interdomestik-web before CD can access protected preview deployments.