### PR TITLE
fix: disable gha cache export in CD image build

### DIFF
--- a/.github/actions/build-attested-image/action.yml
+++ b/.github/actions/build-attested-image/action.yml
@@ -40,8 +40,6 @@ runs:
         sbom: true
         tags: ${{ inputs.tags }}
         labels: ${{ inputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         build-args: |
           COMMIT_SHA=${{ github.sha }}
           INTERDOMESTIK_DEPLOY_ENV=${{ inputs.deploy-env }}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -31,10 +31,10 @@ RUN pnpm install --frozen-lockfile
 
 # Build the project
 # This assumes the build command in package.json runs turbo build
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 # Skip linting during build to speed up
-ENV NEXT_IGNORE_ESLINT 1
-ENV INTERDOMESTIK_BUILDING 1
+ENV NEXT_IGNORE_ESLINT=1
+ENV INTERDOMESTIK_BUILDING=1
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 RUN DATABASE_URL="postgres://p:p@127.0.0.1:54322/postgres" \
@@ -44,8 +44,8 @@ RUN DATABASE_URL="postgres://p:p@127.0.0.1:54322/postgres" \
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -65,8 +65,8 @@ USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
+ENV PORT=3000
 # set hostname to localhost
-ENV HOSTNAME "0.0.0.0"
+ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "apps/web/server.js"]

--- a/scripts/ci/cd-attestation-contract.test.mjs
+++ b/scripts/ci/cd-attestation-contract.test.mjs
@@ -59,6 +59,8 @@ function assertAttestedImageAction() {
   assert.equal(buildStep.with.push, true);
   assert.equal(buildStep.with.provenance, 'mode=max');
   assert.equal(buildStep.with.sbom, true);
+  assert.equal(buildStep.with['cache-from'], undefined);
+  assert.equal(buildStep.with['cache-to'], undefined);
   assert.match(buildStep.with.tags, /\$\{\{\s*inputs\.tags\s*\}\}/u);
   assert.match(buildStep.with['build-args'], /COMMIT_SHA=\$\{\{\s*github\.sha\s*\}\}/u);
   assert.match(

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37576759,
+  "maxTrackedBytes": 37576806,
   "maxTrackedFiles": 4550,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
     "source/scripts": 7028248,
     "docs/text": 5705447,
-    "tests/e2e": 4964749,
-    "config/data/messages": 1548379,
+    "tests/e2e": 4964861,
+    "config/data/messages": 1548314,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,


### PR DESCRIPTION
## Summary
- Disable GitHub Actions cache import/export for the attested release image build so the self-hosted Mac CD runner cannot fail after a successful image push during BuildKit GHA cache export.
- Keep SBOM/provenance/attestation checks intact and add a contract assertion that release image builds stay off GHA cache.
- Normalize Dockerfile ENV syntax and refresh the tracked repo-size budget by the measured byte drift.

## Verification
- node scripts/ci/cd-attestation-contract.test.mjs
- node scripts/ci/workflow-contracts.test.mjs
- git diff --check
- pnpm repo:size:check
- pnpm security:guard
- pnpm pr:verify