### PR TITLE
fix: allow current Vercel deployment health hosts

### DIFF
--- a/scripts/ci/fetch-vercel-health.mjs
+++ b/scripts/ci/fetch-vercel-health.mjs
@@ -12,7 +12,7 @@ function requireValue(name, value) {
 
 function isVercelAppUrl(value) {
   const hostname = value.hostname.toLowerCase();
-  return /^interdomestik-web(?:-[a-z0-9-]+)?-ecohub\.vercel\.app$/u.test(hostname);
+  return /^interdomestik(?:-web)?(?:-[a-z0-9-]+)?-ecohub\.vercel\.app$/u.test(hostname);
 }
 
 function isAllowedHealthUrl(value) {

--- a/scripts/ci/fetch-vercel-health.test.mjs
+++ b/scripts/ci/fetch-vercel-health.test.mjs
@@ -22,6 +22,22 @@ test('fetchVercelHealth sends bypass header for Vercel preview hosts', async () 
   assert.equal(receivedHeaders['x-vercel-protection-bypass'], 'bypass-secret');
 });
 
+test('fetchVercelHealth allows Vercel deployment hosts without the web infix', async () => {
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
+  let receivedUrl;
+  let receivedHeaders;
+  await fetchVercelHealth({
+    healthUrl: 'https://interdomestik-5w2sgjmdp-ecohub.vercel.app/api/health',
+    requestImpl: async (url, headers) => {
+      receivedUrl = url;
+      receivedHeaders = headers;
+      return response(200);
+    },
+  });
+  assert.equal(receivedUrl.href, 'https://interdomestik-5w2sgjmdp-ecohub.vercel.app/api/health');
+  assert.equal(receivedHeaders['x-vercel-protection-bypass'], 'bypass-secret');
+});
+
 test('fetchVercelHealth rejects redirects before reading health body', async () => {
   await assert.rejects(
     fetchVercelHealth({

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37549307,
+  "maxTrackedBytes": 37549944,
   "maxTrackedFiles": 4541,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7018847,
+    "source/scripts": 7018852,
     "docs/text": 5705447,
-    "tests/e2e": 4947015,
+    "tests/e2e": 4947647,
     "config/data/messages": 1548062,
     "other": 129182
   },


### PR DESCRIPTION
## Summary
- allow the current Vercel deployment host family (`interdomestik-*-ecohub.vercel.app`) in the health/provenance fetcher
- keep the allowlist bounded to Interdomestik Ecohub Vercel hosts plus production domains
- update repo size budget for the tracked test/source-byte increase

## Verification
- `node --test scripts/ci/fetch-vercel-health.test.mjs scripts/ci/fetch-vercel-attestation-bypass.test.mjs scripts/ci/fetch-vercel-attestation.test.mjs`
- `node scripts/repo-size-budget-sync.mjs`
- `pnpm repo:size:check`

## Production readiness context
CD run 28255198957 progressed past the previously missing `VERCEL_AUTOMATION_BYPASS_SECRET` blocker and failed in `deploy-staging` because `fetch-vercel-health.mjs` rejected `https://interdomestik-5w2sgjmdp-ecohub.vercel.app/api/health` as an unallowed host. This PR fixes that allowlist mismatch.