### PR TITLE
docs: add T-503 evidence intake package

### DIFF
--- a/docs/release/t503-evidence-intake/README.md
+++ b/docs/release/t503-evidence-intake/README.md
@@ -1,0 +1,62 @@
+# T-503 Evidence Intake Package
+
+Created: 2026-07-02
+Posture: evidence-ready only
+
+This package prepares the final T-503 release evidence intake path. It does not
+mark any G01-G10 gate as complete, waived, approved, supplied, or verified.
+
+## Use This Package For
+
+- collecting real G04, G05, G09, and G10 production release-cycle artifacts;
+- creating a signed waiver artifact when an owner explicitly accepts a controlled
+  exception instead of supplying the final artifact;
+- computing SHA-256 values for artifacts before editing
+  `docs/release/production-evidence.yaml`;
+- reviewing whether the release evidence is strong enough to unblock a later
+  current-authority gate.
+
+## Do Not Use This Package For
+
+- bypassing `pnpm release:evidence:check`;
+- replacing claimant-specific POA, consent, or fee evidence with sponsor-level
+  documents;
+- marking final paid, final recovered, final closed, or destructive T-503 status
+  removal before current authority explicitly approves it;
+- changing runtime, auth, tenancy, routing, RLS, schema, billing, or
+  `apps/web/src/proxy.ts`.
+
+## Files
+
+- `qualifying-evidence-checklist.md`: what qualifies for each missing gate.
+- `manifest-patch-example.yaml`: copy-only example for the release manifest.
+- `waiver-templates/G04-bank-payment-proof-waiver.md`
+- `waiver-templates/G05-600-mkd-reconciliation-waiver.md`
+- `waiver-templates/G09-poa-consent-terms-waiver.md`
+- `waiver-templates/G10-closure-evidence-waiver.md`
+
+## Intake Commands
+
+After a real artifact or signed waiver is placed under
+`docs/release/evidence/`, compute its hash:
+
+```bash
+shasum -a 256 docs/release/evidence/<artifact-file>
+```
+
+Then update only the matching gate in `docs/release/production-evidence.yaml`
+with:
+
+- `status: supplied`, `approved`, `verified`, or `waived`;
+- the artifact path;
+- the SHA-256 hash;
+- signoff name, role, and signed date.
+
+Finally run:
+
+```bash
+pnpm release:evidence:check
+```
+
+The command must fail until every G01-G10 gate has a non-pending passing status,
+valid signoff, existing artifact path, and matching SHA-256.

--- a/docs/release/t503-evidence-intake/README.md
+++ b/docs/release/t503-evidence-intake/README.md
@@ -48,9 +48,13 @@ Then update only the matching gate in `docs/release/production-evidence.yaml`
 with:
 
 - `status: supplied`, `approved`, `verified`, or `waived`;
-- the artifact path;
-- the SHA-256 hash;
+- the matching `required_artifacts[*].path`;
+- the matching `required_artifacts[*].sha256`;
 - signoff name, role, and signed date.
+
+Preserve the existing gate entry shape, including `id`, `description`, `owner`,
+and any unrelated artifacts. Do not replace a full gate entry with only the
+partial fields shown in the example.
 
 Finally run:
 

--- a/docs/release/t503-evidence-intake/manifest-patch-example.yaml
+++ b/docs/release/t503-evidence-intake/manifest-patch-example.yaml
@@ -3,6 +3,9 @@
 #
 # Target file when ready:
 # docs/release/production-evidence.yaml
+#
+# This is a partial patch example. Merge these fields into existing gate entries
+# and preserve required manifest fields such as `description` and `owner`.
 
 gates:
   - id: G04

