### PR TITLE
refactor: split CRM task save repository path

### DIFF
--- a/apps/web/src/adapters/crm/task-repository-save.ts
+++ b/apps/web/src/adapters/crm/task-repository-save.ts
@@ -1,0 +1,143 @@
+import type { CrmActorContext } from '@interdomestik/domain-crm/context';
+import type {
+  CrmTask,
+  CrmTaskHistoryEntry,
+  CrmTaskRepository,
+  CrmTaskSubjectReference,
+  CrmTaskSubjectVisibility,
+} from '@interdomestik/domain-crm/tasks';
+import { CrmTaskRepositoryFailure } from '@interdomestik/domain-crm/tasks';
+import type { db } from '@interdomestik/database/db';
+import { crmTaskHistory, crmTasks } from '@interdomestik/database/schema';
+import { and, eq, type SQL } from 'drizzle-orm';
+
+type CrmTaskDb = typeof db;
+type CrmTaskRow = typeof crmTasks.$inferSelect;
+type CrmTaskInsert = typeof crmTasks.$inferInsert;
+type CrmTaskHistoryInsert = typeof crmTaskHistory.$inferInsert;
+type CrmTaskSaveParams = Parameters<CrmTaskRepository['saveTask']>[0];
+
+export type CrmTaskSaveDeps = {
+  branchVisible(actor: CrmActorContext, branchId: string | null): boolean;
+  historyValues(taskId: string, entry: CrmTaskHistoryEntry): CrmTaskHistoryInsert;
+  hydrateVisibleTask(
+    database: Pick<CrmTaskDb, 'query'>,
+    actor: CrmActorContext,
+    row: CrmTaskRow
+  ): Promise<CrmTask | null>;
+  isIdempotencyUniqueViolation(error: unknown): boolean;
+  replayIdempotentCreate(
+    database: CrmTaskDb,
+    actor: CrmActorContext,
+    task: CrmTask
+  ): Promise<CrmTask | null>;
+  taskValues(task: CrmTask): CrmTaskInsert;
+  taskVisibilityPredicate(actor: CrmActorContext, taskId?: string): SQL | undefined;
+  validateSubjectReference(
+    database: Pick<CrmTaskDb, 'query'>,
+    params: { actor: CrmActorContext; subjectReference: CrmTaskSubjectReference }
+  ): Promise<CrmTaskSubjectVisibility>;
+};
+
+async function assertWritableTaskSubject(
+  database: Pick<CrmTaskDb, 'query'>,
+  params: CrmTaskSaveParams,
+  deps: CrmTaskSaveDeps
+): Promise<void> {
+  const visibility = await deps.validateSubjectReference(database, {
+    actor: params.actor,
+    subjectReference: params.task.subjectReference,
+  });
+  if (!visibility.visible) throw new CrmTaskRepositoryFailure(visibility.reason);
+  if (visibility.branchId !== params.task.branchId) {
+    throw new CrmTaskRepositoryFailure('subject_not_visible');
+  }
+  if (!deps.branchVisible(params.actor, params.task.branchId)) {
+    throw new CrmTaskRepositoryFailure('subject_not_visible');
+  }
+}
+
+async function hydrateSavedTask(
+  database: Pick<CrmTaskDb, 'query'>,
+  actor: CrmActorContext,
+  row: CrmTaskRow,
+  deps: CrmTaskSaveDeps
+): Promise<CrmTask> {
+  const task = await deps.hydrateVisibleTask(database, actor, row);
+  if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
+  return task;
+}
+
+async function createSavedTask(
+  database: CrmTaskDb,
+  params: CrmTaskSaveParams,
+  deps: CrmTaskSaveDeps
+): Promise<CrmTask> {
+  if (params.task.lifecycleVersion !== 1) {
+    throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+  }
+  const replayed = await deps.replayIdempotentCreate(database, params.actor, params.task);
+  if (replayed) return replayed;
+
+  try {
+    const [row] = await database.transaction(async tx => {
+      // db-access-guard: tenant-scoped -- reason: CRM task create runs inside withTenantContext after subject visibility validates the actor tenant and branch.
+      const [created] = await tx.insert(crmTasks).values(deps.taskValues(params.task)).returning();
+      // db-access-guard: tenant-scoped -- reason: CRM task history create runs inside withTenantContext and copies actor tenant from validated task history.
+      await tx
+        .insert(crmTaskHistory)
+        .values(params.task.history.map(entry => deps.historyValues(params.task.taskId, entry)));
+      return [created];
+    });
+    return hydrateSavedTask(database, params.actor, row, deps);
+  } catch (error) {
+    if (!deps.isIdempotencyUniqueViolation(error)) throw error;
+    const replayedAfterRace = await deps.replayIdempotentCreate(database, params.actor, params.task);
+    if (!replayedAfterRace) throw new CrmTaskRepositoryFailure('idempotency_conflict');
+    return replayedAfterRace;
+  }
+}
+
+async function updateSavedTask(
+  database: CrmTaskDb,
+  params: CrmTaskSaveParams & { expectedLifecycleVersion: number },
+  deps: CrmTaskSaveDeps
+): Promise<CrmTask> {
+  if (params.task.lifecycleVersion !== params.expectedLifecycleVersion + 1) {
+    throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+  }
+  // db-access-guard: tenant-scoped -- reason: CRM task save constrains by actor tenant, branch-visible task id, and expected lifecycle version.
+  const [row] = await database.transaction(async tx => {
+    // db-access-guard: tenant-scoped -- reason: CRM task save runs inside withTenantContext and constrains by actor tenant, branch-visible task id, and expected lifecycle version.
+    const [updated] = await tx
+      .update(crmTasks)
+      .set(deps.taskValues(params.task))
+      .where(
+        and(
+          deps.taskVisibilityPredicate(params.actor, params.task.taskId),
+          eq(crmTasks.lifecycleVersion, params.expectedLifecycleVersion)
+        )
+      )
+      .returning();
+    if (!updated) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
+
+    const newest = params.task.history.at(-1);
+    if (newest) {
+      // db-access-guard: tenant-scoped -- reason: CRM task history append runs inside withTenantContext and copies the actor tenant from the validated domain event.
+      await tx.insert(crmTaskHistory).values(deps.historyValues(params.task.taskId, newest));
+    }
+    return [updated];
+  });
+  return hydrateSavedTask(database, params.actor, row, deps);
+}
+
+export async function saveCrmTaskInRepository(
+  database: CrmTaskDb,
+  params: CrmTaskSaveParams,
+  deps: CrmTaskSaveDeps
+): Promise<CrmTask> {
+  await assertWritableTaskSubject(database, params, deps);
+  return params.expectedLifecycleVersion == null
+    ? createSavedTask(database, params, deps)
+    : updateSavedTask(database, { ...params, expectedLifecycleVersion: params.expectedLifecycleVersion }, deps);
+}

