### PR TITLE
fix: harden staging release gate session recovery

### DIFF
--- a/scripts/release-gate/admin-checks.ts
+++ b/scripts/release-gate/admin-checks.ts
@@ -19,6 +19,7 @@ const {
   waitForPortalMarkerState,
 } = require('./admin-checks-locators.ts');
 const { buildP06CanonicalRouteScenarios } = require('./p06-scenarios.ts');
+const { buildRolePanelDiscoveryUrls } = require('./role-panel-targets.ts');
 
 const INFRA_NAVIGATION_ERROR_PATTERNS = [
   /ERR_CONNECTION_REFUSED/i,
@@ -321,7 +322,6 @@ async function runP03AndP04(browser, runCtx, deps) {
   }
 
   const rolePanelTarget = resolveConfiguredRolePanelTarget(runCtx);
-  const hasExplicitTarget = rolePanelTarget.source !== 'default';
   const targetUrl = rolePanelTarget.targetUrl;
   async function waitForRolePanelVisible(page, timeoutMs = TIMEOUTS.nav) {
     const startedAt = Date.now();
@@ -363,17 +363,11 @@ async function runP03AndP04(browser, runCtx, deps) {
     return ok ? page.url() : null;
   }
 
-  async function ensureRolePanelLoaded(page, initialTargetUrl) {
-    const initialResolved = await tryRolePanelTarget(page, initialTargetUrl).catch(() => null);
-    if (initialResolved) return initialResolved;
-
-    if (hasExplicitTarget && !rolePanelTarget.allowFallbackDiscovery) return null;
-
-    const safeDefaultTarget = buildRoute(runCtx.baseUrl, runCtx.locale, ROUTES.defaultAdminUserUrl);
-    if (safeDefaultTarget !== initialTargetUrl) {
-      return await tryRolePanelTarget(page, safeDefaultTarget).catch(() => null);
+  async function ensureRolePanelLoaded(page) {
+    for (const candidateUrl of buildRolePanelDiscoveryUrls(runCtx, rolePanelTarget)) {
+      const resolved = await tryRolePanelTarget(page, candidateUrl).catch(() => null);
+      if (resolved) return resolved;
     }
-
     return null;
   }
 
@@ -384,7 +378,7 @@ async function runP03AndP04(browser, runCtx, deps) {
       try {
         await loginWithRunContext(page, runCtx, 'admin_ks', { forceFresh: true });
 
-        const resolvedTarget = await ensureRolePanelLoaded(page, targetUrl);
+        const resolvedTarget = await ensureRolePanelLoaded(page);
         evidenceP03.push(
           `attempt=${attempt} target_source=${rolePanelTarget.source}`,
           `target_fallback_allowed=${rolePanelTarget.allowFallbackDiscovery}`

--- a/scripts/release-gate/config.ts
+++ b/scripts/release-gate/config.ts
@@ -33,7 +33,7 @@ const ROUTES = {
   rbacTargets: ['member', 'agent', 'staff', 'admin'],
   memberDocuments: '/member/documents',
   staffClaimsList: '/staff/claims',
-  defaultAdminUserUrl: '/admin/users/golden_ks_a_member_6?tenantId=tenant_ks',
+  defaultAdminUserUrl: '/admin/users/golden_ks_a_member_1?tenantId=tenant_ks',
   crossTenantProbe: '/admin/users/golden_ks_staff?tenantId=tenant_ks',
   tenantOverrideProbeFallback: '/admin/users/golden_mk_staff?tenantId=tenant_mk',
 };

--- a/scripts/release-gate/p06-marker-assertion.test.ts
+++ b/scripts/release-gate/p06-marker-assertion.test.ts
@@ -4,7 +4,7 @@ import test from 'node:test';
 
 const require = createRequire(import.meta.url);
 const { MARKERS } = require('./config.ts');
-const { assertP06UrlMarkers } = require('./p06-marker-assertion.ts');
+const { assertP06UrlMarkers, shouldForceFreshAfterNotFound } = require('./p06-marker-assertion.ts');
 
 test('assertP06UrlMarkers uses session-aware navigation before collecting markers', async () => {
   let loginRetryCount = 0;
@@ -39,4 +39,68 @@ test('assertP06UrlMarkers uses session-aware navigation before collecting marker
   assert.equal(result.status, 'PASS');
   assert.equal(loginRetryCount, 0);
   assert.deepEqual(navigated, ['https://interdomestik-web.vercel.app/en/agent']);
+});
+
+test('assertP06UrlMarkers force-refreshes when cached session reaches not-found', async () => {
+  let loginRetryCount = 0;
+  const navigated = [];
+  const page = {
+    async goto(url) {
+      navigated.push(url);
+    },
+    locator(selector) {
+      return {
+        count: async () => {
+          const refreshed = loginRetryCount > 0;
+          if (selector === `[data-testid="${MARKERS.notFound}"]:visible`) return refreshed ? 0 : 1;
+          if (selector === `[data-testid="${MARKERS.staff}"]:visible`) return refreshed ? 1 : 0;
+          return 0;
+        },
+        isVisible: async () => false,
+      };
+    },
+    url: () => navigated.at(-1) || '',
+  };
+
+  const result = await assertP06UrlMarkers(
+    page,
+    'staff',
+    'S2',
+    'https://interdomestik-web.vercel.app/en/staff',
+    { staff: true },
+    {
+      loginWithRunContext: async (_page, _runCtx, accountKey, options) => {
+        assert.equal(accountKey, 'staff');
+        assert.equal(options.forceFresh, true);
+        loginRetryCount += 1;
+      },
+      runCtx: {},
+    }
+  );
+
+  assert.equal(result.status, 'PASS');
+  assert.equal(loginRetryCount, 1);
+  assert.deepEqual(navigated, [
+    'https://interdomestik-web.vercel.app/en/staff',
+    'https://interdomestik-web.vercel.app/en/staff',
+  ]);
+});
+
+test('shouldForceFreshAfterNotFound only retries positive-marker not-found failures', () => {
+  assert.equal(
+    shouldForceFreshAfterNotFound({
+      status: 'FAIL',
+      expected: { agent: true },
+      observed: { notFound: true },
+    }),
+    true
+  );
+  assert.equal(
+    shouldForceFreshAfterNotFound({
+      status: 'FAIL',
+      expected: { admin: false },
+      observed: { notFound: true },
+    }),
+    false
+  );
 });

--- a/scripts/release-gate/p06-marker-assertion.ts
+++ b/scripts/release-gate/p06-marker-assertion.ts
@@ -2,14 +2,29 @@ const { TIMEOUTS } = require('./config.ts');
 const { gotoWithSessionRetry } = require('./session-navigation.ts');
 const { collectUrlMarkerAssertion } = require('./shared.ts');
 
+function shouldForceFreshAfterNotFound(result) {
+  const expectsReadyMarker = Object.values(result.expected || {}).some(value => value === true);
+  return result.status === 'FAIL' && expectsReadyMarker && result.observed?.notFound === true;
+}
+
 async function assertP06UrlMarkers(page, accountKey, label, url, expected, deps) {
   const { loginWithRunContext, runCtx } = deps;
+  const navigate = () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: TIMEOUTS.nav });
   await gotoWithSessionRetry({
     page,
-    navigate: () => page.goto(url, { waitUntil: 'domcontentloaded', timeout: TIMEOUTS.nav }),
+    navigate,
     retryLogin: () => loginWithRunContext(page, runCtx, accountKey, { forceFresh: true }),
   });
 
+  const result = await collectUrlMarkerAssertion(page, label, url, expected);
+  if (!shouldForceFreshAfterNotFound(result)) return result;
+
+  await loginWithRunContext(page, runCtx, accountKey, { forceFresh: true });
+  await gotoWithSessionRetry({
+    page,
+    navigate,
+    retryLogin: () => loginWithRunContext(page, runCtx, accountKey, { forceFresh: true }),
+  });
   return collectUrlMarkerAssertion(page, label, url, expected);
 }
 
@@ -21,4 +36,5 @@ function createP06MarkerAsserter(deps) {
 module.exports = {
   assertP06UrlMarkers,
   createP06MarkerAsserter,
+  shouldForceFreshAfterNotFound,
 };

--- a/scripts/release-gate/role-panel-target.test.ts
+++ b/scripts/release-gate/role-panel-target.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 
 const require = createRequire(import.meta.url);
 const { resolveConfiguredRolePanelTarget } = require('./admin-checks.ts');
+const { buildRolePanelDiscoveryUrls } = require('./role-panel-targets.ts');
 
 test('resolveConfiguredRolePanelTarget uses a non-login member as default role probe', () => {
   const originalTarget = process.env.RELEASE_GATE_TARGET_USER_URL;
@@ -18,11 +19,32 @@ test('resolveConfiguredRolePanelTarget uses a non-login member as default role p
     assert.equal(resolved.allowFallbackDiscovery, true);
     assert.equal(
       resolved.targetUrl,
-      'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_6?tenantId=tenant_ks'
+      'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_1?tenantId=tenant_ks'
     );
   } finally {
     if (originalTarget !== undefined) {
       process.env.RELEASE_GATE_TARGET_USER_URL = originalTarget;
     }
   }
+});
+
+test('buildRolePanelDiscoveryUrls tries same-tenant safe member fallbacks for default target', () => {
+  const urls = buildRolePanelDiscoveryUrls(
+    { baseUrl: 'https://interdomestik-web.vercel.app', locale: 'en' },
+    {
+      source: 'default',
+      allowFallbackDiscovery: true,
+      targetUrl:
+        'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_1?tenantId=tenant_ks',
+    }
+  );
+
+  assert.deepEqual(urls, [
+    'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_1?tenantId=tenant_ks',
+    'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_2?tenantId=tenant_ks',
+    'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_3?tenantId=tenant_ks',
+    'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_4?tenantId=tenant_ks',
+    'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_5?tenantId=tenant_ks',
+    'https://interdomestik-web.vercel.app/en/admin/users/golden_ks_a_member_6?tenantId=tenant_ks',
+  ]);
 });

--- a/scripts/release-gate/role-panel-targets.ts
+++ b/scripts/release-gate/role-panel-targets.ts
@@ -1,0 +1,26 @@
+const { ROUTES } = require('./config.ts');
+const { buildRoute } = require('./shared.ts');
+
+const SAFE_ROLE_PANEL_FALLBACK_PATHS = [
+  '/admin/users/golden_ks_a_member_2?tenantId=tenant_ks',
+  '/admin/users/golden_ks_a_member_3?tenantId=tenant_ks',
+  '/admin/users/golden_ks_a_member_4?tenantId=tenant_ks',
+  '/admin/users/golden_ks_a_member_5?tenantId=tenant_ks',
+  '/admin/users/golden_ks_a_member_6?tenantId=tenant_ks',
+];
+
+function buildRolePanelDiscoveryUrls(runCtx, rolePanelTarget) {
+  const urls = [rolePanelTarget.targetUrl];
+  if (rolePanelTarget.source !== 'default' && !rolePanelTarget.allowFallbackDiscovery) {
+    return urls;
+  }
+
+  const fallbackPaths = [ROUTES.defaultAdminUserUrl, ...SAFE_ROLE_PANEL_FALLBACK_PATHS];
+  for (const routePath of fallbackPaths) {
+    urls.push(buildRoute(runCtx.baseUrl, runCtx.locale, routePath));
+  }
+
+  return Array.from(new Set(urls));
+}
+
+module.exports = { buildRolePanelDiscoveryUrls };

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37631489,
-  "maxTrackedFiles": 4575,
+  "maxTrackedBytes": 37635278,
+  "maxTrackedFiles": 4576,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7055410,
+    "source/scripts": 7056331,
     "docs/text": 5711417,
-    "tests/e2e": 4979776,
+    "tests/e2e": 4982644,
     "config/data/messages": 1554888,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- force-refresh stale cached release-gate sessions when a positive readiness marker unexpectedly resolves to not-found
- make role-panel target discovery deterministic with safe KS member fixture fallbacks
- move fallback target construction into a focused helper and keep canonical Phase C routes unchanged

## Verification
- pnpm test:release-gate
- pnpm check:modularity-guard
- pnpm repo:size:check
- pnpm pr:verify
- pnpm security:guard
- pnpm e2e:gate

## Notes
- apps/web/src/proxy.ts untouched
- production deploy remains skipped on main; this PR is for staging CD e2e stabilization