--- a/docs/release/t503-evidence-intake/manifest-patch-example.yaml
+++ b/docs/release/t503-evidence-intake/manifest-patch-example.yaml
@@ -1,0 +1,46 @@
+# Copy-only example. Do not apply until the referenced artifacts exist and their
+# hashes are computed. This file is not read by `pnpm release:evidence:check`.
+#
+# Target file when ready:
+# docs/release/production-evidence.yaml
+
+gates:
+  - id: G04
+    status: waived
+    required_artifacts:
+      - path: docs/release/evidence/G04-bank-payment-proof-waiver.md
+        sha256: REPLACE_WITH_ACTUAL_SHA256
+    signoff:
+      name: REPLACE_WITH_SIGNER_NAME
+      role: Finance owner / Release owner
+      signed_at: 2026-07-02
+
+  - id: G05
+    status: waived
+    required_artifacts:
+      - path: docs/release/evidence/G05-600-mkd-reconciliation-waiver.md
+        sha256: REPLACE_WITH_ACTUAL_SHA256
+    signoff:
+      name: REPLACE_WITH_SIGNER_NAME
+      role: Finance owner / Release owner
+      signed_at: 2026-07-02
+
+  - id: G09
+    status: waived
+    required_artifacts:
+      - path: docs/release/evidence/G09-poa-consent-terms-waiver.md
+        sha256: REPLACE_WITH_ACTUAL_SHA256
+    signoff:
+      name: REPLACE_WITH_SIGNER_NAME
+      role: Claims/legal owner / Release owner
+      signed_at: 2026-07-02
+
+  - id: G10
+    status: waived
+    required_artifacts:
+      - path: docs/release/evidence/G10-closure-evidence-waiver.md
+        sha256: REPLACE_WITH_ACTUAL_SHA256
+    signoff:
+      name: REPLACE_WITH_SIGNER_NAME
+      role: Claims/finance owner / Release owner
+      signed_at: 2026-07-02

--- a/docs/release/t503-evidence-intake/qualifying-evidence-checklist.md
+++ b/docs/release/t503-evidence-intake/qualifying-evidence-checklist.md
@@ -53,7 +53,7 @@ Qualifies as real evidence:
 - claimant-specific consent to process case/personal data;
 - claimant-specific service-fee terms or fee acceptance;
 - case identifier tying the documents to T-503;
-- legal/case owner and release owner signoff.
+- Claims/legal owner and release owner signoff.
 
 Does not qualify by itself:
 
@@ -73,7 +73,7 @@ Qualifies as real evidence:
 - Interdomestik fee calculation and receipt or ledger treatment;
 - final finance reconciliation;
 - client/member/claimant acknowledgement;
-- legal/case owner, finance owner, and release owner signoff.
+- Claims/legal owner, Claims/finance owner, and release owner signoff.
 
 Allowed final statuses:
 

--- a/docs/release/t503-evidence-intake/qualifying-evidence-checklist.md
+++ b/docs/release/t503-evidence-intake/qualifying-evidence-checklist.md
@@ -1,0 +1,92 @@
+# T-503 Qualifying Evidence Checklist
+
+This checklist distinguishes real production evidence from controlled waiver
+evidence. A waiver is valid only when it is signed, hashed, stored as an
+artifact, and explicitly accepted by the responsible owner.
+
+## G04 Bank Payment Proof
+
+Qualifies as real evidence:
+
+- original bank statement or bank export proving the payment;
+- exact mapping to the Butel invoice or payment reference;
+- received amount and payment date;
+- finance owner signoff;
+- release owner signoff when used for T-503 release-cycle unblock.
+
+Does not qualify by itself:
+
+- invoice without bank movement;
+- bank statement with no clear invoice/payment mapping;
+- verbal confirmation without artifact and signoff.
+
+Waiver is acceptable only for controlled continuation, not final paid closure,
+unless finance and release owner explicitly accept the residual risk.
+
+## G05 600 MKD Reconciliation
+
+Qualifies as real evidence:
+
+- finance decision selecting one treatment for the 600 MKD difference;
+- ledger/accounting entry or reconciliation memo;
+- bank reference when the difference was paid;
+- explicit approval from finance and release owner.
+
+Acceptable treatments:
+
+- remaining receivable;
+- approved write-off;
+- offset against another invoice/payment;
+- already paid, with proof.
+
+Does not qualify by itself:
+
+- payment proof that still leaves the 600 MKD difference unexplained;
+- draft spreadsheet without approval;
+- general sponsor invoice acceptance without finance treatment.
+
+## G09 POA, Consent, And Service-Fee Terms
+
+Qualifies as real evidence:
+
+- claimant-specific POA or authorization;
+- claimant-specific consent to process case/personal data;
+- claimant-specific service-fee terms or fee acceptance;
+- case identifier tying the documents to T-503;
+- legal/case owner and release owner signoff.
+
+Does not qualify by itself:
+
+- sponsor-level Butel contracts;
+- employer membership roster;
+- general service terms with no claimant-specific authorization.
+
+Sponsor documents may support eligibility, but they do not replace
+claimant-specific authorization for individual legal or insurer representation.
+
+## G10 Closure Evidence
+
+Qualifies as real evidence:
+
+- final settlement, recovery, no-recovery, transfer, or cancellation decision;
+- payment proof or written no-payment final outcome;
+- Interdomestik fee calculation and receipt or ledger treatment;
+- final finance reconciliation;
+- client/member/claimant acknowledgement;
+- legal/case owner, finance owner, and release owner signoff.
+
+Allowed final statuses:
+
+- `CLOSED_PAID`
+- `CLOSED_NO_RECOVERY`
+- `CLOSED_TRANSFERRED`
+- `CLOSED_CANCELLED`
+- `STILL_OPEN`
+
+Does not qualify by itself:
+
+- court progress documents without final outcome;
+- draft settlement discussion;
+- finance proof without case closure decision;
+- closure statement without client/member/claimant acknowledgement when that
+  acknowledgement is required.

