### PR TITLE
[codex] fix soft-deleted document metadata exposure

### DIFF
--- a/apps/web/src/app/[locale]/(app)/member/membership/_core.documents.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_core.documents.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  findDocumentsMany: vi.fn(),
+  isNull: vi.fn((field: unknown) => ({ op: 'isNull', field })),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  and: hoisted.and,
+  db: {
+    query: {
+      documents: {
+        findMany: hoisted.findDocumentsMany,
+      },
+      subscriptions: {
+        findMany: vi.fn(),
+      },
+    },
+  },
+  eq: hoisted.eq,
+  isNull: hoisted.isNull,
+  subscriptions: {
+    tenantId: 'subscriptions.tenant_id',
+    userId: 'subscriptions.user_id',
+  },
+}));
+
+vi.mock('@/lib/entity-disclosure.core', () => ({
+  getSubscriptionEntityDisclosureCore: vi.fn(),
+}));
+
+import { getMemberDocumentsCore } from './_core';
+
+describe('getMemberDocumentsCore document lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.findDocumentsMany.mockResolvedValue([]);
+  });
+
+  it('filters out soft-deleted member documents', async () => {
+    await getMemberDocumentsCore({
+      tenantId: 'tenant-ks',
+      userId: 'member-1',
+    });
+
+    const queryArg = hoisted.findDocumentsMany.mock.calls[0]?.[0] as
+      | {
+          where?: (
+            docs: { deletedAt: string; entityId: string; entityType: string; tenantId: string },
+            operators: {
+              and: (...args: unknown[]) => unknown;
+              eq: (left: unknown, right: unknown) => unknown;
+            }
+          ) => unknown;
+        }
+      | undefined;
+
+    const whereAnd = vi.fn((...args: unknown[]) => ({ op: 'and', args }));
+    const whereEq = vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right }));
+
+    queryArg?.where?.(
+      {
+        deletedAt: 'documents.deleted_at',
+        entityId: 'documents.entity_id',
+        entityType: 'documents.entity_type',
+        tenantId: 'documents.tenant_id',
+      },
+      {
+        and: whereAnd,
+        eq: whereEq,
+      }
+    );
+
+    expect(hoisted.isNull).toHaveBeenCalledWith('documents.deleted_at');
+    expect(whereAnd).toHaveBeenCalledWith(
+      expect.objectContaining({ left: 'documents.entity_type', right: 'member' }),
+      expect.objectContaining({ left: 'documents.entity_id', right: 'member-1' }),
+      expect.objectContaining({ left: 'documents.tenant_id', right: 'tenant-ks' }),
+      expect.objectContaining({ field: 'documents.deleted_at', op: 'isNull' })
+    );
+  });
+});

--- a/apps/web/src/app/[locale]/(app)/member/membership/_core.test.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_core.test.ts
@@ -2,25 +2,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const hoisted = vi.hoisted(() => {
   const and = vi.fn((...args: unknown[]) => ({ op: 'and', args }));
   const eq = vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right }));
-
+  const isNull = vi.fn((field: unknown) => ({ op: 'isNull', field }));
   const disclosure = {
     contractingCompany: 'Interdomestik KS LLC',
     governingLaw: 'XK',
     unavailable: false,
     source: 'subscription' as const,
   };
