### PR TITLE
feat: allow signed waiver evidence gates

### DIFF
--- a/docs/release/production-evidence.schema.json
+++ b/docs/release/production-evidence.schema.json
@@ -14,7 +14,10 @@
           "id": { "type": "string", "pattern": "^G(0[1-9]|10)$" },
           "description": { "type": "string", "minLength": 1 },
           "owner": { "type": "string", "minLength": 1 },
-          "status": { "type": "string", "enum": ["pending", "supplied", "approved", "verified"] },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "supplied", "approved", "verified", "waived"]
+          },
           "required_artifacts": {
             "type": "array",
             "minItems": 1,

--- a/scripts/ci/release-evidence-check.test.mjs
+++ b/scripts/ci/release-evidence-check.test.mjs
@@ -56,3 +56,37 @@ test('release evidence check accepts supplied artifact with matching hash', () =
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('release evidence check accepts waived gates with signed waiver artifact', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'release-evidence-waiver-'));
+  try {
+    const artifact = path.join(dir, 'waiver.md');
+    writeFileSync(artifact, 'signed controlled waiver\n');
+    const manifest = path.join(dir, 'manifest.yaml');
+    writeFileSync(
+      manifest,
+      [
+        'gates:',
+        ...Array.from({ length: 10 }, (_, index) => {
+          const id = `G${String(index + 1).padStart(2, '0')}`;
+          return [
+            `  - id: ${id}`,
+            `    description: waived test ${id}`,
+            '    owner: release owner',
+            '    status: waived',
+            '    required_artifacts:',
+            `      - path: ${artifact}`,
+            '        sha256: 04c7840e69cd191db3b94c370cabe913bbd11bcb233f794a9b0ff8658c76751f',
+            '    signoff: { name: test, role: release owner, signed_at: 2026-07-02 }',
+          ].join('\n');
+        }),
+      ].join('\n')
+    );
+
+    const result = run(manifest);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /PASS gates=10/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/release-evidence-check.mjs
+++ b/scripts/release-evidence-check.mjs
@@ -7,7 +7,7 @@ import yaml from 'js-yaml';
 
 const rootDir = process.cwd();
 const defaultManifest = 'docs/release/production-evidence.yaml';
-const passingStatuses = new Set(['supplied', 'approved', 'verified']);
+const passingStatuses = new Set(['supplied', 'approved', 'verified', 'waived']);
 const requiredGateFields = ['id', 'description', 'required_artifacts', 'owner', 'status', 'signoff'];
 const requiredSignoffFields = ['name', 'role', 'signed_at'];
 
@@ -72,7 +72,7 @@ function validateGate(gate) {
   if (shapeErrors.length > 0) return shapeErrors.map(error => `${gate.id || '<unknown>'}: ${error}`);
   const errors = [];
   if (!passingStatuses.has(String(gate.status).toLowerCase())) {
-    errors.push(`${gate.id}: status=${gate.status} is not one of supplied, approved, verified`);
+    errors.push(`${gate.id}: status=${gate.status} is not one of supplied, approved, verified, waived`);
   }
   errors.push(...validateSignoff(gate));
   for (const artifact of gate.required_artifacts) {

--- a/scripts/release-evidence-check.mjs
+++ b/scripts/release-evidence-check.mjs
@@ -8,6 +8,7 @@ import yaml from 'js-yaml';
 const rootDir = process.cwd();
 const defaultManifest = 'docs/release/production-evidence.yaml';
 const passingStatuses = new Set(['supplied', 'approved', 'verified', 'waived']);
+const passingStatusList = Array.from(passingStatuses).join(', ');
 const requiredGateFields = ['id', 'description', 'required_artifacts', 'owner', 'status', 'signoff'];
 const requiredSignoffFields = ['name', 'role', 'signed_at'];
 
@@ -72,7 +73,7 @@ function validateGate(gate) {
   if (shapeErrors.length > 0) return shapeErrors.map(error => `${gate.id || '<unknown>'}: ${error}`);
   const errors = [];
   if (!passingStatuses.has(String(gate.status).toLowerCase())) {
-    errors.push(`${gate.id}: status=${gate.status} is not one of supplied, approved, verified, waived`);
+    errors.push(`${gate.id}: status=${gate.status} is not one of ${passingStatusList}`);
   }
   errors.push(...validateSignoff(gate));
   for (const artifact of gate.required_artifacts) {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 37680212,
+  "maxTrackedBytes": 35604900,
   "maxTrackedFiles": 4622,
   "maxCategoryBytes": {
-    "large support/generated-ish": 18125131,
-    "source/scripts": 7100405,
-    "docs/text": 5725386,
-    "tests/e2e": 5041944,
-    "config/data/messages": 1557791,
+    "large support/generated-ish": 16058909,
+    "source/scripts": 7100423,
+    "docs/text": 5715014,
+    "tests/e2e": 5043164,
+    "config/data/messages": 1557835,
     "other": 129555
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35604900,
+  "maxTrackedBytes": 35604950,
   "maxTrackedFiles": 4622,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
-    "source/scripts": 7100423,
+    "source/scripts": 7100473,
     "docs/text": 5715014,
     "tests/e2e": 5043164,
     "config/data/messages": 1557835,


### PR DESCRIPTION
## Summary
- Allow `waived` as a formal production evidence gate status.
- Keep waiver gates subject to the same artifact path, SHA-256, and signoff validation as supplied/approved/verified gates.
- Add regression coverage proving a signed waiver artifact can satisfy all G01-G10 gates in a supplied manifest.
- Sync repo size budget because the checker/test edits changed tracked inventory; no unrelated runtime/source scope is included.

## Scope
- Production release evidence checker/schema/test plus required repo-size budget sync.
- Does not change `docs/release/production-evidence.yaml`; default production evidence remains pending until actual signed waiver artifacts or real evidence are committed.
- No runtime, routing, auth, tenancy, RLS, schema, billing, or proxy changes.

## Verification
- `node --test scripts/ci/release-evidence-check.test.mjs`
- `pnpm test:release-gate -- scripts/ci/release-evidence-check.test.mjs`
- `pnpm repo:size:check`
- `pnpm plan:audit`
- `pnpm track:audit`
- `pnpm security:guard`
- `pnpm e2e:gate` via MCP completed with `apps/web/test-results/.last-run.json` status passed
- `pnpm pr:verify`
- `git diff --check`
- `pnpm release:evidence:check` still fails as expected because default manifest remains pending
