### PR TITLE
fix: follow canonical auth redirects in release gate

### DIFF
--- a/scripts/raw-role-array-allowlist.json
+++ b/scripts/raw-role-array-allowlist.json
@@ -48,9 +48,9 @@
     "packages/domain-users/src/admin/get-staff.ts:15:67:staff,admin",
     "packages/domain-users/src/admin/role-rules.ts:1:38:agent,branch_manager",
     "scripts/release-gate/config.ts:33:16:member,agent,staff,admin",
-    "scripts/release-gate/shared.ts:551:54:agent,staff,admin",
-    "scripts/release-gate/shared.ts:554:53:staff,admin",
-    "scripts/release-gate/shared.ts:557:53:agent,admin",
-    "scripts/release-gate/shared.ts:559:51:agent,staff"
+    "scripts/release-gate/shared.ts:547:54:agent,staff,admin",
+    "scripts/release-gate/shared.ts:550:53:staff,admin",
+    "scripts/release-gate/shared.ts:553:53:agent,admin",
+    "scripts/release-gate/shared.ts:555:51:agent,staff"
   ]
 }

--- a/scripts/release-gate/login-request-guard.test.ts
+++ b/scripts/release-gate/login-request-guard.test.ts
@@ -2,16 +2,29 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 const { createAuthState, loginAs } = require('./shared.ts');
+const { postLoginRequestWithTrustedRedirect } = require('./login-request-guard.ts');
 
 const RELEASE_GATE_BASE_URL = 'https://interdomestik-web.vercel.app';
 const RELEASE_GATE_LOCALE = 'en';
 
-function restoreEnv(name, value) {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
+function successLoginResponse(path = '/api/auth/sign-in/email') {
+  return {
+    ok: () => true,
+    status: () => 200,
+    headers: () => ({}),
+    url: () => `${RELEASE_GATE_BASE_URL}${path}`,
+  };
+}
+
+async function withBypassSecret(fn) {
+  const originalBypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
+  try {
+    return await fn();
+  } finally {
+    if (originalBypassSecret === undefined) delete process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    else process.env.VERCEL_AUTOMATION_BYPASS_SECRET = originalBypassSecret;
   }
-  process.env[name] = value;
 }
 
 function createLoggedInPage(requestCalls) {
@@ -33,12 +46,7 @@ function createLoggedInPage(requestCalls) {
     request: {
       post: async (...args) => {
         requestCalls.push(args);
-        return {
-          ok: () => true,
-          status: () => 200,
-          headers: () => ({}),
-          url: () => `${RELEASE_GATE_BASE_URL}/api/auth/sign-in/email`,
-        };
+        return successLoginResponse();
       },
     },
     goto: async () => {},
@@ -49,11 +57,8 @@ function createLoggedInPage(requestCalls) {
 }
 
 test('loginAs sends Vercel protection headers on preview API login requests', async () => {
-  const originalBypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-  process.env.VERCEL_AUTOMATION_BYPASS_SECRET = 'bypass-secret';
   const requestCalls = [];
-
-  try {
+  await withBypassSecret(async () => {
     await loginAs(createLoggedInPage(requestCalls), {
       account: 'member',
       credentials: { email: 'member@example.com', password: 'test-credential-2026' },
@@ -61,14 +66,46 @@ test('loginAs sends Vercel protection headers on preview API login requests', as
       locale: RELEASE_GATE_LOCALE,
       authState: createAuthState(),
     });
-  } finally {
-    restoreEnv('VERCEL_AUTOMATION_BYPASS_SECRET', originalBypassSecret);
-  }
+  });
 
   assert.equal(requestCalls.length, 1);
   assert.equal(requestCalls[0][1].headers['x-vercel-protection-bypass'], 'bypass-secret');
   assert.equal(requestCalls[0][1].headers['x-vercel-set-bypass-cookie'], 'true');
   assert.equal(requestCalls[0][1].maxRedirects, 0);
+});
+
+test('loginAs manually follows only same-origin auth canonical redirects', async () => {
+  const requestCalls = [];
+  const page = createLoggedInPage(requestCalls);
+  page.request.post = async (...args) => {
+    requestCalls.push(args);
+    if (requestCalls.length === 1) {
+      return {
+        ok: () => false,
+        status: () => 307,
+        headers: () => ({
+          location: `${RELEASE_GATE_BASE_URL}/api/auth/sign-in/email/`,
+        }),
+        url: () => `${RELEASE_GATE_BASE_URL}/api/auth/sign-in/email`,
+      };
+    }
+    return successLoginResponse('/api/auth/sign-in/email/');
+  };
+
+  await withBypassSecret(async () => {
+    await loginAs(page, {
+      account: 'member',
+      credentials: { email: 'member@example.com', password: 'test-credential-2026' },
+      baseUrl: RELEASE_GATE_BASE_URL,
+      locale: RELEASE_GATE_LOCALE,
+      authState: createAuthState(),
+    });
+  });
+
+  assert.equal(requestCalls.length, 2);
+  assert.equal(requestCalls[1][0], `${RELEASE_GATE_BASE_URL}/api/auth/sign-in/email/`);
+  assert.equal(requestCalls[1][1].headers['x-vercel-protection-bypass'], 'bypass-secret');
+  assert.equal(requestCalls[1][1].maxRedirects, 0);
 });
 
 test('loginAs rejects external successful responses from protected deployment login', async () => {
@@ -91,4 +128,20 @@ test('loginAs rejects external successful responses from protected deployment lo
       }),
     /AUTH_LOGIN_REDIRECTED account=member status=200 expected_origin=https:\/\/interdomestik-web\.vercel\.app actual_origin=https:\/\/vercel\.com url=https:\/\/vercel\.com\/sso-api/
   );
+});
+
+test('trusted redirect helper does not follow external auth redirects', async () => {
+  let postCalls = 0;
+  const response = {
+    status: () => 307,
+    headers: () => ({ location: 'https://vercel.com/sso-api' }),
+  };
+  const result = await postLoginRequestWithTrustedRedirect({
+    request: { post: async () => ((postCalls += 1), response) },
+    loginUrl: `${RELEASE_GATE_BASE_URL}/api/auth/sign-in/email`,
+    requestOptions: {},
+    origin: RELEASE_GATE_BASE_URL,
+  });
+  assert.equal(result, response);
+  assert.equal(postCalls, 1);
 });

--- a/scripts/release-gate/login-request-guard.ts
+++ b/scripts/release-gate/login-request-guard.ts
@@ -1,4 +1,4 @@
-const { ACCOUNTS, ROLE_IPS } = require('./config.ts');
+const { ACCOUNTS, ROLE_IPS, ROUTES } = require('./config.ts');
 const { buildVercelProtectionHeaders } = require('./vercel-protection.ts');
 
 function resolveForwardedForIp(account) {
@@ -17,6 +17,55 @@ function buildLoginRequestHeaders({ account, authOrigin, baseUrl, locale }) {
   };
 }
 
+function defaultPathForAccount(account) {
+  const roleMarker = ACCOUNTS[account]?.roleMarker;
+  if (roleMarker && ROUTES.rbacTargets.includes(roleMarker)) return roleMarker;
+  return account.replace('_ks', '').replace('_mk', '');
+}
+
+function getResponseHeader(response, name) {
+  const headers = response.headers?.() || {};
+  return headers[name.toLowerCase()] || headers[name] || '';
+}
+
+function normalizePathname(pathname) {
+  return pathname.replace(/\/+$/, '') || '/';
+}
+
+function resolveTrustedLoginRedirectUrl({ response, origin }) {
+  const status = response.status();
+  if (status !== 307 && status !== 308) return null;
+
+  const location = getResponseHeader(response, 'location');
+  if (!location) return null;
+
+  let redirectUrl;
+  try {
+    redirectUrl = new URL(location, origin);
+  } catch {
+    return null;
+  }
+
+  if (redirectUrl.origin !== origin) return null;
+  if (normalizePathname(redirectUrl.pathname) !== '/api/auth/sign-in/email') return null;
+  return redirectUrl.href;
+}
+
+async function postLoginRequestWithTrustedRedirect({
+  request,
+  loginUrl,
+  requestOptions,
+  origin,
+  recordAttempt = () => {},
+}) {
+  recordAttempt();
+  const response = await request.post(loginUrl, requestOptions);
+  const trustedRedirectUrl = resolveTrustedLoginRedirectUrl({ response, origin });
+  if (!trustedRedirectUrl) return response;
+  recordAttempt();
+  return request.post(trustedRedirectUrl, requestOptions);
+}
+
 function assertLoginResponseOrigin({ account, response, origin }) {
   const responseUrl = response.url();
   const actualOrigin = new URL(responseUrl).origin;
@@ -30,5 +79,8 @@ function assertLoginResponseOrigin({ account, response, origin }) {
 module.exports = {
   assertLoginResponseOrigin,
   buildLoginRequestHeaders,
+  defaultPathForAccount,
+  postLoginRequestWithTrustedRedirect,
   resolveForwardedForIp,
+  resolveTrustedLoginRedirectUrl,
 };

--- a/scripts/release-gate/shared.ts
+++ b/scripts/release-gate/shared.ts
@@ -3,6 +3,8 @@ const { ROUTES, MARKERS, SELECTORS, TIMEOUTS, ROLE_IPS, ACCOUNTS } = require('./
 const {
   assertLoginResponseOrigin,
   buildLoginRequestHeaders,
+  defaultPathForAccount,
+  postLoginRequestWithTrustedRedirect,
   resolveForwardedForIp,
 } = require('./login-request-guard.ts');
 
@@ -160,14 +162,6 @@ function computeRetryDelayMs({ attempt, retryAfterSeconds, randomFn = Math.rando
     jitterMs,
     totalMs: baseMs + jitterMs,
   };
-}
-
-function defaultPathForAccount(account) {
-  const roleMarker = ACCOUNTS[account]?.roleMarker;
-  if (roleMarker && ROUTES.rbacTargets.includes(roleMarker)) {
-    return roleMarker;
-  }
-  return account.replace('_ks', '').replace('_mk', '');
 }
 
 function logLoginAttempt({ account, attempt, status, retryAfterSeconds }) {
@@ -331,15 +325,17 @@ async function loginAs(page, params) {
       }
 
       try {
-        response = await page.request.post(loginUrl, {
-          data: {
-            email: credentials.email,
-            password: credentials.password,
+        response = await postLoginRequestWithTrustedRedirect({
+          request: page.request,
+          loginUrl,
+          requestOptions: {
+            data: { email: credentials.email, password: credentials.password },
+            headers: loginHeaders,
+            maxRedirects: 0,
           },
-          headers: loginHeaders,
-          maxRedirects: 0,
+          origin,
+          recordAttempt: () => recordAuthLoginAttempt(authState, nowFn()),
         });
-        recordAuthLoginAttempt(authState, nowFn());
       } catch (networkError) {
         logLoginAttempt({
           account,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37562352,
+  "maxTrackedBytes": 37565751,
   "maxTrackedFiles": 4547,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7021093,
+    "source/scripts": 7022560,
     "docs/text": 5705447,
-    "tests/e2e": 4957497,
+    "tests/e2e": 4959429,
     "config/data/messages": 1548379,
     "other": 129182
   },


### PR DESCRIPTION
## Summary
- manually replay release-gate login POSTs only for trusted same-origin `/api/auth/sign-in/email` 307/308 canonical redirects
- keep `maxRedirects: 0` so Vercel/SSO redirects still fail closed and bypass headers are not forwarded externally
- move redirect/default-path logic into the small login guard helper so the legacy `shared.ts` file does not grow

## Verification
- `pnpm test:release-gate`
- `pnpm security:guard`
- `pnpm repo:size:check`

## CD failure addressed
- CD run 28274659871 failed staging release gate with repeated `AUTH_LOGIN_FAILED ... status=307 url=.../api/auth/sign-in/email`. This patch permits the app canonical auth redirect while preserving the prior Vercel-protection safety fix.