### PR TITLE
fix: match collapsed role rows in release gate

### DIFF
--- a/scripts/release-gate/admin-checks-locators.ts
+++ b/scripts/release-gate/admin-checks-locators.ts
@@ -52,8 +52,15 @@ function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function caseInsensitiveLiteral(value) {
+  return String(value).replace(/[a-z]/gi, char => `[${char.toLowerCase()}${char.toUpperCase()}]`);
+}
+
 function roleTextPattern(roleName) {
-  return new RegExp(String.raw`\b${escapeRegExp(roleName)}`, 'i');
+  const normalizedRoleName = String(roleName || '').trim();
+  if (!normalizedRoleName) return /a^/;
+  const roleLiteral = caseInsensitiveLiteral(escapeRegExp(normalizedRoleName));
+  return new RegExp(String.raw`\b${roleLiteral}(?=\b|Tenant-wide)`);
 }
 
 function roleRowLocator(page, roleName) {

--- a/scripts/release-gate/admin-checks-locators.ts
+++ b/scripts/release-gate/admin-checks-locators.ts
@@ -53,7 +53,7 @@ function escapeRegExp(value) {
 }
 
 function roleTextPattern(roleName) {
-  return new RegExp(String.raw`\b${escapeRegExp(roleName)}\b`, 'i');
+  return new RegExp(String.raw`\b${escapeRegExp(roleName)}`, 'i');
 }
 
 function roleRowLocator(page, roleName) {

--- a/scripts/release-gate/admin-checks.test.ts
+++ b/scripts/release-gate/admin-checks.test.ts
@@ -128,11 +128,16 @@ class FakePage {
 }
 
 test('removeRoleFromTable clicks the visible role row action', async () => {
+  const backupRow = new FakeRowLocator('promoter_backupTenant-wideRemove');
   const promoterRow = new FakeRowLocator('PromoterTenant-wideRemove');
-  const page = new FakePage([new FakeRowLocator('RoleBranchActions'), promoterRow]);
+  const page = new FakePage([new FakeRowLocator('RoleBranchActions'), backupRow, promoterRow]);
 
   const removed = await removeRoleFromTable(page, 'promoter');
 
   assert.equal(removed, true);
+  assert.equal(backupRow.button.clickCount, 0);
+  assert.equal(promoterRow.button.clickCount, 1);
+
+  assert.equal(await removeRoleFromTable(page, ' '), false);
   assert.equal(promoterRow.button.clickCount, 1);
 });

--- a/scripts/release-gate/admin-checks.test.ts
+++ b/scripts/release-gate/admin-checks.test.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 import test from 'node:test';
 
 const require = createRequire(import.meta.url);
-const { findRoleRowByText, removeRoleFromTable } = require('./admin-checks.ts');
+const { removeRoleFromTable } = require('./admin-checks.ts');
 
 class FakeButtonLocator {
   states: boolean[];
@@ -127,17 +127,8 @@ class FakePage {
   }
 }
 
-test('findRoleRowByText matches a visible role row by text content', async () => {
-  const promoterRow = new FakeRowLocator('PromoterTenant-wideRemove');
-  const page = new FakePage([new FakeRowLocator('RoleBranchActions'), promoterRow]);
-
-  const found = await findRoleRowByText(page, 'promoter');
-
-  assert.equal(found, promoterRow);
-});
-
 test('removeRoleFromTable clicks the visible role row action', async () => {
-  const promoterRow = new FakeRowLocator('Promoter Tenant-wide Remove');
+  const promoterRow = new FakeRowLocator('PromoterTenant-wideRemove');
   const page = new FakePage([new FakeRowLocator('RoleBranchActions'), promoterRow]);
 
   const removed = await removeRoleFromTable(page, 'promoter');

--- a/scripts/release-gate/admin-checks.ts
+++ b/scripts/release-gate/admin-checks.ts
@@ -245,27 +245,6 @@ async function runP02(browser, runCtx, deps) {
   return checkResult('P0.2', failures.length ? 'FAIL' : 'PASS', evidence, failures);
 }
 
-async function findRoleRowByText(page, roleName) {
-  const table = page.locator(SELECTORS.userRolesTable);
-  const normalizedRoleName = String(roleName || '')
-    .trim()
-    .toLowerCase();
-  const rows = table.locator('tr');
-  const rowCount = await rows.count();
-
-  for (let index = 0; index < rowCount; index += 1) {
-    const row = rows.nth(index);
-    const text = String((await row.textContent().catch(() => '')) || '')
-      .replace(/\s+/g, ' ')
-      .trim();
-    if (text.toLowerCase().includes(normalizedRoleName)) {
-      return row;
-    }
-  }
-
-  return null;
-}
-
 function collectRbacFailures(input) {
   const { account, portal, route, matrix, current, runCtx, memberDriftSignatureAdded } = input;
   const failures = [];
@@ -740,7 +719,6 @@ async function runP06(browser, runCtx, deps) {
 }
 
 module.exports = {
-  findRoleRowByText,
   isInfraNavigationFailure,
   removeRoleFromTable,
   runCheckWithInfraRetry,


### PR DESCRIPTION
## Summary
- loosen the release-gate role row matcher so it sees OpsTable rows whose cell text collapses together, e.g. PromoterTenant-wideRemove
- remove the stale unused text-scanning helper that masked the actual locator path
- keep the existing role-removal test covering the collapsed row text case

## Verification
- git diff --check
- pnpm test:release-gate
- pnpm security:guard
- pnpm pr:verify

## CD context
Post-merge CD e2e-staging was failing only P0.3/P0.4 after the app mutation succeeded. The staging artifact showed the role row present as "Promoter Tenant-wide Remove", while Playwright row text can collapse to "PromoterTenant-wideRemove". This fix targets the verifier, not runtime role mutation behavior.