### PR TITLE
fix: allow trusted Vercel preview auth hosts

### DIFF
--- a/apps/web/src/lib/auth/config.test.ts
+++ b/apps/web/src/lib/auth/config.test.ts
@@ -19,6 +19,8 @@ describe('authConfig', () => {
 
   it('does not fall back to localhost for production auth base URL', async () => {
     vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VERCEL', '');
+    vi.stubEnv('VERCEL_URL', '');
     vi.stubEnv('BETTER_AUTH_URL', '');
     vi.stubEnv('NEXT_PUBLIC_APP_URL', '');
     vi.resetModules();
@@ -26,5 +28,25 @@ describe('authConfig', () => {
     const { authConfig: productionAuthConfig } = await import('./config');
 
     expect(productionAuthConfig.baseURL).toBe('https://www.interdomestik.com');
+  });
+
+  it('allows known Vercel preview auth hosts with a canonical fallback', async () => {
+    vi.stubEnv('VERCEL', '1');
+    vi.stubEnv('VERCEL_URL', 'interdomestik-3ig3hb7jl-ecohub.vercel.app');
+    vi.stubEnv('BETTER_AUTH_URL', 'https://staging.interdomestik.com');
+    vi.resetModules();
+
+    const { authConfig: vercelAuthConfig } = await import('./config');
+
+    expect(vercelAuthConfig.baseURL).toEqual({
+      allowedHosts: expect.arrayContaining([
+        'www.interdomestik.com',
+        'ida.interdomestik.com',
+        'staging.interdomestik.com',
+        'interdomestik-*-ecohub.vercel.app',
+      ]),
+      fallback: 'https://staging.interdomestik.com',
+      protocol: 'https',
+    });
   });
 });

--- a/apps/web/src/lib/auth/config.ts
+++ b/apps/web/src/lib/auth/config.ts
@@ -1,11 +1,8 @@
 import { BetterAuthOptions } from 'better-auth';
-import { getTrustedOrigins } from './utils';
+import { getAuthBaseURL, getTrustedOrigins } from './utils';
 
 export const authConfig = {
-  baseURL:
-    process.env.BETTER_AUTH_URL ||
-    process.env.NEXT_PUBLIC_APP_URL ||
-    'https://www.interdomestik.com',
+  baseURL: getAuthBaseURL(),
   trustedOrigins: getTrustedOrigins(),
   rateLimit: {
     // Contract: Rate limiting must be disabled for deterministic automated runs (Playwright/CI),

--- a/apps/web/src/lib/auth/utils.ts
+++ b/apps/web/src/lib/auth/utils.ts
@@ -32,3 +32,42 @@ export function getTrustedOrigins(): string[] | undefined {
   if (origins.length === 0) return undefined;
   return origins;
 }
+
+const DYNAMIC_AUTH_ALLOWED_HOSTS = [
+  'interdomestik.com',
+  'www.interdomestik.com',
+  'app.interdomestik.com',
+  'ida.interdomestik.com',
+  'staging.interdomestik.com',
+  'ks.interdomestik.com',
+  'mk.interdomestik.com',
+  'interdomestik-web.vercel.app',
+  'interdomestik-*-ecohub.vercel.app',
+];
+
+type DynamicAuthBaseURL = {
+  allowedHosts: string[];
+  fallback: string;
+  protocol: 'https';
+};
+
+type AuthBaseURL = string | DynamicAuthBaseURL;
+
+export function getAuthBaseURL(): AuthBaseURL {
+  if (process.env.VERCEL === '1' || process.env.VERCEL_URL) {
+    return {
+      allowedHosts: DYNAMIC_AUTH_ALLOWED_HOSTS,
+      fallback:
+        process.env.BETTER_AUTH_URL ||
+        process.env.NEXT_PUBLIC_APP_URL ||
+        'https://www.interdomestik.com',
+      protocol: 'https' as const,
+    };
+  }
+
+  return (
+    process.env.BETTER_AUTH_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    'https://www.interdomestik.com'
+  );
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37565751,
+  "maxTrackedBytes": 37567376,
   "maxTrackedFiles": 4547,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7022560,
+    "source/scripts": 7023417,
     "docs/text": 5705447,
-    "tests/e2e": 4959429,
+    "tests/e2e": 4960197,
     "config/data/messages": 1548379,
     "other": 129182
   },


### PR DESCRIPTION
## Summary
- allow better-auth to resolve known Interdomestik Vercel preview auth hosts with dynamic `baseURL.allowedHosts`
- keep the non-Vercel production fallback at `https://www.interdomestik.com`
- add auth config coverage for the Vercel preview host pattern and update repo-size budget to the measured tracked size

## Evidence
CD run 28276036985 reached staging deploy successfully, then failed e2e-staging with every release-gate login returning `403` on `https://interdomestik-3ig3hb7jl-ecohub.vercel.app/api/auth/sign-in/email`. Better-auth 1.6.15 rejects untrusted origins/hosts with 403; docs and installed code support dynamic `baseURL.allowedHosts` for preview deployments.

## Verification
- `pnpm --filter @interdomestik/web test:unit --run src/lib/auth/config.test.ts`
- `pnpm --filter @interdomestik/web type-check`
- `pnpm test:release-gate`
- `pnpm security:guard`
- `pnpm repo:size:check`
