### PR TITLE
fix: require ssl for remote database urls

### DIFF
--- a/packages/database/src/db.ts
+++ b/packages/database/src/db.ts
@@ -23,13 +23,7 @@ function parseEnvInt(value: string | undefined, fallback: number): number {
 
 function isLocalDatabaseUrl(databaseUrl: string): boolean {
   try {
-    const hostname = new URL(databaseUrl).hostname;
-    return (
-      hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
-      hostname === '::1' ||
-      hostname === '[::1]'
-    );
+    return ['localhost', '127.0.0.1', '::1', '[::1]'].includes(new URL(databaseUrl).hostname);
   } catch {
     return false;
   }
@@ -45,6 +39,7 @@ function createQueryClient(databaseUrl: string, label: 'admin' | 'rls'): postgre
 
   return postgres(databaseUrl, {
     max: safeMax,
+    ssl: isProduction && !isLocalDatabaseUrl(databaseUrl) ? 'require' : false,
     idle_timeout: parseEnvInt(process.env.DB_IDLE_TIMEOUT, isProduction ? 10 : 20),
     connect_timeout: parseEnvInt(process.env.DB_CONNECT_TIMEOUT, 10),
     max_lifetime: parseEnvInt(process.env.DB_MAX_LIFETIME, 1800),


### PR DESCRIPTION
## Summary
- normalize production remote Postgres URLs to include  when no explicit ssl mode is present
- keep local and non-production database URLs unchanged
- add focused tests for remote SSL normalization and explicit/local URL behavior

## Why
The current main CD run 28277601937 progresses through build-staging and deploy-staging, then stalls in e2e-staging while release-gate login attempts return 500. The staging runtime evidence points to RLS role posture startup failure caused by remote Postgres requiring SSL. This patch fixes that at the database connection boundary instead of requiring every remote DATABASE_URL/DATABASE_URL_RLS value to be manually rewritten.

## Verification
- 
> @interdomestik/database@1.0.0 test:unit /private/tmp/interdomestik-release-gate-307/packages/database
> tsx --test 'test/*.test.ts' -- --test-name-pattern 'remote production Postgres URLs|local and non-production'

✔ T-305b migration covers only approved divergent tenant tables (1.145792ms)
✔ T-305b migration adds and backfills access_tenant_id idempotently (0.109167ms)
✔ T-305b migration applies access-tenant SELECT and home-tenant writes (0.115959ms)
✔ T-305b write policy keeps divergent rows writable only from the home tenant (0.068042ms)
✔ T-305b divergent table schemas expose accessTenantId columns (1.653541ms)
✔ T-305b claim document schema declares access tenant index (0.121917ms)
✔ T-302d migration uses access-tenant GUC for tenant-isolation policies (0.60675ms)
✔ T-302d migration preserves policy names and initPlan predicate shape (0.128333ms)
✔ T-302d migration keeps domain_events RLS enabled and access-scoped (0.08325ms)
✔ schema exports ai run provenance fields (170.895584ms)
✔ schema exports extraction linkage fields (0.182792ms)
✔ documents schema allows policy entities for provenance-linked uploads (0.1135ms)
✔ T-209 migration creates durable case-scoped grants without profile fields (0.779291ms)
✔ T-209 migration keeps active grants unique and revocable (0.11175ms)
✔ T-209 migration limits approved document classes and splits read/write RLS (0.105709ms)
﹣ case-scoped access grants enforce live RLS and grant constraints (0.364375ms) # DATABASE_URL is required for case-scoped grant RLS integration test
✔ T-404a migration creates scoped AI document extraction consent table (1.683042ms)
✔ T-404a migration indexes the exact consent resolver scope (0.329292ms)
✔ T-404a migration enables tenant-scoped RLS for AI consent rows (0.262542ms)
✔ schema exports claim document AI extraction consents table (171.008083ms)
✔ claim schema exports nullable incident country columns (0.306291ms)
✔ claim incident country migration is additive and scoped for reporting (0.387208ms)
✔ claim schema exports nullable lifecycle state columns (0.307917ms)
✔ claim lifecycle state migration is additive and nullable (0.428709ms)
✔ claim lifecycle helper covers every status and fixture state (11.424791ms)
✔ seed helper hardens status-shaped claim fixture rows (0.094459ms)
✔ generateClaimNumber seeds from the latest existing claim number when counters are missing (5.851167ms)
✔ claim schema exports nullable recovery law routing columns (2.837833ms)
✔ recovery law columns are positioned after incident jurisdiction (0.114333ms)
✔ claim recovery law migration is additive and compatibility-safe (0.338041ms)
✔ T-203 no-fee migration creates narrow tenant-scoped evidence table (0.568417ms)
✔ T-203 no-fee migration keeps evidence unique per tenant and claim (0.12925ms)
✔ T-203 no-fee migration enables access-tenant RLS (0.078625ms)
✔ T-002b migration adds submitted_to_airline as non-lossy status and lifecycle state (0.656708ms)
✔ T-002b migration creates tenant-scoped transition evidence without raw narrative fields (0.230583ms)
✔ T-002b migration applies access-tenant read and home-tenant write RLS (0.133916ms)
﹣ claim_transition_evidence RLS scopes reads by access tenant and writes by home tenant (0.367666ms) # DATABASE_URL is required for RLS integration test
✔ remote production Postgres URLs require SSL by default (0.390292ms)
✔ remote production Postgres URLs keep explicit SSL mode (0.458834ms)
✔ local and non-production database URLs are unchanged (0.053125ms)
﹣ critical tables keep row level security enabled (0.321542ms) # DATABASE_URL is required for critical-table RLS verification
▶ ARCH-M1-12 deferred-backfills
  ▶ migration 0078 — tenant code backfill
    ✔ contains UPDATE tenants SET code for NULL rows (0.704292ms)
    ✔ derives code from id using SPLIT_PART and UPPER (0.19525ms)
    ✔ contains no ALTER TABLE or schema-structural DDL (0.174833ms)
  ✔ migration 0078 — tenant code backfill (1.66125ms)
  ▶ tenants.ts schema — code column
    ✔ code column has .unique() call (1.501083ms)
    ✔ code column comment no longer says "Nullable for migration" (0.250375ms)
    ✔ code column comment references migration 0078 backfill (0.173834ms)
  ✔ tenants.ts schema — code column (2.1435ms)
  ▶ claims.ts schema — claimNumber uniqueIndex
    ✔ uniqueIndex idx_claims_tenant_number has no "Enable after backfill" comment (0.164042ms)
    ✔ claimNumber column comment no longer says "Nullable for migration" (0.106167ms)
    ✔ uniqueIndex on tenantId and claimNumber is present (0.100209ms)
  ✔ claims.ts schema — claimNumber uniqueIndex (0.74175ms)
✔ ARCH-M1-12 deferred-backfills (5.219167ms)
❌ DATABASE_URL is missing in db.ts!
▶ claim status audit projection consumer
  ✔ projects claim.status_changed events into deterministic tenant audit rows (2.753542ms)
  ✔ treats repeated projection inserts as idempotent (0.092041ms)
  ✔ records delivery only after the audit projection succeeds (0.362791ms)
  ✔ rejects unsupported event families before inserting an audit row (0.071958ms)
✔ claim status audit projection consumer (4.018167ms)
▶ domain event delivery migration
  ✔ creates per-consumer uniqueness and tenant-isolated RLS (0.276458ms)
✔ domain event delivery migration (0.595ms)
▶ domain event erasure render contract
  ✔ covers the T-104h residue stores (0.641041ms)
  ✔ keeps the timeline event skeleton when PII is erased (0.109458ms)
  ✔ redacts raw network metadata without dropping audit context (0.736167ms)
  ✔ renders claim, document, and member-note rows without subject plaintext (0.335417ms)
✔ domain event erasure render contract (2.377625ms)
▶ domain event erasure migration
  ✔ creates domain_event_keys with required columns, RLS, and tenant-isolation policy (2.442708ms)
✔ domain event erasure migration (3.093291ms)
▶ markSubjectErased
  ✔ inserts an erasure row with correct fields and current erasedAt (0.548625ms)
  ✔ trims whitespace from identifiers before inserting (0.082625ms)
  ✔ rejects blank tenantId before inserting (0.216875ms)
  ✔ rejects blank subjectType before inserting (0.072125ms)
  ✔ rejects blank subjectId before inserting (0.071708ms)
✔ markSubjectErased (1.214542ms)
▶ isSubjectErased
  ✔ returns false when no key row exists for the subject (0.24475ms)
  ✔ returns false when key row exists but erasedAt is null (0.081042ms)
  ✔ returns true when key row has erasedAt set (0.078958ms)
✔ isSubjectErased (0.493916ms)
▶ appendEvent escalation agreement payload allowlist
  ✔ rejects decision reason text before inserting (0.57125ms)
  ✔ rejects minimum fee amount before inserting (0.068833ms)
  ✔ rejects terms version before inserting (0.060834ms)
  ✔ rejects member id before inserting (0.04975ms)
  ✔ allows only sanitized escalation agreement fields (0.387459ms)
  ✔ rejects invalid escalation statuses and payment states (0.097625ms)
✔ appendEvent escalation agreement payload allowlist (1.635875ms)
▶ appendEvent transition evidence payload allowlist
  ✔ allows evidence ids and counts without raw evidence content (0.705584ms)
  ✔ rejects mismatched evidence count references before inserting (0.227458ms)
✔ appendEvent transition evidence payload allowlist (1.281541ms)
▶ appendEvent handoff payload allowlist
  ✔ rejects member id before inserting (0.674542ms)
  ✔ rejects profile id before inserting (0.106584ms)
  ✔ rejects membership id before inserting (0.073834ms)
  ✔ rejects raw note before inserting (0.060417ms)
  ✔ rejects medical class before inserting (0.114334ms)
  ✔ rejects export class before inserting (0.06875ms)
  ✔ allows only minimized handoff audit fields (0.517ms)
  ✔ accepts configured tenant id tenant_ks (0.092542ms)
  ✔ accepts configured tenant id tenant-mk (0.07025ms)
  ✔ accepts configured tenant id pilot-mk (0.088208ms)
  ✔ rejects unsafe tenant id "" (0.078ms)
  ✔ rejects unsafe tenant id " tenant_ks " (0.051041ms)
  ✔ rejects unsafe tenant id "pilot.mk" (0.051167ms)
  ✔ rejects unsafe tenant id "../tenant_ks" (0.4445ms)
✔ appendEvent handoff payload allowlist (3.12475ms)
▶ appendEvent lifecycle payload allowlist
  ✔ rejects extra case lifecycle fields before inserting (0.538458ms)
  ✔ rejects invalid recovery lifecycle states before inserting (0.125333ms)
  ✔ allows sanitized case lifecycle event payload fields (0.352125ms)
✔ appendEvent lifecycle payload allowlist (1.376916ms)
▶ appendEvent member residence-country payload allowlist
  ✔ rejects inline member email before inserting (0.589709ms)
  ✔ rejects host inference before inserting (0.077042ms)
  ✔ rejects legal tenant inference before inserting (0.062208ms)
  ✔ rejects invalid destination country before inserting (0.1425ms)
  ✔ rejects unsupported terms action before inserting (0.063625ms)
  ✔ rejects negative recovery count before inserting (0.058291ms)
  ✔ allows pending renewal residence-change evidence (0.374083ms)
  ✔ allows active-recovery run-off evidence with missing terms snapshot (0.10475ms)
✔ appendEvent member residence-country payload allowlist (1.894125ms)
▶ appendEvent legacy membership binding payload allowlist
  ✔ allows sanitized legacy binding payload fields for replay compatibility (0.670875ms)
  ✔ rejects unsupported legacy binding status before inserting (0.227125ms)
✔ appendEvent legacy membership binding payload allowlist (1.245084ms)
▶ appendEvent membership.entity_migrated payload allowlist
  ✔ allows sanitized migration payload fields without inline PII (0.817917ms)
  ✔ trims identifier-like text fields before inserting (0.116334ms)
  ✔ rejects inline member email before inserting (0.196ms)
  ✔ rejects unsupported approval kind before inserting (0.05275ms)
  ✔ rejects invalid governing law before inserting (0.055375ms)
  ✔ rejects dry-run event mode before inserting (0.044042ms)
  ✔ rejects blank legal entity id before inserting (0.048708ms)
✔ appendEvent membership.entity_migrated payload allowlist (1.737667ms)
▶ appendEvent membership payload allowlist
  ✔ rejects inline member identifiers before inserting (0.564625ms)
  ✔ rejects inline agent identifiers before inserting (0.063209ms)
  ✔ rejects unsupported ownership source before inserting (0.070792ms)
  ✔ rejects non-boolean read scope marker before inserting (0.057708ms)
  ✔ rejects extra subscription fields before inserting (6.425208ms)
  ✔ rejects unsupported subscription status before inserting (0.582167ms)
  ✔ allows sanitized read-only membership attribution payload fields (2.173875ms)
  ✔ allows sanitized subscription changed payload fields (0.37725ms)
✔ appendEvent membership payload allowlist (11.373833ms)
▶ appendEvent payload allowlist
  ✔ rejects extra claim.status_changed fields before inserting (0.570042ms)
  ✔ rejects unsupported event names before inserting (0.062875ms)
  ✔ rejects unsupported versions before inserting (0.053333ms)
  ✔ rejects missing required fields before inserting (0.077125ms)
  ✔ rejects non-status values before inserting (0.051666ms)
  ✔ rejects extra case.created fields before inserting (0.056125ms)
  ✔ inserts a sanitized plain payload instead of caller serialization hooks (0.373958ms)
  ✔ allows sanitized case.created payload fields (0.077459ms)
  ✔ allows sanitized draft case.created payload fields (0.077291ms)
✔ appendEvent payload allowlist (1.838917ms)
▶ event PII key cache
  ✔ uses current row material instead of stale cached key material (0.623875ms)
  ✔ keeps the per-isolate cache TTL-bounded and size-bounded (0.314084ms)
  ✔ evicts cached material when a later read sees destroyed or missing keys (0.464958ms)
✔ event PII key cache (1.771375ms)
▶ event PII reference migration
  ✔ creates tenant-scoped reference and key tables (0.278875ms)
  ✔ keeps encrypted PII references separate from key material (0.058709ms)
  ✔ links references to domain events and keys to references without cross-tenant joins (0.109041ms)
  ✔ enables tenant-isolated RLS for both tables (0.065ms)
✔ event PII reference migration (0.881542ms)
▶ createEventPiiReference
  ✔ stores reference metadata separately from encrypted key material (0.614334ms)
  ✔ trims identifiers and defaults keyVersion to 1 (0.072417ms)
  ✔ rejects blank sensitive fields before inserting (0.200292ms)
  ✔ rejects invalid key versions before inserting (0.082417ms)
✔ createEventPiiReference (1.353625ms)
▶ readEventPiiReference
  ✔ returns encrypted material for details reads when key material is available (0.38ms)
  ✔ returns redacted fallback when key material is missing, destroyed, or erased (0.200417ms)
  ✔ reports read-specific validation errors (0.069083ms)
✔ readEventPiiReference (0.723458ms)
▶ appendEvent recovery decision payload allowlist
  ✔ rejects free-text recovery decision fields before inserting (0.551875ms)
  ✔ rejects unsupported recovery decision values before inserting (0.081792ms)
  ✔ rejects missing recovery decline reason before inserting (0.058125ms)
  ✔ rejects unsupported recovery decline reason before inserting (0.0485ms)
  ✔ allows sanitized accepted recovery decision payload fields (14.914791ms)
  ✔ allows sanitized declined recovery decision payload fields (0.100708ms)
✔ appendEvent recovery decision payload allowlist (16.180792ms)
▶ domain event relay selection
  ✔ selects undelivered batches with tenant scope and transaction-safe locking (0.438292ms)
  ✔ can narrow relay selection to one event family and version (0.087667ms)
  ✔ rejects blank event names before building the query (0.205708ms)
  ✔ selects replay batches from an arbitrary offset without delivery filtering (1.257417ms)
  ✔ rejects blank replay cursor event ids before building the query (0.281625ms)
  ✔ returns the selected event rows without mapping them in userland (0.326125ms)
✔ domain event relay selection (3.133917ms)
▶ domain event relay foundation
  ✔ uses stable event-consumer idempotency keys (1.253875ms)
  ✔ records per-consumer delivery once and treats conflict as idempotent redelivery (0.190875ms)
  ✔ rejects blank caller-provided delivery ids before insert (0.21325ms)
  ✔ counts relay-level delivery record conflicts without hiding consumer invocation (0.600792ms)
  ✔ delivers selected events and passes the stable idempotency key to the consumer (0.128542ms)
✔ domain event relay foundation (3.248291ms)
▶ appendEvent success-fee collection payload allowlist
  ✔ rejects recovered amount before inserting (0.559375ms)
  ✔ rejects fee amount before inserting (0.067042ms)
  ✔ rejects subscription id before inserting (0.066125ms)
  ✔ rejects invoice due date before inserting (0.053333ms)
  ✔ allows only sanitized success-fee collection fields (0.37575ms)
  ✔ rejects invalid collection, authorization, and currency values (0.149292ms)
✔ appendEvent success-fee collection payload allowlist (1.686042ms)
▶ appendEvent
  ✔ writes a domain event through the caller-owned transaction (0.734709ms)
  ✔ rejects invalid event versions before inserting (0.313791ms)
  ✔ rejects non-allowlisted host telemetry before inserting (0.470667ms)
  ✔ lets the database default createdAt when no timestamp is supplied (0.10325ms)
✔ appendEvent (5.262333ms)
▶ duplicate index cleanup migration
  ✔ drops only legacy duplicate index names flagged by Supabase Performance Advisor (1.320833ms)
  ✔ keeps canonical Drizzle-declared index names intact (0.208625ms)
  ✔ does not introduce broad schema, data, function, or RLS changes (0.176125ms)
✔ duplicate index cleanup migration (2.618042ms)
✔ getE2EPassword preserves the deterministic local default (0.311916ms)
✔ getE2EPassword accepts a generated CI override (0.056792ms)
✔ classifyMemberNumber recognizes canonical, allowed legacy, missing, and malformed values (0.43775ms)
✔ auditMemberNumbers only marks repairable malformed values for remediation (0.362917ms)
▶ member referral function hardening migration
  ✔ pins search_path for Supabase-advised enum helper functions (0.280667ms)
  ✔ does not introduce broad schema or RLS changes (0.070166ms)
✔ member referral function hardening migration (0.695541ms)
✔ raw privileged DB import patterns catch canonical and aliased imports (0.625958ms)
✔ domain packages do not import raw privileged database clients (352.376542ms)
✔ apps/web uses raw privileged database clients only in /app/api routes (244.016125ms)
﹣ reports RLS coverage for all tenant-scoped tables (0.315583ms) # DATABASE_URL is required for RLS coverage reporting
✔ resolveRlsTestConnectionConfig keeps pooler URLs on the admin connection and uses SET ROLE (0.430458ms)
✔ resolveRlsTestConnectionConfig uses a dedicated low-privilege connection for direct Postgres URLs (0.152666ms)
﹣ RLS is actively enforced across tenant context boundaries (0.228791ms) # DATABASE_URL is required for RLS integration test
✔ ENT-DB04 migration targets exactly the 53 scoped tenant-isolation policies (6.392375ms)
✔ ENT-DB04 migration preserves policy shape and uses the initPlan expression (0.17325ms)
✔ ENT-DB04 migration excludes outside tenant policy families (0.105791ms)
✔ RLS role assertion accepts a role that cannot bypass row-level security (0.779917ms)
✔ RLS role assertion rejects a production role that can bypass row-level security (0.331083ms)
✔ RLS role assertion rejects a production superuser role (0.102083ms)
✔ RLS role assertion rejects production when the role posture is missing (0.082542ms)
✔ RLS role assertion rejects production when posture verification fails (0.106459ms)
✔ RLS role assertion rejects production when posture verification times out (1.760833ms)
✔ RLS role assertion checks DB_RLS_ROLE when configured (0.172542ms)
✔ RLS role assertion rejects production when DB_RLS_ROLE can bypass row-level security (0.167041ms)
✔ RLS role assertion rejects production when DB_RLS_ROLE is a superuser (0.108542ms)
✔ RLS role assertion rejects production when DB_RLS_ROLE is missing from pg_roles (0.125917ms)
✔ RLS role assertion rejects invalid DB_RLS_ROLE before querying (0.093875ms)
✔ RLS role assertion checks only the connection role when DB_RLS_ROLE is unset (0.058167ms)
✔ assertRlsRoleIdentifier rejects unsafe role names (0.056ms)
✔ RLS role posture evaluation treats malformed rows as unverifiable (0.034666ms)
🧹 Cleaning up data with prefixes: golden_...
  Found 1 users to clean up. removing dependencies...
✨ Cleanup complete.
🧹 Cleaning up data with prefixes: golden_...
  Found 1 users to clean up. removing dependencies...
✨ Cleanup complete.
🧹 Cleaning up data with prefixes: golden_...
  Found 1 users to clean up. removing dependencies...
✨ Cleanup complete.
✔ cleanupByPrefixes deletes AI provenance rows before documents uploaded by seeded users (13.586541ms)
✔ cleanupByPrefixes deletes email campaign logs before deleting seeded users (2.064375ms)
✔ cleanupByPrefixes deletes CRM user dependencies before deleting seeded users (9.966375ms)
✔ buildSeededMembershipCardIdentifiers returns deterministic values for seeded subscriptions (101.676ms)
✔ seedGolden orchestrator preserves sequential module-call order (1.454125ms)
✔ subscriptions schema exports nullable entity-of-record columns (0.322791ms)
✔ entity-of-record columns are positioned after agentId (0.080917ms)
✔ subscriptions entity-of-record migration is additive, backfills from tenants, and adds check constraint (0.352375ms)
✔ T-504 migration creates the three additive entity decomposition tables (0.975709ms)
✔ T-504 migration backfills idempotently from tenants without destructive cutover (0.29725ms)
✔ T-504 migration adds compatibility view, aggregate proof, and repair posture (0.143334ms)
﹣ T-504 entity tables use home tenant RLS, not access or booking tenant hints (0.463791ms) # DATABASE_URL is required for T-504 RLS integration test
✔ T-504 schema exports explicit legal, host, and booking boundaries (0.82875ms)
✔ T-504 keeps subscription legal entity compatibility additive and nullable (0.159ms)
✔ T-504 exposes the compatibility boundary view shape (0.329667ms)
✔ tenant schema exports nullable governing_law and terms_version columns (0.302416ms)
✔ governing_law and terms_version are positioned after country_code (0.071583ms)
✔ tenant governing_law migration is additive and backfills from country_code (0.310583ms)
✔ withAccessTenant scopes by the explicit accessTenantId column (1.113458ms)
✔ withAccessTenant can build only the access tenant predicate (0.092958ms)
✔ withAccessTenant rejects blank access tenant scope (0.154208ms)
✔ user schema exports nullable residence country distinct from tenant (0.296416ms)
✔ residence country is positioned after tenant identity (0.069958ms)
✔ user residence country migration is additive and not host-derived (0.250625ms)
ℹ tests 225
ℹ suites 30
ℹ pass 219
ℹ fail 0
ℹ cancelled 0
ℹ skipped 6
ℹ todo 0
ℹ duration_ms 1600.086625
- 
> @interdomestik/database@1.0.0 type-check /private/tmp/interdomestik-release-gate-307/packages/database
> tsc --noEmit
- 
> @interdomestik/web@1.0.0 type-check /private/tmp/interdomestik-release-gate-307/apps/web
> tsc --noEmit
- 
> interdomestik@1.0.0 repo:size:check /private/tmp/interdomestik-release-gate-307
> node scripts/repo-size-audit.mjs --check

Code                     Actual     Limit      Label                            
-----------------------  ---------  ---------  ---------------------------------
tracked-bytes            35.83 MiB  35.83 MiB  Tracked repo size                
tracked-files            4549       4547       Tracked file count               
category:source/scripts  6.70 MiB   6.70 MiB   Tracked category "source/scripts"
category:tests/e2e       4.73 MiB   4.73 MiB   Tracked category "tests/e2e"     
 ELIFECYCLE  Command failed with exit code 1.
- 
> interdomestik@1.0.0 security:guard /private/tmp/interdomestik-release-gate-307
> node scripts/security-guard.mjs

🛡️ Running Security Guard on pnpm-lock.yaml...

Evidence storage path guard passed: no raw claims evidence path templates found.
Service-role storage boundary guard passed: all admin Storage access is centralized.
Signed URL exposure guard passed: headers, logs, and anchors are bounded.
Next TypeScript build integrity guard passed: ignoreBuildErrors is not set.
Workflow seed credential guard passed: no shared workflow seed secrets found.
Modularity guard passed: 3 changed text file(s) checked against origin/main.
Raw role-array guard passed: role-array literals match the approved baseline.
Claim status writer inventory guard passed (13 writers).
Tenant cache guard passed.
Brand discipline guard passed: checked copy stays explicit and protective.
✅ Security Guard passed. All enforced checks are clean.
- 
> interdomestik@1.0.0 pr:verify /private/tmp/interdomestik-release-gate-307
> pnpm memory:precheck && pnpm repo:size:check && pnpm test:release-gate && pnpm check:e2e-contracts && pnpm lint:production-warnings && pnpm db:migrations:check-journal && pnpm db:rls:test:required && pnpm i18n:check && pnpm i18n:purity:check && pnpm check:db-access && pnpm check:architecture-boundaries && pnpm coverage:gate && pnpm check:fast && node scripts/run-with-default-db-url.mjs pnpm --filter @interdomestik/web run e2e:smoke


> interdomestik@1.0.0 memory:precheck /private/tmp/interdomestik-release-gate-307
> node scripts/plan-conformance/memory-precheck.mjs

[memory-precheck] advisory mode only; verification will continue
[memory-precheck] changed=3 matched_rules=1 retrievals=1
[memory-precheck] rule=tenant-sensitive-database files=packages/database/src/connection-url.ts, packages/database/src/db.ts, packages/database/test/connection-url.test.ts
  - [candidate] ci.e2e_gate.failure: Database-layer changes tied to tenant isolation should rerun pnpm db:rls:test:required before pnpm e2e:gate so CI gate failures are caught earlier. | verify: pnpm db:rls:test:required, pnpm e2e:gate

> interdomestik@1.0.0 repo:size:check /private/tmp/interdomestik-release-gate-307
> node scripts/repo-size-audit.mjs --check

Code                     Actual     Limit      Label                            
-----------------------  ---------  ---------  ---------------------------------
tracked-bytes            35.83 MiB  35.83 MiB  Tracked repo size                
tracked-files            4549       4547       Tracked file count               
category:source/scripts  6.70 MiB   6.70 MiB   Tracked category "source/scripts"
category:tests/e2e       4.73 MiB   4.73 MiB   Tracked category "tests/e2e"     
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
