### PR TITLE
fix: bound Vercel deploy in CD

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -125,8 +125,10 @@ runs:
           echo "::error::Vercel output digest changed after attestation"
           exit 1
         fi
-        deployment_url="$(npx --yes vercel@latest deploy --prebuilt --archive=tgz --env "COMMIT_SHA=${COMMIT_SHA}" "${target_args[@]}")"
-        deployment_url="$(printf '%s\n' "${deployment_url}" | tail -n 1)"
+        deployment_url="$(node scripts/ci/run-vercel-deploy-with-timeout.mjs \
+          --timeout-seconds "${VERCEL_DEPLOY_TIMEOUT_SECONDS:-900}" \
+          -- deploy --yes --prebuilt --archive=tgz \
+          --env "COMMIT_SHA=${COMMIT_SHA}" "${target_args[@]}")"
         base_url="${deployment_url}"
         if [[ "${base_url}" != https://* ]]; then
           base_url="https://${base_url}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,8 +15,7 @@ env:
 jobs:
   build-staging:
     runs-on: [self-hosted, interdomestik-mac]
-    environment:
-      name: staging
+    environment: { name: staging }
     permissions:
       contents: read
       packages: write
@@ -61,6 +60,7 @@ jobs:
   deploy-staging:
     needs: build-staging
     runs-on: [self-hosted, interdomestik-mac]
+    timeout-minutes: 25
     environment:
       name: staging
     permissions:
@@ -222,9 +222,8 @@ jobs:
   deploy-production:
     needs: build-production
     runs-on: [self-hosted, interdomestik-mac]
-    environment:
-      name: production
-      url: https://www.interdomestik.com
+    timeout-minutes: 25
+    environment: { name: production, url: https://www.interdomestik.com }
     permissions:
       contents: read
       id-token: write

--- a/apps/web/e2e/gate/staff-support-handoffs.spec.ts
+++ b/apps/web/e2e/gate/staff-support-handoffs.spec.ts
@@ -452,7 +452,8 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
     const secondSubject = `${subject} second`;
     const claimHelpPath = `${routes.memberHelp(testInfo)}?claimId=${encodeURIComponent(claimId)}`;
     const currentMemberSurface = () => memberPage.getByTestId('member-page-ready').last();
-
+    const supportForm = () =>
+      currentMemberSurface().locator('[data-testid="member-support-handoff-form"]:visible').last();
     await cleanupHandoffBySubject(subject);
     await cleanupHandoffBySubject(secondSubject);
 
@@ -460,14 +461,14 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
       await gotoApp(memberPage, claimHelpPath, testInfo, {
         marker: 'member-page-ready',
       });
-      await expect(memberPage.getByTestId('member-support-handoff-form')).toBeVisible();
-      await expect(memberPage.getByTestId('member-support-handoff-claim')).toHaveValue(claimId);
+      await expect(supportForm()).toBeVisible();
+      await expect(supportForm().getByTestId('member-support-handoff-claim')).toHaveValue(claimId);
 
-      await memberPage.getByTestId('member-support-handoff-subject').fill(subject);
-      await memberPage
+      await supportForm().getByTestId('member-support-handoff-subject').fill(subject);
+      await supportForm()
         .getByTestId('member-support-handoff-message')
         .fill('First advisory test handoff with enough detail for submission.');
-      await memberPage.getByTestId('member-support-handoff-submit').click();
+      await supportForm().getByTestId('member-support-handoff-submit').click();
 
       await expect(memberPage).toHaveURL(/\/member\/help\?support=created$/, {
         timeout: 15000,
@@ -493,17 +494,13 @@ test.describe('CRM01 staff support handoff receiving queue', () => {
         'member-support-handoff-advisory-claim'
       );
       await expect(claimAdvisory).toBeVisible({ timeout: 15000 });
-      await expect(currentMemberSurface().getByTestId('member-support-handoff-claim')).toHaveValue(
-        claimId
-      );
+      await expect(supportForm().getByTestId('member-support-handoff-claim')).toHaveValue(claimId);
 
-      await currentMemberSurface()
-        .getByTestId('member-support-handoff-subject')
-        .fill(secondSubject);
-      await currentMemberSurface()
+      await supportForm().getByTestId('member-support-handoff-subject').fill(secondSubject);
+      await supportForm()
         .getByTestId('member-support-handoff-message')
         .fill('Second advisory test handoff proving the advisory remains non-blocking.');
-      await currentMemberSurface().getByTestId('member-support-handoff-submit').click();
+      await supportForm().getByTestId('member-support-handoff-submit').click();
 
       await expect(memberPage).toHaveURL(/\/member\/help\?support=created$/, {
         timeout: 15000,

--- a/scripts/ci/cd-deploy-digest-boundary.test.mjs
+++ b/scripts/ci/cd-deploy-digest-boundary.test.mjs
@@ -127,7 +127,10 @@ test('Vercel deploy action validates config, builds, deploys, and exports base U
   assert.match(deployStep.env.VERCEL_AUTOMATION_BYPASS_SECRET, /inputs\.vercel-automation-bypass-secret/u);
   assert.match(deployStep.run, /current_vercel_output_digest="\$\(node scripts\/ci\/hash-vercel-output\.mjs\)"/u);
   assert.match(deployStep.run, /Vercel output digest changed after attestation/u);
-  assert.match(deployStep.run, /vercel@latest deploy/u);
+  assert.match(deployStep.run, /-- deploy --yes --prebuilt/u);
+  assert.match(deployStep.run, /VERCEL_DEPLOY_TIMEOUT_SECONDS:-900/u);
+  assert.match(deployStep.run, /run-vercel-deploy-with-timeout\.mjs/u);
+  assert.match(deployStep.run, /--yes --prebuilt/u);
   assert.match(deployStep.run, /--prebuilt/u);
   assert.match(deployStep.run, /--archive=tgz/u);
   assert.match(deployStep.run, /--env "COMMIT_SHA=\$\{COMMIT_SHA\}"/u);

--- a/scripts/ci/run-vercel-deploy-with-timeout.mjs
+++ b/scripts/ci/run-vercel-deploy-with-timeout.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_TIMEOUT_SECONDS = 900;
+const SAFE_SYSTEM_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+
+function parseArgs(argv) {
+  const separatorIndex = argv.indexOf('--');
+  const options = separatorIndex === -1 ? argv : argv.slice(0, separatorIndex);
+  const vercelArgs = separatorIndex === -1 ? [] : argv.slice(separatorIndex + 1);
+  let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+
+  for (let index = 0; index < options.length; index += 1) {
+    const option = options[index];
+    if (option === '--timeout-seconds') {
+      timeoutSeconds = Number.parseInt(options[index + 1] || '', 10);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown option: ${option}`);
+  }
+
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+    throw new Error('--timeout-seconds must be a positive integer');
+  }
+  if (vercelArgs[0] !== 'deploy') {
+    throw new Error('Vercel deploy arguments must be provided after --');
+  }
+
+  return { timeoutSeconds, vercelArgs };
+}
+
+function appendTail(current, chunk, maxChars = 12_000) {
+  const next = current + chunk;
+  return next.length > maxChars ? next.slice(-maxChars) : next;
+}
+
+function compactTail(value, maxLines = 80) {
+  return value.split(/\r?\n/u).filter(Boolean).slice(-maxLines).join('\n');
+}
+
+function resolveNpxCliPath() {
+  const npmCliPath = path.resolve(
+    path.dirname(process.execPath),
+    '..',
+    'lib',
+    'node_modules',
+    'npm',
+    'bin',
+    'npx-cli.js'
+  );
+  if (!fs.existsSync(npmCliPath)) {
+    throw new Error(`Unable to locate npm npx CLI at ${npmCliPath}`);
+  }
+  return npmCliPath;
+}
+
+async function main() {
+  const { timeoutSeconds, vercelArgs } = parseArgs(process.argv.slice(2));
+  let stdoutTail = '';
+  let stderrTail = '';
+  let timedOut = false;
+
+  const child = spawn(
+    process.execPath,
+    [resolveNpxCliPath(), '--yes', 'vercel@latest', ...vercelArgs],
+    {
+      detached: process.platform !== 'win32',
+      env: { ...process.env, PATH: SAFE_SYSTEM_PATH },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+
+  const timer = setTimeout(() => {
+    timedOut = true;
+    const pid = child.pid;
+    if (!pid) return;
+    const killTarget = process.platform === 'win32' ? pid : -pid;
+    try {
+      process.kill(killTarget, 'SIGTERM');
+    } catch {}
+    setTimeout(() => {
+      try {
+        process.kill(killTarget, 'SIGKILL');
+      } catch {}
+    }, 2_000).unref();
+  }, timeoutSeconds * 1000);
+
+  child.stdout.on('data', chunk => {
+    stdoutTail = appendTail(stdoutTail, chunk.toString());
+  });
+  child.stderr.on('data', chunk => {
+    const text = chunk.toString();
+    stderrTail = appendTail(stderrTail, text);
+    process.stderr.write(text);
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', code => resolve(code ?? 1));
+  });
+  clearTimeout(timer);
+
+  if (timedOut) {
+    console.error(`::error::Vercel deploy timed out after ${timeoutSeconds}s`);
+    const outputTail = compactTail(`${stdoutTail}\n${stderrTail}`);
+    if (outputTail) console.error(outputTail);
+    process.exit(124);
+  }
+
+  if (exitCode !== 0) {
+    console.error(`::error::Vercel deploy failed with exit code ${exitCode}`);
+    const outputTail = compactTail(`${stdoutTail}\n${stderrTail}`);
+    if (outputTail) console.error(outputTail);
+    process.exit(exitCode);
+  }
+
+  const lastStdoutLine = stdoutTail.split(/\r?\n/u).findLast(Boolean);
+  if (!lastStdoutLine) {
+    console.error('::error::Vercel deploy produced no deployment URL');
+    process.exit(1);
+  }
+  console.log(lastStdoutLine);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -548,8 +548,8 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(buildProductionStep.uses, './.github/actions/build-attested-image');
   assert.equal(buildProductionStep.with['deploy-env'], 'production');
   assert.equal(buildProductionStep.with['app-url'], 'https://www.interdomestik.com');
-
   assert.deepEqual(normalizeNeeds(deployStagingJob.needs), ['build-staging']);
+  assert.equal(deployStagingJob['timeout-minutes'], 25);
   assert.equal(deployStagingJob.outputs.base_url, '${{ steps.vercel.outputs.base_url }}');
   assert.equal(deployStagingJob.outputs.hostname, '${{ steps.vercel.outputs.hostname }}');
   assert.equal(deployStagingJob.env.EXPECTED_COMMIT_SHA, '${{ github.sha }}');
@@ -575,7 +575,6 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.equal(stagingProvenanceStep.env.BASE_URL, '${{ steps.vercel.outputs.base_url }}');
   assert.match(stagingProvenanceStep.env.VERCEL_AUTOMATION_BYPASS_SECRET, /secrets\.VERCEL/u);
   assert.match(stagingProvenanceStep.run, /fetch-vercel-health\.mjs[\s\S]*EXPECTED_COMMIT_SHA/u);
-
   assert.deepEqual(normalizeNeeds(e2eStagingJob.needs), ['deploy-staging']);
   assert.deepEqual(e2eStagingJob.environment, { name: 'staging', deployment: false });
   assert.equal(e2eStagingJob.env.BASE_URL, '${{ needs.deploy-staging.outputs.base_url }}');
@@ -597,6 +596,7 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.match(stagingGateStep.run, /--suite p0/);
   assert.match(stagingGateStep.run, /--authBaseUrl "\$\{AUTH_BASE_URL\}"/);
   assert.deepEqual(normalizeNeeds(deployProductionJob.needs), ['build-production']);
+  assert.equal(deployProductionJob['timeout-minutes'], 25);
   const vercelProductionDeployStep = findStep(
     deployProductionJob.steps,
     'Deploy Production to Vercel'

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37576806,
-  "maxTrackedFiles": 4550,
+  "maxTrackedBytes": 37581080,
+  "maxTrackedFiles": 4551,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7028248,
+    "source/scripts": 7032079,
     "docs/text": 5705447,
-    "tests/e2e": 4964861,
-    "config/data/messages": 1548314,
+    "tests/e2e": 4965209,
+    "config/data/messages": 1548409,
     "other": 129182
   },
   "maxLargestFileBytes": 3263773,


### PR DESCRIPTION
## Summary
- wrap Vercel deploy in a timeout-bounded non-interactive runner helper
- add explicit deploy job timeouts for staging and production
- update CD workflow contract tests and repo-size budget

## Verification
- node scripts/ci/cd-deploy-digest-boundary.test.mjs
- node scripts/ci/workflow-contracts.test.mjs
- pnpm security:guard
- pnpm pr:verify
