### PR TITLE
fix: harden tenant app origin local host detection

### DIFF
--- a/apps/web/src/lib/tenant/tenant-app-origin-security.test.ts
+++ b/apps/web/src/lib/tenant/tenant-app-origin-security.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveTenantAppOrigin } from './tenant-hosts';
+import { isLocalTenantAppHost } from './tenant-local-hosts';
+
+describe('tenant app origin local-host security', () => {
+  const mutableEnv = process.env as Record<string, string | undefined>;
+  const originalKsHost = process.env.KS_HOST;
+
+  afterEach(() => {
+    if (originalKsHost === undefined) {
+      delete mutableEnv.KS_HOST;
+      return;
+    }
+    mutableEnv.KS_HOST = originalKsHost;
+  });
+
+  it.each([
+    'localhost',
+    'ks.localhost',
+    'ks.localhost:3000',
+    '127.0.0.1',
+    '127.0.0.1:3000',
+    'ks.127.0.0.1.nip.io',
+    'ks.10.0.2.15.nip.io:3000',
+    'ks.192.168.1.20.nip.io',
+    '[::1]:3000',
+  ])('classifies %s as local', host => {
+    expect(isLocalTenantAppHost(host)).toBe(true);
+  });
+
+  it.each([
+    'localhost.attacker.test',
+    'ks.localhost.attacker.test',
+    'ks.127.0.0.1.nip.io.attacker.test',
+    'ks.8.8.8.8.nip.io',
+    'evilnip.io',
+    'interdomestik.com',
+  ])('does not classify %s as local', host => {
+    expect(isLocalTenantAppHost(host)).toBe(false);
+  });
+
+  it('does not downgrade lookalike tenant hosts to http', () => {
+    mutableEnv.KS_HOST = 'ks.127.0.0.1.nip.io.attacker.test';
+
+    expect(resolveTenantAppOrigin('tenant_ks')).toBe('https://ks.127.0.0.1.nip.io.attacker.test');
+
+    mutableEnv.KS_HOST = 'ks.localhost.attacker.test';
+
+    expect(resolveTenantAppOrigin('tenant_ks')).toBe('https://ks.localhost.attacker.test');
+  });
+
+  it('keeps legitimate local tenant hosts on http', () => {
+    mutableEnv.KS_HOST = 'ks.127.0.0.1.nip.io:3000';
+
+    expect(resolveTenantAppOrigin('tenant_ks')).toBe('http://ks.127.0.0.1.nip.io:3000');
+  });
+});

--- a/apps/web/src/lib/tenant/tenant-hosts.ts
+++ b/apps/web/src/lib/tenant/tenant-hosts.ts
@@ -6,6 +6,7 @@ import {
   type TenantId,
 } from './tenant-host-aliases';
 import { isKnownIdaFrontDoorHost } from './tenant-front-door';
+import { isLocalTenantAppHost } from './tenant-local-hosts';
 import type { TenantResolutionResult } from './tenant-resolution-types';
 
 export type { TenantId } from './tenant-host-aliases';
