### PR TITLE
fix: stabilize staging release gate role checks

### DIFF
--- a/scripts/release-gate/admin-checks.ts
+++ b/scripts/release-gate/admin-checks.ts
@@ -137,7 +137,7 @@ async function runP01(browser, runCtx, deps) {
       await loginWithRunContext(page, runCtx, account);
 
       const matrix = expectedMatrixForAccount(account);
-      for (const portal of ROUTES.rbacTargets) {
+      for (const portal of new Set([matrix.canonical, ...ROUTES.rbacTargets])) {
         const route = `/${portal}`;
         await gotoWithSessionRetry({
           page,
@@ -150,7 +150,7 @@ async function runP01(browser, runCtx, deps) {
         });
         await page.waitForTimeout(450);
 
-        const current = await collectMarkersWithWait(page, matrix.canonical);
+        const current = await collectMarkersWithWait(page, portal === matrix.canonical && portal);
         evidence.push(`${account} ${markerSummary(route, current)}`);
 
         const rbacResult = collectRbacFailures({
@@ -458,7 +458,7 @@ async function runP03AndP04(browser, runCtx, deps) {
       const context = await browser.newContext();
       const page = await context.newPage();
       try {
-        await loginWithRunContext(page, runCtx, 'admin_ks');
+        await loginWithRunContext(page, runCtx, 'admin_ks', { forceFresh: true });
 
         const resolvedTarget = await ensureRolePanelLoaded(page, targetUrl);
         evidenceP03.push(

--- a/scripts/release-gate/shared.ts
+++ b/scripts/release-gate/shared.ts
@@ -227,9 +227,9 @@ async function bootstrapAccountLanding(page, params) {
 
   page.on('response', onResponse);
   try {
-    // Keep login bootstrap tolerant: account data can drift, and strict role marker
-    // assertions here create false exceptions before route-specific checks run.
-    // Route checks (P0.1/P0.6/etc.) remain authoritative for marker semantics.
+    // Keep bootstrap tolerant: account data can drift.
+    // Strict assertions here can false-fail before route checks.
+    // P0 route checks remain authoritative for markers.
     await gotoWithTransientRetry({
       navigate: () => page.goto(targetUrl, { waitUntil: 'networkidle', timeout: TIMEOUTS.nav }),
     });
@@ -529,11 +529,11 @@ async function assertUrlMarkers(page, label, url, expected) {
 async function collectMarkersWithWait(page, preferredMarker) {
   const start = Date.now();
   let current = await markerSnapshot(page);
+
   while (Date.now() - start < TIMEOUTS.marker) {
-    if (current.notFound) break;
     if (preferredMarker) {
       if (current[preferredMarker]) break;
-    } else if (Object.values(current).some(Boolean)) {
+    } else if (current.notFound || Object.values(current).some(Boolean)) {
       break;
     }
     await sleep(300);


### PR DESCRIPTION
## Summary
- visit each account canonical portal before other RBAC targets in P0.1
- keep preferred positive role marker waits from exiting early on transient not-found snapshots
- force a fresh admin session before P0.3/P0.4 role-panel checks

## Evidence
- pnpm test:release-gate
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate

## Release safety
- no production deployment triggered
- no production migration run
- production evidence gating and environment approval remain unchanged
- apps/web/src/proxy.ts untouched

T-503 remains NO-GO until a post-merge tag/manual production CD run passes production-evidence and production verification.