### PR TITLE
ci: harden canonical staging alias assignment

### DIFF
--- a/scripts/ci/configure-vercel-gate-url.mjs
+++ b/scripts/ci/configure-vercel-gate-url.mjs
@@ -1,6 +1,8 @@
 import { pathToFileURL } from 'node:url';
 
 const VERCEL_TEAM_SLUG = 'ecohub';
+const DEFAULT_ALIAS_ATTEMPTS = 4;
+const DEFAULT_ALIAS_RETRY_MS = 5_000;
 
 export function cleanHostname(value) {
   return String(value || '')
@@ -21,37 +23,76 @@ export function requireHostname(label, value) {
   return hostname;
 }
 
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function aliasEndpoint(deploymentHostname, env) {
+  const endpoint = new URL(
+    `https://api.vercel.com/v2/deployments/${encodeURIComponent(deploymentHostname)}/aliases`
+  );
+  const teamId = env.VERCEL_ORG_ID || '';
+  if (teamId) endpoint.searchParams.set('teamId', teamId);
+  else endpoint.searchParams.set('slug', env.VERCEL_TEAM_SLUG || VERCEL_TEAM_SLUG);
+  return endpoint;
+}
+
+function compactBody(body) {
+  return body.replace(/\s+/gu, ' ').trim().slice(0, 800);
+}
+
+function isTransientAliasFailure(status, body) {
+  return (
+    status === 400 &&
+    /(cert .*not ready|deployment .*not ready|not READY|can not be aliased)/iu.test(body)
+  );
+}
+
 export async function aliasStagingDeployment(
   deploymentHostname,
   aliasHostname,
   env = process.env,
-  fetchImpl = fetch
+  fetchImpl = fetch,
+  waitImpl = delay
 ) {
   const token = env.VERCEL_TOKEN;
   if (!token) throw new Error('VERCEL_TOKEN is required to assign the staging alias');
 
   console.error('Assigning canonical staging alias to the verified Vercel deployment');
-  const endpoint = new URL(
-    `https://api.vercel.com/v2/deployments/${encodeURIComponent(deploymentHostname)}/aliases`
-  );
-  endpoint.searchParams.set('slug', VERCEL_TEAM_SLUG);
+  const endpoint = aliasEndpoint(deploymentHostname, env);
+  const attempts = positiveInteger(env.STAGING_ALIAS_ATTEMPTS, DEFAULT_ALIAS_ATTEMPTS);
+  const retryMs = positiveInteger(env.STAGING_ALIAS_RETRY_MS, DEFAULT_ALIAS_RETRY_MS);
 
-  const response = await fetchImpl(endpoint, {
-    method: 'POST',
-    headers: {
-      authorization: `Bearer ${token}`,
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({ alias: aliasHostname }),
-  });
-  if (response.ok) return;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ alias: aliasHostname, redirect: null }),
+    });
+    if (response.ok) return;
 
-  const body = await response.text();
-  if (response.status === 409 && /already assigned/i.test(body)) {
-    console.error('Canonical staging alias is already assigned to the verified Vercel deployment');
-    return;
+    const body = await response.text();
+    if (response.status === 409 && /already assigned/iu.test(body)) {
+      console.error('Canonical staging alias is already assigned to the verified Vercel deployment');
+      return;
+    }
+    if (attempt < attempts && isTransientAliasFailure(response.status, body)) {
+      console.error(`Canonical staging alias not ready yet; retrying (${attempt}/${attempts})`);
+      await waitImpl(retryMs);
+      continue;
+    }
+    throw new Error(
+      `Failed to assign canonical staging alias: ${response.status} ${compactBody(body)}`
+    );
   }
-  throw new Error(`Failed to assign canonical staging alias: ${response.status}`);
 }
 
 export async function resolveGateUrl(

--- a/scripts/ci/configure-vercel-gate-url.test.mjs
+++ b/scripts/ci/configure-vercel-gate-url.test.mjs
@@ -57,12 +57,27 @@ test('resolveGateUrl aliases staging to canonical gate host', async () => {
   });
 });
 