@@ -72,9 +73,7 @@ export function preferredHostForTenant(tenantId: TenantId): string {
 
 export function resolveTenantAppOrigin(tenantId: TenantId): string {
   const host = preferredHostForTenant(tenantId);
-  const useHttp =
-    host.includes('localhost') || host.includes('127.0.0.1') || host.includes('.nip.io');
-  return `${useHttp ? 'http' : 'https'}://${host}`;
+  return `${isLocalTenantAppHost(host) ? 'http' : 'https'}://${host}`;
 }
 
 function isProductionLikeEnvironment(): boolean {

--- a/apps/web/src/lib/tenant/tenant-local-hosts.ts
+++ b/apps/web/src/lib/tenant/tenant-local-hosts.ts
@@ -1,0 +1,48 @@
+function normalizeAppHost(host: string): string {
+  const raw = host.split(',')[0]?.trim() ?? '';
+  const withoutProtocol = raw.replace(/^[a-z][a-z0-9+.-]*:\/\//iu, '');
+  const withoutPath = withoutProtocol.split('/')[0] ?? '';
+  const bracketedIpv6 = /^\[([^\]]+)\](?::\d+)?$/u.exec(withoutPath);
+  const withoutPort = bracketedIpv6?.[1] ?? withoutPath.replace(/:\d+$/u, '');
+  return withoutPort.toLowerCase().replace(/\.$/u, '');
+}
+
+function parseIpv4(host: string): readonly [number, number, number, number] | null {
+  const octets = host.split('.');
+  if (octets.length !== 4) return null;
+
+  const parsed = octets.map(octet => {
+    if (!/^(?:0|[1-9]\d{0,2})$/u.test(octet)) return null;
+    const value = Number(octet);
+    return value >= 0 && value <= 255 ? value : null;
+  });
+  if (parsed.includes(null)) return null;
+
+  return parsed as [number, number, number, number];
+}
+
+function isPrivateOrLoopbackIpv4(octets: readonly [number, number, number, number]): boolean {
+  const [first, second] = octets;
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+export function isLocalTenantAppHost(host: string): boolean {
+  const normalized = normalizeAppHost(host);
+  if (normalized === 'localhost' || normalized.endsWith('.localhost') || normalized === '::1') {
+    return true;
+  }
+
+  const directIp = parseIpv4(normalized);
+  if (directIp) return isPrivateOrLoopbackIpv4(directIp);
+
+  const nipIoMatch = /^(?:[a-z0-9-]+\.)*((?:\d{1,3}\.){3}\d{1,3})\.nip\.io$/u.exec(normalized);
+  if (!nipIoMatch?.[1]) return false;
+
+  const embeddedIp = parseIpv4(nipIoMatch[1]);
+  return embeddedIp ? isPrivateOrLoopbackIpv4(embeddedIp) : false;
+}


### PR DESCRIPTION
## Summary

Fixes the tenant app-origin local-host classifier that CodeQL flagged as incomplete URL substring sanitization. `resolveTenantAppOrigin()` no longer treats any host containing `localhost`, `127.0.0.1`, or `.nip.io` as local; it now delegates to an anchored parser that only allows exact/local localhost, loopback/private IPv4, bracketed `::1`, and private/loopback `*.nip.io` hosts.

## Changed areas

- `apps/web/src/lib/tenant/tenant-hosts.ts`
- `apps/web/src/lib/tenant/tenant-local-hosts.ts`
- `apps/web/src/lib/tenant/tenant-app-origin-security.test.ts`

## Security rationale

This addresses CodeQL high alert #90 (`js/incomplete-url-substring-sanitization`) by preventing public/lookalike tenant hosts such as `ks.127.0.0.1.nip.io.attacker.test` or `ks.localhost.attacker.test` from being downgraded to `http`. Legitimate deterministic local hosts such as `ks.127.0.0.1.nip.io:3000` still use `http` for local E2E.

## Verification

- Focused unit: `pnpm --filter @interdomestik/web test:unit --run src/lib/tenant/tenant-app-origin-security.test.ts src/lib/tenant/tenant-hosts.test.ts src/lib/tenant/tenant-host-aliases.test.ts` — 3 files, 55 tests passed
- `interdomestik_qa` scope audit — passed, no forbidden protected paths changed
- `pnpm security:guard` — passed
- `pnpm pr:verify` — passed, including 134 passed / 8 skipped PR E2E lane and 13 passed / 9 skipped smoke lane
- `pnpm e2e:gate` — passed, 134 passed / 8 skipped
- `git diff --check` — passed

## Scope and invariants

- `apps/web/src/proxy.ts` untouched
- Canonical routes unchanged
- No auth/routing/tenancy architecture refactor
- No README, AGENTS, or architecture docs touched
- New/changed files stay under the repo modularity threshold

## Review notes

The full Codex Security app diff-scan route was checked but blocked in this session because only the workspace open/complete endpoints were exposed; the required scan-start/context continuation tools were not available. Mandatory repo security evidence is green, and this PR is being routed to Codex/Copilot review.
