### PR TITLE
fix: run admin role mutations in tenant context

### DIFF
--- a/apps/web/src/actions/admin-rbac.roles.test.ts
+++ b/apps/web/src/actions/admin-rbac.roles.test.ts
@@ -4,18 +4,27 @@ import { grantUserRoleCore } from '@interdomestik/domain-users/admin/rbac';
 
 const hoisted = vi.hoisted(() => ({
   branchesFindFirst: vi.fn(),
-  transaction: vi.fn(),
+  withTenantContext: vi.fn(),
 }));
 
+function makeGrantTx(updatedUsers = [{ id: 'user-1' }]) {
+  return {
+    query: { branches: { findFirst: hoisted.branchesFindFirst } },
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue(updatedUsers) })),
+      })),
+    })),
+    delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'role-1' }]) })),
+    })),
+  };
+}
+
 vi.mock('@interdomestik/database', () => ({
-  db: {
-    query: {
-      branches: {
-        findFirst: hoisted.branchesFindFirst,
-      },
-    },
-    transaction: hoisted.transaction,
-  },
+  db: {},
+  withTenantContext: (...args: unknown[]) => hoisted.withTenantContext(...args),
   and: vi.fn(() => ({})),
   eq: vi.fn(() => ({})),
   branches: {
@@ -53,27 +62,9 @@ describe('domain-users rbac: branch required roles', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    hoisted.transaction.mockImplementation(async fn => {
-      const tx = {
-        update: vi.fn(() => ({
-          set: vi.fn(() => ({
-            where: vi.fn(() => ({
-              returning: vi.fn().mockResolvedValue([{ id: 'user-1' }]),
-            })),
-          })),
-        })),
-        delete: vi.fn(() => ({
-          where: vi.fn().mockResolvedValue(undefined),
-        })),
-        insert: vi.fn(() => ({
-          values: vi.fn(() => ({
-            returning: vi.fn().mockResolvedValue([{ id: 'role-1' }]),
-          })),
-        })),
-      };
-
-      return fn(tx);
-    });
+    hoisted.withTenantContext.mockImplementation(
+      async (_context: unknown, fn: (tx: unknown) => Promise<unknown>) => fn(makeGrantTx())
+    );
   });
 
   it('rejects assigning agent role without branchId', async () => {
@@ -87,7 +78,7 @@ describe('domain-users rbac: branch required roles', () => {
 
     expect(result).toEqual({ error: 'Branch is required for role: agent' });
     expect(hoisted.branchesFindFirst).not.toHaveBeenCalled();
-    expect(hoisted.transaction).not.toHaveBeenCalled();
+    expect(hoisted.withTenantContext).not.toHaveBeenCalled();
   });
 
   it('allows restoring a legacy tenant-wide agent role without branchId when explicitly flagged', async () => {
@@ -102,7 +93,7 @@ describe('domain-users rbac: branch required roles', () => {
 
     expect(result).toEqual({ success: true });
     expect(hoisted.branchesFindFirst).not.toHaveBeenCalled();
-    expect(hoisted.transaction).toHaveBeenCalled();
+    expect(hoisted.withTenantContext).toHaveBeenCalled();
   });
 
   it('rejects assigning branch_manager role without branchId', async () => {
@@ -116,7 +107,7 @@ describe('domain-users rbac: branch required roles', () => {
 
     expect(result).toEqual({ error: 'Branch is required for role: branch_manager' });
     expect(hoisted.branchesFindFirst).not.toHaveBeenCalled();
-    expect(hoisted.transaction).not.toHaveBeenCalled();
+    expect(hoisted.withTenantContext).not.toHaveBeenCalled();
   });
 
   it('rejects assigning branch-scoped role to inactive branch', async () => {
@@ -131,7 +122,7 @@ describe('domain-users rbac: branch required roles', () => {
     });
 
     expect(result).toEqual({ error: 'Cannot assign role to inactive branch' });
-    expect(hoisted.transaction).not.toHaveBeenCalled();
+    expect(hoisted.withTenantContext).toHaveBeenCalledTimes(1);
   });
 
   it('rejects assigning branch-scoped role to branch outside tenant', async () => {
@@ -146,32 +137,24 @@ describe('domain-users rbac: branch required roles', () => {
     });
 
     expect(result).toEqual({ error: 'Invalid branch' });
-    expect(hoisted.transaction).not.toHaveBeenCalled();
+    expect(hoisted.withTenantContext).toHaveBeenCalledTimes(1);
   });
 
   it('returns error when grant cannot update a tenant-scoped user', async () => {
     hoisted.branchesFindFirst.mockResolvedValue({ id: 'b-1', isActive: true });
-    hoisted.transaction.mockImplementationOnce(async fn => {
-      const tx = {
-        update: vi.fn(() => ({
-          set: vi.fn(() => ({
-            where: vi.fn(() => ({
-              returning: vi.fn().mockResolvedValue([]),
-            })),
-          })),
-        })),
-        delete: vi.fn(() => ({
-          where: vi.fn().mockResolvedValue(undefined),
-        })),
-        insert: vi.fn(() => ({
-          values: vi.fn(() => ({
-            returning: vi.fn().mockResolvedValue([{ id: 'role-1' }]),
-          })),
-        })),
-      };
-
-      return fn(tx);
-    });
+    hoisted.withTenantContext
+      .mockImplementationOnce(async (_context: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+        fn({
+          query: {
+            branches: {
+              findFirst: hoisted.branchesFindFirst,
+            },
+          },
+        })
+      )
+      .mockImplementationOnce(async (_context: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        return fn(makeGrantTx([]));
+      });
 
     await expect(
       grantUserRoleCore({

--- a/packages/domain-users/src/admin/roles.list.test.ts
+++ b/packages/domain-users/src/admin/roles.list.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   findUserRoles: vi.fn(),
   findUser: vi.fn(),
+  withTenantContext: vi.fn(),
   withTenant: vi.fn((tenantId: string, _tenantColumn: unknown, condition?: unknown) => ({
     tenantId,
     condition,
@@ -11,16 +12,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
-  db: {
-    query: {
-      userRoles: {
-        findMany: (...args: unknown[]) => mocks.findUserRoles(...args),
-      },
-      user: {
-        findFirst: (...args: unknown[]) => mocks.findUser(...args),
-      },
-    },
-  },
+  db: {},
+  withTenantContext: (...args: unknown[]) => mocks.withTenantContext(...args),
   user: {
     id: 'user.id',
     tenantId: 'user.tenantId',
@@ -58,14 +51,21 @@ vi.mock('drizzle-orm', () => ({
 import { listUserRolesCore } from './roles';
 
 describe('listUserRolesCore', () => {
-  const session = {
-    user: { id: 'admin-1', role: 'admin', tenantId: 'tenant_ks' },
-  };
+  const session = { user: { id: 'admin-1', role: 'admin', tenantId: 'tenant_ks' } };
 
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.findUserRoles.mockResolvedValue([]);
     mocks.findUser.mockResolvedValue(null);
+    mocks.withTenantContext.mockImplementation(
+      async (_context: unknown, action: (tx: unknown) => Promise<unknown>) =>
+        action({
+          query: {
+            userRoles: { findMany: mocks.findUserRoles },
+            user: { findFirst: mocks.findUser },
+          },
+        })
+    );
   });
 
   it('falls back to the legacy primary role for elevated seeded users without user_roles rows', async () => {

--- a/packages/domain-users/src/admin/roles.revoke.test.ts
+++ b/packages/domain-users/src/admin/roles.revoke.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  transaction: vi.fn(),
+  withTenantContext: vi.fn(),
   withTenant: vi.fn((tenantId: string, _tenantCol: unknown, condition?: unknown) => ({
     tenantId,
     condition,
@@ -12,9 +12,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
-  db: {
-    transaction: mocks.transaction,
-  },
+  db: {},
+  withTenantContext: (...args: unknown[]) => mocks.withTenantContext(...args),
   user: {
     id: 'user.id',
     tenantId: 'user.tenantId',
@@ -67,25 +66,27 @@ describe('revokeUserRoleCore', () => {
     });
     const updateWhere = vi.fn().mockResolvedValue([{ id: 'user-1' }]);
 
-    mocks.transaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<unknown>) => {
-      const tx = {
-        delete: vi.fn(() => ({ where: deleteWhere })),
-        query: {
-          user: {
-            findFirst: vi.fn().mockResolvedValue({ role: 'agent' }),
+    mocks.withTenantContext.mockImplementationOnce(
+      async (_context: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          delete: vi.fn(() => ({ where: deleteWhere })),
+          query: {
+            user: {
+              findFirst: vi.fn().mockResolvedValue({ role: 'agent' }),
+            },
+            userRoles: {
+              findMany: vi.fn().mockResolvedValue([]),
+            },
           },
-          userRoles: {
-            findMany: vi.fn().mockResolvedValue([]),
-          },
-        },
-        update: vi.fn(() => ({
-          set: vi.fn(() => ({
-            where: updateWhere,
+          update: vi.fn(() => ({
+            set: vi.fn(() => ({
+              where: updateWhere,
+            })),
           })),
-        })),
-      };
-      return fn(tx);
-    });
+        };
+        return fn(tx);
+      }
+    );
 
     const result = await revokeUserRoleCore({
       session,
@@ -110,25 +111,27 @@ describe('revokeUserRoleCore', () => {
       returning: vi.fn().mockResolvedValue([{ id: 'role-1' }]),
     });
 
-    mocks.transaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<unknown>) => {
-      const tx = {
-        delete: vi.fn(() => ({ where: deleteWhere })),
-        query: {
-          user: {
-            findFirst: vi.fn().mockResolvedValue({ role: 'member' }),
+    mocks.withTenantContext.mockImplementationOnce(
+      async (_context: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          delete: vi.fn(() => ({ where: deleteWhere })),
+          query: {
+            user: {
+              findFirst: vi.fn().mockResolvedValue({ role: 'member' }),
+            },
+            userRoles: {
+              findMany: vi.fn().mockResolvedValue([]),
+            },
           },
-          userRoles: {
-            findMany: vi.fn().mockResolvedValue([]),
-          },
-        },
-        update: vi.fn(() => ({
-          set: vi.fn(() => ({
-            where: vi.fn().mockResolvedValue([{ id: 'user-1' }]),
+          update: vi.fn(() => ({
+            set: vi.fn(() => ({
+              where: vi.fn().mockResolvedValue([{ id: 'user-1' }]),
+            })),
           })),
-        })),
-      };
-      return fn(tx);
-    });
+        };
+        return fn(tx);
+      }
+    );
 
     const result = await revokeUserRoleCore({
       session,

--- a/packages/domain-users/src/admin/roles.ts
+++ b/packages/domain-users/src/admin/roles.ts
@@ -1,4 +1,4 @@
-import { and, branches, db, eq, user, userRoles, withTenantContext } from '@interdomestik/database';
+import { and, branches, eq, user, userRoles, withTenantContext } from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { hasPermission, PERMISSIONS, requirePermission } from '@interdomestik/shared-auth';
 import { isNull } from 'drizzle-orm';

--- a/packages/domain-users/src/admin/roles.ts
+++ b/packages/domain-users/src/admin/roles.ts
@@ -1,4 +1,4 @@
-import { and, branches, db, eq, user, userRoles } from '@interdomestik/database';
+import { and, branches, db, eq, user, userRoles, withTenantContext } from '@interdomestik/database';
 import { withTenant } from '@interdomestik/database/tenant-security';
 import { hasPermission, PERMISSIONS, requirePermission } from '@interdomestik/shared-auth';
 import { isNull } from 'drizzle-orm';
@@ -17,47 +17,49 @@ export async function listUserRolesCore(params: {
   requirePermission(session, PERMISSIONS['roles.manage'], hasPermission);
   const tenantId = resolveTenantId(session, params.tenantId);
 
-  if (params.userId) {
-    const explicitRoles = await db.query.userRoles.findMany({
-      where: withTenant(tenantId, userRoles.tenantId, eq(userRoles.userId, params.userId)),
-    });
+  return withTenantContext({ tenantId, role: session.user.role }, async tx => {
+    if (params.userId) {
+      const explicitRoles = await tx.query.userRoles.findMany({
+        where: withTenant(tenantId, userRoles.tenantId, eq(userRoles.userId, params.userId)),
+      });
 
-    const legacyUser = await db.query.user.findFirst({
-      where: withTenant(tenantId, user.tenantId, eq(user.id, params.userId)),
-      columns: {
-        id: true,
-        role: true,
-        branchId: true,
-      },
-    });
+      const legacyUser = await tx.query.user.findFirst({
+        where: withTenant(tenantId, user.tenantId, eq(user.id, params.userId)),
+        columns: {
+          id: true,
+          role: true,
+          branchId: true,
+        },
+      });
 
-    if (!legacyUser || !legacyUser.role || legacyUser.role === 'member') {
-      return explicitRoles;
+      if (!legacyUser || !legacyUser.role || legacyUser.role === 'member') {
+        return explicitRoles;
+      }
+
+      const hasPrimaryRoleRow = explicitRoles.some(
+        row => row.role === legacyUser.role && row.branchId === (legacyUser.branchId ?? null)
+      );
+
+      if (hasPrimaryRoleRow) {
+        return explicitRoles;
+      }
+
+      const legacyPrimaryRole = [
+        {
+          id: `legacy-${legacyUser.id}-${legacyUser.role}-${legacyUser.branchId ?? 'tenant'}`,
+          tenantId,
+          userId: legacyUser.id,
+          role: legacyUser.role,
+          branchId: legacyUser.branchId ?? null,
+        },
+      ];
+
+      return [...legacyPrimaryRole, ...explicitRoles];
     }
 
-    const hasPrimaryRoleRow = explicitRoles.some(
-      row => row.role === legacyUser.role && row.branchId === (legacyUser.branchId ?? null)
-    );
-
-    if (hasPrimaryRoleRow) {
-      return explicitRoles;
-    }
-
-    const legacyPrimaryRole = [
-      {
-        id: `legacy-${legacyUser.id}-${legacyUser.role}-${legacyUser.branchId ?? 'tenant'}`,
-        tenantId,
-        userId: legacyUser.id,
-        role: legacyUser.role,
-        branchId: legacyUser.branchId ?? null,
-      },
-    ];
-
-    return [...legacyPrimaryRole, ...explicitRoles];
-  }
-
-  return db.query.userRoles.findMany({
-    where: withTenant(tenantId, userRoles.tenantId),
+    return tx.query.userRoles.findMany({
+      where: withTenant(tenantId, userRoles.tenantId),
+    });
   });
 }
 
@@ -80,17 +82,18 @@ export async function grantUserRoleCore(
   const role = params.role.trim();
   if (!role) return { error: 'Role is required' };
 
-  // Ensure branch belongs to this tenant and is ACTIVE (when provided).
   let branchId = params.branchId ?? null;
   if (branchId) {
-    const branch = await db.query.branches.findFirst({
-      where: withTenant(tenantId, branches.tenantId, eq(branches.id, branchId)),
-    });
+    const branchIdForLookup = branchId;
+    const branch = await withTenantContext({ tenantId, role: session.user.role }, tx =>
+      tx.query.branches.findFirst({
+        where: withTenant(tenantId, branches.tenantId, eq(branches.id, branchIdForLookup)),
+      })
+    );
     if (!branch) return { error: 'Invalid branch' };
     if (!branch.isActive) return { error: 'Cannot assign role to inactive branch' };
   }
 
-  // Branch Scoping Rules
   if (isBranchRequiredRole(role)) {
     if (params.allowLegacyTenantWide && role === 'agent' && !branchId) {
       branchId = null;
@@ -98,14 +101,10 @@ export async function grantUserRoleCore(
       return { error: `Branch is required for role: ${role}` };
     }
   } else {
-    // For non-branch roles (admin, staff), ensure branchId is null (unless we allow branch-staff later)
-    // For now, clean it up to avoid confusion.
     branchId = null;
   }
 
-  await db.transaction(async tx => {
-    // 1. Update user table (Source of Truth for Session)
-    // We treat this grant as setting the PRIMARY role.
+  await withTenantContext({ tenantId, role: session.user.role }, async tx => {
     const updatedUsers = await tx
       .update(user)
       .set({
@@ -119,8 +118,6 @@ export async function grantUserRoleCore(
       throw new Error('Role grant did not update the user');
     }
 
-    // 2. Add to userRoles (Audit/Multi-role future safe)
-    // First remove existing entry for same role to avoid duplicates if any
     await tx
       .delete(userRoles)
       .where(
@@ -182,7 +179,7 @@ export async function revokeUserRoleCore(
   if (!role) return { error: 'Role is required' };
 
   const branchId = params.branchId ?? null;
-  const deletedRoles = await db.transaction(async tx => {
+  const deletedRoles = await withTenantContext({ tenantId, role: session.user.role }, async tx => {
     const roleDeleteScope =
       branchId === null ? isNull(userRoles.branchId) : eq(userRoles.branchId, branchId);
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37638777,
+  "maxTrackedBytes": 37638951,
   "maxTrackedFiles": 4578,
   "maxCategoryBytes": {
     "large support/generated-ish": 18200754,
-    "source/scripts": 7056944,
+    "source/scripts": 7056831,
     "docs/text": 5711417,
-    "tests/e2e": 4985530,
+    "tests/e2e": 4985817,
     "config/data/messages": 1554888,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- Run admin user-role reads and mutations under `withTenantContext` so RLS policies receive `app.current_access_tenant_id`.
- Keep role grant/revoke on the RLS path instead of falling back to admin DB.
- Update focused role tests and tracked-only repo-size budget.

## CD context
CD run 28345053059 proved staging build/deploy are green and production is correctly skipped on main. The only remaining staging failure was P0.3/P0.4 role mutation. Staging RLS policies require `app.current_access_tenant_id`; the prior domain role path used plain `db`/`db.transaction`, so RLS updated zero rows and safe-action returned `INTERNAL_SERVER_ERROR`.

## Verification
- `corepack pnpm --filter @interdomestik/domain-users test:unit -- --run src/admin/roles.list.test.ts src/admin/roles.revoke.test.ts src/admin/role-id.test.ts`
- `corepack pnpm --filter @interdomestik/web test:unit -- --run src/actions/admin-rbac.roles.test.ts src/actions/admin-rbac.wrapper.test.ts`
- `corepack pnpm security:guard`
- `corepack pnpm pr:verify`
- `corepack pnpm e2e:gate`