### PR TITLE
ci: set explicit workflow token permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,6 +117,7 @@ jobs:
     needs: deploy-staging
     runs-on: [self-hosted, interdomestik-mac]
     environment: { name: staging, deployment: false }
+    permissions: { contents: read }
     env:
       BASE_URL: ${{ needs.deploy-staging.outputs.base_url }}
       AUTH_BASE_URL: https://staging.interdomestik.com
@@ -152,7 +153,6 @@ jobs:
             --authBaseUrl "${AUTH_BASE_URL}" \
             --outDir "${EVIDENCE_DIR}/release-gates" \
             2>&1 | tee "${EVIDENCE_DIR}/logs/release-gate-staging.log"
-
       - name: Upload staging verification artifacts
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -253,6 +253,7 @@ jobs:
     runs-on: [self-hosted, interdomestik-mac]
     timeout-minutes: 20
     environment: { name: production, deployment: false }
+    permissions: { contents: read }
     env:
       BASE_URL: https://www.interdomestik.com
       EVIDENCE_DIR: tmp/cd-evidence/${{ github.run_id }}
@@ -276,7 +277,6 @@ jobs:
       SENTRY_SEVERITY_THRESHOLD: error
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
-
       - uses: ./.github/actions/setup
         with: { install-playwright: 'true' }
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -6,6 +6,9 @@ on:
     - cron: '10 2 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-nightly
   cancel-in-progress: true

--- a/.github/workflows/pilot-gate.yml
+++ b/.github/workflows/pilot-gate.yml
@@ -122,7 +122,6 @@ jobs:
           SONAR_CHECK_MAX_RETRIES: '36'
           SONAR_CHECK_RETRY_DELAY_SECONDS: '10'
         run: bash scripts/sonar-check-run-gate.sh
-
       - name: Decide Sonar gate strategy
         id: sonar_strategy
         shell: bash
@@ -307,6 +306,7 @@ jobs:
       - pilot-gate-preflight
       - pilot-gate-runner
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Enforce pilot gate preflight/result contract
         shell: bash

--- a/scripts/ci/workflow-permissions-contract.test.mjs
+++ b/scripts/ci/workflow-permissions-contract.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const workflowDir = path.join(rootDir, '.github', 'workflows');
+const permissionValues = new Set(['read', 'write', 'none']);
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function readWorkflow(relativePath) {
+  return yaml.load(fs.readFileSync(path.join(rootDir, relativePath), 'utf8'));
+}
+
+function workflowPaths() {
+  return fs
+    .readdirSync(workflowDir)
+    .filter(fileName => fileName.endsWith('.yml') || fileName.endsWith('.yaml'))
+    .sort()
+    .map(fileName => `.github/workflows/${fileName}`);
+}
+
+function assertPermissionMap(location, permissions) {
+  assert.equal(typeof permissions, 'object', `${location} permissions must be a map`);
+  assert.notEqual(permissions, null, `${location} permissions must be explicit`);
+
+  for (const [scope, access] of Object.entries(permissions)) {
+    assert.ok(permissionValues.has(access), `${location} ${scope} permission must be read/write/none`);
+  }
+}
+
+test('GitHub workflows define explicit GITHUB_TOKEN permissions', () => {
+  const missing = [];
+
+  for (const relativePath of workflowPaths()) {
+    const workflow = readWorkflow(relativePath);
+    const workflowHasPermissions = hasOwn(workflow, 'permissions');
+
+    if (workflowHasPermissions) {
+      assertPermissionMap(`${relativePath} workflow`, workflow.permissions);
+    }
+
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      const jobHasPermissions = hasOwn(job, 'permissions');
+
+      if (jobHasPermissions) {
+        assertPermissionMap(`${relativePath} job ${jobName}`, job.permissions);
+      }
+
+      if (!workflowHasPermissions && !jobHasPermissions) {
+        missing.push(`${relativePath} job ${jobName}`);
+      }
+    }
+  }
+
+  assert.deepEqual(missing, []);
+});


### PR DESCRIPTION
## Summary
- Add explicit least-privilege GITHUB_TOKEN permissions to the workflow jobs flagged by CodeQL.
- Add a workflow permissions contract test so future workflows/jobs must declare explicit token permissions.
- No application, proxy, auth, routing, tenancy, or architecture changes.

## Code scanning alerts intended to close
- `actions/missing-workflow-permissions` in `.github/workflows/cd.yml`
- `actions/missing-workflow-permissions` in `.github/workflows/commitlint.yml`
- `actions/missing-workflow-permissions` in `.github/workflows/e2e-nightly.yml`
- `actions/missing-workflow-permissions` in `.github/workflows/pilot-gate.yml`

## Permission choices
- `contents: read` for jobs/workflows that check out repository code.
- `permissions: {}` for the final pilot wrapper job, which only evaluates `needs` results and does not require a token.

## Verification
- `git diff --check`
- `node --test --test-concurrency=1 scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs` (306/306)
- `node --test --test-concurrency=1 scripts/ci/workflow-permissions-contract.test.mjs scripts/ci/workflow-contracts.test.mjs scripts/ci/github-governance-contracts.test.mjs` (23/23)
- `node scripts/security-guard.mjs`

## Residual follow-up
- Dependabot is already clean after PR #1253.
- The remaining code-scanning backlog is now the JS/path/XSS/redirect/regex clusters and should be handled in separate focused slices.