### PR TITLE
fix: make CD E2E role gates deterministic

### DIFF
--- a/apps/web/src/server/auth/effective-portal-access.test.ts
+++ b/apps/web/src/server/auth/effective-portal-access.test.ts
@@ -70,7 +70,15 @@ describe('hasEffectivePortalAccess', () => {
     ).resolves.toBe(true);
   });
 
-  it('treats user_roles as authoritative when rows exist for requested tenant', async () => {
+  it('keeps the same-tenant legacy primary role effective when explicit rows omit it', async () => {
+    mocks.findUserRoles.mockResolvedValueOnce([{ role: 'member' }]);
+
+    await expect(
+      hasEffectivePortalAccess(session('staff'), ['staff'], { requestedTenantId: 'tenant_ks' })
+    ).resolves.toBe(true);
+  });
+
+  it('treats cross-tenant user_roles as authoritative when rows exist for requested tenant', async () => {
     mocks.findUserRoles.mockResolvedValueOnce([{ role: 'member' }]);
 
     await expect(

--- a/apps/web/src/server/auth/effective-portal-access.ts
+++ b/apps/web/src/server/auth/effective-portal-access.ts
@@ -50,18 +50,23 @@ export async function hasEffectivePortalAccess(
   const requestedTenantId = options.requestedTenantId ?? sessionTenantId ?? null;
   const userId = session?.user?.id ?? null;
   const legacyRole = session?.user?.role ?? null;
+  const hasAllowedLegacyRole = Boolean(legacyRole && allowedRoles.includes(legacyRole));
 
   if (!requestedTenantId) {
-    return Boolean(legacyRole && allowedRoles.includes(legacyRole));
+    return hasAllowedLegacyRole;
   }
 
   const explicitRoles = await getExplicitTenantRolesFor(userId, requestedTenantId);
-  if (explicitRoles.length > 0) {
-    return explicitRoles.some(role => allowedRoles.includes(role));
+  if (explicitRoles.some(role => allowedRoles.includes(role))) {
+    return true;
   }
 
-  if (sessionTenantId && requestedTenantId === sessionTenantId) {
-    return Boolean(legacyRole && allowedRoles.includes(legacyRole));
+  if (sessionTenantId && requestedTenantId === sessionTenantId && hasAllowedLegacyRole) {
+    return true;
+  }
+
+  if (explicitRoles.length > 0) {
+    return false;
   }
 
   if (legacyRole === 'super_admin' && allowedRoles.includes('super_admin')) {

--- a/scripts/ci/e2e-lane-runner-contracts.test.mjs
+++ b/scripts/ci/e2e-lane-runner-contracts.test.mjs
@@ -9,6 +9,7 @@ const packageJson = JSON.parse(
 );
 
 test('E2E lane runner delegates subprocess cleanup to the detached command helper', () => {
+  assert.match(runner, /ensureLocalTestHosts/);
   assert.match(runner, /import \{ runDetachedCommand \} from '\.\/ci\/run-detached-command\.mjs'/);
   assert.match(runner, /await runDetachedCommand\(command, args, \{ cwd: rootDir, env \}\)/);
 });

--- a/scripts/ci/ensure-local-test-hosts.mjs
+++ b/scripts/ci/ensure-local-test-hosts.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import dns from 'node:dns/promises';
+import fs from 'node:fs';
+
+export const LOCAL_TEST_HOSTS = [
+  '127.0.0.1.nip.io',
+  'app.127.0.0.1.nip.io',
+  'ida.127.0.0.1.nip.io',
+  'ks.127.0.0.1.nip.io',
+  'mk.127.0.0.1.nip.io',
+  'al.127.0.0.1.nip.io',
+  'pilot.127.0.0.1.nip.io',
+];
+
+function isLoopbackAddress(address) {
+  return ['127.0.0.1', '::1'].includes(address);
+}
+
+function activeHostRecords(hostsFileText, hosts = LOCAL_TEST_HOSTS) {
+  const wanted = new Set(hosts);
+  const records = new Map(hosts.map(host => [host, { loopback: false, nonLoopback: [] }]));
+  for (const rawLine of String(hostsFileText).split('\n')) {
+    const [address, ...names] = rawLine.replace(/#.*/u, '').trim().split(/\s+/u).filter(Boolean);
+    if (!address) continue;
+    for (const name of names) {
+      if (!wanted.has(name)) continue;
+      const record = records.get(name);
+      if (isLoopbackAddress(address)) {
+        record.loopback = true;
+      } else {
+        record.nonLoopback.push(address);
+      }
+    }
+  }
+  return records;
+}
+
+export function missingHosts(hostsFileText, hosts = LOCAL_TEST_HOSTS) {
+  const records = activeHostRecords(hostsFileText, hosts);
+  return hosts.filter(host => !records.get(host)?.loopback);
+}
+
+export function nonLoopbackHosts(hostsFileText, hosts = LOCAL_TEST_HOSTS) {
+  const records = activeHostRecords(hostsFileText, hosts);
+  return hosts.filter(host => records.get(host)?.nonLoopback.length > 0);
+}
+
+export function buildHostsEntry(hosts) {
+  return [
+    '',
+    '# interdomestik deterministic local E2E hosts',
+    `127.0.0.1 ${hosts.join(' ')}`,
+    '',
+  ].join('\n');
+}
+
+function appendWithSudo(hostsPath, entry) {
+  const result = spawnSync('/usr/bin/sudo', ['-n', '/usr/bin/tee', '-a', hostsPath], {
+    env: { PATH: '/usr/bin:/bin:/usr/sbin:/sbin' },
+    input: entry,
+    stdio: ['pipe', 'ignore', 'pipe'],
+    encoding: 'utf8',
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || 'sudo tee failed').trim());
+  }
+}
+
+function appendHostsEntry(hostsPath, entry) {
+  try {
+    fs.appendFileSync(hostsPath, entry, { encoding: 'utf8' });
+  } catch (error) {
+    if (error?.code !== 'EACCES' && error?.code !== 'EPERM') throw error;
+    appendWithSudo(hostsPath, entry);
+  }
+}
+
+async function unresolvedLoopbackHosts(hosts) {
+  const checks = await Promise.all(
+    hosts.map(async host => {
+      try {
+        const records = await dns.lookup(host, { all: true });
+        const hasLoopback = records.some(record =>
+          ['127.0.0.1', '::1'].includes(record.address)
+        );
+        return hasLoopback ? null : host;
+      } catch {
+        return host;
+      }
+    })
+  );
+  return checks.filter(Boolean);
+}
+
+export async function ensureLocalTestHosts(options = {}) {
+  const hostsPath = options.hostsPath || '/etc/hosts';
+  const required = options.required ?? process.env.CI === 'true';
+  const hosts = options.hosts || LOCAL_TEST_HOSTS;
+  const prefix = '[local-test-hosts]';
+
+  try {
+    const existing = fs.readFileSync(hostsPath, 'utf8');
+    const conflicts = nonLoopbackHosts(existing, hosts);
+    if (required && conflicts.length > 0) {
+      throw new Error(`hosts mapped to non-loopback addresses: ${conflicts.join(', ')}`);
+    }
+
+    const missing = missingHosts(existing, hosts);
+    if (missing.length === 0) {
+      console.log(`${prefix} ok`);
+      return { ok: true, changed: false, missing: [] };
+    }
+
+    const hostsToAdd = required ? missing : await unresolvedLoopbackHosts(missing);
+    if (hostsToAdd.length === 0) {
+      console.log(`${prefix} dns ok`);
+      return { ok: true, changed: false, missing: [] };
+    }
+
+    appendHostsEntry(hostsPath, buildHostsEntry(hostsToAdd));
+    const updated = fs.readFileSync(hostsPath, 'utf8');
+    const stillMissing = missingHosts(updated, hostsToAdd);
+    if (stillMissing.length > 0) {
+      throw new Error(`hosts still missing: ${stillMissing.join(', ')}`);
+    }
+
+    console.log(`${prefix} added ${hostsToAdd.join(', ')}`);
+    return { ok: true, changed: true, missing: [] };
+  } catch (error) {
+    if (required) throw error;
+    console.warn(`${prefix} skipped: ${error.message}`);
+    return { ok: false, changed: false, missing: hosts };
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await ensureLocalTestHosts({
+    required: process.env.CI === 'true' || process.argv.includes('--required'),
+  });
+}

--- a/scripts/ci/local-test-hosts.test.mjs
+++ b/scripts/ci/local-test-hosts.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  buildHostsEntry,
+  ensureLocalTestHosts,
+  LOCAL_TEST_HOSTS,
+  missingHosts,
+  nonLoopbackHosts,
+} from './ensure-local-test-hosts.mjs';
+
+test('local test host set covers current compatibility E2E hosts', () => {
+  assert.deepEqual(LOCAL_TEST_HOSTS, [
+    '127.0.0.1.nip.io',
+    'app.127.0.0.1.nip.io',
+    'ida.127.0.0.1.nip.io',
+    'ks.127.0.0.1.nip.io',
+    'mk.127.0.0.1.nip.io',
+    'al.127.0.0.1.nip.io',
+    'pilot.127.0.0.1.nip.io',
+  ]);
+});
+
+test('missingHosts returns only hostnames absent from the hosts file text', () => {
+  const existing = '127.0.0.1 localhost ks.127.0.0.1.nip.io\n';
+  assert.deepEqual(missingHosts(existing, ['ks.127.0.0.1.nip.io', 'mk.127.0.0.1.nip.io']), [
+    'mk.127.0.0.1.nip.io',
+  ]);
+});
+
+test('missingHosts ignores hostnames that only appear in comments', () => {
+  const existing = '127.0.0.1 localhost\n# ks.127.0.0.1.nip.io\n';
+  assert.deepEqual(missingHosts(existing, ['ks.127.0.0.1.nip.io']), [
+    'ks.127.0.0.1.nip.io',
+  ]);
+});
+
+test('missingHosts requires an active loopback mapping', () => {
+  const existing = '192.0.2.10 ks.127.0.0.1.nip.io\n';
+  assert.deepEqual(missingHosts(existing, ['ks.127.0.0.1.nip.io']), [
+    'ks.127.0.0.1.nip.io',
+  ]);
+  assert.deepEqual(nonLoopbackHosts(existing, ['ks.127.0.0.1.nip.io']), [
+    'ks.127.0.0.1.nip.io',
+  ]);
+});
+
+test('ensureLocalTestHosts appends missing hosts idempotently', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-hosts-'));
+  const hostsPath = path.join(dir, 'hosts');
+  fs.writeFileSync(hostsPath, '127.0.0.1 localhost\n');
+
+  const first = await ensureLocalTestHosts({
+    hostsPath,
+    hosts: ['ks.127.0.0.1.nip.io', 'pilot.127.0.0.1.nip.io'],
+    required: true,
+  });
+  const second = await ensureLocalTestHosts({
+    hostsPath,
+    hosts: ['ks.127.0.0.1.nip.io', 'pilot.127.0.0.1.nip.io'],
+    required: true,
+  });
+
+  assert.equal(first.changed, true);
+  assert.equal(second.changed, false);
+  assert.match(buildHostsEntry(['pilot.127.0.0.1.nip.io']), /127\.0\.0\.1 pilot/u);
+  assert.deepEqual(missingHosts(fs.readFileSync(hostsPath, 'utf8'), LOCAL_TEST_HOSTS), [
+    '127.0.0.1.nip.io',
+    'app.127.0.0.1.nip.io',
+    'ida.127.0.0.1.nip.io',
+    'mk.127.0.0.1.nip.io',
+    'al.127.0.0.1.nip.io',
+  ]);
+});
+
+test('ensureLocalTestHosts fails required mode on stale non-loopback mappings', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-hosts-'));
+  const hostsPath = path.join(dir, 'hosts');
+  fs.writeFileSync(hostsPath, '192.0.2.10 ks.127.0.0.1.nip.io\n');
+
+  await assert.rejects(
+    () =>
+      ensureLocalTestHosts({
+        hostsPath,
+        hosts: ['ks.127.0.0.1.nip.io'],
+        required: true,
+      }),
+    /hosts mapped to non-loopback addresses: ks\.127\.0\.0\.1\.nip\.io/u
+  );
+});
+
+test('ensureLocalTestHosts logs only hosts appended after local DNS filtering', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-hosts-'));
+  const hostsPath = path.join(dir, 'hosts');
+  fs.writeFileSync(hostsPath, '127.0.0.1 base\n');
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = message => logs.push(String(message));
+  try {
+    const result = await ensureLocalTestHosts({
+      hostsPath,
+      hosts: ['localhost', 'interdomestik.invalid'],
+      required: false,
+    });
+
+    assert.equal(result.changed, true);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.deepEqual(logs, ['[local-test-hosts] added interdomestik.invalid']);
+  assert.match(fs.readFileSync(hostsPath, 'utf8'), /interdomestik\.invalid/u);
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37615546,
-  "maxTrackedFiles": 4566,
+  "maxTrackedBytes": 37625245,
+  "maxTrackedFiles": 4569,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7048674,
+    "source/scripts": 7053558,
     "docs/text": 5711417,
-    "tests/e2e": 4971492,
-    "config/data/messages": 1553965,
+    "tests/e2e": 4975617,
+    "config/data/messages": 1554655,
     "other": 129244
   },
   "maxLargestFileBytes": 3263773,

--- a/scripts/run-e2e-lane.mjs
+++ b/scripts/run-e2e-lane.mjs
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ensureLocalTestHosts } from './ci/ensure-local-test-hosts.mjs';
 import { runDetachedCommand } from './ci/run-detached-command.mjs';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -142,6 +143,7 @@ async function run(command, args, env = baseEnv) {
 }
 
 if (shouldRunLocalDoctor) await run('pnpm', ['run', 'doctor'], laneEnv);
+await ensureLocalTestHosts({ required: process.env.CI === 'true' });
 if (lane.gatekeeper) await run('bash', ['scripts/m4-gatekeeper.sh'], laneEnv);
 if (lane.state) await run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);
 await run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);


### PR DESCRIPTION
## Summary

Fixes the current CD staging E2E failure class by aligning portal-access checks with the role read model and making local host-routed E2E deterministic in CI.

- Keep same-tenant legacy primary roles effective even when explicit `user_roles` rows exist, matching the admin role read model that merges primary + explicit roles.
- Preserve cross-tenant explicit-role authority and super-admin behavior.
- Add a deterministic local-test host preflight for `*.127.0.0.1.nip.io` aliases in the E2E lane, with CI fail-closed `/etc/hosts` repair and local DNS-first behavior.
- Add regression/contract tests for both fixes and update the tracked repo-size budget.

## Why

The failed CD run showed:

- Staff `/staff` canonical route returning notFound despite a valid staff primary role.
- Multi-role staff/member scenarios losing the staff marker.
- Prior CI lanes intermittently depending on external nip.io DNS for local host-routed tests.

This keeps the current Phase C compatibility hosts deterministic without changing `apps/web/src/proxy.ts`, canonical routes, or the future `aid.interdomestik.com` architecture path.

## Verification

- `pnpm --filter @interdomestik/web test:unit --run src/server/auth/effective-portal-access.test.ts`
- `node --test scripts/ci/local-test-hosts.test.mjs scripts/ci/e2e-lane-runner-contracts.test.mjs`
- `node --check scripts/ci/ensure-local-test-hosts.mjs && node --check scripts/run-e2e-lane.mjs`
- `pnpm check:modularity-guard`
- `pnpm test:ci:contracts`
- `pnpm --filter @interdomestik/web test:unit --run 'src/app/[locale]/admin/users/[id]/_components/admin-user-roles-panel.test.tsx'`
- `pnpm --filter @interdomestik/domain-users test:unit --run roles.list.test.ts roles.revoke.test.ts`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate`

## Notes

No production deploy was triggered. No destructive migration was run. `apps/web/src/proxy.ts` was not touched.
