### PR TITLE
fix: harden standalone shell test conditionals

### DIFF
--- a/quick-stress-test.sh
+++ b/quick-stress-test.sh
@@ -18,16 +18,16 @@ for i in {1..20}; do
             -d "{
                 \"email\": \"$EMAIL\",
                 \"name\": \"$NAME\",
-                \"role\": \"$([ $((i % 2)) -eq 0 ] && echo 'agent' || echo 'user')\",
+                \"role\": \"$(if [[ $((i % 2)) -eq 0 ]]; then echo 'agent'; else echo 'user'; fi)\",
                 \"password\": \"testpassword123\"
             }" 2>/dev/null)
         
         status_code="${response: -3}"
         echo "Registration $i: HTTP $status_code"
         
-        if [ "$status_code" = "200" ]; then
+        if [[ "$status_code" = "200" ]]; then
             echo "✅ SUCCESS: $EMAIL"
-        elif [ "$status_code" = "429" ]; then
+        elif [[ "$status_code" = "429" ]]; then
             echo "⚠️ RATE_LIMITED: $EMAIL"
         else
             echo "❌ FAILED: $EMAIL (HTTP $status_code)"
@@ -35,7 +35,7 @@ for i in {1..20}; do
     } &
     
     # Launch 5 at a time
-    if [ $((i % 5)) -eq 0 ]; then
+    if [[ $((i % 5)) -eq 0 ]]; then
         sleep 0.5
     fi
 done
@@ -51,14 +51,14 @@ for i in {1..50}; do
     {
         response=$(curl -s -w "%{http_code}" "$BASE_URL/api/health" 2>/dev/null)
         
-        if [ "${response: -3}" = "200" ]; then
+        if [[ "${response: -3}" = "200" ]]; then
             echo "✅ Health check $i: OK"
         else
             echo "❌ Health check $i: FAILED"
         fi
     } &
     
-    if [ $((i % 10)) -eq 0 ]; then
+    if [[ $((i % 10)) -eq 0 ]]; then
         sleep 0.1
     fi
 done

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37694861,
+  "maxTrackedBytes": 37694922,
   "maxTrackedFiles": 4598,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7079821,
+    "source/scripts": 7079882,
     "docs/text": 5714429,
     "tests/e2e": 5017482,
     "config/data/messages": 1555082,

--- a/simulated-stress-test.sh
+++ b/simulated-stress-test.sh
@@ -20,7 +20,7 @@ fi
 # Test 2: Circuit breaker implementation
 echo ""
 echo "2. ✅ Circuit Breaker Patterns:"
-if [ -f "packages/shared-utils/src/circuit-breaker.ts" ]; then
+if [[ -f "packages/shared-utils/src/circuit-breaker.ts" ]]; then
     echo "   ✓ Circuit breaker class implemented"
     echo "   ✓ State management (OPEN/CLOSED/HALF_OPEN)"
     echo "   ✓ Pre-configured breakers for services"
@@ -32,7 +32,7 @@ fi
 # Test 3: Transaction retry logic
 echo ""
 echo "3. ✅ Transaction Retry Logic:"
-if [ -f "packages/shared-utils/src/resilience.ts" ]; then
+if [[ -f "packages/shared-utils/src/resilience.ts" ]]; then
     echo "   ✓ Exponential backoff retry implemented"
     echo "   ✓ Deadlock detection logic"
     echo "   ✓ Consistent lock ordering"
@@ -44,7 +44,7 @@ fi
 # Test 4: Health monitoring
 echo ""
 echo "4. ✅ Health Monitoring:"
-if [ -f "apps/web/src/app/api/health/route.ts" ]; then
+if [[ -f "apps/web/src/app/api/health/route.ts" ]]; then
     echo "   ✓ Health endpoint created"
     echo "   ✓ Database health checks"
     echo "   ✓ Service dependency monitoring"
@@ -56,7 +56,7 @@ fi
 # Test 5: Background job queue
 echo ""
 echo "5. ✅ Background Job Queue:"
-if [ -f "packages/shared-utils/src/job-queue.ts" ]; then
+if [[ -f "packages/shared-utils/src/job-queue.ts" ]]; then
     echo "   ✓ Job queue implementation"
     echo "   ✓ Priority-based processing"
     echo "   ✓ Auto-retry mechanism"
@@ -143,13 +143,13 @@ done
 
 echo "Implementation Coverage: $FINAL_SCORE/100 ($(($FINAL_SCORE * 100 / $TOTAL_SCORE))%)"
 
-if [ $FINAL_SCORE -ge 90 ]; then
+if [[ $FINAL_SCORE -ge 90 ]]; then
     echo "🎉 ASSESSMENT: EXCELLENT - Production Ready!"
     echo "   ✓ All critical resilience patterns implemented"
     echo "   ✓ Handles high-load scenarios effectively"
     echo "   ✓ Graceful degradation under stress"
     echo "   ✓ Automatic recovery from failures"
-elif [ $FINAL_SCORE -ge 70 ]; then
+elif [[ $FINAL_SCORE -ge 70 ]]; then
     echo "⚠️ ASSESSMENT: GOOD - Mostly Production Ready"
     echo "   ✓ Most resilience patterns implemented"
     echo "   ⚠️ Some areas need improvement"

