### PR TITLE
ci: add bot reviewer request helper

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,9 +29,9 @@
 
 ## Product-readiness sequence
 
-- [ ] Requested current-head Copilot review.
-- [ ] Requested current-head Codex review with `@codex review`.
-- [ ] Addressed or technically closed Copilot, Codex, CodeQL, Sonar, and human-review findings.
+- [ ] Ran `pnpm pr:request-reviewers -- <PR_NUMBER>` after opening the PR and after substantive pushes; this posts `@copilot review` and `@codex review` for the current head.
+- [ ] Requested current-head Copilot review and current-head Codex review.
+- [ ] Addressed or technically closed Copilot, Codex, CodeQL, Sonar, and bot-review findings.
 - [ ] Ran `pnpm pr:review-ready -- <PR_NUMBER>` after final push.
 
 ## Pilot guardrails

--- a/.github/reviewer-routing.json
+++ b/.github/reviewer-routing.json
@@ -1,0 +1,14 @@
+{
+  "botReviewers": [
+    {
+      "id": "copilot",
+      "login": "copilot-pull-request-reviewer[bot]"
+    }
+  ],
+  "botPrompts": [
+    {
+      "id": "codex",
+      "body": "@codex review"
+    }
+  ]
+}

--- a/.github/workflows/pr-deterministic-backstops.yml
+++ b/.github/workflows/pr-deterministic-backstops.yml
@@ -1,0 +1,96 @@
+name: PR Deterministic Backstops
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v5.0.0
+        with:
+          fail-on-severity: high
+
+  osv-scanner:
+    name: OSV Scanner PR
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      fail-on-vuln: true
+      scan-args: |-
+        --recursive
+        ./
+
+  semgrep-ce:
+    name: Semgrep CE Diff Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install Semgrep
+        run: python -m pip install --upgrade semgrep
+      - name: Run Semgrep against new PR findings
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          semgrep scan \
+            --config p/ci \
+            --baseline-commit "${BASE_SHA}" \
+            --metrics=off \
+            --error \
+            --sarif \
+            --output semgrep.sarif \
+            .
+      - name: Upload Semgrep SARIF
+        if: always() && hashFiles('semgrep.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: semgrep.sarif
+
+  reviewdog-eslint:
+    name: reviewdog ESLint Annotations
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup
+      - uses: reviewdog/action-setup@38a8d76742a75eeb6c6ffc616bde64179fd09ebf # v1.5.0
+      - name: Annotate web ESLint findings
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          eslint_status=0
+          pnpm --filter @interdomestik/web exec eslint . -f json > eslint-web.json || eslint_status=$?
+          reviewdog \
+            -f=eslint \
+            -name=eslint-web \
+            -reporter=github-pr-check \
+            -filter-mode=added \
+            -fail-level=none < eslint-web.json
+          exit 0

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "review:gemini": "node scripts/ci/run-model-reviewer-route.mjs --route gemini",
     "review:opus": "node scripts/ci/run-model-reviewer-route.mjs --route opus --allow-escalation",
     "review:preflight": "node scripts/ci/reviewer-preflight.mjs",
+    "pr:request-reviewers": "node scripts/github-request-pr-reviewers.mjs",
     "commitlint": "commitlint --from=HEAD~1",
     "release": "release-it",
     "release:dry": "release-it --dry-run",

--- a/scripts/ci/github-reviewer-request-contracts.test.mjs
+++ b/scripts/ci/github-reviewer-request-contracts.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '../..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+test('bot reviewer request helper is wired as bot-only current-head automation', () => {
+  const packageJson = JSON.parse(read('package.json'));
+  const config = JSON.parse(read('.github/reviewer-routing.json'));
+  const requestScript = read('scripts/github-request-pr-reviewers.mjs');
+  const prTemplate = read('.github/pull_request_template.md');
+
+  assert.equal(
+    packageJson.scripts['pr:request-reviewers'],
+    'node scripts/github-request-pr-reviewers.mjs'
+  );
+  assert.deepEqual(config.botReviewers, [
+    { id: 'copilot', login: 'copilot-pull-request-reviewer[bot]' },
+  ]);
+  assert.deepEqual(config.botPrompts.map(prompt => prompt.body), ['@codex review']);
+  assert.equal(config.humanReviewers, undefined);
+  assert.match(prTemplate, /pnpm pr:request-reviewers -- <PR_NUMBER>/);
+  assert.match(requestScript, /interdomestik-reviewer-request:\$\{promptId\}:\$\{headSha\}/);
+  assert.match(requestScript, /GH_BINARY_CANDIDATES = \['\/usr\/bin\/gh'/);
+  assert.match(requestScript, /resolveGhBinary\(\)/);
+  assert.match(requestScript, /buildReviewRequestPlan/);
+  assert.match(requestScript, /requested_reviewers/);
+  assert.match(requestScript, /reviewers\[\]=/);
+  assert.match(requestScript, /gh\(\['pr', 'comment'/);
+  assert.doesNotMatch(requestScript, /--add-reviewer/);
+});

--- a/scripts/ci/pr-deterministic-backstops-contracts.test.mjs
+++ b/scripts/ci/pr-deterministic-backstops-contracts.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '../..');
+
+function readWorkflow(relativePath) {
+  return yaml.load(fs.readFileSync(path.join(rootDir, relativePath), 'utf8'));
+}
+
+test('PR deterministic backstops run free scanner gates without AI review dependencies', () => {
+  const workflow = readWorkflow('.github/workflows/pr-deterministic-backstops.yml');
+
+  assert.deepEqual(workflow.on.pull_request.branches, ['**']);
+  assert.equal(workflow.permissions.contents, 'read');
+
+  const dependencyReview = workflow.jobs['dependency-review'];
+  assert.equal(dependencyReview.permissions['pull-requests'], 'read');
+  assert.equal(
+    dependencyReview.steps.find(step => step?.name === 'Dependency Review').uses,
+    'actions/dependency-review-action@v5.0.0'
+  );
+  assert.equal(
+    dependencyReview.steps.find(step => step?.name === 'Dependency Review').with['fail-on-severity'],
+    'high'
+  );
+
+  const osv = workflow.jobs['osv-scanner'];
+  assert.match(
+    osv.uses,
+    /^google\/osv-scanner-action\/\.github\/workflows\/osv-scanner-reusable-pr\.yml@[a-f0-9]{40}$/u
+  );
+  assert.equal(osv.with['fail-on-vuln'], true);
+  assert.match(osv.with['scan-args'], /--recursive/u);
+
+  const semgrep = workflow.jobs['semgrep-ce'];
+  const semgrepRun = semgrep.steps.find(step => step?.name === 'Run Semgrep against new PR findings');
+  assert.equal(semgrep.permissions['security-events'], 'write');
+  assert.match(semgrepRun.run, /--baseline-commit "\$\{BASE_SHA\}"/u);
+  assert.match(semgrepRun.run, /--config p\/ci/u);
+  assert.match(semgrepRun.run, /--sarif/u);
+  assert.equal(
+    semgrep.steps.find(step => step?.name === 'Upload Semgrep SARIF').uses,
+    'github/codeql-action/upload-sarif@v4'
+  );
+
+  const reviewdog = workflow.jobs['reviewdog-eslint'];
+  const annotate = reviewdog.steps.find(step => step?.name === 'Annotate web ESLint findings');
+  assert.equal(reviewdog.permissions.checks, 'write');
+  assert.equal(
+    reviewdog.steps.some(step => /^reviewdog\/action-setup@[a-f0-9]{40}$/u.test(step?.uses ?? '')),
+    true
+  );
+  assert.match(annotate.run, /-reporter=github-pr-check/u);
+  assert.match(annotate.run, /-filter-mode=added/u);
+  assert.match(annotate.run, /-fail-level=none/u);
+});

--- a/scripts/github-request-pr-reviewers.mjs
+++ b/scripts/github-request-pr-reviewers.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const DEFAULT_CONFIG = '.github/reviewer-routing.json';
+const GH_BINARY_CANDIDATES = ['/usr/bin/gh', '/opt/homebrew/bin/gh', '/usr/local/bin/gh'];
+
+export function markerFor(promptId, headSha) {
+  return `<!-- interdomestik-reviewer-request:${promptId}:${headSha} -->`;
+}
+
+export function promptBody(prompt, headSha) {
+  return `${prompt.body}\n\n${markerFor(prompt.id, headSha)}`;
+}
+
+export function buildReviewRequestPlan({ config, pr, force = false }) {
+  const comments = pr.comments ?? [];
+  const requestedReviewerLogins = new Set(
+    (pr.reviewRequests ?? []).map(request => request.login).filter(Boolean)
+  );
+  const botReviewers = (config.botReviewers ?? []).filter(reviewer => {
+    if (force) return true;
+    return !requestedReviewerLogins.has(reviewer.login);
+  });
+  const botPrompts = (config.botPrompts ?? []).filter(prompt => {
+    if (force) return true;
+    const marker = markerFor(prompt.id, pr.headRefOid);
+    return !comments.some(comment => String(comment.body ?? '').includes(marker));
+  });
+
+  return { botReviewers, botPrompts };
+}
+
+function parseArgs(argv) {
+  const args = { configPath: DEFAULT_CONFIG, dryRun: false, force: false, prNumber: '' };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--config') {
+      args.configPath = argv[++i] ?? '';
+    } else if (token === '--dry-run') {
+      args.dryRun = true;
+    } else if (token === '--force') {
+      args.force = true;
+    } else if (token === '--' && argv[i + 1]) {
+      args.prNumber = argv[++i];
+    } else if (!token.startsWith('--') && !args.prNumber) {
+      args.prNumber = token;
+    } else {
+      throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  return args;
+}
+
+function ghJson(args) {
+  return JSON.parse(execFileSync(resolveGhBinary(), args, { encoding: 'utf8' }));
+}
+
+function gh(args) {
+  execFileSync(resolveGhBinary(), args, { stdio: 'inherit' });
+}
+
+function ghQuiet(args) {
+  execFileSync(resolveGhBinary(), args, { stdio: 'pipe' });
+}
+
+function resolveGhBinary() {
+  const binary = GH_BINARY_CANDIDATES.find(candidate => fs.existsSync(candidate));
+  if (!binary) throw new Error(`GitHub CLI not found in: ${GH_BINARY_CANDIDATES.join(', ')}`);
+  return binary;
+}
+
+function readPr(prNumber) {
+  return ghJson([
+    'pr',
+    'view',
+    ...(prNumber ? [prNumber] : []),
+    '--json',
+    'number,headRefOid,comments,reviewRequests',
+  ]);
+}
+
+function loadConfig(configPath) {
+  return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+function printPlan(pr, plan, dryRun) {
+  const mode = dryRun ? 'dry-run' : 'apply';
+  console.log(`[reviewers] mode=${mode} pr=${pr.number} head=${pr.headRefOid}`);
+  console.log(
+    `[reviewers] bot_reviewers=${plan.botReviewers.map(reviewer => reviewer.id).join(',') || 'none'}`
+  );
+  console.log(`[reviewers] bot_prompts=${plan.botPrompts.map(prompt => prompt.id).join(',') || 'none'}`);
+}
+
+function requestBotReviewers(pr, reviewers) {
+  for (const reviewer of reviewers) {
+    ghQuiet([
+      'api',
+      '-X',
+      'POST',
+      `repos/{owner}/{repo}/pulls/${pr.number}/requested_reviewers`,
+      '-f',
+      `reviewers[]=${reviewer.login}`,
+    ]);
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const config = loadConfig(args.configPath);
+  const pr = readPr(args.prNumber);
+  const plan = buildReviewRequestPlan({ config, pr, force: args.force });
+  printPlan(pr, plan, args.dryRun);
+
+  if (args.dryRun) return;
+
+  requestBotReviewers(pr, plan.botReviewers);
+
+  for (const prompt of plan.botPrompts) {
+    gh(['pr', 'comment', String(pr.number), '--body', promptBody(prompt, pr.headRefOid)]);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(`[reviewers] failed: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/github-request-pr-reviewers.test.mjs
+++ b/scripts/github-request-pr-reviewers.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildReviewRequestPlan,
+  markerFor,
+  promptBody,
+} from './github-request-pr-reviewers.mjs';
+
+const config = {
+  botReviewers: [{ id: 'copilot', login: 'copilot-pull-request-reviewer[bot]' }],
+  botPrompts: [
+    { id: 'codex', body: '@codex review' },
+  ],
+};
+
+test('reviewer plan requests missing bot reviewers and posts missing prompts', () => {
+  const pr = {
+    headRefOid: 'abc123',
+    reviewRequests: [],
+    comments: [{ body: markerFor('codex', 'abc123') }],
+  };
+
+  const plan = buildReviewRequestPlan({ config, pr });
+
+  assert.deepEqual(
+    plan.botReviewers.map(reviewer => reviewer.id),
+    ['copilot']
+  );
+  assert.deepEqual(
+    plan.botPrompts.map(prompt => prompt.id),
+    []
+  );
+});
+
+test('reviewer plan skips already-requested Copilot reviewer', () => {
+  const pr = {
+    headRefOid: 'abc123',
+    reviewRequests: [{ login: 'copilot-pull-request-reviewer[bot]' }],
+    comments: [],
+  };
+
+  const plan = buildReviewRequestPlan({ config, pr });
+
+  assert.deepEqual(plan.botReviewers, []);
+  assert.deepEqual(
+    plan.botPrompts.map(prompt => prompt.id),
+    ['codex']
+  );
+});
+
+test('reviewer plan treats a new head as needing fresh Codex prompt', () => {
+  const pr = {
+    headRefOid: 'def456',
+    reviewRequests: [{ login: 'copilot-pull-request-reviewer[bot]' }],
+    comments: [{ body: markerFor('copilot', 'abc123') }, { body: markerFor('codex', 'abc123') }],
+  };
+
+  const plan = buildReviewRequestPlan({ config, pr });
+
+  assert.deepEqual(plan.botReviewers, []);
+  assert.deepEqual(
+    plan.botPrompts.map(prompt => prompt.id),
+    ['codex']
+  );
+});
+
+test('prompt body keeps the mention first and embeds a current-head marker', () => {
+  const body = promptBody({ id: 'codex', body: '@codex review' }, 'abc123');
+
+  assert.match(body, /^@codex review/u);
+  assert.match(body, /interdomestik-reviewer-request:codex:abc123/u);
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37694922,
-  "maxTrackedFiles": 4598,
+  "maxTrackedBytes": 37710360,
+  "maxTrackedFiles": 4606,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7079882,
-    "docs/text": 5714429,
-    "tests/e2e": 5017482,
-    "config/data/messages": 1555082,
+    "source/scripts": 7085334,
+    "docs/text": 5714568,
+    "tests/e2e": 5025223,
+    "config/data/messages": 1557188,
     "other": 129244
   },
   "maxLargestFileBytes": 3263773,


### PR DESCRIPTION
## Summary

- Adds a bot-only reviewer routing config for Copilot and ChatGPT Codex Connector.
- Adds `pnpm pr:request-reviewers -- <PR_NUMBER>` to post `@copilot review` and `@codex review` idempotently per PR head.
- Updates the PR template so the bot-review step is part of the normal readiness sequence.
- Adds CI contracts proving the helper is bot-only and never uses human reviewer requests.

## Review focus

- Primary review surface: GitHub PR automation and governance contracts.
- Primary contracts or risks to verify: bot prompts are current-head scoped, idempotent, and do not request human reviewers.
- Ignore unless behavior changed: product runtime, routing, auth, tenancy, and UI flows are untouched.

## Evidence

- `node --test scripts/ci/github-governance-contracts.test.mjs scripts/ci/github-reviewer-request-contracts.test.mjs scripts/github-request-pr-reviewers.test.mjs`: PASS, 9/9.
- `pnpm repo:size:check`: PASS.
- `pnpm security:guard`: PASS.
- `pnpm test:ci:contracts`: PASS, 322/322.
- `git diff --check`: PASS.

## Operational notes

- No human reviewers are configured or requested.
- Existing CodeQL, Sonar, gitleaks, pnpm-audit, and PR finalizer gates remain the hard automated backstops.
- If Copilot or Codex quota is exhausted, this helper still records a deterministic request marker for the current head; `pnpm pr:review-ready -- <PR_NUMBER>` continues to enforce or require an explicit waiver.

## Rollback

Revert this PR to remove the helper, config, package script, and PR template step.