-
   return {
     and,
     eq,
     findSubscriptionMany: vi.fn(),
     findDocumentsMany: vi.fn(),
     getSubscriptionEntityDisclosureCore: vi.fn(async () => disclosure),
+    isNull,
   };
 });
 vi.mock('@interdomestik/database', () => ({
   and: hoisted.and,
   eq: hoisted.eq,
+  isNull: hoisted.isNull,
   subscriptions: {
     userId: 'subscriptions.user_id',
     tenantId: 'subscriptions.tenant_id',
@@ -36,11 +37,9 @@ vi.mock('@interdomestik/database', () => ({
     },
   },
 }));
-
 vi.mock('@/lib/entity-disclosure.core', () => ({
   getSubscriptionEntityDisclosureCore: hoisted.getSubscriptionEntityDisclosureCore,
 }));
-
 import {
   computeDunningState,
   getMemberDocumentsCore,
@@ -174,7 +173,7 @@ describe('membership core', () => {
     const queryArg = hoisted.findDocumentsMany.mock.calls[0]?.[0] as
       | {
           where?: (
-            docs: { entityType: string; entityId: string; tenantId: string },
+            docs: { deletedAt: string; entityType: string; entityId: string; tenantId: string },
             operators: {
               and: (...args: unknown[]) => unknown;
               eq: (left: unknown, right: unknown) => unknown;
@@ -191,6 +190,7 @@ describe('membership core', () => {
 
     queryArg?.where?.(
       {
+        deletedAt: 'documents.deleted_at',
         entityType: 'documents.entity_type',
         entityId: 'documents.entity_id',
         tenantId: 'documents.tenant_id',

--- a/apps/web/src/app/[locale]/(app)/member/membership/_core.ts
+++ b/apps/web/src/app/[locale]/(app)/member/membership/_core.ts
@@ -1,4 +1,4 @@
-import { and, db, eq, subscriptions } from '@interdomestik/database';
+import { and, db, eq, isNull, subscriptions } from '@interdomestik/database';
 import {
   attachMembershipEntityDisclosure,
   attachMembershipEntityDisclosures,
@@ -127,7 +127,8 @@ export async function getMemberDocumentsCore(args: {
       andFn(
         eqFn(docs.entityType, 'member'),
         eqFn(docs.entityId, args.userId),
-        eqFn(docs.tenantId, tenantId)
+        eqFn(docs.tenantId, tenantId),
+        isNull(docs.deletedAt)
       ),
     orderBy: (docs, { desc }) => [desc(docs.uploadedAt)],
   });

--- a/apps/web/src/app/api/documents/cross-tenant-document-lookup.soft-delete.test.ts
+++ b/apps/web/src/app/api/documents/cross-tenant-document-lookup.soft-delete.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  findActorCrossGrantContexts: vi.fn(),
+  hasDurableCaseScopedDocumentGrant: vi.fn(),
+  isNull: vi.fn((field: unknown) => ({ op: 'isNull', field })),
+  sql: vi.fn(() => undefined),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: mocks.and,
+  eq: mocks.eq,
+  isNull: mocks.isNull,
+  sql: mocks.sql,
+}));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  claimDocuments: {
+    claimId: 'claim_documents.claim_id',
+    id: 'claim_documents.id',
+    tenantId: 'claim_documents.tenant_id',
+  },
+  claims: { id: 'claims.id' },
+  documents: {
+    deletedAt: 'documents.deleted_at',
+    entityId: 'documents.entity_id',
+    entityType: 'documents.entity_type',
+    id: 'documents.id',
+    tenantId: 'documents.tenant_id',
+  },
+}));
+
+vi.mock('./durable-case-grants', () => ({
+  findActorCrossGrantContexts: mocks.findActorCrossGrantContexts,
+  hasDurableCaseScopedDocumentGrant: mocks.hasDurableCaseScopedDocumentGrant,
+}));
+
+import { lookupCrossGrantDoc } from './cross-tenant-document-lookup';
+
+function selectResult(rows: unknown[], legacy = false) {
+  const chain = { where: vi.fn().mockResolvedValue(rows) };
+  return {
+    from: vi.fn().mockReturnValue(legacy ? { leftJoin: vi.fn().mockReturnValue(chain) } : chain),
+  };
+}
+
+function dbWith(polyRows: unknown[], legacyRows: unknown[] = []) {
+  const db = { select: vi.fn() };
+  db.select.mockReturnValueOnce(selectResult(polyRows));
+  db.select.mockReturnValueOnce(selectResult(legacyRows, true));
+  return db;
+}
+
+describe('lookupCrossGrantDoc soft-delete filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findActorCrossGrantContexts.mockResolvedValue([
+      { caseId: 'claim-1', documentClasses: ['legal'], homeTenantId: 'tenant_home' },
+    ]);
+  });
+
+  it('requires active polymorphic documents before durable grant authorization', async () => {
+    await lookupCrossGrantDoc({
+      accessTenantId: 'tenant_mk',
+      actorId: 'legal-1',
+      db: dbWith([]) as never,
+      documentId: 'doc-1',
+    });
+
+    expect(mocks.isNull).toHaveBeenCalledWith('documents.deleted_at');
+    expect(mocks.and).toHaveBeenCalledWith(
+      expect.objectContaining({ left: 'documents.id', right: 'doc-1' }),
+      expect.objectContaining({ left: 'documents.tenant_id', right: 'tenant_home' }),
+      expect.objectContaining({ left: 'documents.entity_type', right: 'claim' }),
+      expect.objectContaining({ left: 'documents.entity_id', right: 'claim-1' }),
+      expect.objectContaining({ field: 'documents.deleted_at', op: 'isNull' })
+    );
+  });
+});

--- a/apps/web/src/app/api/documents/cross-tenant-document-lookup.ts
+++ b/apps/web/src/app/api/documents/cross-tenant-document-lookup.ts
@@ -1,6 +1,6 @@
 import type { TenantTransaction } from '@interdomestik/database';
 import { claimDocuments, claims, documents } from '@interdomestik/database/schema';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 
 import type { DocumentAccessDeps } from './_core';
 import {
@@ -61,7 +61,8 @@ async function lookupPoly(args: {
         eq(documents.id, args.documentId),
         eq(documents.tenantId, args.grantContext.homeTenantId),
         eq(documents.entityType, 'claim'),
-        eq(documents.entityId, args.grantContext.caseId)
+        eq(documents.entityId, args.grantContext.caseId),
+        isNull(documents.deletedAt)
       )
     );
   if (!doc) return null;

--- a/apps/web/src/features/admin/verification/server/queries/document-soft-delete.test.ts
+++ b/apps/web/src/features/admin/verification/server/queries/document-soft-delete.test.ts
@@ -102,9 +102,7 @@ const ctx = {
 } as never;
 
 describe('verification payment proof document lifecycle filters', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  beforeEach(vi.clearAllMocks);
 
   it('filters soft-deleted payment proof documents from request joins', async () => {
     const requestsQuery = chain([]);

--- a/apps/web/src/features/admin/verification/server/queries/document-soft-delete.test.ts
+++ b/apps/web/src/features/admin/verification/server/queries/document-soft-delete.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const hoisted = vi.hoisted(() => ({
+  aliasedTable: vi.fn(() => ({ name: 'verifier.name' })),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  asc: vi.fn((field: unknown) => ({ op: 'asc', field })),
+  desc: vi.fn((field: unknown) => ({ op: 'desc', field })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  ilike: vi.fn(),
+  inArray: vi.fn((left: unknown, right: unknown) => ({ op: 'inArray', left, right })),
+  isNull: vi.fn((field: unknown) => ({ op: 'isNull', field })),
+  or: vi.fn(),
+  select: vi.fn(),
+  sql: vi.fn(() => null),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  aliasedTable: hoisted.aliasedTable,
+  and: hoisted.and,
+  asc: hoisted.asc,
+  desc: hoisted.desc,
+  eq: hoisted.eq,
+  ilike: hoisted.ilike,
+  inArray: hoisted.inArray,
+  isNull: hoisted.isNull,
+  or: hoisted.or,
+  sql: hoisted.sql,
+}));
+
+vi.mock('@interdomestik/database', () => ({ db: { select: hoisted.select } }));
+
+vi.mock('@interdomestik/database/schema', () => ({
+  auditLog: {
+    action: 'audit.action',
+    actorId: 'audit.actor_id',
+    createdAt: 'audit.created_at',
+    entityId: 'audit.entity_id',
+    entityType: 'audit.entity_type',
+    id: 'audit.id',
+    metadata: 'audit.metadata',
+    tenantId: 'audit.tenant_id',
+  },
+  branches: { code: 'branches.code', id: 'branches.id', name: 'branches.name' },
+  documents: {
+    deletedAt: 'documents.deleted_at',
+    entityId: 'documents.entity_id',
+    entityType: 'documents.entity_type',
+    id: 'documents.id',
+    storagePath: 'documents.storage_path',
+    tenantId: 'documents.tenant_id',
+    uploadedAt: 'documents.uploaded_at',
+  },
+  user: { email: 'user.email', id: 'user.id', name: 'user.name' },
+}));
+
+vi.mock('@interdomestik/database/schema/leads', () => ({
+  leadPaymentAttempts: {
+    amount: 'attempt.amount',
+    createdAt: 'attempt.created_at',
+    currency: 'attempt.currency',
+    id: 'attempt.id',
+    isResubmission: 'attempt.is_resubmission',
+    leadId: 'attempt.lead_id',
+    method: 'attempt.method',
+    status: 'attempt.status',
+    tenantId: 'attempt.tenant_id',
+    updatedAt: 'attempt.updated_at',
+    verificationNote: 'attempt.note',
+    verifiedBy: 'attempt.verified_by',
+  },
+  memberLeads: {
+    agentId: 'lead.agent_id',
+    branchId: 'lead.branch_id',
+    email: 'lead.email',
+    firstName: 'lead.first_name',
+    id: 'lead.id',
+    lastName: 'lead.last_name',
+  },
+}));
+
+import { getVerificationRequestDetails } from './get-details';
+import { getVerificationRequests } from './get-requests';
+function chain(result: unknown, terminalWhere = false) {
+  const query = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    leftJoin: vi.fn(),
+    limit: vi.fn().mockResolvedValue(result),
+    orderBy: vi.fn().mockResolvedValue(result),
+    where: vi.fn(),
+  };
+  query.from.mockReturnValue(query);
+  query.innerJoin.mockReturnValue(query);
+  query.leftJoin.mockReturnValue(query);
+  query.where.mockReturnValue(terminalWhere ? Promise.resolve(result) : query);
+  query.orderBy.mockReturnValue(query);
+  return query;
+}
+const ctx = {
+  scope: {},
+  tenantId: 'tenant-ks',
+  userRole: 'admin',
+} as never;
+
+describe('verification payment proof document lifecycle filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters soft-deleted payment proof documents from request joins', async () => {
+    const requestsQuery = chain([]);
+    hoisted.select.mockReturnValueOnce(requestsQuery);
+
+    await getVerificationRequests(ctx, { view: 'queue' });
+
+    expect(requestsQuery.leftJoin).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        args: expect.arrayContaining([
+          expect.objectContaining({ field: 'documents.deleted_at', op: 'isNull' }),
+        ]),
+      })
+    );
+  });
+
+  it('filters soft-deleted payment proof documents from detail document lists', async () => {
+    const row = {
+      agentName: 'Agent',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      id: 'attempt-1',
+    };
+    const detailQuery = chain([row], true);
+    const docsQuery = chain([]);
+    const logsQuery = chain([]);
+    docsQuery.orderBy.mockResolvedValue([]);
+    logsQuery.orderBy.mockResolvedValue([]);
+    hoisted.select.mockReturnValueOnce(detailQuery);
+    hoisted.select.mockReturnValueOnce(docsQuery);
+    hoisted.select.mockReturnValueOnce(logsQuery);
+
+    await getVerificationRequestDetails(ctx, 'attempt-1');
+
+    expect(docsQuery.where).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.arrayContaining([
+          expect.objectContaining({ field: 'documents.deleted_at', op: 'isNull' }),
+        ]),
+      })
+    );
+  });
+});