+test('resolveGateUrl fails closed when staging alias assignment fails', async () => {
+  await assert.rejects(
+    () =>
+      resolveGateUrl(
+        'https://deploy.vercel.app',
+        'deploy.vercel.app',
+        { DEPLOY_ENVIRONMENT: 'staging', DEPLOY_PRODUCTION: 'false', VERCEL_TOKEN: 'token' },
+        async () => {
+          throw new Error('Failed to assign canonical staging alias: 400');
+        }
+      ),
+    /Failed to assign canonical staging alias: 400/u
+  );
+});
+
 test('aliasStagingDeployment assigns aliases through the Vercel REST API', async () => {
   const calls = [];
   await aliasStagingDeployment(
     'deploy.vercel.app',
     'staging.interdomestik.com',
-    { VERCEL_TOKEN: 'token' },
+    { VERCEL_TOKEN: 'token', VERCEL_ORG_ID: 'team_123' },
     async (url, init) => {
       calls.push({ url: String(url), init });
       return new Response('', { status: 200 });
@@ -70,10 +85,49 @@ test('aliasStagingDeployment assigns aliases through the Vercel REST API', async
   );
   assert.equal(
     calls[0].url,
-    'https://api.vercel.com/v2/deployments/deploy.vercel.app/aliases?slug=ecohub'
+    'https://api.vercel.com/v2/deployments/deploy.vercel.app/aliases?teamId=team_123'
   );
   assert.equal(calls[0].init.headers.authorization, 'Bearer token');
-  assert.equal(calls[0].init.body, JSON.stringify({ alias: 'staging.interdomestik.com' }));
+  assert.equal(
+    calls[0].init.body,
+    JSON.stringify({ alias: 'staging.interdomestik.com', redirect: null })
+  );
+});
+
+test('aliasStagingDeployment retries transient Vercel alias readiness failures', async () => {
+  const statuses = [
+    new Response('The deployment is not READY and can not be aliased', { status: 400 }),
+    new Response('', { status: 200 }),
+  ];
+  const waits = [];
+
+  await aliasStagingDeployment(
+    'deploy.vercel.app',
+    'staging.interdomestik.com',
+    {
+      VERCEL_TOKEN: 'token',
+      VERCEL_ORG_ID: 'team_123',
+      STAGING_ALIAS_ATTEMPTS: '2',
+      STAGING_ALIAS_RETRY_MS: '1',
+    },
+    async () => statuses.shift(),
+    async ms => waits.push(ms)
+  );
+
+  assert.deepEqual(waits, [1]);
+});
+
+test('aliasStagingDeployment includes response body on hard alias failure', async () => {
+  await assert.rejects(
+    () =>
+      aliasStagingDeployment(
+        'deploy.vercel.app',
+        'staging.interdomestik.com',
+        { VERCEL_TOKEN: 'token', VERCEL_ORG_ID: 'team_123', STAGING_ALIAS_ATTEMPTS: '1' },
+        async () => new Response('The supplied alias is invalid', { status: 400 })
+      ),
+    /Failed to assign canonical staging alias: 400 The supplied alias is invalid/u
+  );
 });
 
 test('configure helper does not shell out for alias assignment', () => {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37735743,
+  "maxTrackedBytes": 37738801,
   "maxTrackedFiles": 4614,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7089249,
+    "source/scripts": 7090657,
     "docs/text": 5730328,
-    "tests/e2e": 5030109,
+    "tests/e2e": 5031759,
     "config/data/messages": 1558010,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- Keep staging CD fail-closed on the canonical `staging.interdomestik.com` gate URL instead of falling back to a Vercel preview deployment URL.
- Assign the canonical staging alias with Vercel's alias API using `VERCEL_ORG_ID` as `teamId` when available, with bounded retries for transient alias-readiness errors.
- Surface compact Vercel response bodies on hard alias failures so DNS/domain/certificate issues are actionable in CD logs.
- Sync the repo-size budget for the changed test/source files.

## Why
Post-merge CD could build and deploy staging, but the canonical alias assignment failed. Falling back to a random `*.vercel.app` deployment would make the staging gate prove the wrong surface. This keeps the canonical staging gate strict while making the infrastructure failure easier to diagnose.

## Verification
- Focused CD/workflow contract tests: 33/33 passed.
- `pnpm security:guard`: passed.
- `pnpm e2e:gate`: passed, 134 passed / 8 skipped.
- `pnpm pr:verify`: completed through final smoke with all reported suites green.

## Scope
- No changes to `apps/web/src/proxy.ts`.
- No auth, route, tenant, or canonical route changes.
- Production jobs remain unchanged.

## Operational note
`staging.interdomestik.com` still needs external DNS/domain configuration: add `A staging.interdomestik.com 76.76.21.21` at the DNS provider currently serving `ns1.aryll.net` / `ns2.aryll.net`.