--- a/apps/web/src/adapters/crm/task-repository.ts
+++ b/apps/web/src/adapters/crm/task-repository.ts
@@ -23,6 +23,8 @@ import {
   supportHandoffs,
 } from '@interdomestik/database/schema';
 
+import { saveCrmTaskInRepository, type CrmTaskSaveDeps } from './task-repository-save';
+
 type CrmTaskDb = typeof db;
 type CrmTaskRow = typeof crmTasks.$inferSelect;
 type CrmTaskHistoryRow = typeof crmTaskHistory.$inferSelect;
@@ -394,6 +396,17 @@ async function validateSubjectReference(
   return { branchId: row.branchId ?? null, tenantId: row.tenantId, visible: true };
 }
 
+const taskSaveDeps: CrmTaskSaveDeps = {
+  branchVisible,
+  historyValues,
+  hydrateVisibleTask,
+  isIdempotencyUniqueViolation,
+  replayIdempotentCreate,
+  taskValues,
+  taskVisibilityPredicate,
+  validateSubjectReference,
+};
+
 export function createCrmTaskRepository(
   database: CrmTaskDb = db,
   runInTenantContext: CrmTaskTenantRunner = createTenantRunner(database)
@@ -473,82 +486,7 @@ export function createCrmTaskRepository(
 
     async saveTask(params) {
       return runInTenantContext(params.actor, async scopedDatabase => {
-        const visibility = await validateSubjectReference(scopedDatabase, {
-          actor: params.actor,
-          subjectReference: params.task.subjectReference,
-        });
-        if (!visibility.visible) throw new CrmTaskRepositoryFailure(visibility.reason);
-        if (visibility.branchId !== params.task.branchId) {
-          throw new CrmTaskRepositoryFailure('subject_not_visible');
-        }
-        if (!branchVisible(params.actor, params.task.branchId)) {
-          throw new CrmTaskRepositoryFailure('subject_not_visible');
-        }
-
-        if (params.expectedLifecycleVersion == null) {
-          if (params.task.lifecycleVersion !== 1) {
-            throw new CrmTaskRepositoryFailure('lifecycle_conflict');
-          }
-          const replayed = await replayIdempotentCreate(scopedDatabase, params.actor, params.task);
-          if (replayed) return replayed;
-
-          try {
-            const [row] = await scopedDatabase.transaction(async tx => {
-              // db-access-guard: tenant-scoped -- reason: CRM task create runs inside withTenantContext after subject visibility validates the actor tenant and branch.
-              const [created] = await tx
-                .insert(crmTasks)
-                .values(taskValues(params.task))
-                .returning();
-              // db-access-guard: tenant-scoped -- reason: CRM task history create runs inside withTenantContext and copies actor tenant from validated task history.
-              await tx
-                .insert(crmTaskHistory)
-                .values(params.task.history.map(entry => historyValues(params.task.taskId, entry)));
-              return [created];
-            });
-            const task = await hydrateVisibleTask(scopedDatabase, params.actor, row);
-            if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
-            return task;
-          } catch (error) {
-            if (!isIdempotencyUniqueViolation(error)) throw error;
-            const replayedAfterRace = await replayIdempotentCreate(
-              scopedDatabase,
-              params.actor,
-              params.task
-            );
-            if (!replayedAfterRace) throw new CrmTaskRepositoryFailure('idempotency_conflict');
-            return replayedAfterRace;
-          }
-        }
-
-        const expectedLifecycleVersion = params.expectedLifecycleVersion;
-        if (params.task.lifecycleVersion !== expectedLifecycleVersion + 1) {
-          throw new CrmTaskRepositoryFailure('lifecycle_conflict');
-        }
-        // db-access-guard: tenant-scoped -- reason: CRM task save constrains by actor tenant, branch-visible task id, and expected lifecycle version.
-        const [row] = await scopedDatabase.transaction(async tx => {
-          // db-access-guard: tenant-scoped -- reason: CRM task save runs inside withTenantContext and constrains by actor tenant, branch-visible task id, and expected lifecycle version.
-          const [updated] = await tx
-            .update(crmTasks)
-            .set(taskValues(params.task))
-            .where(
-              and(
-                taskVisibilityPredicate(params.actor, params.task.taskId),
-                eq(crmTasks.lifecycleVersion, expectedLifecycleVersion)
-              )
-            )
-            .returning();
-          if (!updated) throw new CrmTaskRepositoryFailure('lifecycle_conflict');
-
-          const newest = params.task.history.at(-1);
-          if (newest) {
-            // db-access-guard: tenant-scoped -- reason: CRM task history append runs inside withTenantContext and copies the actor tenant from the validated domain event.
-            await tx.insert(crmTaskHistory).values(historyValues(params.task.taskId, newest));
-          }
-          return [updated];
-        });
-        const task = await hydrateVisibleTask(scopedDatabase, params.actor, row);
-        if (!task) throw new CrmTaskRepositoryFailure('subject_not_visible');
-        return task;
+        return saveCrmTaskInRepository(scopedDatabase, params, taskSaveDeps);
       });
     },
 

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37663983,
-  "maxTrackedFiles": 4618,
+  "maxTrackedBytes": 37666326,
+  "maxTrackedFiles": 4619,
   "maxCategoryBytes": {
     "large support/generated-ish": 18122374,
-    "source/scripts": 7098062,
+    "source/scripts": 7100405,
     "docs/text": 5714568,
     "tests/e2e": 5041944,
     "config/data/messages": 1557791,


### PR DESCRIPTION
## Summary

- Split the CRM task repository `saveTask` create/update path into `task-repository-save.ts`.
- Keep `createCrmTaskRepository().saveTask` as a small dispatcher through the existing tenant context runner.
- Preserve existing idempotency replay, lifecycle conflict handling, subject visibility checks, transaction boundaries, and `db-access-guard` annotations.
- Sync repo-size budget for the new source file.

## Why

This targets Sonar `typescript:S3776` on `apps/web/src/adapters/crm/task-repository.ts`, where `saveTask` exceeded the cognitive complexity limit. The legacy file is now smaller (`563 -> 501` lines), and the new helper file is under the repo 150-line modularity ceiling (`143` lines).

## Verification

Passed locally:

- `./node_modules/.bin/tsc --noEmit -p apps/web/tsconfig.json --pretty false`
- `node scripts/check-modularity-guard.mjs`
- `node scripts/repo-size-audit.mjs --check`
- `node scripts/repo-size-budget-sync.mjs --check`
- `git diff --cached --check`
- `node scripts/check-db-access-guard.mjs`
- `node scripts/check-architecture-boundaries.mjs`
- `node scripts/check-case-recovery-boundaries.mjs`
- `node scripts/check-country-host-alias-guard.mjs`
- `interdomestik_qa.scope_audit` with protected paths forbidden

Local pnpm-based gates are currently blocked before test execution by the merged dependency freshness policy from PR #1262:

- `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`
- 19 lockfile entries published on 2026-06-30 are still inside the local 24h minimum-release-age window, including `supabase@2.109.0`, `turbo@2.10.2`, `vite@8.1.2`, and `electron-to-chromium@1.5.383`.

Remote CI/Sonar should be treated as the merge authority once this PR runs.

## Scope / Risk

- No `apps/web/src/proxy.ts` changes.
- No route, auth, tenancy, schema, RLS, billing, or architecture-doc changes.
- Runtime behavior should be unchanged; this is a refactor of existing CRM task persistence flow.

## Rollback

Revert this commit to restore the previous inline save path.
