### PR TITLE
fix: resolve sonar new-code maintainability findings

### DIFF
--- a/apps/web/e2e/gate/front-door-session-context.spec.ts
+++ b/apps/web/e2e/gate/front-door-session-context.spec.ts
@@ -58,7 +58,7 @@ test.describe('Front-door session context', () => {
     const projectHeaders = testInfo.project.use.extraHTTPHeaders ?? {};
     const tenantId = frontDoorTenant(testInfo);
     if (tenantId === null) {
-      test.skip(true, 'front-door contract only runs in explicit ida projects');
+      expect(tenantId).toBeNull();
       return;
     }
     const seededUser = userForTenant(tenantId);

--- a/apps/web/e2e/gate/front-door-session-context.spec.ts
+++ b/apps/web/e2e/gate/front-door-session-context.spec.ts
@@ -28,10 +28,8 @@ function userForTenant(tenantId: FrontDoorTenant) {
 test.describe('Front-door session context', () => {
   test('renders ida.* public landing without a tenant cookie', async ({ browser }, testInfo) => {
     const { origin, locale } = projectInfo(testInfo.project.use.baseURL?.toString());
-    if (!new URL(origin).hostname.startsWith('ida.')) {
-      test.skip(true, 'front-door public contract only runs in ida projects');
-      return;
-    }
+    const isIdaHost = new URL(origin).hostname.startsWith('ida.');
+    test.skip(!isIdaHost, 'front-door public contract only runs in ida projects');
 
     const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
     try {
@@ -57,9 +55,9 @@ test.describe('Front-door session context', () => {
     const { origin, locale } = projectInfo(testInfo.project.use.baseURL?.toString());
     const projectHeaders = testInfo.project.use.extraHTTPHeaders ?? {};
     const tenantId = frontDoorTenant(testInfo);
+    test.skip(tenantId === null, 'front-door session contract only runs in front-door projects');
     if (tenantId === null) {
-      expect(tenantId).toBeNull();
-      return;
+      throw new Error('unreachable: front-door session skip did not abort the test');
     }
     const seededUser = userForTenant(tenantId);
     const forwardedHostHeader = 'x-forwarded-host';

--- a/apps/web/e2e/gate/ida-live-login-cutover.spec.ts
+++ b/apps/web/e2e/gate/ida-live-login-cutover.spec.ts
@@ -31,9 +31,9 @@ test.describe('ida live-login cutover gate', () => {
     const origin = getRootURL(testInfo);
     const locale = getLocale(testInfo);
     const hostCase = countryHostCase(new URL(origin).hostname);
+    test.skip(hostCase === null, 'live-login cutover gate only runs on country-host projects');
     if (!hostCase) {
-      expect(hostCase).toBeNull();
-      return;
+      throw new Error('unreachable: live-login cutover skip did not abort the test');
     }
 
     const loginUrl = new URL(path(testInfo, '/login'));

--- a/apps/web/e2e/gate/ida-live-login-cutover.spec.ts
+++ b/apps/web/e2e/gate/ida-live-login-cutover.spec.ts
@@ -32,7 +32,7 @@ test.describe('ida live-login cutover gate', () => {
     const locale = getLocale(testInfo);
     const hostCase = countryHostCase(new URL(origin).hostname);
     if (!hostCase) {
-      test.skip(true, 'cutover redirect applies only to country-host projects');
+      expect(hostCase).toBeNull();
       return;
     }
 

--- a/apps/web/e2e/setup.state.spec.ts
+++ b/apps/web/e2e/setup.state.spec.ts
@@ -51,6 +51,7 @@ authTest.describe('E2E Setup', () => {
 
     // Verify file exists
     expect(fs.existsSync(outFile)).toBeTruthy();
+    expect(path.basename(outFile)).toBe(`${getAuthStateScopeFromTestInfo(testInfo)}.json`);
     console.log(`[Setup] Successfully saved state to ${outFile}`);
   });
 });

--- a/apps/web/e2e/smoke/ida-dashboard-smoke.spec.ts
+++ b/apps/web/e2e/smoke/ida-dashboard-smoke.spec.ts
@@ -55,7 +55,7 @@ test.describe('@smoke ida.localhost canonical dashboard smoke', () => {
       const origin = new URL(baseURL).origin;
       const forwardedHostHeader = ['x-forwarded', 'host'].join('-');
       if (!new URL(origin).hostname.startsWith('ida.')) {
-        test.skip(true, 'ida dashboard smoke only runs in canonical ida projects');
+        expect(new URL(origin).hostname.startsWith('ida.')).toBe(false);
         return;
       }
 

--- a/apps/web/e2e/smoke/ida-dashboard-smoke.spec.ts
+++ b/apps/web/e2e/smoke/ida-dashboard-smoke.spec.ts
@@ -53,11 +53,9 @@ test.describe('@smoke ida.localhost canonical dashboard smoke', () => {
       if (!baseURL) throw new Error('smoke-ida requires project.use.baseURL');
 
       const origin = new URL(baseURL).origin;
+      const isIdaHost = new URL(origin).hostname.startsWith('ida.');
       const forwardedHostHeader = ['x-forwarded', 'host'].join('-');
-      if (!new URL(origin).hostname.startsWith('ida.')) {
-        expect(new URL(origin).hostname.startsWith('ida.')).toBe(false);
-        return;
-      }
+      test.skip(!isIdaHost, 'ida dashboard smoke only runs in ida projects');
 
       expect(projectHeaders[forwardedHostHeader]).toBeUndefined();
       expect(projectHeaders['x-tenant-id']).toBe('tenant_ks');

--- a/apps/web/src/lib/proxy-session-state.ts
+++ b/apps/web/src/lib/proxy-session-state.ts
@@ -58,9 +58,9 @@ export function hasRecentActiveSession(cacheKey: string): boolean {
 
 function base64UrlToBytes(value: string): Uint8Array | null {
   try {
-    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const normalized = value.replaceAll('-', '+').replaceAll('_', '/');
     const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
-    return Uint8Array.from(atob(padded), char => char.charCodeAt(0));
+    return Uint8Array.from(atob(padded), char => char.codePointAt(0) ?? 0);
   } catch {
     return null;
   }
@@ -106,12 +106,10 @@ function isActiveSessionPayload(payload: unknown): boolean {
   const session = (payload as { session?: { expiresAt?: unknown } }).session;
   if (!session || typeof session !== 'object' || !session.expiresAt) return false;
   const rawExpiresAt = session.expiresAt;
-  const expiresAt =
-    rawExpiresAt instanceof Date
-      ? rawExpiresAt.getTime()
-      : typeof rawExpiresAt === 'number'
-        ? rawExpiresAt
-        : Date.parse(String(rawExpiresAt));
+  let expiresAt = Number.NaN;
+  if (rawExpiresAt instanceof Date) expiresAt = rawExpiresAt.getTime();
+  if (typeof rawExpiresAt === 'number') expiresAt = rawExpiresAt;
+  if (typeof rawExpiresAt === 'string') expiresAt = Date.parse(rawExpiresAt);
   return Number.isFinite(expiresAt) && expiresAt > Date.now();
 }
 

--- a/list_s1874_files.mjs
+++ b/list_s1874_files.mjs
@@ -20,4 +20,5 @@ issues.forEach(issue => {
 });
 
 console.log(`Files with ${targetRule} (${files.length}):`);
-files.sort(compareText).forEach(f => console.log(f));
+files.sort(compareText);
+files.forEach(f => console.log(f));

--- a/packages/domain-claims/src/claims/ai-workflows.ts
+++ b/packages/domain-claims/src/claims/ai-workflows.ts
@@ -4,7 +4,11 @@ import {
   prepareClaimDocumentAiRun,
   type PreparedQueuedClaimAiRun,
 } from './ai-workflow-preparation';
-import type { ClaimAiWorkflowQueueInput, QueuedClaimAiRun } from './ai-workflow-types';
+import type {
+  ClaimAiClaimSnapshot,
+  ClaimAiWorkflowQueueInput,
+  QueuedClaimAiRun,
+} from './ai-workflow-types';
 
 type QueueInsertTx = {
   insert: (table: unknown) => { values: (rows: unknown) => unknown };
@@ -36,7 +40,7 @@ export async function queueClaimDocumentAiWorkflows(args: {
   tenantId: ClaimAiWorkflowQueueInput['tenantId'];
   userId: ClaimAiWorkflowQueueInput['userId'];
   files: ClaimAiWorkflowQueueInput['files'];
-  claimSnapshot?: ClaimAiWorkflowQueueInput['claimSnapshot'];
+  claimSnapshot?: ClaimAiClaimSnapshot | null;
 }): Promise<QueuedClaimAiRun[]> {
   if (args.files.length === 0) {
     return [];

--- a/packages/domain-membership-billing/src/entity-migration-readiness/classifier.ts
+++ b/packages/domain-membership-billing/src/entity-migration-readiness/classifier.ts
@@ -30,17 +30,18 @@ export function classifyEntityMigrationReadinessCandidate(
   const repairCategories = ENTITY_MIGRATION_REPAIR_CATEGORIES.filter(category =>
     repairs.has(category)
   );
+  let status: EntityMigrationReadinessResult['status'] = 'eligible';
+  if (activeRecoveryCaseCount > 0) {
+    status = 'blocked_active_recovery_runoff';
+  } else if (repairCategories.length > 0) {
+    status = 'blocked_repair_required';
+  }
 
   return {
     memberId: candidate.memberId,
     tenantId: candidate.tenantId,
     subscriptionId: candidate.subscriptionId,
-    status:
-      activeRecoveryCaseCount > 0
-        ? 'blocked_active_recovery_runoff'
-        : repairCategories.length > 0
-          ? 'blocked_repair_required'
-          : 'eligible',
+    status,
     repairCategories,
     evidence: buildEntityMigrationReadinessEvidence(candidate),
     activeRecoveryCaseCount,

--- a/packages/domain-membership-billing/src/entity-migration/planning.ts
+++ b/packages/domain-membership-billing/src/entity-migration/planning.ts
@@ -39,16 +39,12 @@ export function buildMemberEntityMigrationPlan(
   }
 
   if (command.mode === 'dry_run') {
-    return readyPlan(
-      command,
-      previous,
-      target,
-      approval,
+    return readyPlan(command, previous, target, approval, {
       readiness,
       subscriptionId,
-      'dry_run_ready',
-      false
-    );
+      status: 'dry_run_ready',
+      writesPlanned: false,
+    });
   }
 
   if (command.approval && !approval) {
@@ -59,7 +55,12 @@ export function buildMemberEntityMigrationPlan(
     return blockedPlan(command, previous, target, null, readiness, 'blocked_approval_required');
   }
 
-  return readyPlan(command, previous, target, approval, readiness, subscriptionId, 'ready', true);
+  return readyPlan(command, previous, target, approval, {
+    readiness,
+    subscriptionId,
+    status: 'ready',
+    writesPlanned: true,
+  });
 }
 
 function buildPreviousSnapshot(candidate: EntityMigrationReadinessCandidate): MemberEntitySnapshot {
@@ -123,23 +124,25 @@ function readyPlan(
   previous: MemberEntitySnapshot,
   target: MemberEntityMigrationTarget,
   approval: MemberEntityMigrationApproval | null,
-  readiness: ReturnType<typeof classifyEntityMigrationReadinessCandidate>,
-  subscriptionId: string,
-  status: 'ready' | 'dry_run_ready',
-  writesPlanned: boolean
+  options: {
+    readiness: ReturnType<typeof classifyEntityMigrationReadinessCandidate>;
+    subscriptionId: string;
+    status: 'ready' | 'dry_run_ready';
+    writesPlanned: boolean;
+  }
 ): MemberEntityMigrationPlan {
   return {
     memberId: command.candidate.memberId,
     tenantId: command.candidate.tenantId,
-    subscriptionId,
+    subscriptionId: options.subscriptionId,
     mode: command.mode,
-    status,
+    status: options.status,
     previous,
     target,
-    readiness,
+    readiness: options.readiness,
     termsAction: 'reissue_and_recapture',
     approval,
     dataRepairCategories: [],
-    writesPlanned,
+    writesPlanned: options.writesPlanned,
   };
 }

--- a/packages/qa/src/utils/paths.ts
+++ b/packages/qa/src/utils/paths.ts
@@ -31,7 +31,8 @@ function realpathWithExistingParent(resolvedPath: string): string {
   while (true) {
     try {
       const canonicalCurrent = fs.realpathSync.native(currentPath);
-      return path.join(canonicalCurrent, ...missingSegments.reverse());
+      missingSegments.reverse();
+      return path.join(canonicalCurrent, ...missingSegments);
     } catch {
       const parentPath = path.dirname(currentPath);
       if (parentPath === currentPath) {

--- a/scripts/check-portal-layout-topology.mjs
+++ b/scripts/check-portal-layout-topology.mjs
@@ -24,10 +24,10 @@ const FORBIDDEN_PATHS = [
 const ROUTE_ROOT = 'apps/web/src/app/[locale]';
 const comparePath = (left, right) => left.localeCompare(right);
 const PORTAL_ROOTS = PORTAL_LAYOUTS.map(file => file.replace(/\/layout\.tsx$/u, ''));
-const FORBIDDEN_GROUP_LAYOUTS = [
+const FORBIDDEN_GROUP_LAYOUTS = new Set([
   'apps/web/src/app/[locale]/(agent)/layout.tsx',
   'apps/web/src/app/[locale]/(staff)/layout.tsx',
-];
+]);
 
 function toPosix(value) {
   return value.split(path.sep).join('/');
@@ -56,7 +56,7 @@ function walkFiles(root, dir, results = []) {
 function isPortalLayoutCandidate(file) {
   if (!file.endsWith('/layout.tsx')) return false;
   if (PORTAL_LAYOUTS.includes(file)) return true;
-  if (FORBIDDEN_GROUP_LAYOUTS.includes(file)) return true;
+  if (FORBIDDEN_GROUP_LAYOUTS.has(file)) return true;
   if (PORTAL_ROOTS.some(portalRoot => file.startsWith(`${portalRoot}/`))) return true;
   if (file.includes('/legacy/')) return true;
   if (file.includes('/(dashboard)/agent/')) return true;

--- a/scripts/ci/fetch-vercel-attestation.mjs
+++ b/scripts/ci/fetch-vercel-attestation.mjs
@@ -140,8 +140,10 @@ async function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch(error => {
+  try {
+    await main();
+  } catch (error) {
     console.error(error);
     process.exit(1);
-  });
+  }
 }

--- a/scripts/release-gate/admin-checks-response-capture.ts
+++ b/scripts/release-gate/admin-checks-response-capture.ts
@@ -1,6 +1,6 @@
 const SECRET_BODY_FIELD_PATTERN =
   /(["']?(?:access_token|authorization|id_token|password|refresh_token|secret|session|token)["']?\s*[:=]\s*)["']?[^"',\s}]+["']?/gi;
-const BEARER_PATTERN = /\b(Bearer)\s+[A-Za-z0-9._~+/-]+=*/gi;
+const BEARER_PATTERN = /\b(Bearer)\s+[-A-Za-z0-9._~+/=]+/gi;
 
 function redactResponseBody(raw) {
   return String(raw || '')
@@ -38,8 +38,9 @@ function createMutationResponseCapture(page, baseUrl) {
       const body = shouldCaptureResponseBody(status, contentType)
         ? compactResponseBody(await response.text().catch(() => ''), 420)
         : '';
+      const bodySuffix = body ? ` body=${body}` : '';
       entries.push(
-        `${method} ${status} ${compactResponseUrl(response.url())} content_type=${contentType || 'unknown'}${body ? ` body=${body}` : ''}`
+        `${method} ${status} ${compactResponseUrl(response.url())} content_type=${contentType || 'unknown'}${bodySuffix}`
       );
     })();
     pending.push(task);

--- a/scripts/release-gate/login-request-guard.ts
+++ b/scripts/release-gate/login-request-guard.ts
@@ -29,7 +29,11 @@ function getResponseHeader(response, name) {
 }
 
 function normalizePathname(pathname) {
-  return pathname.replace(/\/+$/, '') || '/';
+  let normalized = pathname;
+  while (normalized.endsWith('/') && normalized !== '/') {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized || '/';
 }
 
 function resolveTrustedLoginRedirectUrl({ response, origin }) {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37729097,
+  "maxTrackedBytes": 37730358,
   "maxTrackedFiles": 4614,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
-    "source/scripts": 7093388,
+    "source/scripts": 7093890,
     "docs/text": 5714568,
-    "tests/e2e": 5035809,
-    "config/data/messages": 1557285,
+    "tests/e2e": 5035798,
+    "config/data/messages": 1558055,
     "other": 129244
   },
   "maxLargestFileBytes": 3263773,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37730358,
+  "maxTrackedBytes": 37730613,
   "maxTrackedFiles": 4614,
   "maxCategoryBytes": {
     "large support/generated-ish": 18198803,
     "source/scripts": 7093890,
     "docs/text": 5714568,
-    "tests/e2e": 5035798,
+    "tests/e2e": 5036053,
     "config/data/messages": 1558055,
     "other": 129244
   },


### PR DESCRIPTION
## Summary
- resolves the actionable Sonar new-code blocker/medium maintainability findings across QA scripts, release-gate helpers, proxy session parsing, E2E gate tests, and billing/claims domain helpers
- keeps Phase C routing/auth/tenancy invariants intact; `apps/web/src/proxy.ts` was not touched
- refreshes repo size budget using tracked files only

## Verification
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate`

## Notes
- GitHub Dependabot/code scanning APIs currently report 0 open alerts; this PR targets Sonar new-code code-quality findings, not runtime behavior changes
- two local untracked audit prompt files were left untouched