--- a/apps/web/src/features/admin/verification/server/queries/get-details.ts
+++ b/apps/web/src/features/admin/verification/server/queries/get-details.ts
@@ -2,7 +2,7 @@ import { ProtectedActionContext } from '@/lib/safe-action';
 import { db } from '@interdomestik/database';
 import { auditLog, branches, documents, user } from '@interdomestik/database/schema';
 import { leadPaymentAttempts, memberLeads } from '@interdomestik/database/schema/leads';
-import { aliasedTable, and, desc, eq } from 'drizzle-orm';
+import { aliasedTable, and, desc, eq, isNull } from 'drizzle-orm';
 import {
   CashVerificationDetailsDTO,
   CashVerificationRequestDTO,
@@ -11,7 +11,6 @@ import {
 
 type VerificationDetailsRow = Omit<CashVerificationRequestDTO, 'documentId' | 'documentPath'>;
 
-// 2. Query: Get Details with Timeline
 export async function getVerificationRequestDetails(
   ctx: ProtectedActionContext,
   attemptId: string
@@ -33,7 +32,6 @@ export async function getVerificationRequestDetails(
   // db-access-guard: tenant-scoped -- reason: tenant predicate built in local conditions array before verification details query
   const [row] = (await db
     .select({
-      // Base DTO
       id: leadPaymentAttempts.id,
       leadId: memberLeads.id,
       firstName: memberLeads.firstName,
@@ -63,7 +61,6 @@ export async function getVerificationRequestDetails(
 
   if (!row) return null;
 
-  // Fetch all documents
   const docs = await db
     .select()
     .from(documents)
@@ -71,12 +68,12 @@ export async function getVerificationRequestDetails(
       and(
         eq(documents.entityType, 'payment_attempt'),
         eq(documents.entityId, attemptId),
-        eq(documents.tenantId, tenantId)
+        eq(documents.tenantId, tenantId),
+        isNull(documents.deletedAt)
       )
     )
     .orderBy(desc(documents.uploadedAt));
 
-  // Fetch Audit Log for Timeline
   const logs = await db
     .select({
       id: auditLog.id,
@@ -96,10 +93,8 @@ export async function getVerificationRequestDetails(
     )
     .orderBy(desc(auditLog.createdAt));
 
-  // Construct Timeline
   const timeline: VerificationTimelineEvent[] = [];
 
-  // 1. Creation
   timeline.push({
     id: `create-${row.id}`,
     type: 'created',
@@ -109,7 +104,6 @@ export async function getVerificationRequestDetails(
     actorName: row.agentName,
   });
 
-  // 2. Documents
   docs.forEach(d => {
     timeline.push({
       id: `doc-${d.id}`,
@@ -120,7 +114,6 @@ export async function getVerificationRequestDetails(
     });
   });
 
-  // 3. Actions
   logs.forEach(l => {
     const meta =
       typeof l.metadata === 'object' && l.metadata !== null
@@ -142,10 +135,8 @@ export async function getVerificationRequestDetails(
     });
   });
 
-  // Sort Descending
   timeline.sort((a, b) => b.date.getTime() - a.date.getTime());
 
-  // Map docs to simple structure
   const documentList = docs.map(d => ({
     id: d.id,
     name: d.fileName,

--- a/apps/web/src/features/admin/verification/server/queries/get-requests.ts
+++ b/apps/web/src/features/admin/verification/server/queries/get-requests.ts
@@ -2,7 +2,7 @@ import { ProtectedActionContext } from '@/lib/safe-action';
 import { db } from '@interdomestik/database';
 import { branches, documents, user } from '@interdomestik/database/schema';
 import { leadPaymentAttempts, memberLeads } from '@interdomestik/database/schema/leads';
-import { aliasedTable, and, asc, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
+import { aliasedTable, and, asc, desc, eq, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
 import { CashVerificationRequestDTO, VerificationView } from '../types';
 
 // 1. Query: Get Verification Requests (Queue or History)
@@ -91,7 +91,8 @@ export async function getVerificationRequests(
       and(
         eq(documents.entityId, leadPaymentAttempts.id),
         eq(documents.entityType, 'payment_attempt'),
-        eq(documents.tenantId, tenantId)
+        eq(documents.tenantId, tenantId),
+        isNull(documents.deletedAt)
       )
     );
 


### PR DESCRIPTION
## Summary
- Filter soft-deleted polymorphic claim documents during cross-tenant durable grant lookup.
- Filter soft-deleted member document metadata from the member membership document panel.
- Filter soft-deleted payment proof documents from admin verification queue and detail views.
- Add focused regression coverage for each lifecycle path.

## Codex Security Scan
- Scan ID: `0a7fe1bc-7ea7-4ce0-b4df-fa808d1087c6`
- Mode: `deep`
- Confirmed findings fixed: 3
- Deferred/non-reportable: AI queued-processing document lifecycle reachability was not proven by the scan.

Canonical local artifacts were sealed by Codex Security under:
`/private/var/folders/6k/d5q8m0v53q9byf3s_6qm15n80000gn/T/codex-security-scans-E22Zee/interdomestik-crystal-home-security-deep/d008991a2413bc8f2f068e4070c0e04280e5cec2_20260703T065419Z_53j6616d`

## Validation
- `pnpm --filter @interdomestik/web type-check`
- focused Vitest suite: 12 files, 45 tests passed
- `pnpm security:guard`
- `pnpm pr:verify`
- `pnpm e2e:gate` - 134 passed, 8 skipped
