### PR TITLE
fix: harden codex local mcp config path

### DIFF
--- a/scripts/ci/codex-contracts.test.mjs
+++ b/scripts/ci/codex-contracts.test.mjs
@@ -65,7 +65,9 @@ test('mcp setup verifies Codex project config as well as local QA server prerequ
 test('Codex local MCP generator writes machine-specific user config without changing project config', () => {
   const localConfigGenerator = readText('scripts/configure-codex-local-mcp.mjs');
 
-  assert.match(localConfigGenerator, /CODEX_HOME/);
+  assert.match(localConfigGenerator, /process\.env\.CODEX_HOME/);
+  assert.match(localConfigGenerator, /refusing to update local MCP config/);
+  assert.match(localConfigGenerator, /os\.homedir\(\)/);
   assert.match(localConfigGenerator, /config\.toml/);
   assert.match(localConfigGenerator, /mcp_servers\.\$\{serverName\}/);
   assert.match(localConfigGenerator, /scripts\/start-repo-qa\.sh/);

--- a/scripts/configure-codex-local-mcp.mjs
+++ b/scripts/configure-codex-local-mcp.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '..');
-const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+const codexHome = path.join(os.homedir(), '.codex');
 const codexConfigPath = path.join(codexHome, 'config.toml');
 const serverName = 'interdomestik_qa';
 const requiredRepoQaTools = [
@@ -24,6 +24,14 @@ const requiredRepoQaTools = [
   'security_guard',
   'e2e_gate',
 ];
+
+if (typeof process.env.CODEX_HOME === 'string' && process.env.CODEX_HOME.trim() !== '') {
+  console.error(
+    'CODEX_HOME is set; refusing to update local MCP config because this script only manages the default ~/.codex/config.toml.'
+  );
+  console.error('Unset CODEX_HOME first, or update $CODEX_HOME/config.toml manually.');
+  process.exit(1);
+}
 
 function tomlString(value) {
   return JSON.stringify(value);

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37704776,
+  "maxTrackedBytes": 37692932,
   "maxTrackedFiles": 4598,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7077233,
-    "docs/text": 5730189,
-    "tests/e2e": 5014225,
+    "source/scripts": 7079276,
+    "docs/text": 5714429,
+    "tests/e2e": 5016098,
     "config/data/messages": 1555082,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- Remove arbitrary `CODEX_HOME` path targeting from the local Codex MCP config generator.
- Keep local setup anchored to `${HOME}/.codex/config.toml`, with tests isolating via `HOME`.
- Update the Codex contract test and refresh the tracked repo-size budget.

## Security alerts targeted
- CodeQL high #80 `js/path-injection`
- CodeQL high #81 `js/path-injection`
- CodeQL high #82 `js/path-injection`
- CodeQL high #148 `js/path-injection`

## Verification
- `node --test --test-concurrency=1 scripts/ci/codex-contracts.test.mjs`
- `node --check scripts/configure-codex-local-mcp.mjs`
- `node --check scripts/ci/codex-contracts.test.mjs`
- isolated `HOME` smoke for `scripts/configure-codex-local-mcp.mjs`
- `pnpm repo:size:check`
- `pnpm test:ci:contracts`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate`

## Scope control
- Scripts/test/budget only.
- No changes to `apps/web/src/proxy.ts`.
- No runtime auth, routing, tenancy, canonical route, or readiness-marker changes.
- Pre-existing untracked audit prompt files were left untouched.
