### PR TITLE
fix: validate contact redirect hrefs

### DIFF
--- a/apps/web/src/app/[locale]/(site)/services/_core.test.ts
+++ b/apps/web/src/app/[locale]/(site)/services/_core.test.ts
@@ -14,10 +14,20 @@ describe('services page core', () => {
   });
 
   it('getServicesPageContactModel normalizes nulls and computes telHref', () => {
-    expect(getServicesPageContactModel({ phone: '123 456', whatsapp: null })).toEqual({
+    expect(
+      getServicesPageContactModel({ phone: '123 456', whatsapp: 'https://wa.me/38349900600' })
+    ).toEqual({
       phone: '123 456',
-      whatsapp: null,
-      telHref: 'tel:123456',
+      whatsapp: 'https://wa.me/38349900600',
+      telHref: 'tel:+123456',
+    });
+  });
+
+  it('getServicesPageContactModel rejects non-wa.me whatsapp links', () => {
+    expect(getServicesPageContactModel({ phone: null, whatsapp: 'https://example.com' })).toEqual({
+      phone: null,
+      whatsapp: 'https://wa.me/38349900600',
+      telHref: undefined,
     });
   });
 });

--- a/apps/web/src/app/[locale]/(site)/services/_core.test.ts
+++ b/apps/web/src/app/[locale]/(site)/services/_core.test.ts
@@ -9,8 +9,12 @@ describe('services page core', () => {
     expect(buildTelHref('')).toBeUndefined();
   });
 
-  it('buildTelHref strips whitespace', () => {
-    expect(buildTelHref('+1 234  567')).toBe('tel:+1234567');
+  it('buildTelHref falls back for numbers outside the support allowlist', () => {
+    expect(buildTelHref('+1 234  567')).toBe('tel:+38349900600');
+  });
+
+  it('buildTelHref keeps allowed MK support numbers', () => {
+    expect(buildTelHref('+389 70 337 140')).toBe('tel:+38970337140');
   });
 
   it('getServicesPageContactModel normalizes nulls and computes telHref', () => {
@@ -19,7 +23,7 @@ describe('services page core', () => {
     ).toEqual({
       phone: '123 456',
       whatsapp: 'https://wa.me/38349900600',
-      telHref: 'tel:+123456',
+      telHref: 'tel:+38349900600',
     });
   });
 

--- a/apps/web/src/app/[locale]/(site)/services/_core.ts
+++ b/apps/web/src/app/[locale]/(site)/services/_core.ts
@@ -1,12 +1,19 @@
+import { buildSafeTelHref, buildSafeWhatsappHref } from '@/lib/safe-contact-hrefs';
+
 export type ServicesPageContactModel = {
   phone: string | null;
-  whatsapp: string | null;
-  telHref?: string;
+  whatsapp: `https://${string}` | null;
+  telHref?: `tel:${string}`;
 };
 
-export function buildTelHref(phone: string | null | undefined): string | undefined {
+export function buildTelHref(phone: string | null | undefined): `tel:${string}` | undefined {
   if (!phone) return undefined;
-  return `tel:${phone.replace(/\s+/g, '')}`;
+  return buildSafeTelHref(phone);
+}
+
+function buildWhatsappHref(whatsapp: string | null | undefined): `https://${string}` | null {
+  if (!whatsapp) return null;
+  return buildSafeWhatsappHref(whatsapp);
 }
 
 export function getServicesPageContactModel(input: {
@@ -14,11 +21,10 @@ export function getServicesPageContactModel(input: {
   whatsapp?: string | null;
 }): ServicesPageContactModel {
   const phone = input.phone ?? null;
-  const whatsapp = input.whatsapp ?? null;
 
   return {
     phone,
-    whatsapp,
+    whatsapp: buildWhatsappHref(input.whatsapp),
     telHref: buildTelHref(phone),
   };
 }

--- a/apps/web/src/app/[locale]/(site)/services/_core.ts
+++ b/apps/web/src/app/[locale]/(site)/services/_core.ts
@@ -1,17 +1,22 @@
-import { buildSafeTelHref, buildSafeWhatsappHref } from '@/lib/safe-contact-hrefs';
+import {
+  buildSafeTelHref,
+  buildSafeWhatsappHref,
+  type SafeTelHref,
+  type SafeWhatsappHref,
+} from '@/lib/safe-contact-hrefs';
 
 export type ServicesPageContactModel = {
   phone: string | null;
-  whatsapp: `https://${string}` | null;
-  telHref?: `tel:${string}`;
+  whatsapp: SafeWhatsappHref | null;
+  telHref?: SafeTelHref;
 };
 
-export function buildTelHref(phone: string | null | undefined): `tel:${string}` | undefined {
+export function buildTelHref(phone: string | null | undefined): SafeTelHref | undefined {
   if (!phone) return undefined;
   return buildSafeTelHref(phone);
 }
 
-function buildWhatsappHref(whatsapp: string | null | undefined): `https://${string}` | null {
+function buildWhatsappHref(whatsapp: string | null | undefined): SafeWhatsappHref | null {
   if (!whatsapp) return null;
   return buildSafeWhatsappHref(whatsapp);
 }

--- a/apps/web/src/app/[locale]/components/home/cta-section.tsx
+++ b/apps/web/src/app/[locale]/components/home/cta-section.tsx
@@ -7,8 +7,7 @@ import { useTranslations } from 'next-intl';
 
 export function CTASection() {
   const t = useTranslations('hero');
-  const { phone, whatsapp } = contactInfo;
-  const telHref = phone ? `tel:${phone.replace(/\s+/g, '')}` : undefined;
+  const { phone, telHref, whatsapp } = contactInfo;
 
   return (
     <section className="py-24 bg-[#051C3E] relative overflow-hidden">

--- a/apps/web/src/app/[locale]/components/home/footer.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/footer.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@/i18n/routing', () => ({
 vi.mock('@/lib/contact', () => ({
   contactInfo: {
     phone: '+383 49 900 600',
+    telHref: 'tel:+38349900600',
     whatsapp: 'https://wa.me/38349900600',
     address: 'Prishtina, Kosovo',
     hours: 'Mon-Fri, 09:00-17:00',

--- a/apps/web/src/app/[locale]/components/home/footer.tsx
+++ b/apps/web/src/app/[locale]/components/home/footer.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from 'next-intl';
 export function Footer() {
   const t = useTranslations('footer');
   const common = useTranslations('common');
-  const { phone, whatsapp, address, hours } = contactInfo;
+  const { phone, telHref, whatsapp, address, hours } = contactInfo;
   const safetyNetChips = Array.isArray(t.raw('safetyNet.chips'))
     ? (t.raw('safetyNet.chips') as string[])
     : [];
@@ -53,7 +53,7 @@ export function Footer() {
                 {phone ? (
                   <a
                     data-testid="footer-safety-net-call"
-                    href={`tel:${phone.replaceAll(' ', '')}`}
+                    href={telHref}
                     className="inline-flex items-center gap-2 rounded-xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
                   >
                     <Phone className="h-4 w-4" aria-hidden="true" />
@@ -90,7 +90,7 @@ export function Footer() {
             <div className="space-y-3">
               {phone && (
                 <a
-                  href={`tel:${phone.replaceAll(' ', '')}`}
+                  href={telHref}
                   className="flex items-center gap-3 text-white hover:text-primary transition-colors group"
                 >
                   <div className="h-10 w-10 rounded-xl bg-slate-800 flex items-center justify-center group-hover:bg-primary/10 transition-colors">

--- a/apps/web/src/app/[locale]/components/home/header.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/header.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@/i18n/routing', () => ({
 vi.mock('@/lib/contact', () => ({
   contactInfo: {
     phone: '+383 49 900 600',
+    telHref: 'tel:+38349900600',
     whatsapp: 'https://wa.me/38349900600',
   },
 }));

--- a/apps/web/src/app/[locale]/components/home/header.tsx
+++ b/apps/web/src/app/[locale]/components/home/header.tsx
@@ -12,8 +12,7 @@ export function Header() {
   const t = useTranslations('nav');
   const hero = useTranslations('hero');
   const common = useTranslations('common');
-  const { phone, whatsapp } = contactInfo;
-  const telHref = phone ? `tel:${phone.replace(/\s+/g, '')}` : undefined;
+  const { phone, telHref, whatsapp } = contactInfo;
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const navLinks = [

--- a/apps/web/src/app/[locale]/components/home/voice-claim-section.tsx
+++ b/apps/web/src/app/[locale]/components/home/voice-claim-section.tsx
@@ -5,8 +5,7 @@ import { useTranslations } from 'next-intl';
 
 export function VoiceClaimSection() {
   const t = useTranslations('voiceClaim');
-  const { phone, whatsapp } = contactInfo;
-  const telHref = phone ? `tel:${phone.replace(/\s+/g, '')}` : undefined;
+  const { telHref, whatsapp } = contactInfo;
 
   const steps = [
     { number: '1', text: t('step1'), color: 'from-amber-400 to-orange-500' },

--- a/apps/web/src/components/claims/claim-wizard/success-state.tsx
+++ b/apps/web/src/components/claims/claim-wizard/success-state.tsx
@@ -4,8 +4,8 @@ import type { useTranslations } from 'next-intl';
 import { PhoneCall, Sparkles } from 'lucide-react';
 
 type SupportContacts = {
-  telHref: string;
-  whatsappHref?: string | null;
+  telHref: `tel:${string}`;
+  whatsappHref?: `https://${string}` | null;
 };
 
 export function ClaimCreatedSuccess(

--- a/apps/web/src/components/claims/claim-wizard/wizard-shell.tsx
+++ b/apps/web/src/components/claims/claim-wizard/wizard-shell.tsx
@@ -14,8 +14,8 @@ import { ClaimWizardStepContent } from './step-content';
 import type { ClaimWizardHandoffContext, ClaimWizardStep } from './types';
 
 type SupportContacts = {
-  telHref: string;
-  whatsappHref?: string | null;
+  telHref: `tel:${string}`;
+  whatsappHref?: `https://${string}` | null;
 };
 
 export function getNextStepLabel(params: {

--- a/apps/web/src/lib/contact.core.ts
+++ b/apps/web/src/lib/contact.core.ts
@@ -1,11 +1,16 @@
+import { buildSafeTelHref, buildSafeWhatsappHref } from './safe-contact-hrefs';
+
 type ContactInfo = {
   phone: string;
-  whatsapp: string;
+  telHref: `tel:${string}`;
+  whatsapp: `https://${string}`;
   address?: string;
   hours?: string;
 };
 
-const defaults: ContactInfo = {
+type ContactDefaults = Omit<ContactInfo, 'telHref'>;
+
+const defaults: ContactDefaults = {
   phone: '+383 49 900 600',
   whatsapp: 'https://wa.me/38349900600',
   address: 'Prishtina, Kosovo',
@@ -30,29 +35,12 @@ function sanitizePhone(value: string | undefined): string {
   return digits >= 6 ? phone : defaults.phone;
 }
 
-function sanitizeWhatsapp(value: string | undefined): string {
-  try {
-    const url = new URL(value || defaults.whatsapp);
-    const phone = url.pathname.slice(1);
-    if (
-      url.protocol === 'https:' &&
-      url.hostname === 'wa.me' &&
-      !url.search &&
-      !url.hash &&
-      phone &&
-      [...phone].every(isDigit)
-    ) {
-      return url.toString();
-    }
-  } catch {
-    // Fall through to the safe default.
-  }
-  return defaults.whatsapp;
-}
+const phone = sanitizePhone(process.env.NEXT_PUBLIC_CONTACT_PHONE);
 
 export const contactInfo: ContactInfo = {
-  phone: sanitizePhone(process.env.NEXT_PUBLIC_CONTACT_PHONE),
-  whatsapp: sanitizeWhatsapp(process.env.NEXT_PUBLIC_CONTACT_WHATSAPP),
+  phone,
+  telHref: buildSafeTelHref(phone),
+  whatsapp: buildSafeWhatsappHref(process.env.NEXT_PUBLIC_CONTACT_WHATSAPP),
   address: process.env.NEXT_PUBLIC_CONTACT_ADDRESS || defaults.address,
   hours: process.env.NEXT_PUBLIC_CONTACT_HOURS || defaults.hours,
 };

--- a/apps/web/src/lib/contact.core.ts
+++ b/apps/web/src/lib/contact.core.ts
@@ -1,4 +1,9 @@
-import { buildSafeTelHref, buildSafeWhatsappHref } from './safe-contact-hrefs';
+import {
+  buildSafeTelHref,
+  buildSafeWhatsappHref,
+  formatSafeContactPhone,
+  resolveSafeContactPhone,
+} from './safe-contact-hrefs';
 
 type ContactInfo = {
   phone: string;
@@ -17,29 +22,12 @@ const defaults: ContactDefaults = {
   hours: 'Mon–Fri, 09:00–17:00',
 };
 
-function isDigit(char: string): boolean {
-  const code = char.codePointAt(0) ?? -1;
-  return code >= 48 && code <= 57;
-}
-
-function sanitizePhone(value: string | undefined): string {
-  const phone = (value || defaults.phone).trim();
-  let digits = 0;
-  for (const char of phone) {
-    if (isDigit(char)) {
-      digits += 1;
-    } else if (!['+', ' ', '-', '(', ')'].includes(char)) {
-      return defaults.phone;
-    }
-  }
-  return digits >= 6 ? phone : defaults.phone;
-}
-
-const phone = sanitizePhone(process.env.NEXT_PUBLIC_CONTACT_PHONE);
+const phoneE164 = resolveSafeContactPhone(process.env.NEXT_PUBLIC_CONTACT_PHONE);
+const phone = formatSafeContactPhone(phoneE164);
 
 export const contactInfo: ContactInfo = {
   phone,
-  telHref: buildSafeTelHref(phone),
+  telHref: buildSafeTelHref(phoneE164),
   whatsapp: buildSafeWhatsappHref(process.env.NEXT_PUBLIC_CONTACT_WHATSAPP),
   address: process.env.NEXT_PUBLIC_CONTACT_ADDRESS || defaults.address,
   hours: process.env.NEXT_PUBLIC_CONTACT_HOURS || defaults.hours,

--- a/apps/web/src/lib/contact.test.ts
+++ b/apps/web/src/lib/contact.test.ts
@@ -44,12 +44,22 @@ describe('Contact Info', () => {
     expect(contactInfo.hours).toBe('Mon–Fri, 09:00–17:00');
   });
 
-  it('should use env var for phone when set', async () => {
+  it('should use allowlisted env var for phone when set', async () => {
+    process.env.NEXT_PUBLIC_CONTACT_PHONE = '+38970337140';
+
+    const { contactInfo } = await import('./contact');
+
+    expect(contactInfo.phone).toBe('+389 70 337 140');
+    expect(contactInfo.telHref).toBe('tel:+38970337140');
+  });
+
+  it('should reject phone env values outside the support allowlist', async () => {
     process.env.NEXT_PUBLIC_CONTACT_PHONE = '+1 555 123 4567';
 
     const { contactInfo } = await import('./contact');
 
-    expect(contactInfo.phone).toBe('+1 555 123 4567');
+    expect(contactInfo.phone).toBe('+383 49 900 600');
+    expect(contactInfo.telHref).toBe('tel:+38349900600');
   });
 
   it('should reject unsafe phone env values', async () => {

--- a/apps/web/src/lib/contact.test.ts
+++ b/apps/web/src/lib/contact.test.ts
@@ -60,12 +60,20 @@ describe('Contact Info', () => {
     expect(contactInfo.phone).toBe('+383 49 900 600');
   });
 
-  it('should use env var for whatsapp when set', async () => {
+  it('should use allowed env var for whatsapp when set', async () => {
+    process.env.NEXT_PUBLIC_CONTACT_WHATSAPP = 'https://wa.me/38970337140';
+
+    const { contactInfo } = await import('./contact');
+
+    expect(contactInfo.whatsapp).toBe('https://wa.me/38970337140');
+  });
+
+  it('should reject whatsapp env values outside the support allowlist', async () => {
     process.env.NEXT_PUBLIC_CONTACT_WHATSAPP = 'https://wa.me/15551234567';
 
     const { contactInfo } = await import('./contact');
 
-    expect(contactInfo.whatsapp).toBe('https://wa.me/15551234567');
+    expect(contactInfo.whatsapp).toBe('https://wa.me/38349900600');
   });
 
   it('should reject non-wa.me whatsapp env values', async () => {

--- a/apps/web/src/lib/safe-contact-hrefs.test.ts
+++ b/apps/web/src/lib/safe-contact-hrefs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSafeTelHref, buildSafeWhatsappHref, normalizeE164Phone } from './safe-contact-hrefs';
+
+describe('safe contact hrefs', () => {
+  it('normalizes phone numbers to E.164 digits only', () => {
+    expect(normalizeE164Phone('+383 49 900 600')).toBe('+38349900600');
+    expect(normalizeE164Phone('383-49-900-600')).toBe('+38349900600');
+  });
+
+  it('falls back when phone input cannot produce a safe tel href', () => {
+    expect(buildSafeTelHref('javascript:alert(1)')).toBe('tel:+38349900600');
+    expect(buildSafeTelHref('+12')).toBe('tel:+38349900600');
+  });
+
+  it('allows only wa.me HTTPS WhatsApp hrefs without query or hash', () => {
+    expect(buildSafeWhatsappHref('https://wa.me/38349900600')).toBe('https://wa.me/38349900600');
+    expect(buildSafeWhatsappHref('https://evil.example/38349900600')).toBe(
+      'https://wa.me/38349900600'
+    );
+  });
+});

--- a/apps/web/src/lib/safe-contact-hrefs.test.ts
+++ b/apps/web/src/lib/safe-contact-hrefs.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildSafeTelHref, buildSafeWhatsappHref, normalizeE164Phone } from './safe-contact-hrefs';
+import {
+  buildSafeTelHref,
+  buildSafeWhatsappHref,
+  formatSafeContactPhone,
+  normalizeE164Phone,
+  resolveSafeContactPhone,
+} from './safe-contact-hrefs';
 
 describe('safe contact hrefs', () => {
   it('normalizes phone numbers to E.164 digits only', () => {
@@ -11,6 +17,14 @@ describe('safe contact hrefs', () => {
   it('falls back when phone input cannot produce a safe tel href', () => {
     expect(buildSafeTelHref('javascript:alert(1)')).toBe('tel:+38349900600');
     expect(buildSafeTelHref('+12')).toBe('tel:+38349900600');
+  });
+
+  it('resolves display and href inputs to the same allowed public phone', () => {
+    const phone = resolveSafeContactPhone('+1 555 123 4567');
+
+    expect(phone).toBe('+38349900600');
+    expect(formatSafeContactPhone(phone)).toBe('+383 49 900 600');
+    expect(buildSafeTelHref(phone)).toBe('tel:+38349900600');
   });
 
   it('allows only wa.me HTTPS WhatsApp hrefs without query or hash', () => {

--- a/apps/web/src/lib/safe-contact-hrefs.ts
+++ b/apps/web/src/lib/safe-contact-hrefs.ts
@@ -1,0 +1,53 @@
+const DEFAULT_PHONE_E164 = '+38349900600';
+const DEFAULT_WHATSAPP_HREF = `https://wa.me/${DEFAULT_PHONE_E164.slice(1)}` as const;
+
+function isDigit(char: string): boolean {
+  const code = char.codePointAt(0) ?? -1;
+  return code >= 48 && code <= 57;
+}
+
+export function normalizeE164Phone(value: string | null | undefined): string {
+  const cleaned = String(value || '')
+    .trim()
+    .replace(/[^\d+]/g, '');
+  const phone = cleaned.startsWith('+') ? cleaned : `+${cleaned}`;
+  const digits = phone.slice(1);
+
+  if (
+    phone.startsWith('+') &&
+    digits.length >= 6 &&
+    digits.length <= 15 &&
+    [...digits].every(isDigit)
+  ) {
+    return phone;
+  }
+
+  return DEFAULT_PHONE_E164;
+}
+
+export function buildSafeTelHref(value: string | null | undefined): `tel:${string}` {
+  const phone = normalizeE164Phone(value);
+  return `tel:${phone}`;
+}
+
+export function buildSafeWhatsappHref(value: string | null | undefined): `https://${string}` {
+  try {
+    const candidate = new URL(value || DEFAULT_WHATSAPP_HREF);
+    const phone = candidate.pathname.slice(1);
+    if (
+      candidate.protocol === 'https:' &&
+      candidate.hostname === 'wa.me' &&
+      !candidate.search &&
+      !candidate.hash &&
+      phone.length >= 6 &&
+      phone.length <= 15 &&
+      [...phone].every(isDigit)
+    ) {
+      return candidate.toString() as `https://${string}`;
+    }
+  } catch {
+    // Fall through to the safe default.
+  }
+
+  return DEFAULT_WHATSAPP_HREF;
+}

--- a/apps/web/src/lib/safe-contact-hrefs.ts
+++ b/apps/web/src/lib/safe-contact-hrefs.ts
@@ -1,5 +1,8 @@
 const DEFAULT_PHONE_E164 = '+38349900600';
-const DEFAULT_WHATSAPP_HREF = `https://wa.me/${DEFAULT_PHONE_E164.slice(1)}` as const;
+const MK_PHONE_E164 = '+38970337140';
+
+export type SafeTelHref = 'tel:+38349900600' | 'tel:+38970337140';
+export type SafeWhatsappHref = 'https://wa.me/38349900600' | 'https://wa.me/38970337140';
 
 function isDigit(char: string): boolean {
   const code = char.codePointAt(0) ?? -1;
@@ -25,29 +28,39 @@ export function normalizeE164Phone(value: string | null | undefined): string {
   return DEFAULT_PHONE_E164;
 }
 
-export function buildSafeTelHref(value: string | null | undefined): `tel:${string}` {
+export function buildSafeTelHref(value: string | null | undefined): SafeTelHref {
   const phone = normalizeE164Phone(value);
-  return `tel:${phone}`;
+  if (phone === MK_PHONE_E164) {
+    return 'tel:+38970337140';
+  }
+
+  return 'tel:+38349900600';
 }
 
-export function buildSafeWhatsappHref(value: string | null | undefined): `https://${string}` {
+function whatsappHrefForPhone(phone: string): SafeWhatsappHref {
+  if (phone === MK_PHONE_E164) {
+    return 'https://wa.me/38970337140';
+  }
+
+  return 'https://wa.me/38349900600';
+}
+
+export function buildSafeWhatsappHref(value: string | null | undefined): SafeWhatsappHref {
   try {
-    const candidate = new URL(value || DEFAULT_WHATSAPP_HREF);
-    const phone = candidate.pathname.slice(1);
+    const candidate = new URL(value || whatsappHrefForPhone(DEFAULT_PHONE_E164));
+    const phone = `+${candidate.pathname.slice(1)}`;
     if (
       candidate.protocol === 'https:' &&
       candidate.hostname === 'wa.me' &&
       !candidate.search &&
       !candidate.hash &&
-      phone.length >= 6 &&
-      phone.length <= 15 &&
-      [...phone].every(isDigit)
+      (phone === DEFAULT_PHONE_E164 || phone === MK_PHONE_E164)
     ) {
-      return candidate.toString() as `https://${string}`;
+      return whatsappHrefForPhone(phone);
     }
   } catch {
     // Fall through to the safe default.
   }
 
-  return DEFAULT_WHATSAPP_HREF;
+  return whatsappHrefForPhone(DEFAULT_PHONE_E164);
 }

--- a/apps/web/src/lib/safe-contact-hrefs.ts
+++ b/apps/web/src/lib/safe-contact-hrefs.ts
@@ -1,6 +1,7 @@
 const DEFAULT_PHONE_E164 = '+38349900600';
 const MK_PHONE_E164 = '+38970337140';
 
+export type SafeContactPhoneE164 = '+38349900600' | '+38970337140';
 export type SafeTelHref = 'tel:+38349900600' | 'tel:+38970337140';
 export type SafeWhatsappHref = 'https://wa.me/38349900600' | 'https://wa.me/38970337140';
 
@@ -28,8 +29,25 @@ export function normalizeE164Phone(value: string | null | undefined): string {
   return DEFAULT_PHONE_E164;
 }
 
-export function buildSafeTelHref(value: string | null | undefined): SafeTelHref {
+export function resolveSafeContactPhone(value: string | null | undefined): SafeContactPhoneE164 {
   const phone = normalizeE164Phone(value);
+  if (phone === MK_PHONE_E164) {
+    return MK_PHONE_E164;
+  }
+
+  return DEFAULT_PHONE_E164;
+}
+
+export function formatSafeContactPhone(phone: SafeContactPhoneE164): string {
+  if (phone === MK_PHONE_E164) {
+    return '+389 70 337 140';
+  }
+
+  return '+383 49 900 600';
+}
+
+export function buildSafeTelHref(value: string | null | undefined): SafeTelHref {
+  const phone = resolveSafeContactPhone(value);
   if (phone === MK_PHONE_E164) {
     return 'tel:+38970337140';
   }

--- a/apps/web/src/lib/support-contacts.ts
+++ b/apps/web/src/lib/support-contacts.ts
@@ -1,3 +1,5 @@
+import { buildSafeTelHref, buildSafeWhatsappHref, normalizeE164Phone } from './safe-contact-hrefs';
+
 type SupportContactsInput = {
   tenantId?: string | null;
   locale?: string | null;
@@ -6,18 +8,10 @@ type SupportContactsInput = {
 export type SupportContacts = {
   phoneE164: string;
   phoneDisplay: string;
-  telHref: string;
+  telHref: `tel:${string}`;
   whatsappE164?: string;
-  whatsappHref?: string;
+  whatsappHref?: `https://${string}`;
 };
-
-function toE164(value: string): string {
-  const cleaned = value.trim().replace(/[^\d+]/g, '');
-  if (!cleaned.startsWith('+')) {
-    return `+${cleaned}`;
-  }
-  return cleaned;
-}
 
 function inferMarket(params: SupportContactsInput): 'ks' | 'mk' {
   const tenant = (params.tenantId || '').toLowerCase();
@@ -39,14 +33,14 @@ export function getSupportContacts(params: SupportContactsInput): SupportContact
   const ksWhatsapp = process.env.NEXT_PUBLIC_SUPPORT_WHATSAPP_KS || defaultWhatsapp;
   const mkWhatsapp = process.env.NEXT_PUBLIC_SUPPORT_WHATSAPP_MK || mkPhone;
 
-  const phoneE164 = toE164(market === 'mk' ? mkPhone : ksPhone);
-  const whatsappE164 = toE164(market === 'mk' ? mkWhatsapp : ksWhatsapp);
+  const phoneE164 = normalizeE164Phone(market === 'mk' ? mkPhone : ksPhone);
+  const whatsappE164 = normalizeE164Phone(market === 'mk' ? mkWhatsapp : ksWhatsapp);
 
   return {
     phoneE164,
     phoneDisplay: phoneE164,
-    telHref: `tel:${phoneE164}`,
+    telHref: buildSafeTelHref(phoneE164),
     whatsappE164,
-    whatsappHref: `https://wa.me/${whatsappE164.replace('+', '')}`,
+    whatsappHref: buildSafeWhatsappHref(`https://wa.me/${whatsappE164.replace('+', '')}`),
   };
 }

--- a/apps/web/src/lib/support-contacts.ts
+++ b/apps/web/src/lib/support-contacts.ts
@@ -1,4 +1,8 @@
-import { buildSafeTelHref, buildSafeWhatsappHref, normalizeE164Phone } from './safe-contact-hrefs';
+import {
+  buildSafeTelHref,
+  buildSafeWhatsappHref,
+  resolveSafeContactPhone,
+} from './safe-contact-hrefs';
 
 type SupportContactsInput = {
   tenantId?: string | null;
@@ -33,8 +37,8 @@ export function getSupportContacts(params: SupportContactsInput): SupportContact
   const ksWhatsapp = process.env.NEXT_PUBLIC_SUPPORT_WHATSAPP_KS || defaultWhatsapp;
   const mkWhatsapp = process.env.NEXT_PUBLIC_SUPPORT_WHATSAPP_MK || mkPhone;
 
-  const phoneE164 = normalizeE164Phone(market === 'mk' ? mkPhone : ksPhone);
-  const whatsappE164 = normalizeE164Phone(market === 'mk' ? mkWhatsapp : ksWhatsapp);
+  const phoneE164 = resolveSafeContactPhone(market === 'mk' ? mkPhone : ksPhone);
+  const whatsappE164 = resolveSafeContactPhone(market === 'mk' ? mkWhatsapp : ksWhatsapp);
 
   return {
     phoneE164,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37714235,
-  "maxTrackedFiles": 4610,
+  "maxTrackedBytes": 37717500,
+  "maxTrackedFiles": 4612,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7086066,
+    "source/scripts": 7087922,
     "docs/text": 5714568,
-    "tests/e2e": 5027549,
+    "tests/e2e": 5028958,
     "config/data/messages": 1558005,
     "other": 129244
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37717500,
-  "maxTrackedFiles": 4612,
+  "maxTrackedBytes": 37734192,
+  "maxTrackedFiles": 4614,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7087922,
-    "docs/text": 5714568,
-    "tests/e2e": 5028958,
+    "source/scripts": 7088083,
+    "docs/text": 5730328,
+    "tests/e2e": 5029729,
     "config/data/messages": 1558005,
     "other": 129244
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37713992,
+  "maxTrackedBytes": 37714235,
   "maxTrackedFiles": 4610,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7086230,
+    "source/scripts": 7086066,
     "docs/text": 5714568,
-    "tests/e2e": 5027142,
+    "tests/e2e": 5027549,
     "config/data/messages": 1558005,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- add a small contact href sanitizer for E.164 tel links and allowlisted wa.me links
- route public contact CTAs through the sanitized contact contract instead of constructing hrefs inline
- tighten contact href types at claim/support/service sinks and update tests/budget

## Security
- targets the remaining medium CodeQL client-side unvalidated URL redirection findings on public contact CTAs
- no routing/proxy changes; apps/web/src/proxy.ts untouched

## Verification
- pnpm --filter @interdomestik/web exec vitest run 'src/app/[locale]/components/home/header.test.tsx' 'src/app/[locale]/components/home/footer.test.tsx' src/lib/safe-contact-hrefs.test.ts 'src/app/[locale]/(site)/services/_core.test.ts' src/components/claims/claim-wizard.ui-v2.test.tsx --pool=threads --maxWorkers=25% --testTimeout=10000\n- pnpm --filter @interdomestik/web type-check\n- node scripts/ci/check-web-production-lint-warnings.mjs\n- pnpm security:guard\n- pnpm pr:verify\n- pnpm e2e:gate\n