--- a/docs/release/t503-evidence-intake/waiver-templates/G04-bank-payment-proof-waiver.md
+++ b/docs/release/t503-evidence-intake/waiver-templates/G04-bank-payment-proof-waiver.md
@@ -1,0 +1,29 @@
+# G04 Bank Payment Proof Waiver
+
+Gate: G04
+Artifact type: controlled waiver
+
+## Decision
+
+The finance owner and release owner approve continuing T-503 release-cycle
+validation without final bank payment proof mapped to the exact invoice/payment.
+
+## Known Gap
+
+- Missing or incomplete exact bank/payment mapping:
+- Affected invoice/payment reference:
+- Amount expected:
+- Amount proven:
+- Residual risk:
+
+## Limits
+
+This waiver allows controlled continuation only. It does not prove final paid
+closure unless finance and release owner explicitly state that final paid closure
+is accepted despite the gap.
+
+## Signoff
+
+- Finance owner:
+- Release owner:
+- Signed at:

--- a/docs/release/t503-evidence-intake/waiver-templates/G05-600-mkd-reconciliation-waiver.md
+++ b/docs/release/t503-evidence-intake/waiver-templates/G05-600-mkd-reconciliation-waiver.md
@@ -1,0 +1,30 @@
+# G05 600 MKD Reconciliation Waiver
+
+Gate: G05
+Artifact type: controlled waiver
+
+## Decision
+
+The finance owner and release owner approve continuing T-503 release-cycle
+validation while the 600 MKD reconciliation remains unresolved or accepted as a
+controlled finance exception.
+
+## Known Gap
+
+- Difference amount: 600 MKD
+- Current treatment:
+- Ledger/accounting reference:
+- Reason final reconciliation is not supplied:
+- Residual risk:
+
+## Limits
+
+This waiver does not by itself prove final finance closure. Final paid/closed
+posture still requires a finance treatment or explicit acceptance that the
+selected treatment is final.
+
+## Signoff
+
+- Finance owner:
+- Release owner:
+- Signed at:

--- a/docs/release/t503-evidence-intake/waiver-templates/G09-poa-consent-terms-waiver.md
+++ b/docs/release/t503-evidence-intake/waiver-templates/G09-poa-consent-terms-waiver.md
@@ -5,7 +5,7 @@ Artifact type: controlled waiver
 
 ## Decision
 
-The claims/legal owner and release owner approve continuing T-503 release-cycle
+The Claims/legal owner and release owner approve continuing T-503 release-cycle
 validation without final claimant-specific POA, consent, or service-fee terms.
 
 ## Known Gap
@@ -21,7 +21,7 @@ validation without final claimant-specific POA, consent, or service-fee terms.
 Sponsor-level contracts may support eligibility and service relationship. They
 do not replace claimant-specific authorization for individual legal or insurer
 representation. This waiver must not be used to start or claim final individual
-representation unless the legal/case owner explicitly accepts that risk.
+representation unless the Claims/legal owner explicitly accepts that risk.
 
 ## Signoff
 

--- a/docs/release/t503-evidence-intake/waiver-templates/G09-poa-consent-terms-waiver.md
+++ b/docs/release/t503-evidence-intake/waiver-templates/G09-poa-consent-terms-waiver.md
@@ -1,0 +1,30 @@
+# G09 POA, Consent, And Service-Fee Terms Waiver
+
+Gate: G09
+Artifact type: controlled waiver
+
+## Decision
+
+The claims/legal owner and release owner approve continuing T-503 release-cycle
+validation without final claimant-specific POA, consent, or service-fee terms.
+
+## Known Gap
+
+- Missing claimant-specific POA or authorization:
+- Missing claimant-specific consent:
+- Missing claimant-specific service-fee terms:
+- Available sponsor-level evidence:
+- Residual risk:
+
+## Limits
+
+Sponsor-level contracts may support eligibility and service relationship. They
+do not replace claimant-specific authorization for individual legal or insurer
+representation. This waiver must not be used to start or claim final individual
+representation unless the legal/case owner explicitly accepts that risk.
+
+## Signoff
+
+- Claims/legal owner:
+- Release owner:
+- Signed at:

--- a/docs/release/t503-evidence-intake/waiver-templates/G10-closure-evidence-waiver.md
+++ b/docs/release/t503-evidence-intake/waiver-templates/G10-closure-evidence-waiver.md
@@ -1,0 +1,36 @@
+# G10 Closure Evidence Waiver
+
+Gate: G10
+Artifact type: controlled waiver
+
+## Decision
+
+The legal/case owner, finance owner, and release owner approve continuing T-503
+release-cycle validation without final case closure evidence.
+
+## Known Gap
+
+- Final settlement/recovery/no-recovery/transfer/cancellation decision:
+- Payment proof or no-payment final outcome:
+- Fee calculation and receipt or ledger treatment:
+- Final finance reconciliation:
+- Client/member/claimant acknowledgement:
+- Residual risk:
+
+## Limits
+
+This waiver allows controlled continuation only. It does not prove final closure
+unless the owners explicitly select and approve one final status:
+
+- `CLOSED_PAID`
+- `CLOSED_NO_RECOVERY`
+- `CLOSED_TRANSFERRED`
+- `CLOSED_CANCELLED`
+- `STILL_OPEN`
+
+## Signoff
+
+- Legal/case owner:
+- Finance owner:
+- Release owner:
+- Signed at:

--- a/docs/release/t503-evidence-intake/waiver-templates/G10-closure-evidence-waiver.md
+++ b/docs/release/t503-evidence-intake/waiver-templates/G10-closure-evidence-waiver.md
@@ -5,8 +5,8 @@ Artifact type: controlled waiver
 
 ## Decision
 
-The legal/case owner, finance owner, and release owner approve continuing T-503
-release-cycle validation without final case closure evidence.
+The Claims/legal owner, Claims/finance owner, and release owner approve
+continuing T-503 release-cycle validation without final case closure evidence.
 
 ## Known Gap
 
@@ -30,7 +30,7 @@ unless the owners explicitly select and approve one final status:
 
 ## Signoff
 
-- Legal/case owner:
-- Finance owner:
+- Claims/legal owner:
+- Claims/finance owner:
 - Release owner:
 - Signed at:

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35604950,
-  "maxTrackedFiles": 4622,
+  "maxTrackedBytes": 35614395,
+  "maxTrackedFiles": 4629,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
     "source/scripts": 7100473,
-    "docs/text": 5715014,
+    "docs/text": 5723058,
     "tests/e2e": 5043164,
-    "config/data/messages": 1557835,
+    "config/data/messages": 1559236,
     "other": 129555
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35614395,
+  "maxTrackedBytes": 35614822,
   "maxTrackedFiles": 4629,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
     "source/scripts": 7100473,
-    "docs/text": 5723058,
+    "docs/text": 5723328,
     "tests/e2e": 5043164,
-    "config/data/messages": 1559236,
+    "config/data/messages": 1559393,
     "other": 129555
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Summary
- Add a release-facing T-503 evidence intake package for G04/G05/G09/G10.
- Include qualifying evidence checklist, signed waiver templates, SHA-256 intake instructions, and a copy-only manifest patch example.
- Leave docs/release/production-evidence.yaml pending; no gate is marked supplied, approved, verified, or waived.

## Scope
- Documentation/external-tracker-only, Tier 0.
- Includes repo-size budget sync for the added tracked docs.
- No runtime, proxy, auth, tenancy, RLS, schema, billing, production evidence manifest, or canonical tracker/program changes.
- Does not promote destructive T-503 runtime work.

## Verification
- git diff --check
- pnpm docs:verify
- pnpm plan:status
- pnpm plan:audit
- pnpm track:audit
- pnpm repo:size:check
- pnpm release:evidence:check fails as expected because the real G01-G10 manifest remains pending.

## Reviewer/Security Posture
- MCP scope audit passed for allowed paths only.
- No protected Phase C surfaces changed.
- No secrets or production credentials included.

## Residual Risk
- This only prepares evidence intake. T-503 remains blocked until qualifying G01-G10 evidence or signed/hashed accepted waivers are placed under docs/release/evidence/ and the real release evidence checker passes.
