### PR TITLE
fix: restore staging release gate admin access

### DIFF
--- a/apps/web/src/features/admin/overview/server/get-admin-overview-data.ts
+++ b/apps/web/src/features/admin/overview/server/get-admin-overview-data.ts
@@ -5,7 +5,7 @@ import {
   claimLifecycleStatusIn,
   claimLifecycleStatusSql,
 } from '@interdomestik/domain-claims/claims/lifecycle-read-sql';
-import { db } from '@interdomestik/database/db';
+import { withTenantContext } from '@interdomestik/database';
 import { branches, claims, user } from '@interdomestik/database/schema';
 import { and, count, desc, eq, gte } from 'drizzle-orm';
 
@@ -41,50 +41,58 @@ export async function getAdminOverviewData(params: {
     updated24hRes,
     claimsByStageRes,
     claimsByBranchRes,
-  ] = await Promise.all([
-    db
-      .select({ value: count() })
-      .from(user)
-      .where(and(eq(user.tenantId, tenantId), eq(user.role, 'member'))),
-    db
-      .select({ value: count() })
-      .from(user)
-      .where(and(eq(user.tenantId, tenantId), eq(user.role, 'agent'))),
-    db
-      .select({ value: count() })
-      .from(claims)
-      .where(and(eq(claims.tenantId, tenantId), claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES))),
-    db
-      .select({ value: count() })
-      .from(claims)
-      .where(
-        and(
-          eq(claims.tenantId, tenantId),
-          claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES),
-          gte(claims.updatedAt, last24h)
+  ] = await withTenantContext({ tenantId, role: 'admin' }, tx =>
+    Promise.all([
+      tx
+        .select({ value: count() })
+        .from(user)
+        .where(and(eq(user.tenantId, tenantId), eq(user.role, 'member'))),
+      tx
+        .select({ value: count() })
+        .from(user)
+        .where(and(eq(user.tenantId, tenantId), eq(user.role, 'agent'))),
+      tx
+        .select({ value: count() })
+        .from(claims)
+        .where(
+          and(eq(claims.tenantId, tenantId), claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES))
+        ),
+      tx
+        .select({ value: count() })
+        .from(claims)
+        .where(
+          and(
+            eq(claims.tenantId, tenantId),
+            claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES),
+            gte(claims.updatedAt, last24h)
+          )
+        ),
+      tx
+        .select({
+          stage: lifecycleStatus,
+          count: count(),
+        })
+        .from(claims)
+        .where(
+          and(eq(claims.tenantId, tenantId), claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES))
         )
-      ),
-    db
-      .select({
-        stage: lifecycleStatus,
-        count: count(),
-      })
-      .from(claims)
-      .where(and(eq(claims.tenantId, tenantId), claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES)))
-      .groupBy(lifecycleStatus)
-      .orderBy(desc(count())),
-    db
-      .select({
-        branchId: claims.branchId,
-        branchName: branches.name,
-        count: count(),
-      })
-      .from(claims)
-      .leftJoin(branches, and(eq(branches.id, claims.branchId), eq(branches.tenantId, tenantId)))
-      .where(and(eq(claims.tenantId, tenantId), claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES)))
-      .groupBy(claims.branchId, branches.name)
-      .orderBy(desc(count())),
-  ]);
+        .groupBy(lifecycleStatus)
+        .orderBy(desc(count())),
+      tx
+        .select({
+          branchId: claims.branchId,
+          branchName: branches.name,
+          count: count(),
+        })
+        .from(claims)
+        .leftJoin(branches, and(eq(branches.id, claims.branchId), eq(branches.tenantId, tenantId)))
+        .where(
+          and(eq(claims.tenantId, tenantId), claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES))
+        )
+        .groupBy(claims.branchId, branches.name)
+        .orderBy(desc(count())),
+    ])
+  );
 
   return {
     kpis: {

--- a/apps/web/src/lib/tenant/tenant-front-door.test.ts
+++ b/apps/web/src/lib/tenant/tenant-front-door.test.ts
@@ -9,12 +9,18 @@ import {
 describe('tenant-front-door', () => {
   const mutableEnv = process.env as Record<string, string | undefined>;
   const originalIdaHost = process.env.IDA_HOST;
+  const originalVercelUrl = process.env.VERCEL_URL;
 
   afterEach(() => {
     if (originalIdaHost === undefined) {
       delete mutableEnv.IDA_HOST;
     } else {
       mutableEnv.IDA_HOST = originalIdaHost;
+    }
+    if (originalVercelUrl === undefined) {
+      delete mutableEnv.VERCEL_URL;
+    } else {
+      mutableEnv.VERCEL_URL = originalVercelUrl;
     }
   });
 
@@ -30,6 +36,13 @@ describe('tenant-front-door', () => {
     expect(isKnownIdaFrontDoorHost('ida.localhost:3000')).toBe(true);
     expect(isKnownIdaFrontDoorHost('front-door.localhost:3000')).toBe(true);
     expect(isKnownIdaFrontDoorHost('ks.localhost:3000')).toBe(false);
+  });
+
+  it('recognizes only the current Vercel deployment host as a front door', () => {
+    mutableEnv.VERCEL_URL = 'interdomestik-preview-123.vercel.app';
+
+    expect(isKnownIdaFrontDoorHost('interdomestik-preview-123.vercel.app')).toBe(true);
+    expect(isKnownIdaFrontDoorHost('other-preview.vercel.app')).toBe(false);
   });
 
   it('resolves ida front-door hosts as public no-tenant context', () => {

--- a/apps/web/src/lib/tenant/tenant-front-door.ts
+++ b/apps/web/src/lib/tenant/tenant-front-door.ts
@@ -48,11 +48,13 @@ export function normalizeTenantHost(host: string | null | undefined): string {
 export function isKnownIdaFrontDoorHost(host: string | null | undefined): boolean {
   const normalized = normalizeTenantHost(host);
   const configuredIdaHost = normalizeTenantHost(process.env.IDA_HOST);
+  const configuredVercelUrl = normalizeTenantHost(process.env.VERCEL_URL);
 
   return (
     normalized.startsWith('ida.') ||
     DEFAULT_IDA_FRONT_DOOR_HOSTS.has(normalized) ||
-    (configuredIdaHost.length > 0 && normalized === configuredIdaHost)
+    (configuredIdaHost.length > 0 && normalized === configuredIdaHost) ||
+    (configuredVercelUrl.length > 0 && normalized === configuredVercelUrl)
   );
 }
 

--- a/apps/web/src/server/auth/effective-portal-access.test.ts
+++ b/apps/web/src/server/auth/effective-portal-access.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database/db', () => ({
-  db: {
+  dbAdmin: {
     query: {
       tenants: {
         findFirst: (...args: unknown[]) => mocks.findTenant(...args),

--- a/apps/web/src/server/auth/effective-portal-access.ts
+++ b/apps/web/src/server/auth/effective-portal-access.ts
@@ -1,4 +1,4 @@
-import { db } from '@interdomestik/database/db';
+import { dbAdmin } from '@interdomestik/database/db';
 import { eq } from 'drizzle-orm';
 import { notFound } from 'next/navigation';
 
@@ -16,7 +16,8 @@ async function getExplicitTenantRolesFor(
   tenantId: string | null | undefined
 ): Promise<string[]> {
   if (!userId || !tenantId) return [];
-  const rows = await db.query.userRoles.findMany({
+  // db-access-guard: system-exempt -- reason: authz gate resolves role metadata before tenant-scoped RLS context exists
+  const rows = await dbAdmin.query.userRoles.findMany({
     where: (r, { and: andFn }) => andFn(eq(r.userId, userId), eq(r.tenantId, tenantId)),
     columns: { role: true },
   });
@@ -24,8 +25,8 @@ async function getExplicitTenantRolesFor(
 }
 
 async function isActiveTenant(tenantId: string): Promise<boolean> {
-  // db-access-guard: tenant-scoped -- reason: tenantId from validated function parameter at current DB boundary
-  const tenant = await db.query.tenants.findFirst({
+  // db-access-guard: system-exempt -- reason: super-admin authz gate validates active tenant metadata before tenant-scoped RLS context exists
+  const tenant = await dbAdmin.query.tenants.findFirst({
     where: (t, { and: andFn }) => andFn(eq(t.id, tenantId), eq(t.isActive, true)),
     columns: { id: true },
   });

--- a/packages/database/test/no-domain-db-admin-import.test.ts
+++ b/packages/database/test/no-domain-db-admin-import.test.ts
@@ -134,7 +134,8 @@ test('apps/web uses raw privileged database clients only in system boundaries', 
     const relativePath = path.relative(REPO_ROOT, file);
     const isAllowedPath =
       relativePath.startsWith('apps/web/src/app/api/') ||
-      relativePath.startsWith('apps/web/src/lib/auth/');
+      relativePath.startsWith('apps/web/src/lib/auth/') ||
+      relativePath.startsWith('apps/web/src/server/auth/');
     if (!isAllowedPath) {
       violations.push(relativePath);
     }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37567376,
-  "maxTrackedFiles": 4547,
+  "maxTrackedBytes": 37576759,
+  "maxTrackedFiles": 4550,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7023417,
+    "source/scripts": 7028248,
     "docs/text": 5705447,
-    "tests/e2e": 4960197,
+    "tests/e2e": 4964749,
     "config/data/messages": 1548379,
     "other": 129182
   },


### PR DESCRIPTION
## Summary
- use the privileged auth metadata boundary for portal access lookups that run before tenant context exists
- keep admin overview queries tenant-scoped through withTenantContext
- trust only the exact current Vercel preview deployment host for release-gate tenant resolution
- refresh repo size budget to match the current tracked tree after verification

## Verification
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate