### PR TITLE
fix: reduce claim number backfill complexity

### DIFF
--- a/scripts/backfill-claim-number.ts
+++ b/scripts/backfill-claim-number.ts
@@ -3,6 +3,8 @@ import { and, asc, claims, db, eq, isNull, sql } from '@interdomestik/database';
 import { generateClaimNumber } from '@interdomestik/database/claim-number';
 import { parseBackfillArgs } from './incident-country-backfill-report';
 
+type MissingClaimRow = Awaited<ReturnType<typeof listMissingClaims>>[number];
+
 async function getCoverage(tenantId: string | undefined) {
   // db-access-guard: system-exempt -- reason: dry-run operator coverage counts across tenants
   const [row] = await db
@@ -29,62 +31,99 @@ async function listMissingClaims(tenantId: string | undefined, limit: number | u
   return limit ? query.limit(limit) : query;
 }
 
+async function backfillClaimNumber(row: MissingClaimRow): Promise<'updated' | 'skipped'> {
+  if (!row.createdAt) {
+    return 'skipped';
+  }
+
+  try {
+    // db-access-guard: tenant-scoped -- reason: generateClaimNumber guards tenantId + isNull(claimNumber)
+    await db.transaction(async tx => {
+      await generateClaimNumber(tx, {
+        tenantId: row.tenantId,
+        claimId: row.id,
+        createdAt: row.createdAt,
+      });
+    });
+    return 'updated';
+  } catch (err) {
+    console.error(`  SKIP ${row.id}: ${err instanceof Error ? err.message : String(err)}`);
+    return 'skipped';
+  }
+}
+
+async function applyBackfill(rows: MissingClaimRow[]) {
+  const stats = { updated: 0, skipped: 0 };
+
+  for (const row of rows) {
+    const result = await backfillClaimNumber(row);
+    stats[result]++;
+  }
+
+  return stats;
+}
+
+function formatPercent(n: number, d: number) {
+  return d === 0 ? '—' : `${((n / d) * 100).toFixed(1)}%`;
+}
+
+function formatReport(params: {
+  apply: boolean;
+  tenantId: string | undefined;
+  limit: number | undefined;
+  before: Awaited<ReturnType<typeof getCoverage>>;
+  after: Awaited<ReturnType<typeof getCoverage>>;
+  scanned: number;
+  updated: number;
+  skipped: number;
+}) {
+  const lines = [
+    '',
+    '=== claim-number backfill report ===',
+    `  tenant filter : ${params.tenantId ?? '(all)'}`,
+    `  limit         : ${params.limit ?? '(none)'}`,
+    `  write mode    : ${params.apply ? 'APPLY' : 'dry-run'}`,
+    '',
+    `  before        : ${params.before.populated}/${params.before.total} populated (${formatPercent(params.before.populated, params.before.total)})`,
+  ];
+
+  if (params.apply) {
+    lines.push(
+      `  after         : ${params.after.populated}/${params.after.total} populated (${formatPercent(params.after.populated, params.after.total)})`
+    );
+  }
+
+  lines.push('', `  scanned       : ${params.scanned}`);
+
+  if (params.apply) {
+    lines.push(`  updated       : ${params.updated}`, `  skipped       : ${params.skipped}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
 async function main() {
   const { apply, tenantId, limit } = parseBackfillArgs();
 
   const before = await getCoverage(tenantId);
   const missingRows = await listMissingClaims(tenantId, limit);
-
-  let updated = 0;
-  let skipped = 0;
-
-  if (apply) {
-    for (const row of missingRows) {
-      if (!row.createdAt) {
-        skipped++;
-        continue;
-      }
-      const createdAt = row.createdAt;
-      try {
-        // db-access-guard: tenant-scoped -- reason: generateClaimNumber guards tenantId + isNull(claimNumber)
-        await db.transaction(async tx => {
-          await generateClaimNumber(tx, {
-            tenantId: row.tenantId,
-            claimId: row.id,
-            createdAt,
-          });
-        });
-        updated++;
-      } catch (err) {
-        console.error(`  SKIP ${row.id}: ${err instanceof Error ? err.message : String(err)}`);
-        skipped++;
-      }
-    }
-  }
-
+  const { updated, skipped } = apply
+    ? await applyBackfill(missingRows)
+    : { updated: 0, skipped: 0 };
   const after = apply ? await getCoverage(tenantId) : before;
-  const pct = (n: number, d: number) => (d === 0 ? '—' : `${((n / d) * 100).toFixed(1)}%`);
 
   console.log(
-    [
-      '',
-      '=== claim-number backfill report ===',
-      `  tenant filter : ${tenantId ?? '(all)'}`,
-      `  limit         : ${limit ?? '(none)'}`,
-      `  write mode    : ${apply ? 'APPLY' : 'dry-run'}`,
-      '',
-      `  before        : ${before.populated}/${before.total} populated (${pct(before.populated, before.total)})`,
-      apply
-        ? `  after         : ${after.populated}/${after.total} populated (${pct(after.populated, after.total)})`
-        : '',
-      '',
-      `  scanned       : ${missingRows.length}`,
-      apply ? `  updated       : ${updated}` : '',
-      apply ? `  skipped       : ${skipped}` : '',
-      '',
-    ]
-      .filter(l => l !== undefined)
-      .join('\n')
+    formatReport({
+      apply,
+      tenantId,
+      limit,
+      before,
+      after,
+      scanned: missingRows.length,
+      updated,
+      skipped,
+    })
   );
 }
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37693976,
+  "maxTrackedBytes": 37694861,
   "maxTrackedFiles": 4598,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7078936,
+    "source/scripts": 7079821,
     "docs/text": 5714429,
     "tests/e2e": 5017482,
     "config/data/messages": 1555082,


### PR DESCRIPTION
## Summary
- Refactors `scripts/backfill-claim-number.ts` so `main()` is orchestration-only and the Sonar cognitive-complexity hotspot is split into focused helpers.
- Preserves the existing dry-run/apply behavior, transaction path, missing-`createdAt` skip behavior, and `generateClaimNumber` guard path.
- Updates `scripts/repo-size-budget.json` after the tracked script-size delta.

## Phase C / Scope
- Classified as Tier 1 implementation: narrow maintenance-script quality fix.
- `apps/web/src/proxy.ts` untouched.
- Canonical routes and clarity markers untouched.
- No auth, tenancy, routing, schema, RLS, billing, UI, or architecture changes.
- Two unrelated untracked audit prompt files were left untouched locally.

## Sonar Disposition
- Targets `typescript:S3776` on `scripts/backfill-claim-number.ts`.
- Expected result: new-code HIGH maintainability issue count drops from 1 to 0 after Sonar analyzes this PR head.

## Verification
- `pnpm exec prettier --write scripts/backfill-claim-number.ts` passed.
- `git diff --check` passed.
- `pnpm exec prettier --check scripts/backfill-claim-number.ts` passed.
- `pnpm check:modularity-guard` passed.
- `pnpm check:db-access` passed.
- `pnpm lint` passed.
- `pnpm type-check` passed.
- `pnpm pr:verify` passed.
- `pnpm security:guard` passed.
- `pnpm e2e:gate` passed: 134 passed, 8 skipped.

## Rollback
- Revert this commit. The change is limited to a maintenance script refactor plus repo-size budget metadata.