--- a/targeted-resilience-test.sh
+++ b/targeted-resilience-test.sh
@@ -19,7 +19,7 @@ test_database_pool() {
         
         echo "Health check $i: HTTP $status (${duration}ms)"
         
-        if [ "$status" != "200" ]; then
+        if [[ "$status" != "200" ]]; then
             echo "❌ Health check failed at iteration $i"
             return 1
         fi
@@ -54,10 +54,10 @@ test_rate_limiting() {
         
         status_code="${response: -3}"
         
-        if [ "$status_code" = "200" ]; then
+        if [[ "$status_code" = "200" ]]; then
             ((success_count++))
             echo "✅ Registration $i: SUCCESS"
-        elif [ "$status_code" = "429" ]; then
+        elif [[ "$status_code" = "429" ]]; then
             ((rate_limit_count++))
             echo "⚠️ Registration $i: RATE LIMITED"
         else
@@ -66,7 +66,7 @@ test_rate_limiting() {
     done
     
     echo "📈 Rate limiting results: $success_count successful, $rate_limit_count rate limited"
-    if [ $rate_limit_count -gt 0 ]; then
+    if [[ $rate_limit_count -gt 0 ]]; then
         echo "✅ Rate limiting is working correctly"
     else
         echo "⚠️ Rate limiting may not be engaged"
@@ -129,7 +129,7 @@ test_circuit_breaker() {
         # Try to access a non-existent endpoint
         response=$(curl -s -w "%{http_code}" "$BASE_URL/api/nonexistent" 2>/dev/null | tail -c 3)
         
-        if [ "$response" = "404" ]; then
+        if [[ "$response" = "404" ]]; then
             ((failure_count++))
             echo "❌ Request $i: NOT FOUND (expected)"
         else

--- a/test-production-readiness.sh
+++ b/test-production-readiness.sh
@@ -14,7 +14,7 @@ fi
 
 # Test 2: Circuit breaker implementation
 echo "2. Testing circuit breaker implementation..."
-if [ -f "packages/shared-utils/src/circuit-breaker.ts" ]; then
+if [[ -f "packages/shared-utils/src/circuit-breaker.ts" ]]; then
     echo "✅ Circuit breaker implementation found"
     if grep -q "CircuitBreakerState" packages/shared-utils/src/circuit-breaker.ts; then
         echo "✅ Circuit breaker states defined"
@@ -25,7 +25,7 @@ fi
 
 # Test 3: Retry logic
 echo "3. Testing retry logic..."
-if [ -f "packages/shared-utils/src/resilience.ts" ]; then
+if [[ -f "packages/shared-utils/src/resilience.ts" ]]; then
     echo "✅ Resilience utilities found"
     if grep -q "withTransactionRetry" packages/shared-utils/src/resilience.ts; then
         echo "✅ Transaction retry logic implemented"
@@ -36,7 +36,7 @@ fi
 
 # Test 4: Health endpoint
 echo "4. Testing health endpoint..."
-if [ -f "apps/web/src/app/api/health/route.ts" ]; then
+if [[ -f "apps/web/src/app/api/health/route.ts" ]]; then
     echo "✅ Health endpoint implemented"
     if grep -q "database.*health" apps/web/src/app/api/health/route.ts; then
         echo "✅ Database health checks included"
@@ -47,7 +47,7 @@ fi
 
 # Test 5: Job queue
 echo "5. Testing job queue..."
-if [ -f "packages/shared-utils/src/job-queue.ts" ]; then
+if [[ -f "packages/shared-utils/src/job-queue.ts" ]]; then
     echo "✅ Job queue implementation found"
     if grep -q "SimpleJobQueue" packages/shared-utils/src/job-queue.ts; then
         echo "✅ Background job processing implemented"
@@ -58,7 +58,7 @@ fi
 
 # Test 6: Updated member registration
 echo "6. Testing member registration resilience..."
-if [ -f "apps/web/src/lib/actions/agent/register-member.core.ts" ]; then
+if [[ -f "apps/web/src/lib/actions/agent/register-member.core.ts" ]]; then
     echo "✅ Member registration found"
     if grep -q "withTransactionRetry" apps/web/src/lib/actions/agent/register-member.core.ts; then
         echo "✅ Member registration uses transaction retry"


### PR DESCRIPTION
## Summary

- Replace POSIX `[` conditionals with Bash `[[` in four standalone stress/readiness shell scripts.
- Preserve behavior while addressing Sonar `shelldre:S7688` findings in low-risk, non-gate scripts.
- Update the tracked repo size budget for the small script-byte delta.

## Scope

- No routing/auth/tenant/proxy changes.
- No schema/RLS/billing changes.
- `apps/web/src/proxy.ts` untouched.
- User-owned untracked audit prompt docs intentionally left uncommitted.

## Expected Sonar Impact

This targets 22 high Code Quality `shelldre:S7688` findings:

- `quick-stress-test.sh`: 6
- `simulated-stress-test.sh`: 6
- `targeted-resilience-test.sh`: 5
- `test-production-readiness.sh`: 5

## Verification

- `bash -n quick-stress-test.sh simulated-stress-test.sh targeted-resilience-test.sh test-production-readiness.sh`
- `git diff --check`
- `pnpm repo:size:check`
- `pnpm slice:verify`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate` — 134 passed, 8 skipped

Note: local `shellcheck` is not installed, so shell syntax validation used `bash -n` plus the full repo gates above.
