### PR TITLE
fix: add explicit sort comparators

### DIFF
--- a/list_s1874_files.mjs
+++ b/list_s1874_files.mjs
@@ -1,5 +1,7 @@
 import fs from 'fs';
 
+const compareText = (left, right) => left.localeCompare(right);
+
 const data = JSON.parse(fs.readFileSync('sonarqube_top_500_issues.json', 'utf8'));
 const issues = data.issues || [];
 
@@ -18,4 +20,4 @@ issues.forEach(issue => {
 });
 
 console.log(`Files with ${targetRule} (${files.length}):`);
-files.sort().forEach(f => console.log(f));
+files.sort(compareText).forEach(f => console.log(f));

--- a/scripts/check-drizzle-migration-journal.mjs
+++ b/scripts/check-drizzle-migration-journal.mjs
@@ -19,6 +19,7 @@ const REPO_ROOT = resolveRepoRoot();
 const DRIZZLE_DIR = path.resolve(REPO_ROOT, 'packages/database/drizzle');
 const JOURNAL_PATH = path.join(DRIZZLE_DIR, 'meta', '_journal.json');
 const MIGRATION_FILE_PATTERN = /^\d{4}_.+\.sql$/;
+const compareText = (left, right) => left.localeCompare(right);
 
 // Baseline exceptions currently present on main. Keep this list short and temporary.
 const LEGACY_ORPHAN_ALLOWLIST = new Set([
@@ -81,14 +82,14 @@ const journalSql = new Set(journal.entries.map(entry => `${entry.tag.trim()}.sql
 const sqlFiles = fs
   .readdirSync(DRIZZLE_DIR)
   .filter(name => MIGRATION_FILE_PATTERN.test(name))
-  .sort();
+  .sort(compareText);
 
-const missingFromDisk = [...journalSql].filter(file => !sqlFiles.includes(file)).sort();
-const orphanedAll = sqlFiles.filter(file => !journalSql.has(file)).sort();
+const missingFromDisk = [...journalSql].filter(file => !sqlFiles.includes(file)).sort(compareText);
+const orphanedAll = sqlFiles.filter(file => !journalSql.has(file)).sort(compareText);
 const orphanedUnexpected = orphanedAll.filter(file => !LEGACY_ORPHAN_ALLOWLIST.has(file));
 const allowlistStale = [...LEGACY_ORPHAN_ALLOWLIST]
   .filter(file => !orphanedAll.includes(file))
-  .sort();
+  .sort(compareText);
 
 if (missingFromDisk.length > 0) {
   fail(

--- a/scripts/check-i18n-purity.mjs
+++ b/scripts/check-i18n-purity.mjs
@@ -89,7 +89,7 @@ function flattenMessages(value, prefix = '') {
   }
 
   const entries = [];
-  for (const key of Object.keys(value).sort()) {
+  for (const key of Object.keys(value).sort((left, right) => left.localeCompare(right))) {
     const nextPrefix = prefix ? `${prefix}.${key}` : key;
     entries.push(...flattenMessages(value[key], nextPrefix));
   }
@@ -115,7 +115,7 @@ function collectNamespaces(messagesDir, baseLocale) {
   return fs
     .readdirSync(baseDir)
     .filter(name => name.endsWith('.json'))
-    .sort();
+    .sort((left, right) => left.localeCompare(right));
 }
 
 function collectEqualStringEntries({ messagesDir, baseLocale, locales, namespaces }) {
@@ -233,7 +233,7 @@ function main() {
       baseLocale: options.baseLocale,
       locales: options.locales.filter(locale => locale !== options.baseLocale),
       namespaces,
-      equalStringEntries: [...currentKeys].sort(),
+      equalStringEntries: [...currentKeys].sort((left, right) => left.localeCompare(right)),
     };
 
     ensureDirForFile(baselinePath);

--- a/scripts/i18n-keys-parity.ts
+++ b/scripts/i18n-keys-parity.ts
@@ -18,6 +18,7 @@ const __dirname = path.dirname(__filename);
 const LOCALES = ['en', 'sq', 'mk', 'sr'] as const;
 const NAMESPACES = ['admin-claims', 'claims'] as const;
 const MESSAGES_DIR = path.join(__dirname, '../apps/web/src/messages');
+const compareText = (left: string, right: string) => left.localeCompare(right);
 
 type KeyPath = string;
 
@@ -31,7 +32,7 @@ function getKeyPaths(obj: Record<string, unknown>, prefix = ''): KeyPath[] {
       keys.push(fullPath);
     }
   }
-  return keys.sort();
+  return keys.sort(compareText);
 }
 
 function loadNamespace(locale: string, namespace: string): Record<string, unknown> | null {

--- a/scripts/plan-conformance/boundary-diff-report.mjs
+++ b/scripts/plan-conformance/boundary-diff-report.mjs
@@ -20,9 +20,9 @@ function writeJson(filePath, payload) {
   fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
   fs.writeFileSync(absolutePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 }
-
 function normalizePaths(paths) {
-  return [...new Set(paths.map(file => String(file || '').trim()).filter(Boolean))].sort();
+  const cleanPaths = paths.map(file => String(file || '').trim()).filter(Boolean);
+  return [...new Set(cleanPaths)].sort((left, right) => left.localeCompare(right));
 }
 
 function matchesAnyPattern(filePath, patterns) {

--- a/scripts/plan-conformance/boundary-taxonomy-validate.mjs
+++ b/scripts/plan-conformance/boundary-taxonomy-validate.mjs
@@ -18,7 +18,7 @@ function isStringArray(value) {
 }
 
 function uniqueSorted(values) {
-  return [...new Set(values)].sort();
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
 }
 
 function validateRepoRelative(patterns, errors, label) {

--- a/scripts/plan-conformance/log.mjs
+++ b/scripts/plan-conformance/log.mjs
@@ -21,7 +21,7 @@ function stableSort(value) {
 
   if (value && typeof value === 'object') {
     return Object.keys(value)
-      .sort()
+      .sort((left, right) => left.localeCompare(right))
       .reduce((acc, key) => {
         acc[key] = stableSort(value[key]);
         return acc;

--- a/scripts/plan-conformance/memory-id.mjs
+++ b/scripts/plan-conformance/memory-id.mjs
@@ -3,6 +3,7 @@
 import crypto from 'node:crypto';
 
 const DEFAULT_SEED_VERSION = 'v1';
+const compareText = (left, right) => left.localeCompare(right);
 
 function stableSort(value) {
   if (Array.isArray(value)) {
@@ -11,7 +12,7 @@ function stableSort(value) {
 
   if (value && typeof value === 'object') {
     return Object.keys(value)
-      .sort()
+      .sort(compareText)
       .reduce((acc, key) => {
         acc[key] = stableSort(value[key]);
         return acc;

--- a/scripts/plan-conformance/memory-index.mjs
+++ b/scripts/plan-conformance/memory-index.mjs
@@ -46,7 +46,7 @@ function toSortedArrayMap(setMap) {
   return Array.from(setMap.entries())
     .sort(([left], [right]) => left.localeCompare(right))
     .reduce((acc, [key, values]) => {
-      acc[key] = Array.from(values).sort();
+      acc[key] = Array.from(values).sort((left, right) => left.localeCompare(right));
       return acc;
     }, Object.create(null));
 }

--- a/scripts/plan-conformance/reliability-baseline.mjs
+++ b/scripts/plan-conformance/reliability-baseline.mjs
@@ -183,7 +183,7 @@ function computeFlaky(entries) {
 
   return {
     flaky_check_count: flaky_checks.length,
-    flaky_checks: flaky_checks.sort(),
+    flaky_checks: flaky_checks.sort((left, right) => left.localeCompare(right)),
   };
 }
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37738580,
+  "maxTrackedBytes": 37739298,
   "maxTrackedFiles": 4614,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7090527,
+    "source/scripts": 7091245,
     "docs/text": 5730328,
     "tests/e2e": 5031668,
     "config/data/messages": 1558010,


### PR DESCRIPTION
## Summary
- Add explicit locale-aware comparators to Sonar-flagged string sorts.
- Cover adjacent comparator-free sorts in the same touched files to avoid same-rule follow-up findings.
- Keep legacy files from growing beyond the modularity guard's baseline.
- Sync repo-size budget.

## Why
Sonar main inventory still had 12 CRITICAL BUG findings for rule S2871/S2871-equivalent: `.sort()` without an explicit comparator. These are deterministic script/tooling fixes and do not touch runtime routing, auth, tenancy, or canonical routes.

## Verification
- `node --check` on touched `.mjs` scripts: passed.
- Focused plan-conformance / i18n-purity / drizzle journal tests: 74/74 passed.
- No comparator-free `.sort()` remains in the targeted files.
- Repo size budget/check: passed.
- `pnpm security:guard`: passed.

## Note
`pnpm exec tsx scripts/i18n-keys-parity.ts` still fails on pre-existing missing locale keys in `admin-claims`; that is translation data drift, not caused by this comparator-only PR.
