### PR TITLE
fix: run staging gates under tenant context

### DIFF
--- a/apps/web/e2e/gate/golden-gate.spec.ts
+++ b/apps/web/e2e/gate/golden-gate.spec.ts
@@ -3,8 +3,6 @@ import { expect, test } from '../fixtures/auth.fixture';
 import { routes } from '../routes';
 import { gotoApp } from '../utils/navigation';
 
-// ═══════════════════════════════════════════════════════════════════════════════
-
 // Canonical users - tenant-aware
 const USERS = {
   SUPER_ADMIN: { email: E2E_USERS.SUPER_ADMIN.email, password: E2E_PASSWORD, tenant: 'tenant_mk' },
@@ -32,9 +30,7 @@ const SEEDED_DATA = {
   CLAIM_MK_1: { title: 'Rear ended in Skopje (Baseline)', amount: '500.00' }, // Branch A
 };
 
-// ═══════════════════════════════════════════════════════════════════════════════
 // LOGIN HELPER
-// ═══════════════════════════════════════════════════════════════════════════════
 
 async function performLocalLogin(
   page: import('@playwright/test').Page,
@@ -78,9 +74,7 @@ function isMkProject(testInfo: import('@playwright/test').TestInfo): boolean {
   return testInfo.project.name.includes('mk');
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
 // GATE TESTS - CRITICAL PATH ONLY
-// ═══════════════════════════════════════════════════════════════════════════════
 
 test.describe('Golden Gate: Critical Path', () => {
   test.describe('1. Member Core Flow', () => {
@@ -184,9 +178,7 @@ test.describe('Golden Gate: Critical Path', () => {
       }
       await performLocalLogin(page, USERS.SUPER_ADMIN, testInfo, 'admin');
 
-      await expect(page.getByTestId('admin-page-ready')).toBeVisible({
-        timeout: 20000,
-      });
+      await expect(page.getByTestId('admin-page-ready').last()).toBeVisible({ timeout: 20000 });
       await expect(page.locator('main')).toContainText(/[0-9]+/);
     });
 

--- a/apps/web/src/app/[locale]/(app)/member/help/_support-handoff-form.tsx
+++ b/apps/web/src/app/[locale]/(app)/member/help/_support-handoff-form.tsx
@@ -2,6 +2,7 @@
 
 import { createMemberSupportHandoff } from '@/actions/support-handoffs/create';
 import { Button } from '@interdomestik/ui/components/button';
+import { useEffect, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
 type MemberClaimOption = {
@@ -32,11 +33,15 @@ type MemberSupportHandoffFormProps = {
   sourceClaimId?: string | null;
 };
 
-function SubmitButton({ label }: { label: string }) {
+function SubmitButton({ isHydrated, label }: { isHydrated: boolean; label: string }) {
   const { pending } = useFormStatus();
 
   return (
-    <Button type="submit" disabled={pending} data-testid="member-support-handoff-submit">
+    <Button
+      type="submit"
+      disabled={!isHydrated || pending}
+      data-testid="member-support-handoff-submit"
+    >
       {label}
     </Button>
   );
@@ -49,10 +54,17 @@ export function MemberSupportHandoffForm({
   selectedClaimId = null,
   sourceClaimId = null,
 }: MemberSupportHandoffFormProps) {
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
   return (
     <form
       action={createMemberSupportHandoff}
       className="space-y-4"
+      data-hydrated={isHydrated ? 'true' : 'false'}
       data-testid="member-support-handoff-form"
     >
       <input type="hidden" name="locale" value={locale} />
@@ -127,7 +139,7 @@ export function MemberSupportHandoffForm({
           </select>
         </div>
       </div>
-      <SubmitButton label={labels.submit} />
+      <SubmitButton isHydrated={isHydrated} label={labels.submit} />
     </form>
   );
 }

--- a/apps/web/src/app/[locale]/admin/users/[id]/_claim-summary.ts
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_claim-summary.ts
@@ -1,10 +1,12 @@
-import { db } from '@interdomestik/database/db';
+import { db as defaultDb } from '@interdomestik/database/db';
 import { claims } from '@interdomestik/database/schema';
 import { resolveClaimLifecycleReadProjection } from '@interdomestik/domain-claims';
 import { claimLifecycleStatusSql } from '@interdomestik/domain-claims/claims/lifecycle-read-sql';
 import { and, count, desc, eq } from 'drizzle-orm';
 
 import type { AdminUserClaimCounts } from './_core';
+
+type DbClient = Pick<typeof defaultDb, 'select'>;
 
 function computeClaimCounts(rows: Array<{ status: string | null; total: unknown }>) {
   const counts: AdminUserClaimCounts = { total: 0, open: 0, resolved: 0, rejected: 0 };
@@ -19,10 +21,12 @@ function computeClaimCounts(rows: Array<{ status: string | null; total: unknown 
 }
 
 export async function getAdminUserClaimSummary(args: {
+  db?: DbClient;
   recentClaimsLimit: number;
   tenantId: string;
   userId: string;
 }) {
+  const db = args.db ?? defaultDb;
   const [claimCounts, recentClaims] = await Promise.all([
     db
       .select({ status: claimLifecycleStatusSql(), total: count() })

--- a/apps/web/src/app/[locale]/admin/users/[id]/_core.ts
+++ b/apps/web/src/app/[locale]/admin/users/[id]/_core.ts
@@ -1,3 +1,4 @@
+import { withTenantContext, type TenantTransaction } from '@interdomestik/database';
 import { db } from '@interdomestik/database/db';
 import {
   subscriptions,
@@ -70,8 +71,10 @@ export type AdminUserProfileOk = {
 
 export type AdminUserProfileResult = { kind: 'not_found' } | AdminUserProfileOk;
 
-async function getMemberWithAgent(userId: string, tenantId: string) {
-  return db.query.user.findFirst({
+type DbClient = typeof db | TenantTransaction;
+
+async function getMemberWithAgent(dbClient: DbClient, userId: string, tenantId: string) {
+  return dbClient.query.user.findFirst({
     where: and(eq(userTable.id, userId), eq(userTable.tenantId, tenantId)),
     with: {
       agent: true,
@@ -86,39 +89,42 @@ export async function getAdminUserProfileCore(args: {
 }): Promise<AdminUserProfileResult> {
   if (!args.tenantId) return { kind: 'not_found' };
 
-  const member = await getMemberWithAgent(args.userId, args.tenantId);
+  return withTenantContext({ tenantId: args.tenantId, role: 'admin' }, async tx => {
+    const member = await getMemberWithAgent(tx, args.userId, args.tenantId!);
 
-  if (!member) return { kind: 'not_found' };
+    if (!member) return { kind: 'not_found' };
 
-  const [subscription, preferences, claimSummary] = await Promise.all([
-    db.query.subscriptions.findFirst({
-      where: and(eq(subscriptions.userId, member.id), eq(subscriptions.tenantId, args.tenantId)),
-      orderBy: (table, { desc: descFn }) => [descFn(table.createdAt)],
-    }),
-    db.query.userNotificationPreferences.findFirst({
-      where: and(
-        eq(userNotificationPreferences.userId, member.id),
-        eq(userNotificationPreferences.tenantId, args.tenantId)
-      ),
-    }),
-    getAdminUserClaimSummary({
-      recentClaimsLimit: args.recentClaimsLimit,
-      tenantId: args.tenantId,
-      userId: member.id,
-    }),
-  ]);
+    const [subscription, preferences, claimSummary] = await Promise.all([
+      tx.query.subscriptions.findFirst({
+        where: and(eq(subscriptions.userId, member.id), eq(subscriptions.tenantId, args.tenantId!)),
+        orderBy: (table, { desc: descFn }) => [descFn(table.createdAt)],
+      }),
+      tx.query.userNotificationPreferences.findFirst({
+        where: and(
+          eq(userNotificationPreferences.userId, member.id),
+          eq(userNotificationPreferences.tenantId, args.tenantId!)
+        ),
+      }),
+      getAdminUserClaimSummary({
+        db: tx,
+        recentClaimsLimit: args.recentClaimsLimit,
+        tenantId: args.tenantId!,
+        userId: member.id,
+      }),
+    ]);
 
-  const membershipStatus = getAdminUserMembershipStatus(subscription);
+    const membershipStatus = getAdminUserMembershipStatus(subscription);
 
-  return {
-    kind: 'ok',
-    member,
-    subscription: (subscription ?? null) as SubscriptionRow | null,
-    preferences: (preferences ?? null) as PreferencesRow | null,
-    counts: claimSummary.counts,
-    recentClaims: claimSummary.recentClaims,
-    membershipStatus,
-  };
+    return {
+      kind: 'ok',
+      member,
+      subscription: (subscription ?? null) as SubscriptionRow | null,
+      preferences: (preferences ?? null) as PreferencesRow | null,
+      counts: claimSummary.counts,
+      recentClaims: claimSummary.recentClaims,
+      membershipStatus,
+    };
+  });
 }
 
 type MemberWithAgent = NonNullable<Awaited<ReturnType<typeof getMemberWithAgent>>>;

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.test.ts
@@ -66,6 +66,8 @@ const mocks = vi.hoisted(() => {
 });
 vi.mock('@interdomestik/database', () => ({
   db: mocks.db,
+  withTenantContext: (_context: unknown, action: (db: typeof mocks.db) => unknown) =>
+    action(mocks.db),
   claims: mocks.claims,
   claimStageHistory: mocks.claimStageHistory,
   user: mocks.user,
@@ -84,11 +86,7 @@ vi.mock('drizzle-orm', () => ({
   inArray: mocks.inArray,
   or: mocks.or,
   isNull: mocks.isNull,
-  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
-    op: 'sql',
-    strings,
-    values,
-  })),
+  sql: vi.fn(() => ({ op: 'sql' })),
 }));
 import { getStaffClaimsList } from './get-staff-claims-list';
 function expectOwnOrUnassignedQueueScope(args: { staffId: string; tenantId: string }) {
@@ -133,7 +131,7 @@ describe('getStaffClaimsList', () => {
     mocks.diasporaClaimsChain.where.mockReturnValue('diaspora-subquery');
   });
 
-  it('returns all branch claims for branch managers when branchId exists', async () => {
+  it('returns branch claims for branch managers', async () => {
     mocks.claimChain.limit.mockResolvedValue([
       {
         id: 'claim-1',
@@ -175,7 +173,7 @@ describe('getStaffClaimsList', () => {
     expect(result[0].isDiasporaOrigin).toBe(false);
   });
 
-  it('falls back to own and unassigned claims when branch manager branch context is missing', async () => {
+  it('falls back when branch-manager branch is missing', async () => {
     mocks.claimChain.limit.mockResolvedValue([]);
 
     await getStaffClaimsList({
@@ -189,7 +187,7 @@ describe('getStaffClaimsList', () => {
     expectOwnOrUnassignedQueueScope({ staffId: 'staff-1', tenantId: 'tenant-ks' });
   });
 
-  it('maps assignee details for queue operator context', async () => {
+  it('maps assignee details', async () => {
     mocks.claimChain.limit.mockResolvedValue([
       {
         id: 'claim-1',
@@ -219,7 +217,7 @@ describe('getStaffClaimsList', () => {
     expect(result.isDiasporaOrigin).toBe(false);
   });
 
-  it('maps diaspora origin fields when the latest canonical note exists', async () => {
+  it('maps diaspora origin fields from the latest note', async () => {
     mocks.claimChain.limit.mockResolvedValue([
       {
         id: 'claim-1',
@@ -258,7 +256,7 @@ describe('getStaffClaimsList', () => {
     expect(result.diasporaCountry).toBe('IT');
   });
 
-  it('applies the diaspora subquery at the query boundary when the diaspora filter is selected', async () => {
+  it('applies the diaspora subquery at the query boundary', async () => {
     mocks.db.select
       .mockReset()
       .mockReturnValueOnce(mocks.diasporaClaimsChain)
@@ -308,7 +306,7 @@ describe('getStaffClaimsList', () => {
     expect(result[0]?.isDiasporaOrigin).toBe(true);
   });
 
-  it('limits the default staff queue to assigned-to-me and unassigned claims even when branchId exists', async () => {
+  it('limits default staff queue to own and unassigned claims', async () => {
     mocks.claimChain.limit.mockResolvedValue([]);
 
     await getStaffClaimsList({
@@ -365,7 +363,7 @@ describe('getStaffClaimsList', () => {
     expectOwnOrUnassignedQueueScope({ staffId: 'staff-3', tenantId: 'tenant-ks' });
   });
 
-  it('applies assignment, status, and search filters within the actionable queue scope', async () => {
+  it('applies assignment, status, and search filters', async () => {
     mocks.claimChain.limit.mockResolvedValue([]);
 
     await getStaffClaimsList({

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
@@ -17,7 +17,7 @@ import {
 } from './staff-claims-list-filters';
 import { mapStaffClaimsListRows, type StaffClaimsListItem } from './staff-claims-list-mapper';
 
-export type { StaffClaimsAssignmentFilter };
+export type { StaffClaimsAssignmentFilter, StaffClaimsListItem };
 
 export async function getStaffClaimsList(params: {
   staffId: string;

--- a/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
+++ b/packages/domain-claims/src/staff-claims/get-staff-claims-list.ts
@@ -2,75 +2,22 @@ import {
   and,
   claimStageHistory,
   claims,
-  db,
   desc,
   eq,
-  ilike,
   inArray,
   user,
+  withTenantContext,
 } from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
-import { aliasedTable, isNull, or, type SQL } from 'drizzle-orm';
-import { ACTIONABLE_CLAIM_STATUSES } from '../claims/constants';
-import { parseDiasporaOriginFromPublicNote } from '../claims/diaspora-origin';
+import { aliasedTable } from 'drizzle-orm';
+import type { DiasporaOriginFilter } from '../claims/diaspora-origin-filter';
 import {
-  buildDiasporaOriginClaimIdsSubquery,
-  type DiasporaOriginFilter,
-} from '../claims/diaspora-origin-filter';
-import { resolveClaimLifecycleReadProjection } from '../claims/lifecycle-read-model';
-import { claimLifecycleStatusIn } from '../claims/lifecycle-read-sql';
+  buildStaffClaimsListConditions,
+  type StaffClaimsAssignmentFilter,
+} from './staff-claims-list-filters';
+import { mapStaffClaimsListRows, type StaffClaimsListItem } from './staff-claims-list-mapper';
 
-export type StaffClaimsAssignmentFilter = 'all' | 'mine' | 'unassigned';
-
-export type StaffClaimsListItem = {
-  id: string;
-  claimNumber: string | null;
-  companyName: string | null;
-  title: string | null;
-  status: string | null;
-  staffId: string | null;
-  assigneeName?: string | null;
-  assigneeEmail?: string | null;
-  stageLabel: string;
-  updatedAt: string | null;
-  memberName?: string;
-  memberNumber?: string | null;
-  isDiasporaOrigin: boolean;
-  diasporaCountry: string | null;
-};
-
-function formatStageLabel(status: string | null | undefined) {
-  if (!status) return 'Draft';
-  return status.charAt(0).toUpperCase() + status.slice(1);
-}
-
-function normalizeDate(value: Date | string | null | undefined) {
-  if (!value) return null;
-  const date = value instanceof Date ? value : new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date.toISOString();
-}
-
-function normalizeSearch(value: string | null | undefined) {
-  const normalized = value?.trim();
-  return normalized || undefined;
-}
-
-function isActionableStatus(
-  value: string | null | undefined
-): value is (typeof ACTIONABLE_CLAIM_STATUSES)[number] {
-  return !!value && (ACTIONABLE_CLAIM_STATUSES as readonly string[]).includes(value);
-}
-
-function buildSearchCondition(term: string) {
-  const pattern = `%${term}%`;
-  return or(
-    ilike(claims.title, pattern),
-    ilike(claims.companyName, pattern),
-    ilike(claims.claimNumber, pattern),
-    ilike(user.name, pattern),
-    ilike(user.memberNumber, pattern)
-  );
-}
+export type { StaffClaimsAssignmentFilter };
 
 export async function getStaffClaimsList(params: {
   staffId: string;
@@ -94,117 +41,67 @@ export async function getStaffClaimsList(params: {
     status,
     viewerRole,
   } = params;
-  const conditions: SQL<unknown>[] = [claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES)];
-  if (branchId != null) {
-    conditions.push(eq(claims.branchId, branchId));
-  }
-
-  const shouldUseOwnOrUnassignedFallback =
-    viewerRole !== 'branch_manager' || (viewerRole === 'branch_manager' && branchId == null);
-
-  if (assignment === 'mine') {
-    conditions.push(eq(claims.staffId, staffId));
-  } else if (assignment === 'unassigned') {
-    conditions.push(isNull(claims.staffId));
-  } else if (shouldUseOwnOrUnassignedFallback) {
-    const ownOrUnassigned = or(eq(claims.staffId, staffId), isNull(claims.staffId));
-    if (ownOrUnassigned) {
-      conditions.push(ownOrUnassigned);
-    }
-  }
-  if (isActionableStatus(status)) {
-    conditions.push(claimLifecycleStatusIn([status]));
-  }
-
-  const searchTerm = normalizeSearch(search);
-  if (searchTerm) {
-    const searchCondition = buildSearchCondition(searchTerm);
-    if (searchCondition) {
-      conditions.push(searchCondition);
-    }
-  }
-  if (diasporaOrigin === 'diaspora') {
-    conditions.push(inArray(claims.id, buildDiasporaOriginClaimIdsSubquery(tenantId)));
-  }
+  const conditions = buildStaffClaimsListConditions({
+    assignment,
+    branchId,
+    diasporaOrigin,
+    search,
+    staffId,
+    status,
+    tenantId,
+    viewerRole,
+  });
   const scopedWhere = withTenant(tenantId, claims.tenantId, and(...conditions));
   const assignee = aliasedTable(user, 'assignee');
 
-  // db-access-guard: tenant-scoped -- reason: tenant predicate built by scopedWhere and consumed by this DB call
-  const rows = await db
-    .select({
-      id: claims.id,
-      claimNumber: claims.claimNumber,
-      companyName: claims.companyName,
-      title: claims.title,
-      status: claims.status,
-      caseLifecycleState: claims.caseLifecycleState,
-      recoveryLifecycleState: claims.recoveryLifecycleState,
-      staffId: claims.staffId,
-      assigneeName: assignee.name,
-      assigneeEmail: assignee.email,
-      updatedAt: claims.updatedAt,
-      memberName: user.name,
-      memberNumber: user.memberNumber,
-    })
-    .from(claims)
-    .leftJoin(user, eq(claims.userId, user.id))
-    .leftJoin(assignee, eq(claims.staffId, assignee.id))
-    .where(scopedWhere)
-    .orderBy(desc(claims.updatedAt), desc(claims.id))
-    .limit(limit);
+  const { rows, historyRows } = await withTenantContext(
+    { tenantId, role: viewerRole },
+    async tx => {
+      // db-access-guard: tenant-scoped -- reason: scopedWhere is consumed under RLS context
+      const rows = await tx
+        .select({
+          id: claims.id,
+          claimNumber: claims.claimNumber,
+          companyName: claims.companyName,
+          title: claims.title,
+          status: claims.status,
+          caseLifecycleState: claims.caseLifecycleState,
+          recoveryLifecycleState: claims.recoveryLifecycleState,
+          staffId: claims.staffId,
+          assigneeName: assignee.name,
+          assigneeEmail: assignee.email,
+          updatedAt: claims.updatedAt,
+          memberName: user.name,
+          memberNumber: user.memberNumber,
+        })
+        .from(claims)
+        .leftJoin(user, eq(claims.userId, user.id))
+        .leftJoin(assignee, eq(claims.staffId, assignee.id))
+        .where(scopedWhere)
+        .orderBy(desc(claims.updatedAt), desc(claims.id))
+        .limit(limit);
 
-  const claimIds = rows.map(row => row.id);
-  const diasporaOriginsByClaimId = new Map<
-    string,
-    NonNullable<ReturnType<typeof parseDiasporaOriginFromPublicNote>>
-  >();
+      const claimIds = rows.map(row => row.id);
+      if (claimIds.length === 0) return { rows, historyRows: [] };
 
-  if (claimIds.length > 0) {
-    const historyRows = await db
-      .select({
-        claimId: claimStageHistory.claimId,
-        note: claimStageHistory.note,
-      })
-      .from(claimStageHistory)
-      .where(
-        withTenant(
-          tenantId,
-          claimStageHistory.tenantId,
-          inArray(claimStageHistory.claimId, claimIds)
+      const historyRows = await tx
+        .select({
+          claimId: claimStageHistory.claimId,
+          note: claimStageHistory.note,
+        })
+        .from(claimStageHistory)
+        .where(
+          withTenant(
+            tenantId,
+            claimStageHistory.tenantId,
+            inArray(claimStageHistory.claimId, claimIds)
+          )
         )
-      )
-      .orderBy(desc(claimStageHistory.createdAt), desc(claimStageHistory.id));
+        .orderBy(desc(claimStageHistory.createdAt), desc(claimStageHistory.id));
 
-    for (const historyRow of historyRows) {
-      if (diasporaOriginsByClaimId.has(historyRow.claimId)) {
-        continue;
-      }
-
-      const diasporaOrigin = parseDiasporaOriginFromPublicNote(historyRow.note);
-      if (diasporaOrigin !== null) {
-        diasporaOriginsByClaimId.set(historyRow.claimId, diasporaOrigin);
-      }
+      return { rows, historyRows };
     }
-  }
+  );
 
-  return rows.map(row => {
-    const diasporaOriginData = diasporaOriginsByClaimId.get(row.id) ?? null;
-    const { status } = resolveClaimLifecycleReadProjection(row);
-    return {
-      id: row.id,
-      claimNumber: row.claimNumber,
-      companyName: row.companyName,
-      title: row.title,
-      status,
-      staffId: row.staffId ?? null,
-      assigneeName: row.assigneeName ?? null,
-      assigneeEmail: row.assigneeEmail ?? null,
-      stageLabel: formatStageLabel(status),
-      updatedAt: normalizeDate(row.updatedAt),
-      memberName: row.memberName ?? undefined,
-      memberNumber: row.memberNumber ?? null,
-      isDiasporaOrigin: diasporaOriginData !== null,
-      diasporaCountry: diasporaOriginData?.country ?? null,
-    };
-  });
+  return mapStaffClaimsListRows(rows, historyRows);
 }

--- a/packages/domain-claims/src/staff-claims/staff-claims-list-filters.ts
+++ b/packages/domain-claims/src/staff-claims/staff-claims-list-filters.ts
@@ -1,0 +1,78 @@
+import { claims, eq, ilike, inArray, user } from '@interdomestik/database';
+import { isNull, or, type SQL } from 'drizzle-orm';
+import { ACTIONABLE_CLAIM_STATUSES } from '../claims/constants';
+import {
+  buildDiasporaOriginClaimIdsSubquery,
+  type DiasporaOriginFilter,
+} from '../claims/diaspora-origin-filter';
+import { claimLifecycleStatusIn } from '../claims/lifecycle-read-sql';
+
+export type StaffClaimsAssignmentFilter = 'all' | 'mine' | 'unassigned';
+
+function normalizeSearch(value: string | null | undefined) {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function isActionableStatus(
+  value: string | null | undefined
+): value is (typeof ACTIONABLE_CLAIM_STATUSES)[number] {
+  return !!value && (ACTIONABLE_CLAIM_STATUSES as readonly string[]).includes(value);
+}
+
+function buildSearchCondition(term: string) {
+  const pattern = `%${term}%`;
+  return or(
+    ilike(claims.title, pattern),
+    ilike(claims.companyName, pattern),
+    ilike(claims.claimNumber, pattern),
+    ilike(user.name, pattern),
+    ilike(user.memberNumber, pattern)
+  );
+}
+
+export function buildStaffClaimsListConditions(params: {
+  assignment: StaffClaimsAssignmentFilter;
+  branchId?: string | null;
+  diasporaOrigin: DiasporaOriginFilter;
+  search?: string;
+  staffId: string;
+  status?: string;
+  tenantId: string;
+  viewerRole?: string | null;
+}): SQL<unknown>[] {
+  const conditions: SQL<unknown>[] = [claimLifecycleStatusIn(ACTIONABLE_CLAIM_STATUSES)];
+
+  if (params.branchId != null) {
+    conditions.push(eq(claims.branchId, params.branchId));
+  }
+
+  const shouldUseFallback =
+    params.viewerRole !== 'branch_manager' ||
+    (params.viewerRole === 'branch_manager' && params.branchId == null);
+
+  if (params.assignment === 'mine') {
+    conditions.push(eq(claims.staffId, params.staffId));
+  } else if (params.assignment === 'unassigned') {
+    conditions.push(isNull(claims.staffId));
+  } else if (shouldUseFallback) {
+    const ownOrUnassigned = or(eq(claims.staffId, params.staffId), isNull(claims.staffId));
+    if (ownOrUnassigned) conditions.push(ownOrUnassigned);
+  }
+
+  if (isActionableStatus(params.status)) {
+    conditions.push(claimLifecycleStatusIn([params.status]));
+  }
+
+  const searchTerm = normalizeSearch(params.search);
+  if (searchTerm) {
+    const searchCondition = buildSearchCondition(searchTerm);
+    if (searchCondition) conditions.push(searchCondition);
+  }
+
+  if (params.diasporaOrigin === 'diaspora') {
+    conditions.push(inArray(claims.id, buildDiasporaOriginClaimIdsSubquery(params.tenantId)));
+  }
+
+  return conditions;
+}

--- a/packages/domain-claims/src/staff-claims/staff-claims-list-mapper.ts
+++ b/packages/domain-claims/src/staff-claims/staff-claims-list-mapper.ts
@@ -1,0 +1,90 @@
+import { parseDiasporaOriginFromPublicNote } from '../claims/diaspora-origin';
+import { resolveClaimLifecycleReadProjection } from '../claims/lifecycle-read-model';
+
+export type StaffClaimsListItem = {
+  id: string;
+  claimNumber: string | null;
+  companyName: string | null;
+  title: string | null;
+  status: string | null;
+  staffId: string | null;
+  assigneeName?: string | null;
+  assigneeEmail?: string | null;
+  stageLabel: string;
+  updatedAt: string | null;
+  memberName?: string;
+  memberNumber?: string | null;
+  isDiasporaOrigin: boolean;
+  diasporaCountry: string | null;
+};
+
+type ClaimRow = {
+  id: string;
+  claimNumber: string | null;
+  companyName: string | null;
+  title: string | null;
+  status: string | null;
+  caseLifecycleState: string | null;
+  recoveryLifecycleState: string | null;
+  staffId: string | null;
+  assigneeName: string | null;
+  assigneeEmail: string | null;
+  updatedAt: Date | string | null;
+  memberName: string | null;
+  memberNumber: string | null;
+};
+type HistoryRow = { claimId: string; note: string | null };
+
+function formatStageLabel(status: string | null | undefined) {
+  if (!status) return 'Draft';
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function normalizeDate(value: Date | string | null | undefined) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function mapDiasporaOrigins(historyRows: HistoryRow[]) {
+  const byClaimId = new Map<
+    string,
+    NonNullable<ReturnType<typeof parseDiasporaOriginFromPublicNote>>
+  >();
+
+  for (const historyRow of historyRows) {
+    if (byClaimId.has(historyRow.claimId)) continue;
+    const diasporaOrigin = parseDiasporaOriginFromPublicNote(historyRow.note);
+    if (diasporaOrigin !== null) byClaimId.set(historyRow.claimId, diasporaOrigin);
+  }
+
+  return byClaimId;
+}
+
+export function mapStaffClaimsListRows(
+  rows: ClaimRow[],
+  historyRows: HistoryRow[]
+): StaffClaimsListItem[] {
+  const diasporaOriginsByClaimId = mapDiasporaOrigins(historyRows);
+
+  return rows.map(row => {
+    const diasporaOriginData = diasporaOriginsByClaimId.get(row.id) ?? null;
+    const { status } = resolveClaimLifecycleReadProjection(row);
+    return {
+      id: row.id,
+      claimNumber: (row.claimNumber as string | null) ?? null,
+      companyName: (row.companyName as string | null) ?? null,
+      title: (row.title as string | null) ?? null,
+      status,
+      staffId: (row.staffId as string | null) ?? null,
+      assigneeName: (row.assigneeName as string | null) ?? null,
+      assigneeEmail: (row.assigneeEmail as string | null) ?? null,
+      stageLabel: formatStageLabel(status),
+      updatedAt: normalizeDate(row.updatedAt as Date | string | null | undefined),
+      memberName: (row.memberName as string | undefined) ?? undefined,
+      memberNumber: (row.memberNumber as string | null) ?? null,
+      isDiasporaOrigin: diasporaOriginData !== null,
+      diasporaCountry: diasporaOriginData?.country ?? null,
+    };
+  });
+}

--- a/packages/domain-claims/src/support-handoffs/create-input.ts
+++ b/packages/domain-claims/src/support-handoffs/create-input.ts
@@ -2,6 +2,7 @@ import {
   SUPPORT_HANDOFF_SOURCES,
   type CreateSupportHandoffInput,
   type SupportHandoffContactPreference,
+  type SupportHandoffSource,
 } from './types';
 
 const MAX_SUBJECT_LENGTH = 120;
@@ -45,8 +46,10 @@ function hasForbiddenOwnershipFields(input: Record<string, unknown>) {
   );
 }
 
-function normalizeSource(value: unknown) {
-  return typeof value === 'string' && SUPPORT_HANDOFF_SOURCE_VALUES.has(value) ? value : null;
+function normalizeSource(value: unknown): SupportHandoffSource | null {
+  return typeof value === 'string' && SUPPORT_HANDOFF_SOURCE_VALUES.has(value)
+    ? (value as SupportHandoffSource)
+    : null;
 }
 
 export function parseMemberSupportHandoffInput(

--- a/packages/domain-claims/src/support-handoffs/create-input.ts
+++ b/packages/domain-claims/src/support-handoffs/create-input.ts
@@ -1,0 +1,79 @@
+import {
+  SUPPORT_HANDOFF_SOURCES,
+  type CreateSupportHandoffInput,
+  type SupportHandoffContactPreference,
+} from './types';
+
+const MAX_SUBJECT_LENGTH = 120;
+const MAX_MESSAGE_LENGTH = 2_000;
+const CONTACT_PREFERENCES = new Set<SupportHandoffContactPreference>([
+  'staff_reply',
+  'phone',
+  'email',
+  'whatsapp',
+]);
+const FORBIDDEN_OWNERSHIP_FIELDS = [
+  'tenantId',
+  'memberId',
+  'branchId',
+  'staffId',
+  'actorId',
+  'status',
+  'urgency',
+  'trustRisk',
+] as const;
+const SUPPORT_HANDOFF_SOURCE_VALUES = new Set<string>(SUPPORT_HANDOFF_SOURCES);
+
+function normalizeText(value: string | null | undefined, maxLength: number) {
+  return value?.trim().replace(/\s+/g, ' ').slice(0, maxLength) ?? '';
+}
+
+function normalizeMessage(value: string | null | undefined) {
+  return value?.trim().slice(0, MAX_MESSAGE_LENGTH) ?? '';
+}
+
+function normalizeContactPreference(value: unknown): SupportHandoffContactPreference {
+  return typeof value === 'string' &&
+    CONTACT_PREFERENCES.has(value as SupportHandoffContactPreference)
+    ? (value as SupportHandoffContactPreference)
+    : 'staff_reply';
+}
+
+function hasForbiddenOwnershipFields(input: Record<string, unknown>) {
+  return FORBIDDEN_OWNERSHIP_FIELDS.some(field =>
+    Object.prototype.hasOwnProperty.call(input, field)
+  );
+}
+
+function normalizeSource(value: unknown) {
+  return typeof value === 'string' && SUPPORT_HANDOFF_SOURCE_VALUES.has(value) ? value : null;
+}
+
+export function parseMemberSupportHandoffInput(
+  input: CreateSupportHandoffInput & Record<string, unknown>
+) {
+  if (hasForbiddenOwnershipFields(input)) {
+    return { success: false as const, error: 'Ownership fields are server-derived' };
+  }
+
+  const subject = normalizeText(input.subject, MAX_SUBJECT_LENGTH);
+  if (!subject) return { success: false as const, error: 'Subject is required' };
+
+  const message = normalizeMessage(input.message);
+  if (message.length < 10) {
+    return { success: false as const, error: 'Message must include enough detail' };
+  }
+
+  return {
+    success: true as const,
+    contactPreference: normalizeContactPreference(input.contactPreference),
+    message,
+    requestedClaimId: normalizeText(input.claimId ?? undefined, 160) || null,
+    sourceClaimId: normalizeText(
+      typeof input.sourceClaimId === 'string' ? input.sourceClaimId : undefined,
+      160
+    ),
+    sourceHint: normalizeSource(input.source),
+    subject,
+  };
+}

--- a/packages/domain-claims/src/support-handoffs/create-store-queries.ts
+++ b/packages/domain-claims/src/support-handoffs/create-store-queries.ts
@@ -1,0 +1,61 @@
+import { claims, desc, eq, subscriptions, type TenantTransaction } from '@interdomestik/database';
+import type { ClaimStatus } from '@interdomestik/database/constants';
+import { withTenant } from '@interdomestik/database/tenant-security';
+import { and } from 'drizzle-orm';
+
+export type ClaimContext = {
+  id: string;
+  branchId: string | null;
+  staffId: string | null;
+  status: ClaimStatus | null;
+  createdAt: Date | string | null;
+  updatedAt: Date | string | null;
+  statusUpdatedAt: Date | string | null;
+};
+
+type SupportHandoffDb = Pick<TenantTransaction, 'select'>;
+
+export async function getMemberSubscriptionBranch(
+  database: SupportHandoffDb,
+  args: { memberId: string; tenantId: string }
+) {
+  const [subscription] = await database
+    .select({ branchId: subscriptions.branchId })
+    .from(subscriptions)
+    .where(
+      withTenant(args.tenantId, subscriptions.tenantId, eq(subscriptions.userId, args.memberId))
+    )
+    .orderBy(desc(subscriptions.createdAt))
+    .limit(1);
+
+  return subscription?.branchId ?? null;
+}
+
+export async function getOwnedClaimContext(args: {
+  database: SupportHandoffDb;
+  claimId: string;
+  memberId: string;
+  tenantId: string;
+}): Promise<ClaimContext | null> {
+  const [claim] = await args.database
+    .select({
+      id: claims.id,
+      branchId: claims.branchId,
+      staffId: claims.staffId,
+      status: claims.status,
+      createdAt: claims.createdAt,
+      updatedAt: claims.updatedAt,
+      statusUpdatedAt: claims.statusUpdatedAt,
+    })
+    .from(claims)
+    .where(
+      withTenant(
+        args.tenantId,
+        claims.tenantId,
+        and(eq(claims.id, args.claimId), eq(claims.userId, args.memberId))
+      )
+    )
+    .limit(1);
+
+  return claim ?? null;
+}

--- a/packages/domain-claims/src/support-handoffs/create-store.ts
+++ b/packages/domain-claims/src/support-handoffs/create-store.ts
@@ -1,0 +1,93 @@
+import { supportHandoffs, withTenantContext } from '@interdomestik/database';
+
+import { deriveSupportHandoffSignals } from './derivation';
+import {
+  type ClaimContext,
+  getMemberSubscriptionBranch,
+  getOwnedClaimContext,
+} from './create-store-queries';
+import type { SupportHandoffContactPreference, SupportHandoffSource } from './types';
+
+function deriveSource(args: {
+  claimContext: ClaimContext | null;
+  sourceClaimId: string;
+  sourceHint: string | null;
+}): SupportHandoffSource {
+  if (args.sourceHint === 'member_claim_detail' && args.sourceClaimId === args.claimContext?.id) {
+    return 'member_claim_detail';
+  }
+
+  return 'member_help';
+}
+
+export async function persistMemberSupportHandoff(params: {
+  contactPreference: SupportHandoffContactPreference;
+  handoffId: string;
+  memberBranchId?: string | null;
+  memberId: string;
+  memberRole: string;
+  message: string;
+  now: Date;
+  requestedClaimId: string | null;
+  sourceClaimId: string;
+  sourceHint: string | null;
+  subject: string;
+  tenantId: string;
+}) {
+  return withTenantContext({ tenantId: params.tenantId, role: params.memberRole }, async tx => {
+    const claimContext = params.requestedClaimId
+      ? await getOwnedClaimContext({
+          database: tx,
+          claimId: params.requestedClaimId,
+          memberId: params.memberId,
+          tenantId: params.tenantId,
+        })
+      : null;
+
+    if (params.requestedClaimId && claimContext == null) {
+      return { success: false as const, error: 'Claim not found or access denied' };
+    }
+
+    const branchId =
+      claimContext?.branchId ??
+      params.memberBranchId ??
+      (await getMemberSubscriptionBranch(tx, {
+        memberId: params.memberId,
+        tenantId: params.tenantId,
+      }));
+    if (!branchId)
+      return { success: false as const, error: 'Branch is required for support routing' };
+
+    const signals = deriveSupportHandoffSignals({ claim: claimContext });
+    const source = deriveSource({
+      claimContext,
+      sourceClaimId: params.sourceClaimId,
+      sourceHint: params.sourceHint,
+    });
+
+    // db-access-guard: tenant-scoped -- reason: tenantId from validated member session before support handoff insert
+    await tx.insert(supportHandoffs).values({
+      id: params.handoffId,
+      tenantId: params.tenantId,
+      memberId: params.memberId,
+      branchId,
+      claimId: claimContext?.id ?? null,
+      source,
+      subject: params.subject,
+      message: params.message,
+      contactPreference: params.contactPreference,
+      status: 'open',
+      urgency: signals.urgency,
+      trustRisk: signals.trustRisk,
+      createdAt: params.now,
+      updatedAt: params.now,
+    });
+
+    return {
+      success: true as const,
+      claimId: claimContext?.id ?? null,
+      signals,
+      source,
+    };
+  });
+}

--- a/packages/domain-claims/src/support-handoffs/create.test.ts
+++ b/packages/domain-claims/src/support-handoffs/create.test.ts
@@ -48,12 +48,11 @@ const mocks = vi.hoisted(() => {
     },
     supportHandoffs: 'support_handoffs',
     withTenant: vi.fn((_tenantId, _column, condition) => ({ condition, scoped: true })),
+    withTenantContext: vi.fn((_context, action) => action(mocks.db)),
   };
 });
 
-vi.mock('node:crypto', () => ({
-  randomUUID: mocks.randomUUID,
-}));
+vi.mock('node:crypto', () => ({ randomUUID: mocks.randomUUID }));
 
 vi.mock('@interdomestik/database', () => ({
   claims: mocks.claims,
@@ -62,6 +61,7 @@ vi.mock('@interdomestik/database', () => ({
   eq: mocks.eq,
   subscriptions: mocks.subscriptions,
   supportHandoffs: mocks.supportHandoffs,
+  withTenantContext: mocks.withTenantContext,
 }));
 
 vi.mock('@interdomestik/database/tenant-security', () => ({

--- a/packages/domain-claims/src/support-handoffs/create.ts
+++ b/packages/domain-claims/src/support-handoffs/create.ts
@@ -1,138 +1,15 @@
 import { randomUUID } from 'node:crypto';
 
-import { claims, db, desc, eq, subscriptions, supportHandoffs } from '@interdomestik/database';
-import type { ClaimStatus } from '@interdomestik/database/constants';
-import { withTenant } from '@interdomestik/database/tenant-security';
 import { ensureTenantId } from '@interdomestik/shared-auth';
-import { and } from 'drizzle-orm';
 
-import { deriveSupportHandoffSignals } from './derivation';
+import { parseMemberSupportHandoffInput } from './create-input';
+import { persistMemberSupportHandoff } from './create-store';
 import {
-  SUPPORT_HANDOFF_SOURCES,
   type CreateSupportHandoffInput,
   type SupportHandoffActionResult,
-  type SupportHandoffContactPreference,
   type SupportHandoffDeps,
   type SupportHandoffSession,
-  type SupportHandoffSource,
 } from './types';
-
-const MAX_SUBJECT_LENGTH = 120;
-const MAX_MESSAGE_LENGTH = 2_000;
-const CONTACT_PREFERENCES = new Set<SupportHandoffContactPreference>([
-  'staff_reply',
-  'phone',
-  'email',
-  'whatsapp',
-]);
-const SUPPORT_HANDOFF_SOURCE_VALUES = new Set<SupportHandoffSource>(SUPPORT_HANDOFF_SOURCES);
-const FORBIDDEN_OWNERSHIP_FIELDS = [
-  'tenantId',
-  'memberId',
-  'branchId',
-  'staffId',
-  'actorId',
-  'status',
-  'urgency',
-  'trustRisk',
-] as const;
-
-type ClaimContext = {
-  id: string;
-  branchId: string | null;
-  staffId: string | null;
-  status: ClaimStatus | null;
-  createdAt: Date | string | null;
-  updatedAt: Date | string | null;
-  statusUpdatedAt: Date | string | null;
-};
-
-function normalizeText(value: string | null | undefined, maxLength: number) {
-  return value?.trim().replace(/\s+/g, ' ').slice(0, maxLength) ?? '';
-}
-
-function normalizeMessage(value: string | null | undefined) {
-  return value?.trim().slice(0, MAX_MESSAGE_LENGTH) ?? '';
-}
-
-function normalizeContactPreference(value: unknown): SupportHandoffContactPreference {
-  return typeof value === 'string' &&
-    CONTACT_PREFERENCES.has(value as SupportHandoffContactPreference)
-    ? (value as SupportHandoffContactPreference)
-    : 'staff_reply';
-}
-
-function normalizeSourceHint(value: unknown): SupportHandoffSource | null {
-  return typeof value === 'string' &&
-    SUPPORT_HANDOFF_SOURCE_VALUES.has(value as SupportHandoffSource)
-    ? (value as SupportHandoffSource)
-    : null;
-}
-
-function deriveSource(args: {
-  claimContext: ClaimContext | null;
-  sourceClaimId: unknown;
-  sourceHint: unknown;
-}): SupportHandoffSource {
-  const sourceHint = normalizeSourceHint(args.sourceHint);
-  const sourceClaimId = normalizeText(
-    typeof args.sourceClaimId === 'string' ? args.sourceClaimId : undefined,
-    160
-  );
-
-  if (sourceHint === 'member_claim_detail' && sourceClaimId === args.claimContext?.id) {
-    return 'member_claim_detail';
-  }
-
-  return 'member_help';
-}
-
-function hasForbiddenOwnershipFields(input: Record<string, unknown>) {
-  return FORBIDDEN_OWNERSHIP_FIELDS.some(field =>
-    Object.prototype.hasOwnProperty.call(input, field)
-  );
-}
-
-async function getMemberSubscriptionBranch(args: { memberId: string; tenantId: string }) {
-  const [subscription] = await db
-    .select({ branchId: subscriptions.branchId })
-    .from(subscriptions)
-    .where(
-      withTenant(args.tenantId, subscriptions.tenantId, eq(subscriptions.userId, args.memberId))
-    )
-    .orderBy(desc(subscriptions.createdAt))
-    .limit(1);
-
-  return subscription?.branchId ?? null;
-}
-
-async function getOwnedClaimContext(args: {
-  claimId: string;
-  memberId: string;
-  tenantId: string;
-}): Promise<ClaimContext | null> {
-  const [claim] = await db
-    .select({
-      id: claims.id,
-      branchId: claims.branchId,
-      staffId: claims.staffId,
-      status: claims.status,
-      createdAt: claims.createdAt,
-      updatedAt: claims.updatedAt,
-      statusUpdatedAt: claims.statusUpdatedAt,
-    })
-    .from(claims)
-    .where(
-      withTenant(
-        args.tenantId,
-        claims.tenantId,
-        and(eq(claims.id, args.claimId), eq(claims.userId, args.memberId))
-      )
-    )
-    .limit(1);
-
-  return claim ?? null;
-}
 
 export async function createMemberSupportHandoffCore(
   params: {
@@ -146,10 +23,6 @@ export async function createMemberSupportHandoffCore(
     return { success: false, error: 'Unauthorized' };
   }
 
-  if (hasForbiddenOwnershipFields(params.input)) {
-    return { success: false, error: 'Ownership fields are server-derived' };
-  }
-
   let tenantId: string;
   try {
     tenantId = ensureTenantId(params.session);
@@ -157,60 +30,29 @@ export async function createMemberSupportHandoffCore(
     return { success: false, error: 'Unauthorized' };
   }
   const memberId = params.session.user.id;
-  const subject = normalizeText(params.input.subject, MAX_SUBJECT_LENGTH);
-  const message = normalizeMessage(params.input.message);
-  const contactPreference = normalizeContactPreference(params.input.contactPreference);
-  const requestedClaimId = normalizeText(params.input.claimId ?? undefined, 160) || null;
+  const parsed = parseMemberSupportHandoffInput(params.input);
+  if (!parsed.success) return parsed;
 
-  if (!subject) {
-    return { success: false, error: 'Subject is required' };
-  }
-
-  if (message.length < 10) {
-    return { success: false, error: 'Message must include enough detail' };
-  }
-
-  const claimContext = requestedClaimId
-    ? await getOwnedClaimContext({ claimId: requestedClaimId, memberId, tenantId })
-    : null;
-
-  if (requestedClaimId && claimContext == null) {
-    return { success: false, error: 'Claim not found or access denied' };
-  }
-
-  const branchId =
-    claimContext?.branchId ??
-    params.session.user.branchId ??
-    (await getMemberSubscriptionBranch({ memberId, tenantId }));
-  if (!branchId) {
-    return { success: false, error: 'Branch is required for support routing' };
-  }
-  const signals = deriveSupportHandoffSignals({ claim: claimContext });
-  const source = deriveSource({
-    claimContext,
-    sourceClaimId: params.input.sourceClaimId,
-    sourceHint: params.input.source,
-  });
   const handoffId = `support_handoff_${randomUUID()}`;
   const now = new Date();
-
-  // db-access-guard: tenant-scoped -- reason: tenantId from validated member session before support handoff insert
-  await db.insert(supportHandoffs).values({
-    id: handoffId,
-    tenantId,
+  const persisted = await persistMemberSupportHandoff({
+    contactPreference: parsed.contactPreference,
+    handoffId,
+    memberBranchId: params.session.user.branchId,
     memberId,
-    branchId,
-    claimId: claimContext?.id ?? null,
-    source,
-    subject,
-    message,
-    contactPreference,
-    status: 'open',
-    urgency: signals.urgency,
-    trustRisk: signals.trustRisk,
-    createdAt: now,
-    updatedAt: now,
+    memberRole: params.session.user.role,
+    message: parsed.message,
+    now,
+    requestedClaimId: parsed.requestedClaimId,
+    sourceClaimId: parsed.sourceClaimId,
+    sourceHint: parsed.sourceHint,
+    subject: parsed.subject,
+    tenantId,
   });
+
+  if (!persisted.success) {
+    return { success: false, error: persisted.error };
+  }
 
   if (deps.logAuditEvent) {
     await deps.logAuditEvent({
@@ -221,10 +63,10 @@ export async function createMemberSupportHandoffCore(
       entityType: 'support_handoff',
       entityId: handoffId,
       metadata: {
-        claimId: claimContext?.id ?? null,
-        source,
-        urgency: signals.urgency,
-        trustRisk: signals.trustRisk,
+        claimId: persisted.claimId,
+        source: persisted.source,
+        urgency: persisted.signals.urgency,
+        trustRisk: persisted.signals.trustRisk,
       },
       headers: params.requestHeaders,
     });


### PR DESCRIPTION
## Summary
- Run admin user detail and staff-claims reads inside tenant context so staging RLS posture matches the deployed app contract.
- Run member support-handoff creation inside tenant context and prevent pre-hydration submit races in the member help form.
- Keep the golden gate readiness assertion tolerant of transient duplicate markers while preserving the contractual `*-page-ready` markers.
- Split touched domain helpers to stay within modularity constraints and keep `apps/web/src/proxy.ts` untouched.

## Verification
- `pnpm pr:verify` passed
- `pnpm security:guard` passed
- `pnpm e2e:gate` passed: 134 passed, 8 skipped
- Focused E2E passed for Super Admin readiness and KS/MK support-handoff flows
- `git diff --check` passed

## Release Notes
- No production deployment was triggered.
- No destructive migration was run.
- Untracked audit prompt docs were left untouched.
- After this PR is green and merged, delete this local and remote branch per Interdomestik branch hygiene.
