### PR TITLE
fix: bind cd gate jobs to environments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,6 +123,7 @@ jobs:
   e2e-staging:
     needs: deploy-staging
     runs-on: [self-hosted, interdomestik-mac]
+    environment: { name: staging, deployment: false }
     env:
       BASE_URL: ${{ needs.deploy-staging.outputs.base_url }}
       AUTH_BASE_URL: https://staging.interdomestik.com
@@ -189,14 +190,12 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver: docker-container
-
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
@@ -253,6 +252,7 @@ jobs:
     needs: deploy-production
     runs-on: [self-hosted, interdomestik-mac]
     timeout-minutes: 20
+    environment: { name: production, deployment: false }
     env:
       BASE_URL: https://www.interdomestik.com
       EVIDENCE_DIR: tmp/cd-evidence/${{ github.run_id }}

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -577,6 +577,7 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.match(stagingProvenanceStep.run, /fetch-vercel-health\.mjs[\s\S]*EXPECTED_COMMIT_SHA/u);
 
   assert.deepEqual(normalizeNeeds(e2eStagingJob.needs), ['deploy-staging']);
+  assert.deepEqual(e2eStagingJob.environment, { name: 'staging', deployment: false });
   assert.equal(e2eStagingJob.env.BASE_URL, '${{ needs.deploy-staging.outputs.base_url }}');
   assert.equal(e2eStagingJob.env.AUTH_BASE_URL, 'https://staging.interdomestik.com');
   assert.equal(
@@ -595,7 +596,6 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.match(stagingGateStep.run, /--envName staging/);
   assert.match(stagingGateStep.run, /--suite p0/);
   assert.match(stagingGateStep.run, /--authBaseUrl "\$\{AUTH_BASE_URL\}"/);
-
   assert.deepEqual(normalizeNeeds(deployProductionJob.needs), ['build-production']);
   const vercelProductionDeployStep = findStep(
     deployProductionJob.steps,
@@ -613,8 +613,8 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
     vercelProductionDeployStep.with['vercel-automation-bypass-secret'],
     /secrets\.VERCEL_AUTOMATION/u
   );
-
   assert.deepEqual(normalizeNeeds(verifyProductionJob.needs), ['deploy-production']);
+  assert.deepEqual(verifyProductionJob.environment, { name: 'production', deployment: false });
   assert.equal(verifyProductionJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');
   assert.equal(verifyProductionJob.env.RELEASE_GATE_EXPECTED_SHA, '${{ github.sha }}');
   for (const envName of RELEASE_GATE_ENV_VARS) {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37551127,
+  "maxTrackedBytes": 37551417,
   "maxTrackedFiles": 4541,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
     "source/scripts": 7019231,
     "docs/text": 5705447,
-    "tests/e2e": 4948437,
-    "config/data/messages": 1548076,
+    "tests/e2e": 4948618,
+    "config/data/messages": 1548185,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,


### PR DESCRIPTION
## Summary
- bind staging release-gate job to the staging GitHub environment
- bind production verification job to the production GitHub environment
- add workflow contract coverage for both environment bindings
- refresh the repo-size budget for the few added workflow/test bytes

## Verification
- node --test scripts/ci/workflow-contracts.test.mjs
- pnpm repo:size:check
- git diff --check