### PR TITLE
fix: harden CSP script inventory parser

### DIFF
--- a/scripts/security/next-csp-nonce-triage.mjs
+++ b/scripts/security/next-csp-nonce-triage.mjs
@@ -5,6 +5,8 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { scriptInventory, summarizeScripts } from './next-csp-script-inventory.mjs';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../..');
 const webRoot = path.join(repoRoot, 'apps/web');
@@ -245,107 +247,6 @@ async function prepareApp() {
   );
 }
 
-function isWhitespace(char) {
-  return /\s/.test(char ?? '');
-}
-
-function skipWhitespace(value, index) {
-  while (index < value.length) {
-    if (!isWhitespace(value[index])) break;
-    index += 1;
-  }
-  return index;
-}
-
-function isAttributeNameChar(char) {
-  return Boolean(char && !/[\s=/>]/.test(char));
-}
-
-function readAttributeName(tag, index) {
-  const start = index;
-  while (index < tag.length && isAttributeNameChar(tag[index])) {
-    index += 1;
-  }
-  return { name: tag.slice(start, index).toLowerCase(), index };
-}
-
-function readQuotedValue(tag, index, quote) {
-  const start = index + 1;
-  const end = tag.indexOf(quote, start);
-  if (end === -1) return { value: tag.slice(start), index: tag.length };
-  return { value: tag.slice(start, end), index: end + 1 };
-}
-
-function readBareValue(tag, index) {
-  const start = index;
-  while (index < tag.length && !isWhitespace(tag[index]) && tag[index] !== '>') {
-    index += 1;
-  }
-  return { value: tag.slice(start, index), index };
-}
-
-function readAttributeValue(tag, index) {
-  index = skipWhitespace(tag, index);
-  if (tag[index] !== '=') return { value: '', index };
-
-  index = skipWhitespace(tag, index + 1);
-  const quote = tag[index];
-  if (quote === '"' || quote === "'") return readQuotedValue(tag, index, quote);
-  return readBareValue(tag, index);
-}
-
-function parseAttributes(tag) {
-  const attributes = {};
-  let index = tag.search(/\s/);
-  if (index === -1) return attributes;
-
-  while (index < tag.length) {
-    index = skipWhitespace(tag, index);
-    if (index >= tag.length || tag[index] === '>' || tag[index] === '/') break;
-
-    const parsedName = readAttributeName(tag, index);
-    if (!parsedName.name) break;
-
-    const parsedValue = readAttributeValue(tag, parsedName.index);
-    attributes[parsedName.name] = parsedValue.value;
-    index = parsedValue.index;
-  }
-
-  return attributes;
-}
-
-function scriptInventory(html) {
-  const scripts = [];
-  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
-  let index = 0;
-  for (const match of html.matchAll(pattern)) {
-    const attributes = parseAttributes(`script${match[1]}`);
-    scripts.push({
-      index,
-      src: attributes.src ?? null,
-      nonce: attributes.nonce ?? null,
-      async: Object.hasOwn(attributes, 'async'),
-      defer: Object.hasOwn(attributes, 'defer'),
-      inlineLength: match[2]?.length ?? 0,
-      firstParty:
-        !attributes.src || attributes.src.startsWith('/_next/') || attributes.src.startsWith('/'),
-    });
-    index += 1;
-  }
-  return scripts;
-}
-
-function summarizeScripts(scripts) {
-  const firstParty = scripts.filter(script => script.firstParty);
-  const missingNonce = firstParty.filter(script => script.nonce !== nonce);
-  return {
-    scriptTagCount: scripts.length,
-    firstPartyScriptCount: firstParty.length,
-    missingFirstPartyNonceCount: missingNonce.length,
-    firstMissingFirstPartyScripts: missingNonce.slice(0, 10),
-  };
-}
-
 function request(url) {
   return new Promise((resolve, reject) => {
     http
@@ -542,7 +443,7 @@ async function captureBrowser(url) {
     return {
       canary,
       domScripts,
-      domScriptSummary: summarizeScripts(domScripts),
+      domScriptSummary: summarizeScripts(domScripts, nonce),
       violations,
       scriptFamilyViolationGroups: groupViolations(violations),
     };
@@ -579,7 +480,7 @@ async function runCase(testCase, port) {
           response.headers['content-security-policy-report-only'] ?? null,
       },
       expectedNonce: nonce,
-      rawHtmlScriptSummary: summarizeScripts(rawScripts),
+      rawHtmlScriptSummary: summarizeScripts(rawScripts, nonce),
       firstRawHtmlScripts: rawScripts.slice(0, 10),
       browser,
     };

--- a/scripts/security/next-csp-script-inventory.mjs
+++ b/scripts/security/next-csp-script-inventory.mjs
@@ -1,0 +1,143 @@
+function isWhitespace(char) {
+  return /\s/.test(char ?? '');
+}
+
+function skipWhitespace(value, index) {
+  while (index < value.length) {
+    if (!isWhitespace(value[index])) break;
+    index += 1;
+  }
+  return index;
+}
+
+function readAttributeName(tag, index) {
+  const start = index;
+  while (index < tag.length && tag[index] && !/[\s=/>]/.test(tag[index])) {
+    index += 1;
+  }
+  return { name: tag.slice(start, index).toLowerCase(), index };
+}
+
+function readQuotedValue(tag, index, quote) {
+  const start = index + 1;
+  const end = tag.indexOf(quote, start);
+  if (end === -1) return { value: tag.slice(start), index: tag.length };
+  return { value: tag.slice(start, end), index: end + 1 };
+}
+
+function readBareValue(tag, index) {
+  const start = index;
+  while (index < tag.length && !isWhitespace(tag[index]) && tag[index] !== '>') {
+    index += 1;
+  }
+  return { value: tag.slice(start, index), index };
+}
+
+function readAttributeValue(tag, index) {
+  index = skipWhitespace(tag, index);
+  if (tag[index] !== '=') return { value: '', index };
+  index = skipWhitespace(tag, index + 1);
+  const quote = tag[index];
+  if (quote === '"' || quote === "'") return readQuotedValue(tag, index, quote);
+  return readBareValue(tag, index);
+}
+
+function parseAttributes(tag) {
+  const attributes = {};
+  let index = tag.search(/\s/);
+  if (index === -1) return attributes;
+  while (index < tag.length) {
+    index = skipWhitespace(tag, index);
+    if (index >= tag.length || tag[index] === '>' || tag[index] === '/') break;
+    const parsedName = readAttributeName(tag, index);
+    if (!parsedName.name) break;
+    const parsedValue = readAttributeValue(tag, parsedName.index);
+    attributes[parsedName.name] = parsedValue.value;
+    index = parsedValue.index;
+  }
+  return attributes;
+}
+
+function findTagEnd(html, index) {
+  let quote = null;
+  while (index < html.length) {
+    const char = html[index];
+    if (quote) {
+      if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '>') {
+      return index;
+    }
+    index += 1;
+  }
+  return -1;
+}
+
+function isTagBoundary(char) {
+  return !char || char === '>' || isWhitespace(char);
+}
+
+function findScriptEnd(html, lowerHtml, index) {
+  let searchIndex = index;
+  while (searchIndex < html.length) {
+    const closeStart = lowerHtml.indexOf('</script', searchIndex);
+    if (closeStart === -1) return null;
+    const afterName = closeStart + '</script'.length;
+    if (!isTagBoundary(html[afterName])) {
+      searchIndex = afterName;
+      continue;
+    }
+    const closeEnd = findTagEnd(html, afterName);
+    if (closeEnd === -1) return null;
+    return { contentEnd: closeStart, closeEnd };
+  }
+  return null;
+}
+
+export function scriptInventory(html) {
+  const scripts = [];
+  const lowerHtml = html.toLowerCase();
+  let index = 0;
+  let searchIndex = 0;
+
+  while (searchIndex < html.length) {
+    const openStart = lowerHtml.indexOf('<script', searchIndex);
+    if (openStart === -1) break;
+    const afterName = openStart + '<script'.length;
+    if (!isTagBoundary(html[afterName]) && html[afterName] !== '/') {
+      searchIndex = afterName;
+      continue;
+    }
+    const openEnd = findTagEnd(html, afterName);
+    if (openEnd === -1) break;
+    const close = findScriptEnd(html, lowerHtml, openEnd + 1);
+    if (!close) break;
+    const attributes = parseAttributes(html.slice(openStart + 1, openEnd));
+    scripts.push({
+      index,
+      src: attributes.src ?? null,
+      nonce: attributes.nonce ?? null,
+      async: Object.hasOwn(attributes, 'async'),
+      defer: Object.hasOwn(attributes, 'defer'),
+      inlineLength: close.contentEnd - openEnd - 1,
+      firstParty:
+        !attributes.src || attributes.src.startsWith('/_next/') || attributes.src.startsWith('/'),
+    });
+    index += 1;
+    searchIndex = close.closeEnd + 1;
+  }
+
+  return scripts;
+}
+
+export function summarizeScripts(scripts, expectedNonce) {
+  const firstParty = scripts.filter(script => script.firstParty);
+  const missingNonce = firstParty.filter(script => script.nonce !== expectedNonce);
+  return {
+    scriptTagCount: scripts.length,
+    firstPartyScriptCount: firstParty.length,
+    missingFirstPartyNonceCount: missingNonce.length,
+    firstMissingFirstPartyScripts: missingNonce.slice(0, 10),
+  };
+}

--- a/scripts/security/next-csp-script-inventory.test.mjs
+++ b/scripts/security/next-csp-script-inventory.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { scriptInventory, summarizeScripts } from './next-csp-script-inventory.mjs';
+
+const nonce = 'c2VjMDUtY29uc3RhbnQtbm9uY2U=';
+
+test('script inventory accepts whitespace before script closing tag end', () => {
+  const scripts = scriptInventory(`
+    <script nonce="${nonce}" src="/_next/static/chunks/main.js"></script >
+    <script nonce="${nonce}">window.__ready = true;</script\t>
+    <script nonce="${nonce}" src="/edge.js"></script\t
+      ignored>
+  `);
+
+  assert.equal(scripts.length, 3);
+  assert.deepEqual(
+    scripts.map(script => ({
+      src: script.src,
+      nonce: script.nonce,
+      inlineLength: script.inlineLength,
+      firstParty: script.firstParty,
+    })),
+    [
+      {
+        src: '/_next/static/chunks/main.js',
+        nonce,
+        inlineLength: 0,
+        firstParty: true,
+      },
+      {
+        src: null,
+        nonce,
+        inlineLength: 'window.__ready = true;'.length,
+        firstParty: true,
+      },
+      {
+        src: '/edge.js',
+        nonce,
+        inlineLength: 0,
+        firstParty: true,
+      },
+    ]
+  );
+});
+
+test('script summary keeps third-party scripts out of first-party nonce counts', () => {
+  const scripts = scriptInventory(`
+    <script nonce="${nonce}" src="/local.js"></script>
+    <script src="https://cdn.example.com/library.js"></script>
+    <script src="/missing-nonce.js"></script>
+  `);
+
+  assert.deepEqual(summarizeScripts(scripts, nonce), {
+    scriptTagCount: 3,
+    firstPartyScriptCount: 2,
+    missingFirstPartyNonceCount: 1,
+    firstMissingFirstPartyScripts: [scripts[2]],
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the CodeQL high `js/bad-tag-filter` alert in `scripts/security/next-csp-nonce-triage.mjs` by extracting the script inventory parser into a focused helper.
- Accepts valid script closing tags with whitespace before `>` such as `</script >` and `</script\t>`.
- Keeps CSP nonce reporting scoped to first-party scripts while excluding third-party scripts from first-party nonce miss counts.

## Changed files
- `scripts/security/next-csp-nonce-triage.mjs`
- `scripts/security/next-csp-script-inventory.mjs`
- `scripts/security/next-csp-script-inventory.test.mjs`

## Validation
- `node --test scripts/security/next-csp-script-inventory.test.mjs`
- `node --check scripts/security/next-csp-nonce-triage.mjs`
- `node --check scripts/security/next-csp-script-inventory.mjs`
- `git diff --check`
- `pnpm repo:size:check`
- `pnpm slice:verify`
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate` (`134 passed, 8 skipped`)

## Backlog after this lands
- Expected to close 1 high CodeQL alert: `js/bad-tag-filter`.
- Remaining CodeQL after expected close: 2 high `js/clear-text-logging`, 17 medium `js/client-side-unvalidated-url-redirection`.
- Dependabot open vulnerabilities: 0.

Phase C invariants preserved: no routing/auth/domain/tenant architecture changes; `apps/web/src/proxy.ts` untouched.
