### PR TITLE
fix: avoid sensitive vercel alias query parameter

### DIFF
--- a/scripts/ci/configure-vercel-gate-url.mjs
+++ b/scripts/ci/configure-vercel-gate-url.mjs
@@ -36,9 +36,7 @@ function aliasEndpoint(deploymentHostname, env) {
   const endpoint = new URL(
     `https://api.vercel.com/v2/deployments/${encodeURIComponent(deploymentHostname)}/aliases`
   );
-  const teamId = env.VERCEL_ORG_ID || '';
-  if (teamId) endpoint.searchParams.set('teamId', teamId);
-  else endpoint.searchParams.set('slug', env.VERCEL_TEAM_SLUG || VERCEL_TEAM_SLUG);
+  endpoint.searchParams.set('slug', VERCEL_TEAM_SLUG);
   return endpoint;
 }
 

--- a/scripts/ci/configure-vercel-gate-url.test.mjs
+++ b/scripts/ci/configure-vercel-gate-url.test.mjs
@@ -77,7 +77,7 @@ test('aliasStagingDeployment assigns aliases through the Vercel REST API', async
   await aliasStagingDeployment(
     'deploy.vercel.app',
     'staging.interdomestik.com',
-    { VERCEL_TOKEN: 'token', VERCEL_ORG_ID: 'team_123' },
+    { VERCEL_TOKEN: 'token' },
     async (url, init) => {
       calls.push({ url: String(url), init });
       return new Response('', { status: 200 });
@@ -85,7 +85,7 @@ test('aliasStagingDeployment assigns aliases through the Vercel REST API', async
   );
   assert.equal(
     calls[0].url,
-    'https://api.vercel.com/v2/deployments/deploy.vercel.app/aliases?teamId=team_123'
+    'https://api.vercel.com/v2/deployments/deploy.vercel.app/aliases?slug=ecohub'
   );
   assert.equal(calls[0].init.headers.authorization, 'Bearer token');
   assert.equal(
@@ -106,7 +106,6 @@ test('aliasStagingDeployment retries transient Vercel alias readiness failures',
     'staging.interdomestik.com',
     {
       VERCEL_TOKEN: 'token',
-      VERCEL_ORG_ID: 'team_123',
       STAGING_ALIAS_ATTEMPTS: '2',
       STAGING_ALIAS_RETRY_MS: '1',
     },
@@ -123,7 +122,7 @@ test('aliasStagingDeployment includes response body on hard alias failure', asyn
       aliasStagingDeployment(
         'deploy.vercel.app',
         'staging.interdomestik.com',
-        { VERCEL_TOKEN: 'token', VERCEL_ORG_ID: 'team_123', STAGING_ALIAS_ATTEMPTS: '1' },
+        { VERCEL_TOKEN: 'token', STAGING_ALIAS_ATTEMPTS: '1' },
         async () => new Response('The supplied alias is invalid', { status: 400 })
       ),
     /Failed to assign canonical staging alias: 400 The supplied alias is invalid/u

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37738801,
+  "maxTrackedBytes": 37738580,
   "maxTrackedFiles": 4614,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7090657,
+    "source/scripts": 7090527,
     "docs/text": 5730328,
-    "tests/e2e": 5031759,
+    "tests/e2e": 5031668,
     "config/data/messages": 1558010,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- Stop deriving the Vercel alias API team query parameter from `VERCEL_ORG_ID`.
- Use the fixed non-secret team slug already used by the merged CD alias helper.
- Keep the canonical staging alias gate strict, with retries and response-body diagnostics intact.
- Sync the repo-size budget after the smaller helper/test footprint.

## Why
PR #1276 merged the strict canonical staging alias fix, but Sonar Main Gate flagged the environment-derived `teamId` query parameter as confidential data in a GET parameter. The staging alias failure we were diagnosing is DNS/domain configuration, not a need to pass `VERCEL_ORG_ID` in the URL.

## Verification
- Focused CD/workflow contract tests: 33/33 passed.
- Repo size budget/check: passed.
- `pnpm security:guard`: passed.

## Scope
- No `apps/web/src/proxy.ts` changes.
- No routing, auth, tenancy, or canonical route changes.
