### PR TITLE
fix: harden qa tooling path handling

### DIFF
--- a/packages/qa/src/tools/audits/utils.ts
+++ b/packages/qa/src/tools/audits/utils.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { canonicalizeRepoRoot, resolveRepoPath } from '../../utils/paths.js';
+
+const ROOT_ENV_FILE_CANDIDATES = ['.env.local', '.env.development.local', '.env'] as const;
 
 export function checkFileExists(
   filePath: string,
@@ -27,11 +30,14 @@ export function checkFileContains(
 }
 
 export function findRootEnvFile(repoRoot: string): string | null {
-  const candidates = ['.env.local', '.env.development.local', '.env'];
+  const canonicalRoot = canonicalizeRepoRoot(repoRoot);
+  if (!canonicalRoot) {
+    return null;
+  }
 
-  for (const candidate of candidates) {
-    const candidatePath = path.join(repoRoot, candidate);
-    if (fs.existsSync(candidatePath)) {
+  for (const candidate of ROOT_ENV_FILE_CANDIDATES) {
+    const candidatePath = resolveRepoPath(candidate, canonicalRoot).resolvedPath;
+    if (fs.existsSync(candidatePath) && fs.statSync(candidatePath).isFile()) {
       return candidatePath;
     }
   }

--- a/packages/qa/src/utils/paths.ts
+++ b/packages/qa/src/utils/paths.ts
@@ -5,26 +5,112 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-function isRepoRoot(dir: string): boolean {
-  return (
-    fs.existsSync(path.join(dir, 'turbo.json')) ||
-    fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))
-  );
+type RepoRootSource = 'MCP_REPO_ROOT' | 'module-relative' | 'cwd-search';
+
+const REPO_MARKERS = ['turbo.json', 'pnpm-workspace.yaml'] as const;
+
+function realpathIfPossible(resolvedPath: string): string {
+  try {
+    return fs.realpathSync.native(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
 }
 
-// Find repo root by walking up from a starting point.
-function findRepoRoot(currentDir: string): string {
-  if (isRepoRoot(currentDir)) {
-    return currentDir;
+function canonicalizeAbsoluteCandidate(candidate: string): string | null {
+  if (!candidate || candidate.includes('\0') || !path.isAbsolute(candidate)) {
+    return null;
   }
 
-  const parentDir = path.dirname(currentDir);
-  if (parentDir === currentDir) {
-    // Reached system root, fallback to CWD
-    return process.cwd();
+  return realpathIfPossible(candidate);
+}
+
+function realpathWithExistingParent(resolvedPath: string): string {
+  const missingSegments: string[] = [];
+  let currentPath = resolvedPath;
+  while (true) {
+    try {
+      const canonicalCurrent = fs.realpathSync.native(currentPath);
+      return path.join(canonicalCurrent, ...missingSegments.reverse());
+    } catch {
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        return resolvedPath;
+      }
+      missingSegments.push(path.basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+}
+
+function hasRepoMarker(dir: string): boolean {
+  return REPO_MARKERS.some(marker => fs.existsSync(path.join(dir, marker)));
+}
+
+export function canonicalizeRepoRoot(candidate: string): string | null {
+  const canonicalCandidate = canonicalizeAbsoluteCandidate(candidate);
+  return canonicalCandidate === REPO_ROOT ? REPO_ROOT : null;
+}
+
+function findRepoRoot(startDir: string): string | null {
+  let currentDir = realpathIfPossible(path.resolve(startDir));
+
+  while (true) {
+    if (hasRepoMarker(currentDir)) {
+      return currentDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return null;
+    }
+
+    currentDir = parentDir;
+  }
+}
+
+function selectTrustedEnvRoot(candidate: string | undefined, trustedRoots: Array<string | null>) {
+  if (!candidate) {
+    return null;
   }
 
-  return findRepoRoot(parentDir);
+  const canonicalCandidate = canonicalizeAbsoluteCandidate(candidate);
+  for (const trustedRoot of trustedRoots) {
+    if (trustedRoot && canonicalCandidate === trustedRoot) {
+      return trustedRoot;
+    }
+  }
+
+  return null;
+}
+
+function resolveRepoRoot(): { repoRoot: string; source: RepoRootSource } {
+  const cwdRoot = findRepoRoot(process.cwd());
+  const moduleRoot = findRepoRoot(path.resolve(__dirname, '../../../..'));
+  const envRoot = selectTrustedEnvRoot(process.env.MCP_REPO_ROOT, [cwdRoot, moduleRoot]);
+  if (envRoot) {
+    return { repoRoot: envRoot, source: 'MCP_REPO_ROOT' };
+  }
+
+  if (moduleRoot) {
+    return { repoRoot: moduleRoot, source: 'module-relative' };
+  }
+
+  if (cwdRoot) {
+    return { repoRoot: cwdRoot, source: 'cwd-search' };
+  }
+
+  throw new Error('Unable to resolve a repository root with required repo markers');
+}
+
+function assertRelativeInput(relativePath: string): void {
+  if (!relativePath || relativePath.includes('\0')) {
+    throw new Error('Path must be a non-empty repository-relative path');
+  }
+
+  if (path.isAbsolute(relativePath)) {
+    throw new Error(`Path must be repository-relative: ${relativePath}`);
+  }
 }
 
 function isWithin(childPath: string, parentPath: string): boolean {
@@ -32,29 +118,32 @@ function isWithin(childPath: string, parentPath: string): boolean {
   return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
 }
 
-const cwdRoot = findRepoRoot(process.cwd());
-const envRoot = process.env.MCP_REPO_ROOT ? path.resolve(process.env.MCP_REPO_ROOT) : null;
-
-// Fallback: Resolve root relative to this file (dist/utils/paths.js -> ../../../..)
-// src/utils/paths.ts -> dist/utils/paths.js
-const relativeRoot = path.resolve(__dirname, '../../../..');
-
-const resolvedEnvRoot = envRoot && isRepoRoot(envRoot) ? envRoot : null;
-const resolvedRelativeRoot = isRepoRoot(relativeRoot) ? relativeRoot : null;
-
-function resolveRepoRootSource(): 'MCP_REPO_ROOT' | 'module-relative' | 'cwd-search' {
-  if (resolvedEnvRoot) {
-    return 'MCP_REPO_ROOT';
+export function resolveRepoPath(relativePath: string, repoRoot = REPO_ROOT) {
+  const canonicalRoot = canonicalizeRepoRoot(repoRoot);
+  if (!canonicalRoot) {
+    throw new Error(`Repository root must be the canonical trusted repo root: ${repoRoot}`);
   }
 
-  if (resolvedRelativeRoot) {
-    return 'module-relative';
+  assertRelativeInput(relativePath);
+  const resolvedPath = path.resolve(canonicalRoot, relativePath);
+  if (!isWithin(resolvedPath, canonicalRoot)) {
+    throw new Error(`Path escapes repository root: ${relativePath}`);
   }
 
-  return 'cwd-search';
+  const canonicalPath = realpathWithExistingParent(resolvedPath);
+  if (!isWithin(canonicalPath, canonicalRoot)) {
+    throw new Error(`Path escapes repository root: ${relativePath}`);
+  }
+
+  return {
+    relativePath: path.relative(canonicalRoot, resolvedPath),
+    resolvedPath,
+  };
 }
 
-export const REPO_ROOT = resolvedEnvRoot ?? resolvedRelativeRoot ?? cwdRoot;
-export const REPO_ROOT_SOURCE = resolveRepoRootSource();
+const resolvedRoot = resolveRepoRoot();
 
-export const WEB_APP = path.join(REPO_ROOT, 'apps/web');
+export const REPO_ROOT = resolvedRoot.repoRoot;
+export const REPO_ROOT_SOURCE = resolvedRoot.source;
+
+export const WEB_APP = resolveRepoPath('apps/web').resolvedPath;

--- a/scripts/ci/qa-audits-contracts.test.mjs
+++ b/scripts/ci/qa-audits-contracts.test.mjs
@@ -7,6 +7,7 @@ import test from 'node:test';
 import { pathToFileURL } from 'node:url';
 
 const repoRoot = process.cwd();
+const tsxLoader = path.join(repoRoot, 'node_modules/tsx/dist/loader.mjs');
 
 function makeTempRepo({ envFileName = '.env.local', envLines = [] } = {}) {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-qa-audit-'));
@@ -27,24 +28,28 @@ function makeTempRepo({ envFileName = '.env.local', envLines = [] } = {}) {
   return tempRoot;
 }
 
-function runAudit(modulePath, exportName, fakeRepoRoot) {
+function runModuleExpression(modulePath, expression, options = {}) {
+  const { cwd = repoRoot, env = {} } = options;
   const moduleUrl = pathToFileURL(path.join(repoRoot, modulePath)).href;
-  const script = `
-    const mod = await import(${JSON.stringify(moduleUrl)});
-    const result = await mod[${JSON.stringify(exportName)}]();
-    console.log(JSON.stringify(result));
-  `;
+  const script = `const mod = await import(${JSON.stringify(moduleUrl)});
+const result = await (${expression});
+console.log(JSON.stringify(result));`;
 
-  const stdout = execFileSync(process.execPath, ['--import', 'tsx', '--eval', script], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      MCP_REPO_ROOT: fakeRepoRoot,
-    },
+  const stdout = execFileSync(process.execPath, ['--import', tsxLoader, '--eval', script], {
+    cwd,
+    env: { ...process.env, ...env },
     encoding: 'utf8',
   });
 
   return JSON.parse(stdout);
+}
+
+function runAudit(modulePath, exportName, fakeRepoRoot) {
+  const canonicalFakeRepoRoot = fs.realpathSync.native(fakeRepoRoot);
+  return runModuleExpression(modulePath, `mod[${JSON.stringify(exportName)}]()`, {
+    cwd: canonicalFakeRepoRoot,
+    env: { MCP_REPO_ROOT: canonicalFakeRepoRoot },
+  });
 }
 
 function getText(result) {
@@ -85,4 +90,60 @@ test('auditAuth accepts .env.local and does not require GitHub OAuth credentials
   assert.doesNotMatch(text, /\.env file missing in root/i);
   assert.doesNotMatch(text, /GITHUB_CLIENT_ID/i);
   assert.match(text, /BETTER_AUTH_SECRET/);
+});
+
+test('repo root helper ignores MCP_REPO_ROOT values without repo markers', () => {
+  const invalidRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-qa-invalid-root-'));
+  const result = runModuleExpression(
+    'packages/qa/src/utils/paths.ts',
+    '({ repoRoot: mod.REPO_ROOT, source: mod.REPO_ROOT_SOURCE })',
+    { env: { MCP_REPO_ROOT: invalidRoot } }
+  );
+
+  assert.equal(result.repoRoot, fs.realpathSync.native(repoRoot));
+  assert.equal(result.source, 'module-relative');
+});
+
+test('repo path helper rejects traversal, absolute paths, and symlink escapes', () => {
+  const fakeRepoRoot = makeTempRepo({ envFileName: null });
+  const canonicalFakeRepoRoot = fs.realpathSync.native(fakeRepoRoot);
+  const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-qa-outside-'));
+  const outsideFile = path.join(outsideRoot, 'secret.txt');
+  fs.writeFileSync(outsideFile, 'outside repo');
+
+  const candidates = ['../outside.txt', outsideFile];
+  try {
+    fs.symlinkSync(outsideRoot, path.join(fakeRepoRoot, 'outside-link'), 'dir');
+    candidates.push('outside-link/secret.txt');
+  } catch {
+    // Some local filesystems disallow symlinks; traversal and absolute-path coverage still applies.
+  }
+
+  const result = runModuleExpression(
+    'packages/qa/src/utils/paths.ts',
+    `(() => {
+      const outcomes = {};
+      for (const candidate of ${JSON.stringify(candidates)}) {
+        try {
+          mod.resolveRepoPath(candidate);
+          outcomes[candidate] = 'allowed';
+        } catch (error) {
+          outcomes[candidate] = error.message;
+        }
+      }
+      outcomes.safe = mod.resolveRepoPath('apps/web/src/proxy.ts').relativePath;
+      return outcomes;
+    })()`,
+    {
+      cwd: canonicalFakeRepoRoot,
+      env: { MCP_REPO_ROOT: canonicalFakeRepoRoot },
+    }
+  );
+
+  assert.equal(result.safe, 'apps/web/src/proxy.ts');
+  assert.match(result['../outside.txt'], /escapes repository root/);
+  assert.match(result[outsideFile], /repository-relative/);
+  if (candidates.includes('outside-link/secret.txt')) {
+    assert.match(result['outside-link/secret.txt'], /escapes repository root/);
+  }
 });

--- a/scripts/ci/qa-paths-contracts.test.mjs
+++ b/scripts/ci/qa-paths-contracts.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+const repoRoot = process.cwd();
+const tsxLoader = path.join(repoRoot, 'node_modules/tsx/dist/loader.mjs');
+const pathsModule = pathToFileURL(path.join(repoRoot, 'packages/qa/src/utils/paths.ts')).href;
+
+function makeTempRepo() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-qa-paths-'));
+  fs.writeFileSync(path.join(tempRoot, 'pnpm-workspace.yaml'), 'packages:\n  - apps/*\n');
+  fs.mkdirSync(path.join(tempRoot, 'apps/web'), { recursive: true });
+  return fs.realpathSync.native(tempRoot);
+}
+
+function runPathExpression(expression, options = {}) {
+  const { cwd = repoRoot, env = {} } = options;
+  const script = `const mod = await import(${JSON.stringify(pathsModule)});
+const result = await (${expression});
+console.log(JSON.stringify(result));`;
+
+  const stdout = execFileSync(process.execPath, ['--import', tsxLoader, '--eval', script], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+
+  return JSON.parse(stdout);
+}
+
+test('canonicalizeRepoRoot rejects empty, relative, and NUL-containing candidates', () => {
+  const result = runPathExpression(`(() => ({
+    empty: mod.canonicalizeRepoRoot(''),
+    dot: mod.canonicalizeRepoRoot('.'),
+    relative: mod.canonicalizeRepoRoot('packages'),
+    nul: mod.canonicalizeRepoRoot('packages\\0qa'),
+    canonical: mod.canonicalizeRepoRoot(process.cwd())
+  }))()`);
+
+  assert.equal(result.empty, null);
+  assert.equal(result.dot, null);
+  assert.equal(result.relative, null);
+  assert.equal(result.nul, null);
+  assert.equal(result.canonical, fs.realpathSync.native(repoRoot));
+});
+
+test('resolveRepoPath rejects missing leaves beneath symlink escapes', () => {
+  const fakeRepoRoot = makeTempRepo();
+  const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'interdomestik-qa-outside-'));
+  const candidates = ['apps/web/missing.txt'];
+
+  try {
+    fs.symlinkSync(outsideRoot, path.join(fakeRepoRoot, 'outside-link'), 'dir');
+    candidates.push('outside-link/missing.txt');
+  } catch {
+    // Some local filesystems disallow symlinks; safe missing-leaf coverage still applies.
+  }
+
+  const result = runPathExpression(
+    `(() => {
+      const outcomes = {};
+      for (const candidate of ${JSON.stringify(candidates)}) {
+        try {
+          outcomes[candidate] = mod.resolveRepoPath(candidate).relativePath;
+        } catch (error) {
+          outcomes[candidate] = error.message;
+        }
+      }
+      return outcomes;
+    })()`,
+    {
+      cwd: fakeRepoRoot,
+      env: { MCP_REPO_ROOT: fakeRepoRoot },
+    }
+  );
+
+  assert.equal(result['apps/web/missing.txt'], 'apps/web/missing.txt');
+  if (candidates.includes('outside-link/missing.txt')) {
+    assert.match(result['outside-link/missing.txt'], /escapes repository root/);
+  }
+});

--- a/scripts/ci/qa-server-contracts.test.mjs
+++ b/scripts/ci/qa-server-contracts.test.mjs
@@ -16,9 +16,11 @@ test('qa server loads the same root env file precedence as the repo runtime', ()
   const utilsSource = readText('packages/qa/src/tools/audits/utils.ts');
 
   assert.match(utilsSource, /findRootEnvFile/);
+  assert.match(utilsSource, /ROOT_ENV_FILE_CANDIDATES/);
   assert.match(utilsSource, /\.env\.local/);
   assert.match(utilsSource, /\.env\.development\.local/);
   assert.match(utilsSource, /'\.env'/);
+  assert.doesNotMatch(utilsSource, /readdirSync/);
   assert.match(serverSource, /findRootEnvFile/);
   assert.doesNotMatch(serverSource, /dotenv\.config\(\{ path: path\.join\(REPO_ROOT, '\.env'\)/);
 });

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37644476,
-  "maxTrackedFiles": 4581,
+  "maxTrackedBytes": 37652457,
+  "maxTrackedFiles": 4582,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7058411,
+    "source/scripts": 7061306,
     "docs/text": 5711417,
-    "tests/e2e": 4991301,
+    "tests/e2e": 4996387,
     "config/data/messages": 1555300,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- canonicalize repo-root detection for QA tooling before using repo-relative paths
- reject empty, absolute, traversal, and symlink-escaping repository paths
- keep root env discovery on an explicit allowlist and assert the contract in CI tests

## Verification
- git diff --check
- node --test --test-concurrency=1 scripts/ci/qa-audits-contracts.test.mjs scripts/ci/qa-server-contracts.test.mjs scripts/ci/codex-contracts.test.mjs
- node scripts/security-guard.mjs
- node --test --test-concurrency=1 scripts/ci/*.test.mjs scripts/check-modularity-guard.test.mjs

## Merge note
Draft until the separate main CD P0.6 staging release-gate failure is fixed or confirmed green. This PR does not touch app routing, auth, tenant logic, or apps/web/src/proxy.ts.