### PR TITLE
fix: harden cd release gate role mutations

### DIFF
--- a/packages/domain-users/src/admin/role-id.test.ts
+++ b/packages/domain-users/src/admin/role-id.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { createRoleAssignmentId } from './role-id';
+
+describe('createRoleAssignmentId', () => {
+  it('creates a non-empty text id for role assignment rows', () => {
+    expect(createRoleAssignmentId()).toMatch(/\S/);
+  });
+});

--- a/packages/domain-users/src/admin/role-id.ts
+++ b/packages/domain-users/src/admin/role-id.ts
@@ -1,0 +1,16 @@
+export function createRoleAssignmentId(): string {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID === 'function') {
+    return randomUUID.call(globalThis.crypto);
+  }
+
+  const getRandomValues = globalThis.crypto?.getRandomValues;
+  if (typeof getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    getRandomValues.call(globalThis.crypto, bytes);
+    const suffix = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+    return `role_${suffix}`;
+  }
+
+  throw new Error('Secure random ID generation is unavailable');
+}

--- a/packages/domain-users/src/admin/roles.ts
+++ b/packages/domain-users/src/admin/roles.ts
@@ -2,8 +2,8 @@ import { and, branches, db, eq, user, userRoles } from '@interdomestik/database'
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { hasPermission, PERMISSIONS, requirePermission } from '@interdomestik/shared-auth';
 import { isNull } from 'drizzle-orm';
-import { randomUUID } from 'node:crypto'; // NOSONAR
 import type { ActionResult, UserDomainDeps, UserSession } from '../types';
+import { createRoleAssignmentId } from './role-id';
 import { isBranchRequiredRole } from './role-rules';
 import { resolveTenantId } from './utils';
 
@@ -135,7 +135,7 @@ export async function grantUserRoleCore(
     const insertedRoles = await tx
       .insert(userRoles)
       .values({
-        id: randomUUID(),
+        id: createRoleAssignmentId(),
         tenantId,
         userId: params.userId,
         role,

--- a/scripts/release-gate/admin-checks.ts
+++ b/scripts/release-gate/admin-checks.ts
@@ -471,7 +471,7 @@ async function runP06(browser, runCtx, deps) {
     const context = await browser.newContext();
     const page = await context.newPage();
     try {
-      await loginWithRunContext(page, runCtx, accountKey);
+      await loginWithRunContext(page, runCtx, accountKey, { forceFresh: true });
       return await fn(page);
     } finally {
       await context.close();

--- a/scripts/release-gate/p06-scenarios.test.ts
+++ b/scripts/release-gate/p06-scenarios.test.ts
@@ -3,6 +3,8 @@ import { createRequire } from 'node:module';
 import test from 'node:test';
 
 const require = createRequire(import.meta.url);
+const { MARKERS } = require('./config.ts');
+const { runP06 } = require('./admin-checks.ts');
 const { buildP06CanonicalRouteScenarios } = require('./p06-scenarios.ts');
 
 test('P0.6 canonical scenarios stay aligned with P0.1 role matrix', () => {
@@ -36,3 +38,86 @@ test('P0.6 canonical scenarios stay aligned with P0.1 role matrix', () => {
     ]
   );
 });
+
+test('P0.6 account setup uses forceFresh login before scenario navigation', async () => {
+  const loginCalls: Array<{ accountKey: string; forceFresh: boolean }> = [];
+  let activePage: any = null;
+  const browser = {
+    async newContext() {
+      return {
+        async newPage() {
+          activePage = createPage();
+          return activePage;
+        },
+        async close() {},
+      };
+    },
+  };
+
+  await runP06(
+    browser,
+    { baseUrl: 'https://interdomestik-web.vercel.app', locale: 'en' },
+    {
+      loginWithRunContext: async (
+        _page: unknown,
+        _runCtx: unknown,
+        accountKey: string,
+        options?: { forceFresh?: boolean }
+      ) => {
+        loginCalls.push({ accountKey, forceFresh: options?.forceFresh === true });
+        activePage.currentAccount = accountKey;
+      },
+    }
+  );
+
+  assert.equal(loginCalls.length > 0, true);
+  assert.equal(
+    loginCalls.every(call => call.forceFresh),
+    true
+  );
+});
+
+function createPage(): any {
+  return {
+    currentAccount: '',
+    currentUrl: '',
+    async goto(url: string) {
+      this.currentUrl = url;
+    },
+    locator(selector: string) {
+      return {
+        count: async () => markerCountFor(selector, this.currentAccount, this.currentUrl),
+        isVisible: async () => false,
+        first: () => ({
+          isVisible: async () => false,
+          innerText: async () => '',
+        }),
+      };
+    },
+    getByTestId() {
+      return { isVisible: async () => false };
+    },
+    url() {
+      return this.currentUrl || '';
+    },
+  };
+}
+
+function markerCountFor(selector: string, account: string, url: string): number {
+  const route = new URL(url || 'https://interdomestik-web.vercel.app/en/member').pathname;
+  const canonicalByAccount: Record<string, string> = {
+    agent: '/en/agent',
+    staff: '/en/staff',
+    admin_ks: '/en/admin',
+  };
+  const markerByAccount: Record<string, string> = {
+    agent: MARKERS.agent,
+    staff: MARKERS.staff,
+    admin_ks: MARKERS.admin,
+  };
+  const canonical = canonicalByAccount[account];
+  const marker = markerByAccount[account];
+  if (canonical && marker && route === canonical && selector.includes(marker)) return 1;
+  if (canonical && route !== canonical && selector.includes(MARKERS.notFound)) return 1;
+  return 0;
+}

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37635278,
-  "maxTrackedFiles": 4576,
+  "maxTrackedBytes": 37638510,
+  "maxTrackedFiles": 4578,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7056331,
+    "source/scripts": 7056910,
     "docs/text": 5711417,
-    "tests/e2e": 4982644,
+    "tests/e2e": 4985297,
     "config/data/messages": 1554888,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- replace the Node-only role assignment UUID import with a runtime-safe helper for deployed server action role grants
- force fresh P0.6 release-gate logins so canonical route checks do not inherit stale session materialization from prior checks
- add focused regression coverage for the P0.6 fresh-login contract and update the tracked repo-size budget

## Verification
- corepack pnpm pr:verify
- corepack pnpm security:guard
- corepack pnpm e2e:gate

## CD context
Targets the latest staging CD failure where P0.1/P0.2 passed but P0.3/P0.4 role mutations failed with an internal server-action error and P0.6 failed after earlier cached sessions. No routing/proxy changes, no production deploy, no destructive migration.