### PR TITLE
fix: harden admin release gate readiness

### DIFF
--- a/apps/web/src/app/[locale]/admin/_core.entry.test.tsx
+++ b/apps/web/src/app/[locale]/admin/_core.entry.test.tsx
@@ -98,4 +98,13 @@ describe('AdminLayout i18n initialization', () => {
 
     expect(renderToStaticMarkup(view)).toContain('Localized Admin Shell');
   });
+
+  it('renders the admin readiness marker at the layout boundary', async () => {
+    const view = await AdminLayout({
+      children: null,
+      params: Promise.resolve({ locale: 'en' }),
+    });
+
+    expect(renderToStaticMarkup(view)).toContain('data-testid="admin-page-ready"');
+  });
 });

--- a/apps/web/src/app/[locale]/admin/_core.entry.tsx
+++ b/apps/web/src/app/[locale]/admin/_core.entry.tsx
@@ -67,51 +67,53 @@ export default async function AdminLayout({
   }
 
   return (
-    <AuthenticatedShell locale={locale} messages={messages} enableNavigationFeedback={false}>
-      <NavigationFeedback>
-        <SidebarProvider defaultOpen={true}>
-          <AdminSidebar
-            user={{
-              branchId: sessionNonNull.user.branchId,
-              name: sessionNonNull.user.name || 'Admin',
-              email: sessionNonNull.user.email,
-              role: sessionNonNull.user.role,
-            }}
-          />
-          <SidebarInset className="bg-mesh flex flex-col min-h-screen">
-            <header className="flex h-16 shrink-0 items-center gap-2 border-b bg-background/80 backdrop-blur-md sticky top-0 z-30 px-6 transition-all">
-              <div className="flex items-center gap-2">
-                <SidebarTrigger
-                  className="-ml-1"
-                  title={tNav('toggleSidebar')}
-                  aria-label={tNav('toggleSidebar')}
-                />
-                <Separator orientation="vertical" className="mr-2 h-4" />
-              </div>
-              <div className="flex-1 flex items-center justify-between">
-                <h1 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-                  {tSidebar('title')}
-                </h1>
-                <div className="flex items-center gap-3">
-                  <PortalSurfaceIndicator role={role} />
-                  {isSuperAdmin ? (
-                    <div className="flex items-center gap-2">
-                      <AdminTenantSelector
-                        tenants={tenantOptions}
-                        defaultTenantId={sessionNonNull.user.tenantId}
-                      />
-                    </div>
-                  ) : null}
+    <div data-testid="admin-page-ready">
+      <AuthenticatedShell locale={locale} messages={messages} enableNavigationFeedback={false}>
+        <NavigationFeedback>
+          <SidebarProvider defaultOpen={true}>
+            <AdminSidebar
+              user={{
+                branchId: sessionNonNull.user.branchId,
+                name: sessionNonNull.user.name || 'Admin',
+                email: sessionNonNull.user.email,
+                role: sessionNonNull.user.role,
+              }}
+            />
+            <SidebarInset className="bg-mesh flex flex-col min-h-screen">
+              <header className="flex h-16 shrink-0 items-center gap-2 border-b bg-background/80 backdrop-blur-md sticky top-0 z-30 px-6 transition-all">
+                <div className="flex items-center gap-2">
+                  <SidebarTrigger
+                    className="-ml-1"
+                    title={tNav('toggleSidebar')}
+                    aria-label={tNav('toggleSidebar')}
+                  />
+                  <Separator orientation="vertical" className="mr-2 h-4" />
                 </div>
+                <div className="flex-1 flex items-center justify-between">
+                  <h1 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                    {tSidebar('title')}
+                  </h1>
+                  <div className="flex items-center gap-3">
+                    <PortalSurfaceIndicator role={role} />
+                    {isSuperAdmin ? (
+                      <div className="flex items-center gap-2">
+                        <AdminTenantSelector
+                          tenants={tenantOptions}
+                          defaultTenantId={sessionNonNull.user.tenantId}
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              </header>
+              {/* SidebarInset renders as <main>, so use <div> here to avoid nested landmarks */}
+              <div className="flex-1 overflow-y-auto p-6 md:p-8">
+                <div className="container mx-auto">{children}</div>
               </div>
-            </header>
-            {/* SidebarInset renders as <main>, so use <div> here to avoid nested landmarks */}
-            <div className="flex-1 overflow-y-auto p-6 md:p-8">
-              <div className="container mx-auto">{children}</div>
-            </div>
-          </SidebarInset>
-        </SidebarProvider>
-      </NavigationFeedback>
-    </AuthenticatedShell>
+            </SidebarInset>
+          </SidebarProvider>
+        </NavigationFeedback>
+      </AuthenticatedShell>
+    </div>
   );
 }

--- a/apps/web/src/app/[locale]/admin/overview/page.tsx
+++ b/apps/web/src/app/[locale]/admin/overview/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminOverviewPage({
   });
 
   return (
-    <div data-testid="admin-page-ready" className="space-y-6">
+    <div className="space-y-6">
       <header className="space-y-1">
         <h1 className="text-2xl font-semibold">{t('title')}</h1>
         <p className="text-sm text-muted-foreground">{t('description')}</p>

--- a/scripts/raw-role-array-allowlist.json
+++ b/scripts/raw-role-array-allowlist.json
@@ -48,9 +48,9 @@
     "packages/domain-users/src/admin/get-staff.ts:15:67:staff,admin",
     "packages/domain-users/src/admin/role-rules.ts:1:38:agent,branch_manager",
     "scripts/release-gate/config.ts:33:16:member,agent,staff,admin",
-    "scripts/release-gate/shared.ts:547:54:agent,staff,admin",
-    "scripts/release-gate/shared.ts:550:53:staff,admin",
-    "scripts/release-gate/shared.ts:553:53:agent,admin",
-    "scripts/release-gate/shared.ts:555:51:agent,staff"
+    "scripts/release-gate/shared.ts:545:54:agent,staff,admin",
+    "scripts/release-gate/shared.ts:548:53:staff,admin",
+    "scripts/release-gate/shared.ts:551:53:agent,admin",
+    "scripts/release-gate/shared.ts:553:51:agent,staff"
   ]
 }

--- a/scripts/release-gate/admin-checks-locators.test.ts
+++ b/scripts/release-gate/admin-checks-locators.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const { waitForPortalMarkerState } = require('./admin-checks-locators.ts');
+
+class FakeLocator {
+  page: FakePage;
+  selector: string;
+
+  constructor(page: FakePage, selector: string) {
+    this.page = page;
+    this.selector = selector;
+  }
+
+  async isVisible() {
+    const match = this.selector.match(/\[data-testid="([^"]+)"\]/);
+    return Boolean(match && this.page.visibleTestIds.has(match[1]));
+  }
+
+  async count() {
+    if (this.selector.includes('admin-page-ready')) {
+      this.page.adminMarkerReads += 1;
+      return this.page.adminMarkerReads > 1 ? 1 : 0;
+    }
+    return (await this.isVisible()) ? 1 : 0;
+  }
+}
+
+class FakeTestIdLocator {
+  page: FakePage;
+  testId: string;
+
+  constructor(page: FakePage, testId: string) {
+    this.page = page;
+    this.testId = testId;
+  }
+
+  async isVisible() {
+    return this.page.visibleTestIds.has(this.testId);
+  }
+}
+
+class FakePage {
+  visibleTestIds: Set<string>;
+  adminMarkerReads: number;
+
+  constructor(visibleTestIds: string[]) {
+    this.visibleTestIds = new Set(visibleTestIds);
+    this.adminMarkerReads = 0;
+  }
+
+  locator(selector: string) {
+    return new FakeLocator(this, selector);
+  }
+
+  getByTestId(testId: string) {
+    return new FakeTestIdLocator(this, testId);
+  }
+}
+
+test('canonical portal marker wait requires the preferred marker snapshot', async () => {
+  const page = new FakePage(['dashboard-page-ready']);
+
+  const snapshot = await waitForPortalMarkerState(page, 'admin');
+
+  assert.equal(snapshot.member, true);
+  assert.equal(snapshot.admin, true);
+  assert.ok(page.adminMarkerReads > 1);
+});

--- a/scripts/release-gate/admin-checks-locators.ts
+++ b/scripts/release-gate/admin-checks-locators.ts
@@ -1,28 +1,31 @@
 const { MARKERS, SELECTORS, TIMEOUTS } = require('./config.ts');
 const { markerSnapshot, resolvePlaywright } = require('./shared.ts');
 
-function markerSelector(markerKey) {
-  return `[data-testid="${MARKERS[markerKey]}"]`;
+function terminalMarkerKeys(preferredMarker) {
+  return preferredMarker
+    ? [preferredMarker, 'notFound']
+    : ['member', 'agent', 'staff', 'admin', 'notFound'];
+}
+
+function hasTerminalMarker(snapshot, preferredMarker) {
+  return terminalMarkerKeys(preferredMarker).some(key => snapshot[key] === true);
 }
 
 async function waitForPortalMarkerState(page, preferredMarker) {
-  if (preferredMarker) {
-    await page
-      .getByTestId(MARKERS[preferredMarker])
-      .waitFor({ state: 'visible', timeout: TIMEOUTS.marker })
-      .catch(() => {});
-    return markerSnapshot(page);
-  }
-
-  const anyPortalSelector = ['member', 'agent', 'staff', 'admin', 'notFound']
-    .map(markerSelector)
-    .join(',');
-  await page
-    .locator(anyPortalSelector)
-    .first()
-    .waitFor({ state: 'visible', timeout: TIMEOUTS.marker })
+  const { expect } = resolvePlaywright();
+  let snapshot = await markerSnapshot(page);
+  if (hasTerminalMarker(snapshot, preferredMarker)) return snapshot;
+  await expect
+    .poll(
+      async () => {
+        snapshot = await markerSnapshot(page);
+        return hasTerminalMarker(snapshot, preferredMarker);
+      },
+      { timeout: TIMEOUTS.marker }
+    )
+    .toBe(true)
     .catch(() => {});
-  return markerSnapshot(page);
+  return snapshot;
 }
 
 async function removeRoleFromTable(page, roleName) {

--- a/scripts/release-gate/admin-checks-locators.ts
+++ b/scripts/release-gate/admin-checks-locators.ts
@@ -1,0 +1,144 @@
+const { MARKERS, SELECTORS, TIMEOUTS } = require('./config.ts');
+const { markerSnapshot, resolvePlaywright } = require('./shared.ts');
+
+function markerSelector(markerKey) {
+  return `[data-testid="${MARKERS[markerKey]}"]`;
+}
+
+async function waitForPortalMarkerState(page, preferredMarker) {
+  if (preferredMarker) {
+    await page
+      .getByTestId(MARKERS[preferredMarker])
+      .waitFor({ state: 'visible', timeout: TIMEOUTS.marker })
+      .catch(() => {});
+    return markerSnapshot(page);
+  }
+
+  const anyPortalSelector = ['member', 'agent', 'staff', 'admin', 'notFound']
+    .map(markerSelector)
+    .join(',');
+  await page
+    .locator(anyPortalSelector)
+    .first()
+    .waitFor({ state: 'visible', timeout: TIMEOUTS.marker })
+    .catch(() => {});
+  return markerSnapshot(page);
+}
+
+async function removeRoleFromTable(page, roleName) {
+  const targetRow = roleRowLocator(page, roleName);
+  try {
+    await targetRow.waitFor({ state: 'visible', timeout: TIMEOUTS.marker });
+    await resolveRoleRowActionButton(targetRow).click({ timeout: TIMEOUTS.action });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveRoleRowActionButton(row) {
+  const byRoleButton = row.getByRole?.('button', { name: SELECTORS.removeRoleButtonName });
+  if (byRoleButton?.first) {
+    return byRoleButton.first();
+  }
+  const genericButton = row.locator('button');
+  return genericButton?.first ? genericButton.first() : genericButton;
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function roleTextPattern(roleName) {
+  return new RegExp(String.raw`\b${escapeRegExp(roleName)}\b`, 'i');
+}
+
+function roleRowLocator(page, roleName) {
+  return page
+    .locator(SELECTORS.userRolesTable)
+    .locator('tr')
+    .filter({ hasText: roleTextPattern(roleName) })
+    .first();
+}
+
+async function addRole(page, roleName) {
+  const { expect } = resolvePlaywright();
+  const trigger = page.locator(SELECTORS.roleSelectTrigger);
+  await trigger.waitFor({ state: 'visible', timeout: TIMEOUTS.action });
+  await trigger.click();
+
+  const roleOption = page.locator(`[data-testid="role-option-${roleName}"]`);
+  const opened = await Promise.race([
+    page
+      .locator(SELECTORS.roleSelectContent)
+      .waitFor({ state: 'visible', timeout: TIMEOUTS.action })
+      .then(() => true)
+      .catch(() => false),
+    roleOption
+      .waitFor({ state: 'visible', timeout: TIMEOUTS.action })
+      .then(() => true)
+      .catch(() => false),
+  ]);
+
+  if (!opened) {
+    await trigger.click().catch(() => {});
+    await roleOption.waitFor({ state: 'visible', timeout: TIMEOUTS.action });
+  }
+
+  await roleOption.click();
+  await expect(trigger).toContainText(roleTextPattern(roleName), { timeout: TIMEOUTS.action });
+  await page.getByRole('button', { name: SELECTORS.grantRoleButtonName }).click();
+}
+
+function compactResponseUrl(rawUrl) {
+  try {
+    const url = new URL(rawUrl);
+    return `${url.pathname}${url.search ? '?…' : ''}`;
+  } catch {
+    return String(rawUrl || '').slice(0, 120);
+  }
+}
+
+function compactResponseBody(raw, maxLength = 180) {
+  return String(raw || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength);
+}
+
+function createMutationResponseCapture(page, baseUrl) {
+  const origin = new URL(baseUrl).origin;
+  const entries = [];
+  const pending = [];
+  const onResponse = response => {
+    const task = (async () => {
+      const request = response.request();
+      const method = request.method();
+      if (method === 'GET' || !response.url().startsWith(origin)) return;
+      const status = response.status();
+      const contentType = String(response.headers?.()['content-type'] || '').split(';')[0];
+      const body = status >= 400 ? compactResponseBody(await response.text().catch(() => '')) : '';
+      entries.push(
+        `${method} ${status} ${compactResponseUrl(response.url())} content_type=${contentType || 'unknown'}${body ? ` body=${body}` : ''}`
+      );
+    })();
+    pending.push(task);
+  };
+
+  page.on('response', onResponse);
+  return {
+    async stop() {
+      page.off('response', onResponse);
+      await Promise.allSettled(pending);
+      return entries;
+    },
+  };
+}
+
+module.exports = {
+  addRole,
+  createMutationResponseCapture,
+  removeRoleFromTable,
+  roleRowLocator,
+  waitForPortalMarkerState,
+};

--- a/scripts/release-gate/admin-checks.test.ts
+++ b/scripts/release-gate/admin-checks.test.ts
@@ -47,6 +47,8 @@ class FakeRowLocator {
     return this.text;
   }
 
+  async waitFor() {}
+
   getByRole(_role: string, _options?: unknown) {
     return this.button;
   }
@@ -73,6 +75,24 @@ class FakeRowsLocator {
   nth(index: number) {
     return this.rows[index];
   }
+
+  filter(options: { hasText: RegExp }) {
+    const row = this.rows.find(candidate => options.hasText.test(candidate.text));
+    return {
+      first: () => {
+        if (!row) {
+          return {
+            waitFor: async () => {
+              throw new Error('row not found');
+            },
+            getByRole: () => new FakeButtonLocator([false]),
+            locator: () => new FakeButtonLocator([false]),
+          };
+        }
+        return row;
+      },
+    };
+  }
 }
 
 class FakeTableLocator {
@@ -92,11 +112,9 @@ class FakeTableLocator {
 
 class FakePage {
   table: FakeTableLocator;
-  waits: number[];
 
   constructor(rows: FakeRowLocator[]) {
     this.table = new FakeTableLocator(rows);
-    this.waits = [];
   }
 
   locator(selector: string) {
@@ -104,10 +122,6 @@ class FakePage {
       throw new Error(`Unexpected top-level selector: ${selector}`);
     }
     return this.table;
-  }
-
-  async waitForTimeout(ms: number) {
-    this.waits.push(ms);
   }
 }
 
@@ -120,13 +134,12 @@ test('findRoleRowByText matches a visible role row by text content', async () =>
   assert.equal(found, promoterRow);
 });
 
-test('removeRoleFromTable waits for the row action button to become enabled before clicking', async () => {
-  const promoterRow = new FakeRowLocator('PromoterTenant-wideRemove', [false, false, true]);
+test('removeRoleFromTable clicks the visible role row action', async () => {
+  const promoterRow = new FakeRowLocator('Promoter Tenant-wide Remove');
   const page = new FakePage([new FakeRowLocator('RoleBranchActions'), promoterRow]);
 
   const removed = await removeRoleFromTable(page, 'promoter');
 
   assert.equal(removed, true);
   assert.equal(promoterRow.button.clickCount, 1);
-  assert.deepEqual(page.waits, [300, 300, 800]);
 });

--- a/scripts/release-gate/admin-checks.ts
+++ b/scripts/release-gate/admin-checks.ts
@@ -5,13 +5,19 @@ const {
   buildRoute,
   buildRouteAllowingLocalePath,
   checkResult,
-  collectMarkersWithWait,
   expectedMatrixForAccount,
   markerSummary,
   markersToString,
   sleep,
   waitForReadyMarker,
 } = require('./shared.ts');
+const {
+  addRole,
+  createMutationResponseCapture,
+  removeRoleFromTable,
+  roleRowLocator,
+  waitForPortalMarkerState,
+} = require('./admin-checks-locators.ts');
 
 const INFRA_NAVIGATION_ERROR_PATTERNS = [
   /ERR_CONNECTION_REFUSED/i,
@@ -148,9 +154,10 @@ async function runP01(browser, runCtx, deps) {
             }),
           retryLogin: () => loginWithRunContext(page, runCtx, account),
         });
-        await page.waitForTimeout(450);
-
-        const current = await collectMarkersWithWait(page, portal === matrix.canonical && portal);
+        const current = await waitForPortalMarkerState(
+          page,
+          portal === matrix.canonical ? portal : null
+        );
         evidence.push(`${account} ${markerSummary(route, current)}`);
 
         const rbacResult = collectRbacFailures({
@@ -223,30 +230,6 @@ async function runP02(browser, runCtx, deps) {
   return checkResult('P0.2', failures.length ? 'FAIL' : 'PASS', evidence, failures);
 }
 
-async function removeRoleFromTable(page, roleName) {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < TIMEOUTS.marker) {
-    const targetRow = await findRoleRowByText(page, roleName);
-    if (targetRow) {
-      const removeButton = resolveRoleRowActionButton(targetRow);
-      const visible = await removeButton
-        .isVisible({ timeout: TIMEOUTS.quickMarker })
-        .catch(() => false);
-      const enabled = visible ? await removeButton.isEnabled().catch(() => false) : false;
-      if (visible && enabled) {
-        await removeButton.click();
-        await page.waitForTimeout(800);
-        return true;
-      }
-    }
-
-    await page.waitForTimeout(300);
-  }
-
-  return false;
-}
-
 async function findRoleRowByText(page, roleName) {
   const table = page.locator(SELECTORS.userRolesTable);
   const normalizedRoleName = String(roleName || '')
@@ -266,43 +249,6 @@ async function findRoleRowByText(page, roleName) {
   }
 
   return null;
-}
-
-function resolveRoleRowActionButton(row) {
-  const byRoleButton = row.getByRole?.('button', { name: SELECTORS.removeRoleButtonName });
-  if (byRoleButton?.first) {
-    return byRoleButton.first();
-  }
-  const genericButton = row.locator('button');
-  return genericButton?.first ? genericButton.first() : genericButton;
-}
-
-async function addRole(page, roleName) {
-  const trigger = page.locator(SELECTORS.roleSelectTrigger);
-  await trigger.waitFor({ state: 'visible', timeout: TIMEOUTS.action });
-  await trigger.click();
-
-  const roleOption = page.locator(`[data-testid="role-option-${roleName}"]`);
-  const opened = await Promise.race([
-    page
-      .locator(SELECTORS.roleSelectContent)
-      .waitFor({ state: 'visible', timeout: TIMEOUTS.action })
-      .then(() => true)
-      .catch(() => false),
-    roleOption
-      .waitFor({ state: 'visible', timeout: TIMEOUTS.action })
-      .then(() => true)
-      .catch(() => false),
-  ]);
-
-  if (!opened) {
-    await trigger.click().catch(() => {});
-    await roleOption.waitFor({ state: 'visible', timeout: TIMEOUTS.action });
-  }
-
-  await page.locator(`[data-testid="role-option-${roleName}"]`).click();
-  await page.getByRole('button', { name: SELECTORS.grantRoleButtonName }).click();
-  await page.waitForTimeout(1200);
 }
 
 function collectRbacFailures(input) {
@@ -485,23 +431,22 @@ async function runP03AndP04(browser, runCtx, deps) {
           `pre-clean removed_existing_role_entries=${cleanupCount}`
         );
 
+        const grantCapture = createMutationResponseCapture(page, runCtx.baseUrl);
         await addRole(page, roleToToggle);
-        const afterAddStart = Date.now();
-        let afterAdd = false;
-        while (Date.now() - afterAddStart < TIMEOUTS.marker) {
-          afterAdd = await page
-            .locator(SELECTORS.userRolesTable)
-            .getByText(new RegExp(String.raw`\b${roleToToggle}\b`, 'i'))
-            .isVisible({ timeout: TIMEOUTS.quickMarker })
-            .catch(() => false);
-          if (afterAdd) break;
-          await sleep(300);
+        const afterAdd = await roleRowLocator(page, roleToToggle)
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.marker })
+          .then(() => true)
+          .catch(() => false);
+        const grantResponses = await grantCapture.stop();
+        if (grantResponses.length > 0) {
+          evidenceP03.push(`grant_responses=${grantResponses.join(' | ')}`);
         }
         evidenceP03.push(`added_role=${roleToToggle} visible_in_roles_table=${afterAdd}`);
         if (!afterAdd) {
           failuresP03.push(`P0.3_ROLE_ADD_FAILED role=${roleToToggle} target=${resolvedTarget}`);
         }
 
+        const revokeCapture = createMutationResponseCapture(page, runCtx.baseUrl);
         const removedAddedRole = await removeRoleFromTable(page, roleToToggle);
         if (!removedAddedRole) {
           failuresP04.push(
@@ -509,16 +454,13 @@ async function runP03AndP04(browser, runCtx, deps) {
           );
         }
 
-        const removalStart = Date.now();
-        let stillVisible = true;
-        while (Date.now() - removalStart < TIMEOUTS.marker) {
-          stillVisible = await page
-            .locator(SELECTORS.userRolesTable)
-            .getByText(new RegExp(String.raw`\b${roleToToggle}\b`, 'i'))
-            .isVisible({ timeout: TIMEOUTS.quickMarker })
-            .catch(() => false);
-          if (!stillVisible) break;
-          await sleep(300);
+        const stillVisible = await roleRowLocator(page, roleToToggle)
+          .waitFor({ state: 'hidden', timeout: TIMEOUTS.marker })
+          .then(() => false)
+          .catch(() => true);
+        const revokeResponses = await revokeCapture.stop();
+        if (revokeResponses.length > 0) {
+          evidenceP04.push(`revoke_responses=${revokeResponses.join(' | ')}`);
         }
         evidenceP04.push(`removed_role=${roleToToggle} remaining_in_roles_table=${stillVisible}`);
         if (stillVisible) {

--- a/scripts/release-gate/shared.ts
+++ b/scripts/release-gate/shared.ts
@@ -445,8 +445,9 @@ async function checkPortalMarkers(page) {
   const snapshot = {};
   for (const markerKey of markerKeys) {
     snapshot[markerKey] = await page
-      .getByTestId(MARKERS[markerKey])
-      .isVisible({ timeout: TIMEOUTS.quickMarker })
+      .locator(`[data-testid="${MARKERS[markerKey]}"]:visible`)
+      .count()
+      .then(count => count > 0)
       .catch(() => false);
   }
 

--- a/scripts/release-gate/shared.ts
+++ b/scripts/release-gate/shared.ts
@@ -1,5 +1,6 @@
 const path = require('node:path');
 const { ROUTES, MARKERS, SELECTORS, TIMEOUTS, ROLE_IPS, ACCOUNTS } = require('./config.ts');
+const { hasVisibleTestId } = require('./visible-marker.ts');
 const {
   assertLoginResponseOrigin,
   buildLoginRequestHeaders,
@@ -444,11 +445,7 @@ async function checkPortalMarkers(page) {
   const markerKeys = ['member', 'agent', 'staff', 'admin', 'notFound'];
   const snapshot = {};
   for (const markerKey of markerKeys) {
-    snapshot[markerKey] = await page
-      .locator(`[data-testid="${MARKERS[markerKey]}"]:visible`)
-      .count()
-      .then(count => count > 0)
-      .catch(() => false);
+    snapshot[markerKey] = await hasVisibleTestId(page, MARKERS[markerKey]);
   }
 
   if (!snapshot.notFound) {

--- a/scripts/release-gate/visible-marker.ts
+++ b/scripts/release-gate/visible-marker.ts
@@ -1,0 +1,9 @@
+async function hasVisibleTestId(page, testId) {
+  const count = await page
+    .locator(`[data-testid="${testId}"]:visible`)
+    .count()
+    .catch(() => 0);
+  return count > 0;
+}
+
+module.exports = { hasVisibleTestId };

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37607282,
-  "maxTrackedFiles": 4559,
+  "maxTrackedBytes": 37613784,
+  "maxTrackedFiles": 4565,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7040662,
+    "source/scripts": 7048565,
     "docs/text": 5711417,
-    "tests/e2e": 4970550,
-    "config/data/messages": 1554655,
+    "tests/e2e": 4969839,
+    "config/data/messages": 1553965,
     "other": 129244
   },
   "maxLargestFileBytes": 3263773,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37613784,
-  "maxTrackedFiles": 4565,
+  "maxTrackedBytes": 37615546,
+  "maxTrackedFiles": 4566,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7048565,
+    "source/scripts": 7048674,
     "docs/text": 5711417,
-    "tests/e2e": 4969839,
+    "tests/e2e": 4971492,
     "config/data/messages": 1553965,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- move the contractual `admin-page-ready` marker to the authorized admin shell so canonical `/admin` and admin child routes expose the same readiness signal
- harden release-gate P0.1/P0.3/P0.4 with Playwright locators/actionability and role mutation response evidence instead of boolean snapshots/manual polling
- remove the duplicate overview-level admin marker and add focused coverage for the shell marker and role panel action path

## Diagnosis
- P0.1 `/en/admin` reached the authorized admin shell but sampled only the shared/member dashboard marker because `admin-page-ready` lived under `/admin/overview`, not the admin layout boundary.
- P0.1 `/en/agent` evidence plus the later passing P0.6 agent route indicated route/readiness sampling behavior rather than auth failure.
- P0.3/P0.4 could not distinguish failed role mutation from stale UI because the gate relied on snapshots/manual polling and did not capture mutation responses.

## Guardrails
- No `proxy.ts` changes.
- No production trigger.
- No gate weakening, no skipped P0.1/P0.3/P0.4, and `RELEASE_GATE_REQUIRE_ROLE_PANEL` stays enforced.
- Canonical routes and `*-page-ready` marker contract are preserved.

## Verification
- `node --import tsx scripts/release-gate/admin-checks.test.ts`
- `node scripts/vitest-unit.mjs 'src/app/[locale]/admin/_core.entry.test.tsx'`\n- `node --import tsx scripts/release-gate/run.test.ts`\n- `pnpm check:modularity-guard`\n- `pnpm check:e2e-contracts`\n- `git diff --check`\n- `pnpm pr:verify`\n- `pnpm security:guard`\n- `pnpm e2e:gate` (134 passed, 8 skipped)