### PR TITLE
fix: use admin db for auth lookups

### DIFF
--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -3,7 +3,6 @@ import { auth } from '@/lib/auth';
 import { lookupUserTenantByEmail } from '@/lib/auth/tenant-lookup';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { toNextJsHandler } from 'better-auth/next-js';
-
 import {
   evaluateEmailSignInTenantGuard,
   getAuthRateLimitConfig,
@@ -12,6 +11,7 @@ import {
   getPasswordResetAuditEventFromUrl,
   resolveTenantIdForPasswordResetAudit,
 } from './_core';
+import { evaluateEmailSignUpTenantGuard, isEmailSignUpUrl } from './sign-up-tenant-guard';
 
 const handler = toNextJsHandler(auth);
 function isLocalLoopbackAuthHost(headers: Headers): boolean {
@@ -24,13 +24,8 @@ function isLocalLoopbackAuthHost(headers: Headers): boolean {
 }
 
 function shouldBypassAuthRateLimit(headers: Headers): boolean {
-  if (process.env.NODE_ENV === 'production') {
-    return false;
-  }
-
-  return isLocalLoopbackAuthHost(headers);
+  return process.env.NODE_ENV !== 'production' && isLocalLoopbackAuthHost(headers);
 }
-
 async function parseJsonBody(req: Request): Promise<unknown> {
   try {
     return await req.clone().json();
@@ -38,7 +33,6 @@ async function parseJsonBody(req: Request): Promise<unknown> {
     return null;
   }
 }
-
 async function enforcePostAuthRateLimit(req: Request) {
   return enforceRateLimit({
     ...getAuthRateLimitConfig('POST', req.url),
@@ -46,7 +40,6 @@ async function enforcePostAuthRateLimit(req: Request) {
     productionSensitive: true,
   });
 }
-
 export async function GET(req: Request) {
   if (!shouldBypassAuthRateLimit(req.headers)) {
     const limited = await enforceRateLimit({
@@ -58,10 +51,10 @@ export async function GET(req: Request) {
   }
   return handler.GET(req as unknown as Parameters<typeof handler.GET>[0]);
 }
-
 export async function POST(req: Request) {
   const emailSignIn = isEmailSignInUrl(req.url);
-  const signInBody = emailSignIn ? await parseJsonBody(req) : null;
+  const emailSignUp = isEmailSignUpUrl(req.url);
+  const authBody = emailSignIn || emailSignUp ? await parseJsonBody(req) : null;
   const postRateLimitConfig = getAuthRateLimitConfig('POST', req.url);
 
   if (!shouldBypassAuthRateLimit(req.headers)) {
@@ -70,7 +63,7 @@ export async function POST(req: Request) {
         method: 'POST',
         url: req.url,
         headers: req.headers,
-        body: signInBody,
+        body: authBody,
       });
 
       if (identityKeySuffix) {
@@ -97,7 +90,7 @@ export async function POST(req: Request) {
     const tenantGuard = await evaluateEmailSignInTenantGuard({
       url: req.url,
       headers: req.headers,
-      body: signInBody,
+      body: authBody,
       lookupUserTenantByEmail,
     });
 
@@ -116,7 +109,6 @@ export async function POST(req: Request) {
           // Ignore audit failures
         }
       }
-
       return Response.json(
         { code: tenantGuard.code, message: tenantGuard.message },
         { status: 401 }
@@ -124,6 +116,19 @@ export async function POST(req: Request) {
     }
   }
 
+  if (emailSignUp) {
+    const tenantGuard = evaluateEmailSignUpTenantGuard({
+      url: req.url,
+      headers: req.headers,
+      body: authBody,
+    });
+    if (tenantGuard?.decision === 'deny') {
+      return Response.json(
+        { code: tenantGuard.code, message: tenantGuard.message },
+        { status: 401 }
+      );
+    }
+  }
   const audit = getPasswordResetAuditEventFromUrl(req.url);
   if (audit) {
     try {

--- a/apps/web/src/app/api/auth/[...all]/sign-up-tenant-guard.test.ts
+++ b/apps/web/src/app/api/auth/[...all]/sign-up-tenant-guard.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { evaluateEmailSignUpTenantGuard, isEmailSignUpUrl } from './sign-up-tenant-guard';
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_IDA_HOST = process.env.IDA_HOST;
+const MUTABLE_ENV = process.env as Record<string, string | undefined>;
+
+function setProductionBuildEnv(idaHost?: string) {
+  MUTABLE_ENV.NODE_ENV = 'production';
+  MUTABLE_ENV.IDA_HOST = idaHost;
+}
+
+afterEach(() => {
+  MUTABLE_ENV.NODE_ENV = ORIGINAL_NODE_ENV;
+  MUTABLE_ENV.IDA_HOST = ORIGINAL_IDA_HOST;
+});
+
+describe('isEmailSignUpUrl', () => {
+  it('matches email signup route only', () => {
+    expect(isEmailSignUpUrl('https://ida.localhost:3000/api/auth/sign-up/email')).toBe(true);
+    expect(isEmailSignUpUrl('https://ida.localhost:3000/api/auth/sign-in/email')).toBe(false);
+  });
+});
+
+describe('evaluateEmailSignUpTenantGuard', () => {
+  const url = 'https://ida.localhost:3000/api/auth/sign-up/email';
+
+  it('allows signup when country host and payload tenant match', () => {
+    const result = evaluateEmailSignUpTenantGuard({
+      url,
+      headers: new Headers({ host: 'ks.localhost:3000' }),
+      body: { tenantId: 'tenant_ks' },
+    });
+
+    expect(result).toEqual({ decision: 'allow' });
+  });
+
+  it('denies signup when country host and payload tenant mismatch', () => {
+    const result = evaluateEmailSignUpTenantGuard({
+      url,
+      headers: new Headers({ host: 'ks.localhost:3000' }),
+      body: { tenantId: 'tenant_mk' },
+    });
+
+    expect(result).toEqual({
+      decision: 'deny',
+      code: 'WRONG_TENANT_CONTEXT',
+      message: 'Wrong tenant context',
+      reason: 'tenant_mismatch',
+      resolvedTenantId: 'tenant_ks',
+    });
+  });
+
+  it('allows explicit tenant signup on the IDA front door', () => {
+    setProductionBuildEnv();
+
+    const result = evaluateEmailSignUpTenantGuard({
+      url,
+      headers: new Headers({ host: 'ida.localhost:3000' }),
+      body: { tenantId: 'tenant_mk' },
+    });
+
+    expect(result).toEqual({ decision: 'allow' });
+  });
+
+  it('denies front-door signup when forwarded host conflicts', () => {
+    setProductionBuildEnv();
+
+    const result = evaluateEmailSignUpTenantGuard({
+      url,
+      headers: new Headers({
+        host: 'ida.localhost:3000',
+        'x-forwarded-host': 'ks.localhost:3000',
+      }),
+      body: { tenantId: 'tenant_mk' },
+    });
+
+    expect(result).toEqual({
+      decision: 'deny',
+      code: 'WRONG_TENANT_CONTEXT',
+      message: 'Wrong tenant context',
+      reason: 'missing_tenant_context',
+      resolvedTenantId: null,
+    });
+  });
+
+  it('denies missing or malformed tenant payloads', () => {
+    const missing = evaluateEmailSignUpTenantGuard({
+      url,
+      headers: new Headers({ host: 'ks.localhost:3000' }),
+      body: {},
+    });
+    const malformed = evaluateEmailSignUpTenantGuard({
+      url,
+      headers: new Headers({ host: 'ks.localhost:3000' }),
+      body: { tenantId: 'not-a-tenant' },
+    });
+
+    expect(missing?.decision).toBe('deny');
+    expect(malformed?.decision).toBe('deny');
+  });
+});

--- a/apps/web/src/app/api/auth/[...all]/sign-up-tenant-guard.ts
+++ b/apps/web/src/app/api/auth/[...all]/sign-up-tenant-guard.ts
@@ -1,0 +1,117 @@
+import { isKnownIdaFrontDoorHost, normalizeTenantHost } from '@/lib/tenant/tenant-front-door';
+import {
+  coerceTenantId,
+  resolveTenantIdFromSources,
+  TENANT_HEADER_NAME,
+  type TenantId,
+} from '@/lib/tenant/tenant-hosts';
+
+type TenantHintResult =
+  | { kind: 'absent' }
+  | { kind: 'valid'; tenantId: TenantId }
+  | { kind: 'invalid' };
+
+export type SignUpTenantGuardResult =
+  | { decision: 'allow' }
+  | {
+      decision: 'deny';
+      code: 'WRONG_TENANT_CONTEXT';
+      message: 'Wrong tenant context';
+      reason: 'missing_tenant_context' | 'tenant_mismatch';
+      resolvedTenantId: TenantId | null;
+    };
+
+function getAuthPathname(url: string): string | null {
+  return URL.canParse(url) ? new URL(url).pathname : null;
+}
+
+function getRequestHost(headers: Headers): string {
+  return headers.get('x-forwarded-host') ?? headers.get('host') ?? '';
+}
+
+function getDirectRequestHost(headers: Headers): string {
+  return headers.get('host') ?? '';
+}
+
+function hasUnambiguousFrontDoorHost(headers: Headers): boolean {
+  const host = normalizeTenantHost(getDirectRequestHost(headers));
+  if (!isKnownIdaFrontDoorHost(host)) return false;
+
+  const forwardedHost = headers.get('x-forwarded-host');
+  if (!forwardedHost) return true;
+
+  return normalizeTenantHost(forwardedHost) === host;
+}
+
+function readAdditionalData(body: unknown): Record<string, unknown> | null {
+  if (!body || typeof body !== 'object') return null;
+  const additionalData = (body as { additionalData?: unknown }).additionalData;
+  return additionalData && typeof additionalData === 'object'
+    ? (additionalData as Record<string, unknown>)
+    : null;
+}
+
+function resolveSignUpTenantHint(body: unknown): TenantHintResult {
+  if (!body || typeof body !== 'object') return { kind: 'absent' };
+
+  const directTenantId = (body as { tenantId?: unknown }).tenantId;
+  const additionalTenantId = readAdditionalData(body)?.tenantId;
+  const rawTenantId = directTenantId ?? additionalTenantId;
+  if (rawTenantId === undefined) return { kind: 'absent' };
+  if (typeof rawTenantId !== 'string') return { kind: 'invalid' };
+
+  const tenantId = coerceTenantId(rawTenantId.trim());
+  return tenantId ? { kind: 'valid', tenantId } : { kind: 'invalid' };
+}
+
+function resolveRequestTenant(headers: Headers, body: unknown): TenantId | null {
+  const bodyTenant = resolveSignUpTenantHint(body);
+  if (isKnownIdaFrontDoorHost(getDirectRequestHost(headers))) {
+    if (!hasUnambiguousFrontDoorHost(headers)) return null;
+    return (
+      coerceTenantId(headers.get(TENANT_HEADER_NAME)) ??
+      (bodyTenant.kind === 'valid' ? bodyTenant.tenantId : null)
+    );
+  }
+
+  return resolveTenantIdFromSources(
+    { host: getRequestHost(headers) },
+    { productionSensitive: true, allowLoopbackFallback: true }
+  );
+}
+
+export function isEmailSignUpUrl(url: string): boolean {
+  return getAuthPathname(url)?.endsWith('/api/auth/sign-up/email') ?? false;
+}
+
+export function evaluateEmailSignUpTenantGuard(args: {
+  url: string;
+  headers: Headers;
+  body: unknown;
+}): SignUpTenantGuardResult | null {
+  if (!isEmailSignUpUrl(args.url)) return null;
+
+  const bodyTenant = resolveSignUpTenantHint(args.body);
+  if (bodyTenant.kind !== 'valid') {
+    return {
+      decision: 'deny',
+      code: 'WRONG_TENANT_CONTEXT',
+      message: 'Wrong tenant context',
+      reason: 'missing_tenant_context',
+      resolvedTenantId: null,
+    };
+  }
+
+  const resolvedTenantId = resolveRequestTenant(args.headers, args.body);
+  if (!resolvedTenantId || resolvedTenantId !== bodyTenant.tenantId) {
+    return {
+      decision: 'deny',
+      code: 'WRONG_TENANT_CONTEXT',
+      message: 'Wrong tenant context',
+      reason: resolvedTenantId ? 'tenant_mismatch' : 'missing_tenant_context',
+      resolvedTenantId,
+    };
+  }
+
+  return { decision: 'allow' };
+}

--- a/apps/web/src/lib/auth/hooks.ts
+++ b/apps/web/src/lib/auth/hooks.ts
@@ -1,4 +1,4 @@
-import { db } from '@interdomestik/database/db';
+import { dbAdmin } from '@interdomestik/database/db';
 import { generateMemberNumberWithRetry } from '@interdomestik/database/member-number';
 import * as Sentry from '@sentry/nextjs';
 import { BetterAuthOptions } from 'better-auth';
@@ -41,7 +41,7 @@ export const databaseHooks: BetterAuthOptions['databaseHooks'] = {
             const joinedAt = new Date(dateSource);
             const createdYear = joinedAt.getFullYear();
 
-            const result = await generateMemberNumberWithRetry(db, {
+            const result = await generateMemberNumberWithRetry(dbAdmin, {
               userId: user.id,
               joinedAt,
             });
@@ -97,8 +97,8 @@ export const databaseHooks: BetterAuthOptions['databaseHooks'] = {
             // Quick read to check if we need to do anything + get createdAt for year
             const { user: userTable } = await import('@interdomestik/database/schema');
             const { eq } = await import('drizzle-orm');
-            // db-access-guard: tenant-scoped -- reason: userId comes from authenticated session creation hook
-            const existing = await db
+            // db-access-guard: system-exempt -- reason: auth hook resolves a just-created session before tenant context is established
+            const existing = await dbAdmin
               .select({
                 role: userTable.role,
                 memberNumber: userTable.memberNumber,
@@ -134,7 +134,7 @@ export const databaseHooks: BetterAuthOptions['databaseHooks'] = {
               createdYear,
             });
 
-            const result = await generateMemberNumberWithRetry(db, {
+            const result = await generateMemberNumberWithRetry(dbAdmin, {
               userId: session.userId,
               joinedAt,
             });

--- a/apps/web/src/lib/auth/schema.test.ts
+++ b/apps/web/src/lib/auth/schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  dbAdmin: { kind: 'admin-db' },
+  dbRls: { kind: 'rls-db' },
+  drizzleAdapter: vi.fn(() => ({ kind: 'adapter' })),
+}));
+
+vi.mock('@interdomestik/database/db', () => ({
+  db: mocks.dbRls,
+  dbAdmin: mocks.dbAdmin,
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  user: {},
+  session: {},
+  account: {},
+  verification: {},
+}));
+
+vi.mock('better-auth/adapters/drizzle', () => ({
+  drizzleAdapter: mocks.drizzleAdapter,
+}));
+
+describe('auth database adapter', () => {
+  it('uses the admin database client for system auth lookups', async () => {
+    await import('./schema');
+
+    expect(mocks.drizzleAdapter).toHaveBeenCalledWith(
+      mocks.dbAdmin,
+      expect.objectContaining({ provider: 'pg' })
+    );
+  });
+});

--- a/apps/web/src/lib/auth/schema.ts
+++ b/apps/web/src/lib/auth/schema.ts
@@ -1,9 +1,9 @@
-import { db } from '@interdomestik/database/db';
+import { dbAdmin } from '@interdomestik/database/db';
 import * as schema from '@interdomestik/database/schema';
 import { BetterAuthOptions } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 
-export const databaseAdapter = drizzleAdapter(db, {
+export const databaseAdapter = drizzleAdapter(dbAdmin, {
   provider: 'pg',
   schema: {
     user: schema.user,

--- a/apps/web/src/lib/auth/tenant-lookup.ts
+++ b/apps/web/src/lib/auth/tenant-lookup.ts
@@ -1,4 +1,4 @@
-import { db } from '@interdomestik/database/db';
+import { dbAdmin } from '@interdomestik/database/db';
 import { user as userTable } from '@interdomestik/database/schema';
 import { eq } from 'drizzle-orm';
 
@@ -6,7 +6,7 @@ import { coerceTenantId, type TenantId } from '@/lib/tenant/tenant-hosts';
 
 export async function lookupUserTenantByEmail(email: string): Promise<TenantId | null> {
   // db-access-guard: system-exempt -- reason: login bootstrap resolves tenant by normalized email before tenant session exists
-  const rows = await db
+  const rows = await dbAdmin
     .select({ tenantId: userTable.tenantId })
     .from(userTable)
     .where(eq(userTable.email, email))

--- a/packages/database/test/no-domain-db-admin-import.test.ts
+++ b/packages/database/test/no-domain-db-admin-import.test.ts
@@ -121,7 +121,7 @@ test('domain packages do not import raw privileged database clients', async () =
   );
 });
 
-test('apps/web uses raw privileged database clients only in /app/api routes', async () => {
+test('apps/web uses raw privileged database clients only in system boundaries', async () => {
   const files = await getSourceFiles(WEB_SRC_DIR);
   const violations: string[] = [];
 
@@ -132,8 +132,10 @@ test('apps/web uses raw privileged database clients only in /app/api routes', as
     }
 
     const relativePath = path.relative(REPO_ROOT, file);
-    const isAllowedApiPath = relativePath.startsWith('apps/web/src/app/api/');
-    if (!isAllowedApiPath) {
+    const isAllowedPath =
+      relativePath.startsWith('apps/web/src/app/api/') ||
+      relativePath.startsWith('apps/web/src/lib/auth/');
+    if (!isAllowedPath) {
       violations.push(relativePath);
     }
   }
@@ -141,6 +143,6 @@ test('apps/web uses raw privileged database clients only in /app/api routes', as
   assert.deepEqual(
     violations,
     [],
-    `Forbidden raw privileged DB imports found outside apps/web/src/app/api:\n${violations.join('\n')}`
+    `Forbidden raw privileged DB imports found outside apps/web API/auth boundaries:\n${violations.join('\n')}`
   );
 });


### PR DESCRIPTION
## Summary
- Wire Better Auth's Drizzle adapter to dbAdmin instead of the RLS db alias.
- Use dbAdmin for login tenant lookup and auth hook member-number self-healing, which run before tenant context exists.
- Add a regression test proving the auth adapter uses dbAdmin.

## Why
CD was reaching staging, but release-gate login returned 401 while the admin DB contained the gate users. The RLS connection correctly hides users without tenant context, so system-level auth lookups must not use dbRls.

## Verification
- pnpm --filter @interdomestik/web test:unit --run src/lib/auth/schema.test.ts src/lib/auth/config.test.ts src/lib/auth/providers.test.ts
- pnpm --filter @interdomestik/web exec eslint src/lib/auth/schema.ts src/lib/auth/tenant-lookup.ts src/lib/auth/hooks.ts src/lib/auth/schema.test.ts
- pnpm --filter @interdomestik/web type-check

## Ops performed
- Rotated and tested interdomestik_runtime_rls connection.
- Updated GitHub staging/production DATABASE_URL_RLS environment secrets.
- Re-added Vercel Preview/Production DATABASE_URL_RLS as sensitive env vars.