### PR TITLE
fix: archive Vercel prebuilt deploy uploads

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -125,7 +125,7 @@ runs:
           echo "::error::Vercel output digest changed after attestation"
           exit 1
         fi
-        deployment_url="$(npx --yes vercel@latest deploy --prebuilt --env "COMMIT_SHA=${COMMIT_SHA}" "${target_args[@]}")"
+        deployment_url="$(npx --yes vercel@latest deploy --prebuilt --archive=tgz --env "COMMIT_SHA=${COMMIT_SHA}" "${target_args[@]}")"
         deployment_url="$(printf '%s\n' "${deployment_url}" | tail -n 1)"
         base_url="${deployment_url}"
         if [[ "${base_url}" != https://* ]]; then

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -129,6 +129,7 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(deployStep.run, /Vercel output digest changed after attestation/u);
   assert.match(deployStep.run, /vercel@latest deploy/u);
   assert.match(deployStep.run, /--prebuilt/u);
+  assert.match(deployStep.run, /--archive=tgz/u);
   assert.match(deployStep.run, /--env "COMMIT_SHA=\$\{COMMIT_SHA\}"/u);
   assert.match(deployStep.run, /deploy_target=.*staging.*preview/u);
   assert.match(deployStep.run, /--target="\$\{deploy_target\}"/u);

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37549944,
+  "maxTrackedBytes": 37550008,
   "maxTrackedFiles": 4541,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
     "source/scripts": 7018852,
     "docs/text": 5705447,
-    "tests/e2e": 4947647,
-    "config/data/messages": 1548062,
+    "tests/e2e": 4947697,
+    "config/data/messages": 1548076,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,


### PR DESCRIPTION
## Summary
- add `--archive=tgz` to Vercel prebuilt deploys to avoid Vercel API upload quota failures
- lock the deploy boundary with a workflow contract assertion
- sync repo size budget after the small tracked delta

## Verification
- `node --test scripts/ci/cd-deploy-digest-boundary.test.mjs`
- `pnpm repo:size:check`
- `git diff --check`

## Context
CD attempt 3 failed in `deploy-staging` before health checks with Vercel CLI error: `Too many requests - try again in 24 hours (more than 5000, code: "api-upload-free")`. The Vercel CLI recommended `--archive=tgz`.