### PR TITLE
fix: surface sanitized health failure body

### DIFF
--- a/scripts/ci/fetch-vercel-health.mjs
+++ b/scripts/ci/fetch-vercel-health.mjs
@@ -36,6 +36,14 @@ function buildHeaders(url) {
   return { 'x-vercel-protection-bypass': secret };
 }
 
+function sanitizeHealthBody(body) {
+  return body
+    .replace(/postgres(?:ql)?:\/\/[^"'\s]+/giu, 'postgres://[redacted]')
+    .replace(/(DATABASE_URL(?:_RLS)?=)[^"'\s]+/giu, '$1[redacted]')
+    .replace(/(password|token|secret|key)["']?\s*[:=]\s*["']?[^"',\s}]+/giu, '$1:[redacted]')
+    .slice(0, 1_200);
+}
+
 async function requestVercelHealth(url, headers, timeoutMs, execFileImpl = execFile) {
   const args = [
     '--silent',
@@ -75,8 +83,12 @@ export async function fetchVercelHealth({
   if (response.status >= 300 && response.status < 400) {
     throw new Error('Health endpoint redirected before returning /api/health');
   }
-  if (!response.ok) throw new Error(`Health endpoint returned ${response.status}`);
   const body = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Health endpoint returned ${response.status}: ${sanitizeHealthBody(body) || '[empty body]'}`
+    );
+  }
   if (!expectedCommitSha) return body;
   const actual = JSON.parse(body)?.build?.commitSha;
   if (actual !== expectedCommitSha) {

--- a/scripts/ci/fetch-vercel-health.test.mjs
+++ b/scripts/ci/fetch-vercel-health.test.mjs
@@ -48,6 +48,32 @@ test('fetchVercelHealth rejects redirects before reading health body', async () 
   );
 });
 
+test('fetchVercelHealth includes a sanitized non-OK response body', async () => {
+  const body = JSON.stringify({
+    status: 'unhealthy',
+    services: {
+      database: {
+        status: 'unhealthy',
+        error:
+          'DATABASE_URL_RLS=postgresql://user:pass@example.com/app role posture could not be verified',
+      },
+    },
+  });
+
+  await assert.rejects(
+    fetchVercelHealth({
+      healthUrl: PREVIEW_HEALTH_URL,
+      requestImpl: async () => response(503, body),
+    }),
+    error => {
+      assert.match(error.message, /Health endpoint returned 503/u);
+      assert.match(error.message, /DATABASE_URL_RLS=\[redacted\]/u);
+      assert.doesNotMatch(error.message, /user:pass@example/u);
+      return true;
+    }
+  );
+});
+
 test('fetchVercelHealth validates the deployed commit SHA', async () => {
   const body = JSON.stringify({ build: { commitSha: 'abc123' } });
   await fetchVercelHealth({

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37550008,
+  "maxTrackedBytes": 37551127,
   "maxTrackedFiles": 4541,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7018852,
+    "source/scripts": 7019231,
     "docs/text": 5705447,
-    "tests/e2e": 4947697,
+    "tests/e2e": 4948437,
     "config/data/messages": 1548076,
     "other": 129182
   },


### PR DESCRIPTION
## Summary
- include a bounded sanitized `/api/health` response body when the CD health check receives a non-2xx status
- redact DB URLs and secret-like values before logging
- add regression coverage and sync repo size budget

## Verification
- `node --test scripts/ci/fetch-vercel-health.test.mjs`
- `pnpm repo:size:check`
- `git diff --check`

## Context
The archived Vercel deploy now succeeds, but staging health still returns 503 without exposing the reason. This lets the next CD run identify the exact runtime blocker without leaking secrets.