### PR TITLE
fix: guard AI document lifecycle deletion

### DIFF
--- a/apps/web/e2e/gate/group-access-privacy-consent.spec.ts
+++ b/apps/web/e2e/gate/group-access-privacy-consent.spec.ts
@@ -20,7 +20,7 @@ test.describe('Group access privacy', () => {
       await expect(summary).toBeVisible();
       await expect(summary.getByText('Aggregate group access dashboard')).toBeVisible();
       await expect(
-        page.getByText(
+        summary.getByText(
           'This view stays aggregate-only. No claim facts, notes, or documents are visible here without explicit member consent.'
         )
       ).toBeVisible();

--- a/apps/web/src/app/api/policies/analyze/_document-lifecycle-guard.ts
+++ b/apps/web/src/app/api/policies/analyze/_document-lifecycle-guard.ts
@@ -1,9 +1,17 @@
-import { ExtractionPipelineError } from '@/lib/ai/extraction-pipeline';
+import {
+  buildDeletedDocumentFailure,
+  throwDeletedDocumentError as throwDeletedRunDocumentError,
+  type DeletedDocumentFailure,
+} from '@/lib/ai/document-run-lifecycle';
 import { sql, type TenantTransaction } from '@interdomestik/database';
 
 export const DELETED_DOCUMENT_ERROR_CODE = 'document_ai_document_deleted';
 export const DELETED_DOCUMENT_ERROR_MESSAGE =
   'AI run skipped because the source document was deleted.';
+export const POLICY_DELETED_DOCUMENT_FAILURE: DeletedDocumentFailure = {
+  errorCode: DELETED_DOCUMENT_ERROR_CODE,
+  errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
+};
 
 export async function lockActiveDocument(
   tx: TenantTransaction,
@@ -21,5 +29,9 @@ export async function lockActiveDocument(
 }
 
 export function throwDeletedDocumentError(): never {
-  throw new ExtractionPipelineError(DELETED_DOCUMENT_ERROR_CODE, DELETED_DOCUMENT_ERROR_MESSAGE);
+  throwDeletedRunDocumentError(POLICY_DELETED_DOCUMENT_FAILURE);
+}
+
+export function buildDeletedPolicyRunFailure(completedAt: Date) {
+  return buildDeletedDocumentFailure(completedAt, POLICY_DELETED_DOCUMENT_FAILURE);
 }

--- a/apps/web/src/app/api/policies/analyze/_document-lifecycle-guard.ts
+++ b/apps/web/src/app/api/policies/analyze/_document-lifecycle-guard.ts
@@ -1,0 +1,25 @@
+import { ExtractionPipelineError } from '@/lib/ai/extraction-pipeline';
+import { sql, type TenantTransaction } from '@interdomestik/database';
+
+export const DELETED_DOCUMENT_ERROR_CODE = 'document_ai_document_deleted';
+export const DELETED_DOCUMENT_ERROR_MESSAGE =
+  'AI run skipped because the source document was deleted.';
+
+export async function lockActiveDocument(
+  tx: TenantTransaction,
+  args: { documentId: string; tenantId: string }
+) {
+  // db-access-guard: tenant-scoped -- reason: row lock is constrained by exact tenantId and documentId before policy AI extraction persistence
+  return tx.execute<{ id: string }>(sql`
+    select "id"
+    from "documents"
+    where "id" = ${args.documentId}
+      and "tenant_id" = ${args.tenantId}
+      and "deleted_at" is null
+    for update
+  `);
+}
+
+export function throwDeletedDocumentError(): never {
+  throw new ExtractionPipelineError(DELETED_DOCUMENT_ERROR_CODE, DELETED_DOCUMENT_ERROR_MESSAGE);
+}

--- a/apps/web/src/app/api/policies/analyze/_pipeline-file.test.ts
+++ b/apps/web/src/app/api/policies/analyze/_pipeline-file.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const selectWhere = vi.fn();
+  const selectInnerJoin = vi.fn(() => ({ where: selectWhere }));
+  const selectFrom = vi.fn(() => ({ innerJoin: selectInnerJoin }));
+  const select = vi.fn(() => ({ from: selectFrom }));
+
+  return {
+    db: { select },
+    selectWhere,
+  };
+});
+
+vi.mock('@/lib/db.server', () => ({ db: mocks.db }));
+vi.mock('@interdomestik/database/schema', () => ({
+  aiRuns: {
+    documentId: 'ai_runs.document_id',
+    id: 'ai_runs.id',
+    status: 'ai_runs.status',
+    tenantId: 'ai_runs.tenant_id',
+  },
+  documents: {
+    deletedAt: 'documents.deleted_at',
+    id: 'documents.id',
+    tenantId: 'documents.tenant_id',
+  },
+}));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ args, op: 'and' })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, right, op: 'eq' })),
+  isNull: vi.fn((field: unknown) => ({ field, op: 'isNull' })),
+}));
+
+import { loadPolicyInput } from './_pipeline-file';
+
+const run = {
+  runId: 'run-1',
+  tenantId: 'tenant-1',
+  documentId: 'doc-1',
+  policyId: 'policy-1',
+  storagePath: 'pii/tenants/tenant-1/policies/user-1/file.pdf',
+  requestJson: {
+    fileName: 'file.pdf',
+    fileUrl: 'pii/tenants/tenant-1/policies/user-1/file.pdf',
+    mimeType: 'application/pdf',
+  },
+};
+
+describe('loadPolicyInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectWhere.mockResolvedValue([{ id: 'run-1' }]);
+  });
+
+  it('rechecks active document state before downloading policy content', async () => {
+    const deps = {
+      downloadFile: vi.fn().mockResolvedValue(Buffer.from('pdf-bytes')),
+      analyzeImage: vi.fn(),
+      analyzePdf: vi.fn().mockResolvedValue('Parsed policy text'),
+      analyzeText: vi.fn(),
+    };
+
+    await expect(loadPolicyInput(run, deps)).resolves.toMatchObject({
+      fileUrl: 'pii/tenants/tenant-1/policies/user-1/file.pdf',
+      parsedText: 'Parsed policy text',
+    });
+
+    expect(mocks.selectWhere).toHaveBeenCalledOnce();
+    expect(deps.downloadFile).toHaveBeenCalledWith(
+      'pii/tenants/tenant-1/policies/user-1/file.pdf',
+      'tenant-1'
+    );
+  });
+
+  it('fails before download when the policy document is no longer active', async () => {
+    mocks.selectWhere.mockResolvedValue([]);
+    const deps = {
+      downloadFile: vi.fn(),
+      analyzeImage: vi.fn(),
+      analyzePdf: vi.fn(),
+      analyzeText: vi.fn(),
+    };
+
+    await expect(loadPolicyInput(run, deps)).rejects.toMatchObject({
+      errorCode: 'document_ai_document_deleted',
+    });
+
+    expect(deps.downloadFile).not.toHaveBeenCalled();
+    expect(deps.analyzePdf).not.toHaveBeenCalled();
+    expect(deps.analyzeImage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/policies/analyze/_pipeline-file.ts
+++ b/apps/web/src/app/api/policies/analyze/_pipeline-file.ts
@@ -5,11 +5,9 @@ import {
   readCandidateWarnings,
   type SanitizedContentMetrics,
 } from '@/lib/ai/extraction-pipeline';
-import { db } from '@/lib/db.server';
-import { aiRuns, documents } from '@interdomestik/database/schema';
-import { and, eq, isNull } from 'drizzle-orm';
+import { assertProcessingRunHasActiveDocument } from '@/lib/ai/document-run-lifecycle';
 
-import { throwDeletedDocumentError } from './_document-lifecycle-guard';
+import { POLICY_DELETED_DOCUMENT_FAILURE } from './_document-lifecycle-guard';
 import type { ClaimedPolicyRun, PolicyExtractionDeps } from './_pipeline-input';
 
 export type LoadedPolicyInput = ClaimedPolicyRun & {
@@ -44,25 +42,7 @@ function getRequestFileUrl(requestJson: Record<string, unknown>, fallback: unkno
 }
 
 async function assertActivePolicyDocument(run: ClaimedPolicyRun) {
-  // db-access-guard: tenant-scoped -- reason: pre-download liveness check is constrained by exact runId, tenantId, and documentId before policy AI processing
-  const [activeRun] = await db
-    .select({ id: aiRuns.id })
-    .from(aiRuns)
-    .innerJoin(
-      documents,
-      and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
-    )
-    .where(
-      and(
-        eq(aiRuns.id, run.runId),
-        eq(aiRuns.status, 'processing'),
-        eq(documents.id, run.documentId),
-        eq(documents.tenantId, run.tenantId),
-        isNull(documents.deletedAt)
-      )
-    );
-
-  if (!activeRun) throwDeletedDocumentError();
+  await assertProcessingRunHasActiveDocument(run, POLICY_DELETED_DOCUMENT_FAILURE);
 }
 
 export async function loadPolicyInput(

--- a/apps/web/src/app/api/policies/analyze/_pipeline-file.ts
+++ b/apps/web/src/app/api/policies/analyze/_pipeline-file.ts
@@ -5,7 +5,11 @@ import {
   readCandidateWarnings,
   type SanitizedContentMetrics,
 } from '@/lib/ai/extraction-pipeline';
+import { db } from '@/lib/db.server';
+import { aiRuns, documents } from '@interdomestik/database/schema';
+import { and, eq, isNull } from 'drizzle-orm';
 
+import { throwDeletedDocumentError } from './_document-lifecycle-guard';
 import type { ClaimedPolicyRun, PolicyExtractionDeps } from './_pipeline-input';
 
 export type LoadedPolicyInput = ClaimedPolicyRun & {
@@ -39,6 +43,28 @@ function getRequestFileUrl(requestJson: Record<string, unknown>, fallback: unkno
   return typeof fallback === 'string' ? fallback : '';
 }
 
+async function assertActivePolicyDocument(run: ClaimedPolicyRun) {
+  // db-access-guard: tenant-scoped -- reason: pre-download liveness check is constrained by exact runId, tenantId, and documentId before policy AI processing
+  const [activeRun] = await db
+    .select({ id: aiRuns.id })
+    .from(aiRuns)
+    .innerJoin(
+      documents,
+      and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
+    )
+    .where(
+      and(
+        eq(aiRuns.id, run.runId),
+        eq(aiRuns.status, 'processing'),
+        eq(documents.id, run.documentId),
+        eq(documents.tenantId, run.tenantId),
+        isNull(documents.deletedAt)
+      )
+    );
+
+  if (!activeRun) throwDeletedDocumentError();
+}
+
 export async function loadPolicyInput(
   run: ClaimedPolicyRun,
   deps: PolicyExtractionDeps
@@ -48,6 +74,8 @@ export async function loadPolicyInput(
   const mimeType = getRequestStringValue(requestJson, 'mimeType');
   const fileUrl = getRequestFileUrl(requestJson, run.storagePath);
   if (!fileUrl) throw new Error('Queued policy analysis run is missing a storage path.');
+
+  await assertActivePolicyDocument(run);
 
   const fileBuffer = await deps.downloadFile(fileUrl, run.tenantId);
   const parsedText = isImageUpload(fileName, mimeType) ? null : await deps.analyzePdf(fileBuffer);

--- a/apps/web/src/app/api/policies/analyze/_pipeline-input.ts
+++ b/apps/web/src/app/api/policies/analyze/_pipeline-input.ts
@@ -2,7 +2,7 @@ import type { PolicyAnalysis } from '@/lib/ai/policy-analyzer';
 import { db } from '@/lib/db.server';
 import { withTenantContext } from '@interdomestik/database';
 import { aiRuns, documents } from '@interdomestik/database/schema';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 
 const POLICY_EXTRACT_WORKFLOW = 'policy_extract' as const;
 
@@ -39,7 +39,11 @@ export async function claimPolicyExtractionRun(
     .from(aiRuns)
     .innerJoin(
       documents,
-      and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
+      and(
+        eq(documents.id, aiRuns.documentId),
+        eq(documents.tenantId, aiRuns.tenantId),
+        isNull(documents.deletedAt)
+      )
     )
     .where(
       and(
@@ -50,6 +54,28 @@ export async function claimPolicyExtractionRun(
     );
 
   if (!queuedRun?.documentId || !queuedRun.policyId) {
+    // db-access-guard: system-exempt -- reason: fallback resolves an already-failed deleted policy AI run by opaque runId after the active-document join intentionally returns no row
+    const [deletedRun] = await db
+      .select({
+        errorCode: aiRuns.errorCode,
+        policyId: aiRuns.entityId,
+        status: aiRuns.status,
+      })
+      .from(aiRuns)
+      .where(
+        and(
+          eq(aiRuns.id, runId),
+          eq(aiRuns.workflow, POLICY_EXTRACT_WORKFLOW),
+          eq(aiRuns.entityType, 'policy')
+        )
+      );
+    if (
+      deletedRun?.policyId &&
+      deletedRun.status === 'failed' &&
+      deletedRun.errorCode === 'document_ai_document_deleted'
+    ) {
+      return { status: 'skipped', policyId: deletedRun.policyId };
+    }
     throw new Error(`Queued policy analysis run ${runId} was not found.`);
   }
 

--- a/apps/web/src/app/api/policies/analyze/_pipeline-persist.test.ts
+++ b/apps/web/src/app/api/policies/analyze/_pipeline-persist.test.ts
@@ -3,65 +3,88 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => {
   const txInsertOnConflictDoNothing = vi.fn();
   const txInsertValues = vi.fn(() => ({ onConflictDoNothing: txInsertOnConflictDoNothing }));
+  const txExecute = vi.fn();
   const txUpdateSet = vi.fn(() => ({ where: vi.fn() }));
+  const txUpdateReturning = vi.fn();
+  const txUpdateWhere = vi.fn(() => ({ returning: txUpdateReturning }));
+  const txUpdateSetWithReturning = vi.fn(() => ({ where: txUpdateWhere }));
   const tx = {
+    execute: txExecute,
     insert: vi.fn(() => ({ values: txInsertValues })),
-    update: vi.fn(() => ({ set: txUpdateSet })),
+    update: vi.fn(() => ({ set: txUpdateSetWithReturning })),
   };
 
   return {
     nanoid: vi.fn(() => 'extraction-1'),
     tx,
+    txExecute,
     txInsertOnConflictDoNothing,
     txInsertValues,
+    txUpdateReturning,
     txUpdateSet,
+    txUpdateSetWithReturning,
     withTenantContext: vi.fn(async (_context: unknown, callback: (txArg: typeof tx) => unknown) =>
       callback(tx)
     ),
   };
 });
 
-vi.mock('@interdomestik/database', () => ({ withTenantContext: mocks.withTenantContext }));
+vi.mock('@interdomestik/database', () => ({
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
+  withTenantContext: mocks.withTenantContext,
+}));
 vi.mock('@interdomestik/database/schema', () => ({
-  aiRuns: { __name: 'ai_runs', id: {} },
+  aiRuns: { __name: 'ai_runs', id: {}, status: 'ai_runs.status' },
   documentExtractions: { __name: 'document_extractions', sourceRunId: {} },
   policies: { __name: 'policies', id: {} },
 }));
-vi.mock('drizzle-orm', () => ({ eq: vi.fn((left: unknown, right: unknown) => ({ left, right })) }));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...conditions: unknown[]) => ({ conditions, op: 'and' })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+}));
 vi.mock('nanoid', () => ({ nanoid: mocks.nanoid }));
 
 import { persistPolicyExtraction } from './_pipeline-persist';
+
+const run = {
+  runId: 'run-1',
+  tenantId: 'tenant-1',
+  documentId: 'doc-1',
+  policyId: 'policy-1',
+  storagePath: 'pii/tenants/tenant-1/policies/user/file.pdf',
+  requestJson: {},
+};
+
+const extraction = {
+  provider: 'Acme',
+  policyNumber: 'POL-1',
+  coverageAmount: 100,
+  currency: 'EUR',
+  deductible: 10,
+  confidence: 0.83,
+  warnings: ['Confirm deductible.'],
+};
+
+const critique = {
+  decision: 'needs_human_review' as const,
+  confidence: 0.83,
+  warnings: ['Confirm deductible.'],
+  warningCodes: ['extraction_warnings'],
+  escalationRecommended: false,
+  persistenceAllowed: true,
+};
 
 describe('persistPolicyExtraction', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('persists schema-valid policy output with confidence and critique metadata', async () => {
+    mocks.txExecute.mockResolvedValue([{ id: 'doc-1' }]);
+    mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
+
     await persistPolicyExtraction({
-      run: {
-        runId: 'run-1',
-        tenantId: 'tenant-1',
-        documentId: 'doc-1',
-        policyId: 'policy-1',
-        storagePath: 'pii/tenants/tenant-1/policies/user/file.pdf',
-        requestJson: {},
-      },
-      extraction: {
-        provider: 'Acme',
-        policyNumber: 'POL-1',
-        coverageAmount: 100,
-        currency: 'EUR',
-        deductible: 10,
-        confidence: 0.83,
-        warnings: ['Confirm deductible.'],
-      },
-      critique: {
-        decision: 'needs_human_review',
-        confidence: 0.83,
-        warnings: ['Confirm deductible.'],
-        warningCodes: ['extraction_warnings'],
-        escalationRecommended: false,
-        persistenceAllowed: true,
-      },
+      run,
+      extraction,
+      critique,
     });
 
     expect(mocks.txInsertValues).toHaveBeenCalledWith(
@@ -72,12 +95,53 @@ describe('persistPolicyExtraction', () => {
         sourceRunId: 'run-1',
       })
     );
-    expect(mocks.txUpdateSet).toHaveBeenLastCalledWith(
+    expect(mocks.txUpdateSetWithReturning).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         responseJson: expect.objectContaining({
           critique: expect.objectContaining({ warningCodes: ['extraction_warnings'] }),
         }),
         status: 'completed',
+      })
+    );
+  });
+
+  it('fails and redacts the run when the source policy document was deleted', async () => {
+    mocks.txExecute.mockResolvedValue([]);
+
+    await expect(persistPolicyExtraction({ run, extraction, critique })).rejects.toMatchObject({
+      errorCode: 'document_ai_document_deleted',
+    });
+
+    expect(mocks.tx.insert).not.toHaveBeenCalled();
+    expect(mocks.txUpdateSetWithReturning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        errorCode: 'document_ai_document_deleted',
+        requestJson: {},
+        outputJson: null,
+        responseJson: null,
+      })
+    );
+  });
+
+  it('does not write policy output when completion loses the processing lock', async () => {
+    mocks.txExecute.mockResolvedValue([{ id: 'doc-1' }]);
+    mocks.txUpdateReturning.mockResolvedValue([]);
+
+    await expect(persistPolicyExtraction({ run, extraction, critique })).rejects.toMatchObject({
+      errorCode: 'document_ai_document_deleted',
+    });
+
+    expect(mocks.tx.insert).not.toHaveBeenCalled();
+    expect(mocks.tx.update).toHaveBeenCalledTimes(2);
+    expect(mocks.tx.update).not.toHaveBeenCalledWith({ __name: 'policies', id: {} });
+    expect(mocks.txUpdateSetWithReturning).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        requestJson: {},
+        outputJson: null,
+        responseJson: null,
       })
     );
   });

--- a/apps/web/src/app/api/policies/analyze/_pipeline-persist.ts
+++ b/apps/web/src/app/api/policies/analyze/_pipeline-persist.ts
@@ -8,7 +8,7 @@ import { nanoid } from 'nanoid';
 
 import {
   DELETED_DOCUMENT_ERROR_CODE,
-  DELETED_DOCUMENT_ERROR_MESSAGE,
+  buildDeletedPolicyRunFailure,
   lockActiveDocument,
   throwDeletedDocumentError,
 } from './_document-lifecycle-guard';
@@ -32,15 +32,7 @@ export async function persistPolicyExtraction(args: {
     if (!activeDocument) {
       await tx
         .update(aiRuns)
-        .set({
-          status: 'failed',
-          completedAt,
-          errorCode: DELETED_DOCUMENT_ERROR_CODE,
-          errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
-          requestJson: {},
-          outputJson: null,
-          responseJson: null,
-        })
+        .set(buildDeletedPolicyRunFailure(completedAt))
         .where(eq(aiRuns.id, args.run.runId));
       throwDeletedDocumentError();
     }
@@ -69,15 +61,7 @@ export async function persistPolicyExtraction(args: {
     if (!completedRun) {
       await tx
         .update(aiRuns)
-        .set({
-          status: 'failed',
-          completedAt,
-          errorCode: DELETED_DOCUMENT_ERROR_CODE,
-          errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
-          requestJson: {},
-          outputJson: null,
-          responseJson: null,
-        })
+        .set(buildDeletedPolicyRunFailure(completedAt))
         .where(eq(aiRuns.id, args.run.runId));
       throwDeletedDocumentError();
     }

--- a/apps/web/src/app/api/policies/analyze/_pipeline-persist.ts
+++ b/apps/web/src/app/api/policies/analyze/_pipeline-persist.ts
@@ -1,11 +1,17 @@
-import type { ExtractionCritique, ExtractionPipelineError } from '@/lib/ai/extraction-pipeline';
+import { ExtractionPipelineError, type ExtractionCritique } from '@/lib/ai/extraction-pipeline';
 import { withTenantContext } from '@interdomestik/database';
 import { aiRuns, documentExtractions, policies } from '@interdomestik/database/schema';
 import { getResponsesWorkflowConfig } from '@interdomestik/domain-ai/models';
 import type { PolicyExtract } from '@interdomestik/domain-ai/schemas/policy-extract';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
+import {
+  DELETED_DOCUMENT_ERROR_CODE,
+  DELETED_DOCUMENT_ERROR_MESSAGE,
+  lockActiveDocument,
+  throwDeletedDocumentError,
+} from './_document-lifecycle-guard';
 import type { ClaimedPolicyRun } from './_pipeline-input';
 
 const POLICY_EXTRACT_WORKFLOW = 'policy_extract' as const;
@@ -19,6 +25,63 @@ export async function persistPolicyExtraction(args: {
   const completedAt = new Date();
 
   await withTenantContext({ tenantId: args.run.tenantId, role: 'system' }, async tx => {
+    const [activeDocument] = await lockActiveDocument(tx, {
+      documentId: args.run.documentId,
+      tenantId: args.run.tenantId,
+    });
+    if (!activeDocument) {
+      await tx
+        .update(aiRuns)
+        .set({
+          status: 'failed',
+          completedAt,
+          errorCode: DELETED_DOCUMENT_ERROR_CODE,
+          errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
+          requestJson: {},
+          outputJson: null,
+          responseJson: null,
+        })
+        .where(eq(aiRuns.id, args.run.runId));
+      throwDeletedDocumentError();
+    }
+
+    const [completedRun] = await tx
+      .update(aiRuns)
+      .set({
+        status: 'completed',
+        responseJson: {
+          event: 'policy/extract.requested',
+          runId: args.run.runId,
+          critique: {
+            decision: args.critique.decision,
+            warningCodes: args.critique.warningCodes,
+            escalationRecommended: args.critique.escalationRecommended,
+          },
+        },
+        outputJson: args.extraction,
+        reviewStatus: 'pending',
+        completedAt,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .where(and(eq(aiRuns.id, args.run.runId), eq(aiRuns.status, 'processing')))
+      .returning({ id: aiRuns.id });
+    if (!completedRun) {
+      await tx
+        .update(aiRuns)
+        .set({
+          status: 'failed',
+          completedAt,
+          errorCode: DELETED_DOCUMENT_ERROR_CODE,
+          errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
+          requestJson: {},
+          outputJson: null,
+          responseJson: null,
+        })
+        .where(eq(aiRuns.id, args.run.runId));
+      throwDeletedDocumentError();
+    }
+
     await tx
       .update(policies)
       .set({
@@ -47,27 +110,6 @@ export async function persistPolicyExtraction(args: {
         updatedAt: completedAt,
       })
       .onConflictDoNothing({ target: documentExtractions.sourceRunId });
-
-    await tx
-      .update(aiRuns)
-      .set({
-        status: 'completed',
-        responseJson: {
-          event: 'policy/extract.requested',
-          runId: args.run.runId,
-          critique: {
-            decision: args.critique.decision,
-            warningCodes: args.critique.warningCodes,
-            escalationRecommended: args.critique.escalationRecommended,
-          },
-        },
-        outputJson: args.extraction,
-        reviewStatus: 'pending',
-        completedAt,
-        errorCode: null,
-        errorMessage: null,
-      })
-      .where(eq(aiRuns.id, args.run.runId));
   });
 }
 
@@ -88,6 +130,9 @@ export async function markPolicyExtractionRunFailed(args: {
         completedAt: new Date(),
         errorCode,
         errorMessage: message,
+        ...(errorCode === DELETED_DOCUMENT_ERROR_CODE
+          ? { requestJson: {}, outputJson: null, responseJson: null }
+          : {}),
       })
       .where(eq(aiRuns.id, args.run.runId));
   });

--- a/apps/web/src/app/api/policies/analyze/_services-critique.test.ts
+++ b/apps/web/src/app/api/policies/analyze/_services-critique.test.ts
@@ -34,12 +34,13 @@ vi.mock('@interdomestik/database', () => ({ withTenantContext: mocks.withTenantC
 vi.mock('@interdomestik/database/schema', () => ({
   aiRuns: { __name: 'ai_runs', id: { __name: 'ai_runs.id' }, status: {} },
   documentExtractions: { __name: 'document_extractions', sourceRunId: {} },
-  documents: { __name: 'documents', id: {} },
+  documents: { __name: 'documents', deletedAt: {}, id: {} },
   policies: { __name: 'policies' },
 }));
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ args })),
   eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+  isNull: vi.fn((field: unknown) => ({ field })),
 }));
 
 import { processPolicyAnalysisRunService } from './_services';

--- a/apps/web/src/app/api/policies/analyze/_services.test.ts
+++ b/apps/web/src/app/api/policies/analyze/_services.test.ts
@@ -4,50 +4,25 @@ const mocks = vi.hoisted(() => {
   const txInsertOnConflictDoNothing = vi.fn().mockResolvedValue(undefined);
   const txInsertValues = vi.fn();
   const txInsertReturning = vi.fn();
-  const txInsert = vi.fn(() => ({
-    values: txInsertValues,
-  }));
+  const txInsert = vi.fn(() => ({ values: txInsertValues }));
   const txUpdateReturning = vi.fn();
-  const txUpdateWhere = vi.fn(() => ({
-    returning: txUpdateReturning,
-  }));
-  const txUpdateSet = vi.fn(() => ({
-    where: txUpdateWhere,
-  }));
-  const txUpdate = vi.fn(() => ({
-    set: txUpdateSet,
-  }));
-  const transaction = vi.fn(
-    async (
-      callback: (tx: { insert: typeof txInsert; update: typeof txUpdate }) => Promise<unknown>
-    ) =>
-      callback({
-        insert: txInsert,
-        update: txUpdate,
-      })
+  const txUpdateWhere = vi.fn(() => ({ returning: txUpdateReturning }));
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
+  const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
+  const txExecute = vi.fn();
+  type Tx = { execute: typeof txExecute; insert: typeof txInsert; update: typeof txUpdate };
+  const transaction = vi.fn(async (callback: (tx: Tx) => Promise<unknown>) =>
+    callback({ execute: txExecute, insert: txInsert, update: txUpdate })
   );
 
   const selectWhere = vi.fn();
-  const selectInnerJoin = vi.fn(() => ({
-    where: selectWhere,
-  }));
-  const selectFrom = vi.fn(() => ({
-    innerJoin: selectInnerJoin,
-    where: selectWhere,
-  }));
-  const select = vi.fn(() => ({
-    from: selectFrom,
-  }));
+  const selectInnerJoin = vi.fn(() => ({ where: selectWhere }));
+  const selectFrom = vi.fn(() => ({ innerJoin: selectInnerJoin, where: selectWhere }));
+  const select = vi.fn(() => ({ from: selectFrom }));
   const updateReturning = vi.fn();
-  const updateWhere = vi.fn(() => ({
-    returning: updateReturning,
-  }));
-  const updateSet = vi.fn(() => ({
-    where: updateWhere,
-  }));
-  const update = vi.fn(() => ({
-    set: updateSet,
-  }));
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
 
   return {
     createAdminClient: vi.fn(),
@@ -71,23 +46,16 @@ const mocks = vi.hoisted(() => {
     txInsertOnConflictDoNothing,
     txInsertReturning,
     txInsertValues,
+    txExecute,
     txUpdate,
     txUpdateReturning,
     txUpdateSet,
-    txUpdateWhere,
-    update,
     updateReturning,
-    updateSet,
-    updateWhere,
     withTenantContext: vi.fn(
       async (
         _context: { tenantId: string; role?: string },
-        callback: (tx: { insert: typeof txInsert; update: typeof txUpdate }) => Promise<unknown>
-      ) =>
-        callback({
-          insert: txInsert,
-          update: txUpdate,
-        })
+        callback: (tx: Tx) => Promise<unknown>
+      ) => callback({ execute: txExecute, insert: txInsert, update: txUpdate })
     ),
   };
 });
@@ -98,22 +66,29 @@ vi.mock('@/lib/db.server', () => ({
 
 vi.mock('@interdomestik/database', () => ({
   createAdminClient: mocks.createAdminClient,
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
   withTenantContext: mocks.withTenantContext,
 }));
 
 vi.mock('@interdomestik/database/schema', () => ({
-  aiRuns: { __name: 'ai_runs' },
+  aiRuns: { __name: 'ai_runs', errorCode: {}, id: {}, status: {} },
   documentExtractions: {
     __name: 'document_extractions',
     sourceRunId: { __name: 'document_extractions.source_run_id' },
   },
-  documents: { __name: 'documents', id: { __name: 'documents.id' } },
+  documents: {
+    __name: 'documents',
+    deletedAt: { __name: 'documents.deleted_at' },
+    id: { __name: 'documents.id' },
+    tenantId: { __name: 'documents.tenant_id' },
+  },
   policies: { __name: 'policies' },
 }));
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ __op: 'and', args })),
   eq: vi.fn((left: unknown, right: unknown) => ({ __op: 'eq', left, right })),
+  isNull: vi.fn((field: unknown) => ({ __op: 'isNull', field })),
 }));
 
 vi.mock('nanoid', () => ({
@@ -137,6 +112,7 @@ describe('queuePolicyAnalysisService', () => {
     mocks.txInsertReturning.mockResolvedValue([{ id: 'policy-1' }]);
     mocks.txInsertOnConflictDoNothing.mockResolvedValue(undefined);
     mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
+    mocks.txExecute.mockResolvedValue([{ id: 'document-1' }]);
   });
 
   it('persists a placeholder policy, document, and queued ai run in one transaction', async () => {
@@ -193,7 +169,10 @@ describe('queuePolicyAnalysisService', () => {
       })
     );
 
-    expect(mocks.txInsert).toHaveBeenNthCalledWith(3, { __name: 'ai_runs' });
+    expect(mocks.txInsert).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ __name: 'ai_runs' })
+    );
     expect(mocks.txInsertValues).toHaveBeenNthCalledWith(
       3,
       expect.objectContaining({
@@ -288,7 +267,7 @@ describe('processPolicyAnalysisRunService', () => {
       { tenantId: 'tenant-1', role: 'system' },
       expect.any(Function)
     );
-    expect(mocks.txUpdate).toHaveBeenCalledWith({ __name: 'ai_runs' });
+    expect(mocks.txUpdate).toHaveBeenCalledWith(expect.objectContaining({ __name: 'ai_runs' }));
     expect(mocks.txUpdateSet).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -296,12 +275,24 @@ describe('processPolicyAnalysisRunService', () => {
         startedAt: expect.any(Date),
       })
     );
-    expect(mocks.txUpdateReturning).toHaveBeenCalledWith({ id: undefined });
+    expect(mocks.txUpdateReturning).toHaveBeenCalledWith({ id: {} });
     expect(mocks.transaction).not.toHaveBeenCalled();
     expect(mocks.txUpdate).toHaveBeenCalledTimes(3);
-    expect(mocks.txUpdate).toHaveBeenNthCalledWith(2, { __name: 'policies' });
+    expect(mocks.txUpdate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ __name: 'ai_runs' })
+    );
     expect(mocks.txUpdateSet).toHaveBeenNthCalledWith(
       2,
+      expect.objectContaining({
+        status: 'completed',
+        outputJson: analysis,
+        completedAt: expect.any(Date),
+      })
+    );
+    expect(mocks.txUpdate).toHaveBeenNthCalledWith(3, { __name: 'policies' });
+    expect(mocks.txUpdateSet).toHaveBeenNthCalledWith(
+      3,
       expect.objectContaining({
         provider: 'Acme Insurance',
         policyNumber: 'POL-123',
@@ -331,15 +322,6 @@ describe('processPolicyAnalysisRunService', () => {
     expect(mocks.txInsertOnConflictDoNothing).toHaveBeenCalledWith({
       target: { __name: 'document_extractions.source_run_id' },
     });
-    expect(mocks.txUpdate).toHaveBeenNthCalledWith(3, { __name: 'ai_runs' });
-    expect(mocks.txUpdateSet).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({
-        status: 'completed',
-        outputJson: analysis,
-        completedAt: expect.any(Date),
-      })
-    );
   });
 
   it('fails the run before persistence when policy extraction does not satisfy the strict schema', async () => {

--- a/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const where = vi.fn();
+  const select = vi.fn(() => ({ from: vi.fn(() => ({ innerJoin: vi.fn(() => ({ where })) })) }));
+  const updateReturning = vi.fn();
+  const updateWhere = vi.fn();
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+  updateWhere.mockReturnValue({ returning: updateReturning });
+  return {
+    db: { select },
+    update,
+    updateReturning,
+    updateSet,
+    updateWhere,
+    where,
+    withTenantContext: vi.fn(async (_context: unknown, callback: (tx: unknown) => unknown) =>
+      callback({ update })
+    ),
+  };
+});
+
+vi.mock('@/lib/db.server', () => ({ db: mocks.db }));
+vi.mock('@interdomestik/database', () => ({ withTenantContext: mocks.withTenantContext }));
+vi.mock('@interdomestik/database/schema', () => ({
+  aiRuns: {
+    documentId: 'ai_runs.document_id',
+    entityId: 'ai_runs.entity_id',
+    entityType: 'ai_runs.entity_type',
+    id: 'ai_runs.id',
+    status: 'ai_runs.status',
+    tenantId: 'ai_runs.tenant_id',
+    workflow: 'ai_runs.workflow',
+  },
+  documents: {
+    deletedAt: 'documents.deleted_at',
+    id: 'documents.id',
+    tenantId: 'documents.tenant_id',
+  },
+}));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+}));
+
+import { failDeletedDocumentClaimAiRun } from './claim-pipeline-document-lifecycle';
+
+function isWorkflow(workflow: unknown): workflow is 'claim_intake_extract' | 'legal_doc_extract' {
+  return workflow === 'claim_intake_extract' || workflow === 'legal_doc_extract';
+}
+
+describe('failDeletedDocumentClaimAiRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateReturning.mockResolvedValue([{ id: 'run-1' }]);
+  });
+
+  it('marks queued AI runs for deleted documents failed and returns skipped', async () => {
+    mocks.where.mockResolvedValue([
+      {
+        claimId: 'claim-1',
+        deletedAt: new Date('2026-07-03T00:00:00Z'),
+        status: 'queued',
+        tenantId: 'tenant-1',
+        workflow: 'claim_intake_extract',
+      },
+    ]);
+
+    await expect(failDeletedDocumentClaimAiRun('run-1', isWorkflow)).resolves.toEqual({
+      status: 'skipped',
+      claimId: 'claim-1',
+      workflow: 'claim_intake_extract',
+    });
+    expect(mocks.withTenantContext).toHaveBeenCalledWith(
+      { tenantId: 'tenant-1', role: 'system' },
+      expect.any(Function)
+    );
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        errorCode: 'claim_ai_document_deleted',
+        completedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it('does not skip deleted-document runs that are no longer queued', async () => {
+    mocks.where.mockResolvedValue([
+      {
+        claimId: 'claim-1',
+        deletedAt: new Date('2026-07-03T00:00:00Z'),
+        status: 'completed',
+        tenantId: 'tenant-1',
+        workflow: 'claim_intake_extract',
+      },
+    ]);
+
+    await expect(failDeletedDocumentClaimAiRun('run-1', isWorkflow)).resolves.toBeNull();
+    expect(mocks.withTenantContext).not.toHaveBeenCalled();
+  });
+
+  it('does not return skipped when the queued update loses its optimistic lock', async () => {
+    mocks.where.mockResolvedValue([
+      {
+        claimId: 'claim-1',
+        deletedAt: new Date('2026-07-03T00:00:00Z'),
+        status: 'queued',
+        tenantId: 'tenant-1',
+        workflow: 'claim_intake_extract',
+      },
+    ]);
+    mocks.updateReturning.mockResolvedValue([]);
+
+    await expect(failDeletedDocumentClaimAiRun('run-1', isWorkflow)).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.test.ts
@@ -28,6 +28,7 @@ vi.mock('@interdomestik/database/schema', () => ({
     documentId: 'ai_runs.document_id',
     entityId: 'ai_runs.entity_id',
     entityType: 'ai_runs.entity_type',
+    errorCode: 'ai_runs.error_code',
     id: 'ai_runs.id',
     outputJson: 'ai_runs.output_json',
     requestJson: 'ai_runs.request_json',
@@ -64,6 +65,7 @@ describe('failDeletedDocumentClaimAiRun', () => {
       {
         claimId: 'claim-1',
         deletedAt: new Date('2026-07-03T00:00:00Z'),
+        errorCode: null,
         status: 'queued',
         tenantId: 'tenant-1',
         workflow: 'claim_intake_extract',
@@ -91,11 +93,32 @@ describe('failDeletedDocumentClaimAiRun', () => {
     );
   });
 
+  it('returns skipped for runs already failed by document deletion', async () => {
+    mocks.where.mockResolvedValue([
+      {
+        claimId: 'claim-1',
+        deletedAt: new Date('2026-07-03T00:00:00Z'),
+        errorCode: 'claim_ai_document_deleted',
+        status: 'failed',
+        tenantId: 'tenant-1',
+        workflow: 'claim_intake_extract',
+      },
+    ]);
+
+    await expect(failDeletedDocumentClaimAiRun('run-1', isWorkflow)).resolves.toEqual({
+      status: 'skipped',
+      claimId: 'claim-1',
+      workflow: 'claim_intake_extract',
+    });
+    expect(mocks.withTenantContext).not.toHaveBeenCalled();
+  });
+
   it('does not skip deleted-document runs that are no longer queued', async () => {
     mocks.where.mockResolvedValue([
       {
         claimId: 'claim-1',
         deletedAt: new Date('2026-07-03T00:00:00Z'),
+        errorCode: null,
         status: 'completed',
         tenantId: 'tenant-1',
         workflow: 'claim_intake_extract',
@@ -111,6 +134,7 @@ describe('failDeletedDocumentClaimAiRun', () => {
       {
         claimId: 'claim-1',
         deletedAt: new Date('2026-07-03T00:00:00Z'),
+        errorCode: null,
         status: 'queued',
         tenantId: 'tenant-1',
         workflow: 'claim_intake_extract',

--- a/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.test.ts
@@ -29,6 +29,9 @@ vi.mock('@interdomestik/database/schema', () => ({
     entityId: 'ai_runs.entity_id',
     entityType: 'ai_runs.entity_type',
     id: 'ai_runs.id',
+    outputJson: 'ai_runs.output_json',
+    requestJson: 'ai_runs.request_json',
+    responseJson: 'ai_runs.response_json',
     status: 'ai_runs.status',
     tenantId: 'ai_runs.tenant_id',
     workflow: 'ai_runs.workflow',
@@ -81,6 +84,9 @@ describe('failDeletedDocumentClaimAiRun', () => {
         status: 'failed',
         errorCode: 'claim_ai_document_deleted',
         completedAt: expect.any(Date),
+        requestJson: {},
+        outputJson: null,
+        responseJson: null,
       })
     );
   });

--- a/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
@@ -31,7 +31,11 @@ export async function failDeletedDocumentClaimAiRun(
     return null;
   }
 
-  if (run.status === 'failed' && run.errorCode === 'claim_ai_document_deleted') {
+  if (
+    run.status === 'failed' &&
+    (run.errorCode === 'claim_ai_document_deleted' ||
+      run.errorCode === 'document_ai_document_deleted')
+  ) {
     return { status: 'skipped', claimId: run.claimId, workflow: run.workflow };
   }
 

--- a/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
@@ -1,0 +1,51 @@
+import { db } from '@/lib/db.server';
+import { withTenantContext } from '@interdomestik/database';
+import { aiRuns, documents } from '@interdomestik/database/schema';
+import { and, eq } from 'drizzle-orm';
+
+import type { ClaimAiWorkflow } from './claim-pipeline-run';
+
+type SkippedRun = { status: 'skipped'; claimId: string; workflow: ClaimAiWorkflow };
+
+export async function failDeletedDocumentClaimAiRun(
+  runId: string,
+  isWorkflow: (workflow: unknown) => workflow is ClaimAiWorkflow
+): Promise<SkippedRun | null> {
+  const [run] = await db
+    .select({
+      tenantId: aiRuns.tenantId,
+      workflow: aiRuns.workflow,
+      claimId: aiRuns.entityId,
+      status: aiRuns.status,
+      deletedAt: documents.deletedAt,
+    })
+    .from(aiRuns)
+    .innerJoin(
+      documents,
+      and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
+    )
+    .where(and(eq(aiRuns.id, runId), eq(aiRuns.entityType, 'claim'), eq(aiRuns.status, 'queued')));
+
+  if (run?.status !== 'queued' || !run.deletedAt || !run.claimId || !isWorkflow(run.workflow)) {
+    return null;
+  }
+
+  const [failedRun] = await withTenantContext(
+    { tenantId: run.tenantId, role: 'system' },
+    async tx =>
+      tx
+        .update(aiRuns)
+        .set({
+          status: 'failed',
+          completedAt: new Date(),
+          errorCode: 'claim_ai_document_deleted',
+          errorMessage: 'Claim AI run skipped because the source document was deleted.',
+        })
+        .where(and(eq(aiRuns.id, runId), eq(aiRuns.status, 'queued')))
+        .returning({ id: aiRuns.id })
+  );
+
+  if (!failedRun) return null;
+
+  return { status: 'skipped', claimId: run.claimId, workflow: run.workflow };
+}

--- a/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
@@ -40,6 +40,9 @@ export async function failDeletedDocumentClaimAiRun(
           completedAt: new Date(),
           errorCode: 'claim_ai_document_deleted',
           errorMessage: 'Claim AI run skipped because the source document was deleted.',
+          requestJson: {},
+          outputJson: null,
+          responseJson: null,
         })
         .where(and(eq(aiRuns.id, runId), eq(aiRuns.status, 'queued')))
         .returning({ id: aiRuns.id })

--- a/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
@@ -17,6 +17,7 @@ export async function failDeletedDocumentClaimAiRun(
       workflow: aiRuns.workflow,
       claimId: aiRuns.entityId,
       status: aiRuns.status,
+      errorCode: aiRuns.errorCode,
       deletedAt: documents.deletedAt,
     })
     .from(aiRuns)
@@ -24,11 +25,17 @@ export async function failDeletedDocumentClaimAiRun(
       documents,
       and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
     )
-    .where(and(eq(aiRuns.id, runId), eq(aiRuns.entityType, 'claim'), eq(aiRuns.status, 'queued')));
+    .where(and(eq(aiRuns.id, runId), eq(aiRuns.entityType, 'claim')));
 
-  if (run?.status !== 'queued' || !run.deletedAt || !run.claimId || !isWorkflow(run.workflow)) {
+  if (!run?.deletedAt || !run.claimId || !isWorkflow(run.workflow)) {
     return null;
   }
+
+  if (run.status === 'failed' && run.errorCode === 'claim_ai_document_deleted') {
+    return { status: 'skipped', claimId: run.claimId, workflow: run.workflow };
+  }
+
+  if (run.status !== 'queued') return null;
 
   const [failedRun] = await withTenantContext(
     { tenantId: run.tenantId, role: 'system' },

--- a/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-document-lifecycle.ts
@@ -3,9 +3,27 @@ import { withTenantContext } from '@interdomestik/database';
 import { aiRuns, documents } from '@interdomestik/database/schema';
 import { and, eq } from 'drizzle-orm';
 
+import {
+  buildDeletedDocumentFailure,
+  throwDeletedDocumentError,
+  type DeletedDocumentFailure,
+} from './document-run-lifecycle';
 import type { ClaimAiWorkflow } from './claim-pipeline-run';
 
 type SkippedRun = { status: 'skipped'; claimId: string; workflow: ClaimAiWorkflow };
+
+export const CLAIM_DELETED_DOCUMENT_FAILURE: DeletedDocumentFailure = {
+  errorCode: 'claim_ai_document_deleted',
+  errorMessage: 'Claim AI run skipped because the source document was deleted.',
+};
+
+export function buildDeletedClaimRunFailure(completedAt: Date) {
+  return buildDeletedDocumentFailure(completedAt, CLAIM_DELETED_DOCUMENT_FAILURE);
+}
+
+export function throwDeletedClaimDocumentError(): never {
+  throwDeletedDocumentError(CLAIM_DELETED_DOCUMENT_FAILURE);
+}
 
 export async function failDeletedDocumentClaimAiRun(
   runId: string,
@@ -46,15 +64,7 @@ export async function failDeletedDocumentClaimAiRun(
     async tx =>
       tx
         .update(aiRuns)
-        .set({
-          status: 'failed',
-          completedAt: new Date(),
-          errorCode: 'claim_ai_document_deleted',
-          errorMessage: 'Claim AI run skipped because the source document was deleted.',
-          requestJson: {},
-          outputJson: null,
-          responseJson: null,
-        })
+        .set(buildDeletedClaimRunFailure(new Date()))
         .where(and(eq(aiRuns.id, runId), eq(aiRuns.status, 'queued')))
         .returning({ id: aiRuns.id })
   );

--- a/apps/web/src/lib/ai/claim-pipeline-failure.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-failure.ts
@@ -1,0 +1,27 @@
+import type { ExtractionPipelineError } from '@/lib/ai/extraction-pipeline';
+import { withTenantContext } from '@interdomestik/database';
+import { aiRuns } from '@interdomestik/database/schema';
+import { eq } from 'drizzle-orm';
+
+import type { ClaimedClaimAiRun } from './claim-pipeline-run';
+
+export async function markClaimAiRunFailed(args: { run: ClaimedClaimAiRun; error: unknown }) {
+  const pipelineError = args.error as Partial<ExtractionPipelineError>;
+  const errorCode =
+    typeof pipelineError.errorCode === 'string'
+      ? pipelineError.errorCode
+      : 'claim_ai_processing_failed';
+  const message = args.error instanceof Error ? args.error.message : 'Claim AI workflow failed.';
+
+  await withTenantContext({ tenantId: args.run.tenantId, role: 'system' }, async tx => {
+    await tx
+      .update(aiRuns)
+      .set({
+        status: 'failed',
+        completedAt: new Date(),
+        errorCode,
+        errorMessage: message,
+      })
+      .where(eq(aiRuns.id, args.run.runId));
+  });
+}

--- a/apps/web/src/lib/ai/claim-pipeline-input.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-input.ts
@@ -1,4 +1,5 @@
 import {
+  ExtractionPipelineError,
   type ExtractionCandidate,
   buildSanitizedContentMetrics,
   readCandidateConfidence,
@@ -11,6 +12,9 @@ import { extractLegalDocument } from '@interdomestik/domain-ai/legal/extract';
 import { claimIntakeExtractSchema } from '@interdomestik/domain-ai/schemas/claim-intake-extract';
 import { legalDocExtractSchema } from '@interdomestik/domain-ai/schemas/legal-doc-extract';
 import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
+import { db } from '@/lib/db.server';
+import { aiRuns, documents } from '@interdomestik/database/schema';
+import { and, eq, isNull } from 'drizzle-orm';
 
 import { readClaimPipelineAiCallContext } from './claim-pipeline-ai-context';
 import type { ClaimedClaimAiRun } from './claim-pipeline-run';
@@ -64,6 +68,28 @@ export async function loadClaimAiInput(
 ): Promise<LoadedClaimAiInput> {
   const requestJson = run.requestJson && typeof run.requestJson === 'object' ? run.requestJson : {};
   const bucket = getBucketFromRequestJson(requestJson);
+  const [activeRun] = await db
+    .select({ id: aiRuns.id })
+    .from(aiRuns)
+    .innerJoin(
+      documents,
+      and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
+    )
+    .where(
+      and(
+        eq(aiRuns.id, run.runId),
+        eq(aiRuns.status, 'processing'),
+        eq(documents.id, run.documentId),
+        eq(documents.tenantId, run.tenantId),
+        isNull(documents.deletedAt)
+      )
+    );
+  if (!activeRun) {
+    throw new ExtractionPipelineError(
+      'claim_ai_document_deleted',
+      'Claim AI run skipped because the source document was deleted.'
+    );
+  }
   const fileBuffer = await deps.downloadFile(bucket, run.storagePath, run.tenantId);
   const documentText = await deps.analyzePdf(fileBuffer, run.mimeType);
 

--- a/apps/web/src/lib/ai/claim-pipeline-input.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-input.ts
@@ -1,5 +1,4 @@
 import {
-  ExtractionPipelineError,
   type ExtractionCandidate,
   buildSanitizedContentMetrics,
   readCandidateConfidence,
@@ -7,16 +6,15 @@ import {
   type SanitizedContentMetrics,
   validateExtractionCandidate,
 } from '@/lib/ai/extraction-pipeline';
+import { assertProcessingRunHasActiveDocument } from '@/lib/ai/document-run-lifecycle';
+import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
 import { extractClaimIntake } from '@interdomestik/domain-ai/claims/intake-extract';
 import { extractLegalDocument } from '@interdomestik/domain-ai/legal/extract';
 import { claimIntakeExtractSchema } from '@interdomestik/domain-ai/schemas/claim-intake-extract';
 import { legalDocExtractSchema } from '@interdomestik/domain-ai/schemas/legal-doc-extract';
-import { resolveEvidenceBucketName } from '@/lib/storage/evidence-bucket';
-import { db } from '@/lib/db.server';
-import { aiRuns, documents } from '@interdomestik/database/schema';
-import { and, eq, isNull } from 'drizzle-orm';
 
 import { readClaimPipelineAiCallContext } from './claim-pipeline-ai-context';
+import { CLAIM_DELETED_DOCUMENT_FAILURE } from './claim-pipeline-document-lifecycle';
 import type { ClaimedClaimAiRun } from './claim-pipeline-run';
 
 export type ClaimPipelineDeps = {
@@ -68,28 +66,7 @@ export async function loadClaimAiInput(
 ): Promise<LoadedClaimAiInput> {
   const requestJson = run.requestJson && typeof run.requestJson === 'object' ? run.requestJson : {};
   const bucket = getBucketFromRequestJson(requestJson);
-  const [activeRun] = await db
-    .select({ id: aiRuns.id })
-    .from(aiRuns)
-    .innerJoin(
-      documents,
-      and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
-    )
-    .where(
-      and(
-        eq(aiRuns.id, run.runId),
-        eq(aiRuns.status, 'processing'),
-        eq(documents.id, run.documentId),
-        eq(documents.tenantId, run.tenantId),
-        isNull(documents.deletedAt)
-      )
-    );
-  if (!activeRun) {
-    throw new ExtractionPipelineError(
-      'claim_ai_document_deleted',
-      'Claim AI run skipped because the source document was deleted.'
-    );
-  }
+  await assertProcessingRunHasActiveDocument(run, CLAIM_DELETED_DOCUMENT_FAILURE);
   const fileBuffer = await deps.downloadFile(bucket, run.storagePath, run.tenantId);
   const documentText = await deps.analyzePdf(fileBuffer, run.mimeType);
 

--- a/apps/web/src/lib/ai/claim-pipeline-persist-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist-lifecycle.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => {
   const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
   const tx = {
     delete: vi.fn(() => ({ where: txDeleteWhere })),
+    execute: vi.fn(),
     insert: vi.fn(() => ({ values: txInsertValues })),
     select: vi.fn(() => ({ from: vi.fn(() => ({ where: selectWhere })) })),
     update: vi.fn(() => ({ set: txUpdateSet })),
@@ -27,7 +28,10 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('@interdomestik/database', () => ({ withTenantContext: mocks.withTenantContext }));
+vi.mock('@interdomestik/database', () => ({
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
+  withTenantContext: mocks.withTenantContext,
+}));
 vi.mock('@interdomestik/database/schema', () => ({
   aiRuns: { __name: 'ai_runs', id: {}, status: 'ai_runs.status' },
   documentExtractions: {
@@ -82,17 +86,19 @@ const critique = {
 describe('persistClaimAiExtraction lifecycle guards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.tx.execute.mockResolvedValue([{ id: 'doc-1' }]);
     mocks.selectWhere.mockResolvedValue([{ id: 'doc-1' }]);
     mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
   });
 
   it('fails and redacts the run when the document was already deleted', async () => {
-    mocks.selectWhere.mockResolvedValue([]);
+    mocks.tx.execute.mockResolvedValue([]);
 
     await expect(
       persistClaimAiExtraction({ run, extraction: { summary: 'derived PII' }, critique })
     ).rejects.toMatchObject({ errorCode: 'claim_ai_document_deleted' });
 
+    expect(mocks.tx.execute).toHaveBeenCalled();
     expect(mocks.tx.insert).not.toHaveBeenCalled();
     expect(mocks.txUpdateSet).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/src/lib/ai/claim-pipeline-persist-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist-lifecycle.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const selectWhere = vi.fn();
+  const txDeleteWhere = vi.fn();
+  const txInsertOnConflictDoNothing = vi.fn();
+  const txInsertValues = vi.fn(() => ({ onConflictDoNothing: txInsertOnConflictDoNothing }));
+  const txUpdateReturning = vi.fn();
+  const txUpdateWhere = vi.fn(() => ({ returning: txUpdateReturning }));
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
+  const tx = {
+    delete: vi.fn(() => ({ where: txDeleteWhere })),
+    insert: vi.fn(() => ({ values: txInsertValues })),
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: selectWhere })) })),
+    update: vi.fn(() => ({ set: txUpdateSet })),
+  };
+
+  return {
+    selectWhere,
+    tx,
+    txDeleteWhere,
+    txUpdateReturning,
+    txUpdateSet,
+    withTenantContext: vi.fn(async (_context: unknown, callback: (txArg: typeof tx) => unknown) =>
+      callback(tx)
+    ),
+  };
+});
+
+vi.mock('@interdomestik/database', () => ({ withTenantContext: mocks.withTenantContext }));
+vi.mock('@interdomestik/database/schema', () => ({
+  aiRuns: { __name: 'ai_runs', id: {}, status: 'ai_runs.status' },
+  documentExtractions: {
+    __name: 'document_extractions',
+    sourceRunId: 'document_extractions.source_run_id',
+    tenantId: 'document_extractions.tenant_id',
+  },
+  documents: {
+    deletedAt: 'documents.deleted_at',
+    id: 'documents.id',
+    tenantId: 'documents.tenant_id',
+  },
+}));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ args, op: 'and' })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, right, op: 'eq' })),
+  isNull: vi.fn((field: unknown) => ({ field, op: 'isNull' })),
+}));
+vi.mock('nanoid', () => ({ nanoid: vi.fn(() => 'extraction-1') }));
+
+import { persistClaimAiExtraction } from './claim-pipeline-persist';
+
+const run = {
+  runId: 'run-1',
+  tenantId: 'tenant-1',
+  workflow: 'claim_intake_extract' as const,
+  documentId: 'doc-1',
+  claimId: 'claim-1',
+  requestedBy: 'user-1',
+  subjectId: 'member-1',
+  storagePath: 'pii/tenants/tenant-1/claims/claim-1/evidence.pdf',
+  fileName: 'evidence.pdf',
+  mimeType: 'application/pdf',
+  uploadedAt: new Date('2026-03-08T10:00:00.000Z'),
+  requestJson: {},
+  claimTitle: 'Claim',
+  claimDescription: null,
+  claimCategory: 'travel',
+  claimAmount: null,
+  claimCurrency: 'EUR',
+};
+
+const critique = {
+  decision: 'needs_human_review' as const,
+  confidence: 0.74,
+  warnings: [],
+  warningCodes: [],
+  escalationRecommended: false,
+  persistenceAllowed: true,
+};
+
+describe('persistClaimAiExtraction lifecycle guards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectWhere.mockResolvedValue([{ id: 'doc-1' }]);
+    mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
+  });
+
+  it('fails and redacts the run when the document was already deleted', async () => {
+    mocks.selectWhere.mockResolvedValue([]);
+
+    await expect(
+      persistClaimAiExtraction({ run, extraction: { summary: 'derived PII' }, critique })
+    ).rejects.toMatchObject({ errorCode: 'claim_ai_document_deleted' });
+
+    expect(mocks.tx.insert).not.toHaveBeenCalled();
+    expect(mocks.txUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        errorCode: 'claim_ai_document_deleted',
+        requestJson: {},
+        outputJson: null,
+        responseJson: null,
+      })
+    );
+  });
+
+  it('deletes inserted extraction output when completion loses the processing lock', async () => {
+    mocks.txUpdateReturning.mockResolvedValue([]);
+
+    await expect(
+      persistClaimAiExtraction({ run, extraction: { summary: 'derived PII' }, critique })
+    ).rejects.toMatchObject({ errorCode: 'claim_ai_document_deleted' });
+
+    expect(mocks.tx.insert).toHaveBeenCalled();
+    expect(mocks.tx.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ __name: 'document_extractions' })
+    );
+    expect(mocks.txDeleteWhere).toHaveBeenCalledWith(expect.objectContaining({ op: 'and' }));
+    expect(mocks.txUpdateSet).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        requestJson: {},
+        outputJson: null,
+        responseJson: null,
+      })
+    );
+  });
+});

--- a/apps/web/src/lib/ai/claim-pipeline-persist.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.test.ts
@@ -1,16 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
+  const selectWhere = vi.fn();
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from: selectFrom }));
   const txInsertOnConflictDoNothing = vi.fn();
   const txInsertValues = vi.fn(() => ({ onConflictDoNothing: txInsertOnConflictDoNothing }));
   const txUpdateSet = vi.fn(() => ({ where: vi.fn() }));
   const tx = {
     insert: vi.fn(() => ({ values: txInsertValues })),
+    select,
     update: vi.fn(() => ({ set: txUpdateSet })),
   };
 
   return {
     nanoid: vi.fn(() => 'extraction-1'),
+    selectWhere,
+    tx,
     txInsertValues,
     txUpdateSet,
     withTenantContext: vi.fn(async (_context: unknown, callback: (txArg: typeof tx) => unknown) =>
@@ -23,14 +29,26 @@ vi.mock('@interdomestik/database', () => ({ withTenantContext: mocks.withTenantC
 vi.mock('@interdomestik/database/schema', () => ({
   aiRuns: { __name: 'ai_runs', id: {} },
   documentExtractions: { __name: 'document_extractions', sourceRunId: {} },
+  documents: {
+    deletedAt: 'documents.deleted_at',
+    id: 'documents.id',
+    tenantId: 'documents.tenant_id',
+  },
 }));
-vi.mock('drizzle-orm', () => ({ eq: vi.fn((left: unknown, right: unknown) => ({ left, right })) }));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ args, op: 'and' })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, right, op: 'eq' })),
+  isNull: vi.fn((field: unknown) => ({ field, op: 'isNull' })),
+}));
 vi.mock('nanoid', () => ({ nanoid: mocks.nanoid }));
 
 import { persistClaimAiExtraction } from './claim-pipeline-persist';
 
 describe('persistClaimAiExtraction', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectWhere.mockResolvedValue([{ id: 'doc-1' }]);
+  });
 
   it('persists legal extraction output with confidence and critique metadata', async () => {
     await persistClaimAiExtraction({
@@ -79,6 +97,51 @@ describe('persistClaimAiExtraction', () => {
           critique: expect.objectContaining({ warningCodes: ['low_confidence'] }),
         }),
         status: 'completed',
+      })
+    );
+  });
+
+  it('fails the run without persisting extraction output when the document was deleted', async () => {
+    mocks.selectWhere.mockResolvedValue([]);
+
+    await persistClaimAiExtraction({
+      run: {
+        runId: 'run-1',
+        tenantId: 'tenant-1',
+        workflow: 'claim_intake_extract',
+        documentId: 'doc-1',
+        claimId: 'claim-1',
+        requestedBy: 'user-1',
+        subjectId: 'member-1',
+        storagePath: 'pii/tenants/tenant-1/claims/claim-1/evidence.pdf',
+        fileName: 'evidence.pdf',
+        mimeType: 'application/pdf',
+        uploadedAt: new Date('2026-03-08T10:00:00.000Z'),
+        requestJson: {},
+        claimTitle: 'Claim',
+        claimDescription: null,
+        claimCategory: 'travel',
+        claimAmount: null,
+        claimCurrency: 'EUR',
+      },
+      extraction: { summary: 'derived PII' },
+      critique: {
+        decision: 'needs_human_review',
+        confidence: 0.74,
+        warnings: [],
+        warningCodes: [],
+        escalationRecommended: false,
+        persistenceAllowed: true,
+      },
+    });
+
+    expect(mocks.tx.insert).not.toHaveBeenCalled();
+    expect(mocks.txUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        errorCode: 'claim_ai_document_deleted',
+        outputJson: null,
+        responseJson: null,
       })
     );
   });

--- a/apps/web/src/lib/ai/claim-pipeline-persist.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.test.ts
@@ -4,10 +4,15 @@ const mocks = vi.hoisted(() => {
   const selectWhere = vi.fn();
   const selectFrom = vi.fn(() => ({ where: selectWhere }));
   const select = vi.fn(() => ({ from: selectFrom }));
+  const txDeleteWhere = vi.fn();
+  const txDelete = vi.fn(() => ({ where: txDeleteWhere }));
   const txInsertOnConflictDoNothing = vi.fn();
   const txInsertValues = vi.fn(() => ({ onConflictDoNothing: txInsertOnConflictDoNothing }));
-  const txUpdateSet = vi.fn(() => ({ where: vi.fn() }));
+  const txUpdateReturning = vi.fn();
+  const txUpdateWhere = vi.fn(() => ({ returning: txUpdateReturning }));
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
   const tx = {
+    delete: txDelete,
     insert: vi.fn(() => ({ values: txInsertValues })),
     select,
     update: vi.fn(() => ({ set: txUpdateSet })),
@@ -17,8 +22,11 @@ const mocks = vi.hoisted(() => {
     nanoid: vi.fn(() => 'extraction-1'),
     selectWhere,
     tx,
+    txDeleteWhere,
     txInsertValues,
+    txUpdateReturning,
     txUpdateSet,
+    txUpdateWhere,
     withTenantContext: vi.fn(async (_context: unknown, callback: (txArg: typeof tx) => unknown) =>
       callback(tx)
     ),
@@ -27,8 +35,12 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@interdomestik/database', () => ({ withTenantContext: mocks.withTenantContext }));
 vi.mock('@interdomestik/database/schema', () => ({
-  aiRuns: { __name: 'ai_runs', id: {} },
-  documentExtractions: { __name: 'document_extractions', sourceRunId: {} },
+  aiRuns: { __name: 'ai_runs', id: {}, status: 'ai_runs.status' },
+  documentExtractions: {
+    __name: 'document_extractions',
+    sourceRunId: 'document_extractions.source_run_id',
+    tenantId: 'document_extractions.tenant_id',
+  },
   documents: {
     deletedAt: 'documents.deleted_at',
     id: 'documents.id',
@@ -48,6 +60,7 @@ describe('persistClaimAiExtraction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.selectWhere.mockResolvedValue([{ id: 'doc-1' }]);
+    mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
   });
 
   it('persists legal extraction output with confidence and critique metadata', async () => {
@@ -97,52 +110,6 @@ describe('persistClaimAiExtraction', () => {
           critique: expect.objectContaining({ warningCodes: ['low_confidence'] }),
         }),
         status: 'completed',
-      })
-    );
-  });
-
-  it('fails the run without persisting extraction output when the document was deleted', async () => {
-    mocks.selectWhere.mockResolvedValue([]);
-
-    await persistClaimAiExtraction({
-      run: {
-        runId: 'run-1',
-        tenantId: 'tenant-1',
-        workflow: 'claim_intake_extract',
-        documentId: 'doc-1',
-        claimId: 'claim-1',
-        requestedBy: 'user-1',
-        subjectId: 'member-1',
-        storagePath: 'pii/tenants/tenant-1/claims/claim-1/evidence.pdf',
-        fileName: 'evidence.pdf',
-        mimeType: 'application/pdf',
-        uploadedAt: new Date('2026-03-08T10:00:00.000Z'),
-        requestJson: {},
-        claimTitle: 'Claim',
-        claimDescription: null,
-        claimCategory: 'travel',
-        claimAmount: null,
-        claimCurrency: 'EUR',
-      },
-      extraction: { summary: 'derived PII' },
-      critique: {
-        decision: 'needs_human_review',
-        confidence: 0.74,
-        warnings: [],
-        warningCodes: [],
-        escalationRecommended: false,
-        persistenceAllowed: true,
-      },
-    });
-
-    expect(mocks.tx.insert).not.toHaveBeenCalled();
-    expect(mocks.txUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'failed',
-        errorCode: 'claim_ai_document_deleted',
-        requestJson: {},
-        outputJson: null,
-        responseJson: null,
       })
     );
   });

--- a/apps/web/src/lib/ai/claim-pipeline-persist.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => {
   const select = vi.fn(() => ({ from: selectFrom }));
   const txDeleteWhere = vi.fn();
   const txDelete = vi.fn(() => ({ where: txDeleteWhere }));
+  const txExecute = vi.fn();
   const txInsertOnConflictDoNothing = vi.fn();
   const txInsertValues = vi.fn(() => ({ onConflictDoNothing: txInsertOnConflictDoNothing }));
   const txUpdateReturning = vi.fn();
@@ -13,6 +14,7 @@ const mocks = vi.hoisted(() => {
   const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
   const tx = {
     delete: txDelete,
+    execute: txExecute,
     insert: vi.fn(() => ({ values: txInsertValues })),
     select,
     update: vi.fn(() => ({ set: txUpdateSet })),
@@ -23,6 +25,7 @@ const mocks = vi.hoisted(() => {
     selectWhere,
     tx,
     txDeleteWhere,
+    txExecute,
     txInsertValues,
     txUpdateReturning,
     txUpdateSet,
@@ -33,7 +36,10 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('@interdomestik/database', () => ({ withTenantContext: mocks.withTenantContext }));
+vi.mock('@interdomestik/database', () => ({
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
+  withTenantContext: mocks.withTenantContext,
+}));
 vi.mock('@interdomestik/database/schema', () => ({
   aiRuns: { __name: 'ai_runs', id: {}, status: 'ai_runs.status' },
   documentExtractions: {
@@ -59,6 +65,7 @@ import { persistClaimAiExtraction } from './claim-pipeline-persist';
 describe('persistClaimAiExtraction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.txExecute.mockResolvedValue([{ id: 'doc-1' }]);
     mocks.selectWhere.mockResolvedValue([{ id: 'doc-1' }]);
     mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
   });

--- a/apps/web/src/lib/ai/claim-pipeline-persist.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.test.ts
@@ -140,6 +140,7 @@ describe('persistClaimAiExtraction', () => {
       expect.objectContaining({
         status: 'failed',
         errorCode: 'claim_ai_document_deleted',
+        requestJson: {},
         outputJson: null,
         responseJson: null,
       })

--- a/apps/web/src/lib/ai/claim-pipeline-persist.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.ts
@@ -1,4 +1,4 @@
-import type { ExtractionCritique, ExtractionPipelineError } from '@/lib/ai/extraction-pipeline';
+import { ExtractionPipelineError, type ExtractionCritique } from '@/lib/ai/extraction-pipeline';
 import { withTenantContext } from '@interdomestik/database';
 import { aiRuns, documentExtractions, documents } from '@interdomestik/database/schema';
 import {
@@ -10,6 +10,10 @@ import { nanoid } from 'nanoid';
 
 import type { ClaimedClaimAiRun, ClaimAiWorkflow } from './claim-pipeline-run';
 
+const DELETED_DOCUMENT_ERROR_CODE = 'claim_ai_document_deleted';
+const DELETED_DOCUMENT_ERROR_MESSAGE =
+  'Claim AI run skipped because the source document was deleted.';
+
 function getEventName(workflow: ClaimAiWorkflow) {
   return workflow === 'legal_doc_extract'
     ? 'legal/extract.requested'
@@ -20,6 +24,10 @@ function getSchemaVersion(workflow: ClaimAiWorkflow) {
   return workflow === 'legal_doc_extract'
     ? LEGAL_DOC_EXTRACT_SCHEMA_VERSION
     : CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION;
+}
+
+function throwDeletedDocumentError(): never {
+  throw new ExtractionPipelineError(DELETED_DOCUMENT_ERROR_CODE, DELETED_DOCUMENT_ERROR_MESSAGE);
 }
 
 export async function persistClaimAiExtraction(args: {
@@ -47,14 +55,14 @@ export async function persistClaimAiExtraction(args: {
         .set({
           status: 'failed',
           completedAt,
-          errorCode: 'claim_ai_document_deleted',
-          errorMessage: 'Claim AI run skipped because the source document was deleted.',
+          errorCode: DELETED_DOCUMENT_ERROR_CODE,
+          errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
           requestJson: {},
           outputJson: null,
           responseJson: null,
         })
         .where(eq(aiRuns.id, args.run.runId));
-      return;
+      throwDeletedDocumentError();
     }
 
     await tx
@@ -77,7 +85,7 @@ export async function persistClaimAiExtraction(args: {
       })
       .onConflictDoNothing({ target: documentExtractions.sourceRunId });
 
-    await tx
+    const [completedRun] = await tx
       .update(aiRuns)
       .set({
         status: 'completed',
@@ -96,27 +104,31 @@ export async function persistClaimAiExtraction(args: {
         errorCode: null,
         errorMessage: null,
       })
-      .where(eq(aiRuns.id, args.run.runId));
-  });
-}
+      .where(and(eq(aiRuns.id, args.run.runId), eq(aiRuns.status, 'processing')))
+      .returning({ id: aiRuns.id });
 
-export async function markClaimAiRunFailed(args: { run: ClaimedClaimAiRun; error: unknown }) {
-  const pipelineError = args.error as Partial<ExtractionPipelineError>;
-  const errorCode =
-    typeof pipelineError.errorCode === 'string'
-      ? pipelineError.errorCode
-      : 'claim_ai_processing_failed';
-  const message = args.error instanceof Error ? args.error.message : 'Claim AI workflow failed.';
-
-  await withTenantContext({ tenantId: args.run.tenantId, role: 'system' }, async tx => {
-    await tx
-      .update(aiRuns)
-      .set({
-        status: 'failed',
-        completedAt: new Date(),
-        errorCode,
-        errorMessage: message,
-      })
-      .where(eq(aiRuns.id, args.run.runId));
+    if (!completedRun) {
+      await tx
+        .delete(documentExtractions)
+        .where(
+          and(
+            eq(documentExtractions.sourceRunId, args.run.runId),
+            eq(documentExtractions.tenantId, args.run.tenantId)
+          )
+        );
+      await tx
+        .update(aiRuns)
+        .set({
+          status: 'failed',
+          completedAt,
+          errorCode: DELETED_DOCUMENT_ERROR_CODE,
+          errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
+          requestJson: {},
+          outputJson: null,
+          responseJson: null,
+        })
+        .where(eq(aiRuns.id, args.run.runId));
+      throwDeletedDocumentError();
+    }
   });
 }

--- a/apps/web/src/lib/ai/claim-pipeline-persist.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.ts
@@ -1,11 +1,11 @@
 import { ExtractionPipelineError, type ExtractionCritique } from '@/lib/ai/extraction-pipeline';
-import { withTenantContext } from '@interdomestik/database';
-import { aiRuns, documentExtractions, documents } from '@interdomestik/database/schema';
+import { sql, type TenantTransaction, withTenantContext } from '@interdomestik/database';
+import { aiRuns, documentExtractions } from '@interdomestik/database/schema';
 import {
   CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION,
   LEGAL_DOC_EXTRACT_SCHEMA_VERSION,
 } from '@interdomestik/domain-ai';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
 import type { ClaimedClaimAiRun, ClaimAiWorkflow } from './claim-pipeline-run';
@@ -30,6 +30,21 @@ function throwDeletedDocumentError(): never {
   throw new ExtractionPipelineError(DELETED_DOCUMENT_ERROR_CODE, DELETED_DOCUMENT_ERROR_MESSAGE);
 }
 
+async function lockActiveDocument(
+  tx: TenantTransaction,
+  args: { documentId: string; tenantId: string }
+) {
+  // db-access-guard: tenant-scoped -- reason: row lock is constrained by exact tenantId and documentId before claim AI extraction persistence
+  return tx.execute<{ id: string }>(sql`
+    select "id"
+    from "documents"
+    where "id" = ${args.documentId}
+      and "tenant_id" = ${args.tenantId}
+      and "deleted_at" is null
+    for update
+  `);
+}
+
 export async function persistClaimAiExtraction(args: {
   run: ClaimedClaimAiRun;
   extraction: Record<string, unknown>;
@@ -38,16 +53,10 @@ export async function persistClaimAiExtraction(args: {
   const completedAt = new Date();
 
   await withTenantContext({ tenantId: args.run.tenantId, role: 'system' }, async tx => {
-    const [activeDocument] = await tx
-      .select({ id: documents.id })
-      .from(documents)
-      .where(
-        and(
-          eq(documents.id, args.run.documentId),
-          eq(documents.tenantId, args.run.tenantId),
-          isNull(documents.deletedAt)
-        )
-      );
+    const [activeDocument] = await lockActiveDocument(tx, {
+      documentId: args.run.documentId,
+      tenantId: args.run.tenantId,
+    });
 
     if (!activeDocument) {
       await tx

--- a/apps/web/src/lib/ai/claim-pipeline-persist.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.ts
@@ -49,6 +49,7 @@ export async function persistClaimAiExtraction(args: {
           completedAt,
           errorCode: 'claim_ai_document_deleted',
           errorMessage: 'Claim AI run skipped because the source document was deleted.',
+          requestJson: {},
           outputJson: null,
           responseJson: null,
         })

--- a/apps/web/src/lib/ai/claim-pipeline-persist.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.ts
@@ -1,11 +1,11 @@
 import type { ExtractionCritique, ExtractionPipelineError } from '@/lib/ai/extraction-pipeline';
 import { withTenantContext } from '@interdomestik/database';
-import { aiRuns, documentExtractions } from '@interdomestik/database/schema';
+import { aiRuns, documentExtractions, documents } from '@interdomestik/database/schema';
 import {
   CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION,
   LEGAL_DOC_EXTRACT_SCHEMA_VERSION,
 } from '@interdomestik/domain-ai';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
 import type { ClaimedClaimAiRun, ClaimAiWorkflow } from './claim-pipeline-run';
@@ -30,6 +30,32 @@ export async function persistClaimAiExtraction(args: {
   const completedAt = new Date();
 
   await withTenantContext({ tenantId: args.run.tenantId, role: 'system' }, async tx => {
+    const [activeDocument] = await tx
+      .select({ id: documents.id })
+      .from(documents)
+      .where(
+        and(
+          eq(documents.id, args.run.documentId),
+          eq(documents.tenantId, args.run.tenantId),
+          isNull(documents.deletedAt)
+        )
+      );
+
+    if (!activeDocument) {
+      await tx
+        .update(aiRuns)
+        .set({
+          status: 'failed',
+          completedAt,
+          errorCode: 'claim_ai_document_deleted',
+          errorMessage: 'Claim AI run skipped because the source document was deleted.',
+          outputJson: null,
+          responseJson: null,
+        })
+        .where(eq(aiRuns.id, args.run.runId));
+      return;
+    }
+
     await tx
       .insert(documentExtractions)
       .values({

--- a/apps/web/src/lib/ai/claim-pipeline-persist.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-persist.ts
@@ -1,4 +1,4 @@
-import { ExtractionPipelineError, type ExtractionCritique } from '@/lib/ai/extraction-pipeline';
+import type { ExtractionCritique } from '@/lib/ai/extraction-pipeline';
 import { sql, type TenantTransaction, withTenantContext } from '@interdomestik/database';
 import { aiRuns, documentExtractions } from '@interdomestik/database/schema';
 import {
@@ -8,11 +8,11 @@ import {
 import { and, eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
+import {
+  buildDeletedClaimRunFailure,
+  throwDeletedClaimDocumentError,
+} from './claim-pipeline-document-lifecycle';
 import type { ClaimedClaimAiRun, ClaimAiWorkflow } from './claim-pipeline-run';
-
-const DELETED_DOCUMENT_ERROR_CODE = 'claim_ai_document_deleted';
-const DELETED_DOCUMENT_ERROR_MESSAGE =
-  'Claim AI run skipped because the source document was deleted.';
 
 function getEventName(workflow: ClaimAiWorkflow) {
   return workflow === 'legal_doc_extract'
@@ -24,10 +24,6 @@ function getSchemaVersion(workflow: ClaimAiWorkflow) {
   return workflow === 'legal_doc_extract'
     ? LEGAL_DOC_EXTRACT_SCHEMA_VERSION
     : CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION;
-}
-
-function throwDeletedDocumentError(): never {
-  throw new ExtractionPipelineError(DELETED_DOCUMENT_ERROR_CODE, DELETED_DOCUMENT_ERROR_MESSAGE);
 }
 
 async function lockActiveDocument(
@@ -61,17 +57,9 @@ export async function persistClaimAiExtraction(args: {
     if (!activeDocument) {
       await tx
         .update(aiRuns)
-        .set({
-          status: 'failed',
-          completedAt,
-          errorCode: DELETED_DOCUMENT_ERROR_CODE,
-          errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
-          requestJson: {},
-          outputJson: null,
-          responseJson: null,
-        })
+        .set(buildDeletedClaimRunFailure(completedAt))
         .where(eq(aiRuns.id, args.run.runId));
-      throwDeletedDocumentError();
+      throwDeletedClaimDocumentError();
     }
 
     await tx
@@ -127,17 +115,9 @@ export async function persistClaimAiExtraction(args: {
         );
       await tx
         .update(aiRuns)
-        .set({
-          status: 'failed',
-          completedAt,
-          errorCode: DELETED_DOCUMENT_ERROR_CODE,
-          errorMessage: DELETED_DOCUMENT_ERROR_MESSAGE,
-          requestJson: {},
-          outputJson: null,
-          responseJson: null,
-        })
+        .set(buildDeletedClaimRunFailure(completedAt))
         .where(eq(aiRuns.id, args.run.runId));
-      throwDeletedDocumentError();
+      throwDeletedClaimDocumentError();
     }
   });
 }

--- a/apps/web/src/lib/ai/claim-pipeline-run.document-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-run.document-lifecycle.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const where = vi.fn();
+  const secondJoin = { where };
+  const firstJoin = { innerJoin: vi.fn(() => secondJoin), where };
+  const fromResult = { innerJoin: vi.fn(() => firstJoin) };
+  const select = vi.fn(() => ({ from: vi.fn(() => fromResult) }));
+  return {
+    db: { select },
+    failDeletedDocumentClaimAiRun: vi.fn(),
+    firstInnerJoin: fromResult.innerJoin,
+    isNull: vi.fn((field: unknown) => ({ op: 'isNull', field })),
+    secondInnerJoin: firstJoin.innerJoin,
+    where,
+  };
+});
+
+vi.mock('@/lib/db.server', () => ({ db: mocks.db }));
+vi.mock('@interdomestik/database', () => ({ withTenantContext: vi.fn() }));
+vi.mock('./claim-pipeline-document-lifecycle', () => ({
+  failDeletedDocumentClaimAiRun: mocks.failDeletedDocumentClaimAiRun,
+}));
+vi.mock('@interdomestik/database/schema', () => ({
+  aiRuns: {
+    documentId: 'ai_runs.document_id',
+    entityId: 'ai_runs.entity_id',
+    entityType: 'ai_runs.entity_type',
+    id: 'ai_runs.id',
+    requestedBy: 'ai_runs.requested_by',
+    requestJson: 'ai_runs.request_json',
+    status: 'ai_runs.status',
+    tenantId: 'ai_runs.tenant_id',
+    workflow: 'ai_runs.workflow',
+  },
+  claims: {
+    category: 'claims.category',
+    claimAmount: 'claims.claim_amount',
+    currency: 'claims.currency',
+    description: 'claims.description',
+    id: 'claims.id',
+    tenantId: 'claims.tenant_id',
+    title: 'claims.title',
+    userId: 'claims.user_id',
+  },
+  documents: {
+    deletedAt: 'documents.deleted_at',
+    fileName: 'documents.file_name',
+    id: 'documents.id',
+    mimeType: 'documents.mime_type',
+    storagePath: 'documents.storage_path',
+    tenantId: 'documents.tenant_id',
+    uploadedAt: 'documents.uploaded_at',
+  },
+}));
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ op: 'eq', left, right })),
+  isNull: mocks.isNull,
+}));
+
+import { claimClaimAiRun } from './claim-pipeline-run';
+
+describe('claimClaimAiRun document lifecycle guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.where.mockResolvedValue([]);
+    mocks.failDeletedDocumentClaimAiRun.mockResolvedValue(null);
+  });
+
+  it('requires an active document row before claiming queued AI work', async () => {
+    await expect(claimClaimAiRun('run-1')).rejects.toThrow(
+      'Queued claim AI run run-1 was not found.'
+    );
+
+    expect(mocks.isNull).toHaveBeenCalledWith('documents.deleted_at');
+    expect(mocks.firstInnerJoin).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        args: expect.arrayContaining([
+          expect.objectContaining({ field: 'documents.deleted_at', op: 'isNull' }),
+        ]),
+      })
+    );
+    expect(mocks.failDeletedDocumentClaimAiRun).toHaveBeenCalledWith('run-1', expect.any(Function));
+  });
+
+  it('does not apply the deleted-document fallback to malformed active rows', async () => {
+    mocks.where.mockResolvedValue([
+      {
+        claimId: 'claim-1',
+        documentId: 'doc-1',
+        requestedBy: 'user-1',
+        status: 'queued',
+        subjectId: null,
+        workflow: 'claim_intake_extract',
+      },
+    ]);
+
+    await expect(claimClaimAiRun('run-1')).rejects.toThrow(
+      'Queued claim AI run run-1 was not found.'
+    );
+    expect(mocks.db.select).toHaveBeenCalledTimes(1);
+    expect(mocks.failDeletedDocumentClaimAiRun).not.toHaveBeenCalled();
+  });
+
+  it('returns skipped when the deleted-document fallback claims the lifecycle case', async () => {
+    mocks.failDeletedDocumentClaimAiRun.mockResolvedValue({
+      status: 'skipped',
+      claimId: 'claim-1',
+      workflow: 'claim_intake_extract',
+    });
+
+    await expect(claimClaimAiRun('run-1')).resolves.toEqual({
+      status: 'skipped',
+      claimId: 'claim-1',
+      workflow: 'claim_intake_extract',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/claim-pipeline-run.ts
+++ b/apps/web/src/lib/ai/claim-pipeline-run.ts
@@ -1,7 +1,9 @@
 import { db } from '@/lib/db.server';
 import { withTenantContext } from '@interdomestik/database';
 import { aiRuns, claims, documents } from '@interdomestik/database/schema';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { failDeletedDocumentClaimAiRun } from './claim-pipeline-document-lifecycle';
 
 export type ClaimAiWorkflow = 'claim_intake_extract' | 'legal_doc_extract';
 
@@ -59,15 +61,25 @@ export async function claimClaimAiRun(
     .from(aiRuns)
     .innerJoin(
       documents,
-      and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
+      and(
+        eq(documents.id, aiRuns.documentId),
+        eq(documents.tenantId, aiRuns.tenantId),
+        isNull(documents.deletedAt)
+      )
     )
     .innerJoin(claims, and(eq(claims.id, aiRuns.entityId), eq(claims.tenantId, aiRuns.tenantId)))
     .where(and(eq(aiRuns.id, runId), eq(aiRuns.entityType, 'claim')));
 
-  const requestedBy = typeof queuedRun?.requestedBy === 'string' ? queuedRun.requestedBy : '';
-  const subjectId = typeof queuedRun?.subjectId === 'string' ? queuedRun.subjectId : '';
+  if (!queuedRun) {
+    const deletedRun = await failDeletedDocumentClaimAiRun(runId, isClaimAiWorkflow);
+    if (deletedRun) return deletedRun;
+    throw new Error(`Queued claim AI run ${runId} was not found.`);
+  }
+
+  const requestedBy = typeof queuedRun.requestedBy === 'string' ? queuedRun.requestedBy : '';
+  const subjectId = typeof queuedRun.subjectId === 'string' ? queuedRun.subjectId : '';
   if (
-    !queuedRun?.documentId ||
+    !queuedRun.documentId ||
     !queuedRun.claimId ||
     !requestedBy ||
     !subjectId ||

--- a/apps/web/src/lib/ai/claim-workflows-critique.test.ts
+++ b/apps/web/src/lib/ai/claim-workflows-critique.test.ts
@@ -31,11 +31,12 @@ vi.mock('@interdomestik/database/schema', () => ({
   aiRuns: { __name: 'ai_runs', id: { __name: 'ai_runs.id' }, status: {}, entityType: {} },
   claims: { __name: 'claim', id: {}, tenantId: {} },
   documentExtractions: { __name: 'document_extractions', sourceRunId: {} },
-  documents: { __name: 'documents', id: {}, tenantId: {} },
+  documents: { __name: 'documents', deletedAt: {}, id: {}, tenantId: {} },
 }));
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ args })),
   eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+  isNull: vi.fn((field: unknown) => ({ field })),
 }));
 vi.mock('@interdomestik/domain-ai/claims/intake-extract', () => ({
   extractClaimIntake: mocks.extractClaimIntake,

--- a/apps/web/src/lib/ai/claim-workflows-dispatch.test.ts
+++ b/apps/web/src/lib/ai/claim-workflows-dispatch.test.ts
@@ -18,9 +18,9 @@ vi.mock('@interdomestik/database/schema', () => ({
   aiRuns: {},
   claims: {},
   documentExtractions: {},
-  documents: {},
+  documents: { deletedAt: {} },
 }));
-vi.mock('drizzle-orm', () => ({ and: vi.fn(), eq: vi.fn() }));
+vi.mock('drizzle-orm', () => ({ and: vi.fn(), eq: vi.fn(), isNull: vi.fn() }));
 vi.mock('nanoid', () => ({ nanoid: vi.fn() }));
 vi.mock('@interdomestik/domain-ai', () => ({
   CLAIM_INTAKE_EXTRACT_SCHEMA_VERSION: 'claim-schema',

--- a/apps/web/src/lib/ai/claim-workflows-persist-failure.test.ts
+++ b/apps/web/src/lib/ai/claim-workflows-persist-failure.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  claimClaimAiRun: vi.fn(),
+  critiqueExtraction: vi.fn(),
+  extractClaimAiCandidate: vi.fn(),
+  loadClaimAiInput: vi.fn(),
+  markClaimAiRunFailed: vi.fn(),
+  persistClaimAiExtraction: vi.fn(),
+  validateClaimAiCandidate: vi.fn(),
+}));
+
+vi.mock('@/lib/inngest/client', () => ({ inngest: { send: vi.fn() } }));
+vi.mock('@/lib/reliability/transient-retry', () => ({
+  throwTransientRetryFailure: vi.fn(),
+  withTransientRetry: vi.fn(async (callback: () => unknown) => ({
+    ok: true,
+    value: await callback(),
+  })),
+}));
+vi.mock('@/lib/ai/dispatch-failure', () => ({ markAiRunDispatchFailedWithTenantContext: vi.fn() }));
+vi.mock('@/lib/ai/claim-storage-download', () => ({ downloadClaimAiFileWithRetry: vi.fn() }));
+vi.mock('./claim-pipeline-run', () => ({ claimClaimAiRun: mocks.claimClaimAiRun }));
+vi.mock('./claim-pipeline-input', () => ({
+  extractClaimAiCandidate: mocks.extractClaimAiCandidate,
+  loadClaimAiInput: mocks.loadClaimAiInput,
+  validateClaimAiCandidate: mocks.validateClaimAiCandidate,
+}));
+vi.mock('./claim-pipeline-persist', () => ({
+  persistClaimAiExtraction: mocks.persistClaimAiExtraction,
+}));
+vi.mock('./claim-pipeline-failure', () => ({ markClaimAiRunFailed: mocks.markClaimAiRunFailed }));
+vi.mock('@/lib/ai/extraction-pipeline', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/ai/extraction-pipeline')>();
+  return { ...actual, critiqueExtraction: mocks.critiqueExtraction };
+});
+
+import { ExtractionPipelineError } from '@/lib/ai/extraction-pipeline';
+
+import { processClaimDocumentWorkflowRunService } from './claim-workflows';
+
+const run = {
+  runId: 'run-1',
+  tenantId: 'tenant-1',
+  workflow: 'claim_intake_extract' as const,
+  documentId: 'doc-1',
+  claimId: 'claim-1',
+  requestedBy: 'user-1',
+  subjectId: 'member-1',
+  storagePath: 'path',
+  fileName: 'file.pdf',
+  mimeType: 'application/pdf',
+  uploadedAt: new Date('2026-03-08T10:00:00.000Z'),
+  requestJson: {},
+  claimTitle: 'Claim',
+  claimDescription: null,
+  claimCategory: 'travel',
+  claimAmount: null,
+  claimCurrency: 'EUR',
+};
+
+describe('processClaimDocumentWorkflowRunService persist failure', () => {
+  it('returns failed when persistence rejects a deleted-document run', async () => {
+    mocks.claimClaimAiRun.mockResolvedValue({ status: 'claimed', run });
+    mocks.loadClaimAiInput.mockResolvedValue({ metrics: { hasText: true } });
+    mocks.extractClaimAiCandidate.mockResolvedValue({
+      candidate: {},
+      rawConfidence: 0.8,
+      warnings: [],
+    });
+    mocks.validateClaimAiCandidate.mockReturnValue({ summary: 'derived PII' });
+    mocks.critiqueExtraction.mockReturnValue({
+      decision: 'needs_human_review',
+      confidence: 0.8,
+      warnings: [],
+      warningCodes: [],
+      escalationRecommended: false,
+      persistenceAllowed: true,
+    });
+    mocks.persistClaimAiExtraction.mockRejectedValue(
+      new ExtractionPipelineError('claim_ai_document_deleted', 'Document was deleted.')
+    );
+
+    await expect(processClaimDocumentWorkflowRunService({ runId: 'run-1' })).resolves.toEqual({
+      status: 'failed',
+      runId: 'run-1',
+      claimId: 'claim-1',
+      workflow: 'claim_intake_extract',
+    });
+    expect(mocks.markClaimAiRunFailed).toHaveBeenCalledWith({
+      run,
+      error: expect.objectContaining({ errorCode: 'claim_ai_document_deleted' }),
+    });
+  });
+});

--- a/apps/web/src/lib/ai/claim-workflows.test.ts
+++ b/apps/web/src/lib/ai/claim-workflows.test.ts
@@ -5,26 +5,16 @@ const mocks = vi.hoisted(() => {
   const txInsertValues = vi.fn();
   const txInsert = vi.fn(() => ({ values: txInsertValues }));
   const txUpdateReturning = vi.fn();
-  const txUpdateWhere = vi.fn(() => ({
-    returning: txUpdateReturning,
-  }));
-  const txUpdateSet = vi.fn(() => ({
-    where: txUpdateWhere,
-  }));
+  const txUpdateWhere = vi.fn(() => ({ returning: txUpdateReturning }));
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
   const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
+  const txExecute = vi.fn();
   const selectWhere = vi.fn();
-  const selectInnerJoin = vi.fn(() => ({
-    innerJoin: selectInnerJoin,
-    where: selectWhere,
-  }));
-  const selectFrom = vi.fn(() => ({
-    innerJoin: selectInnerJoin,
-    where: selectWhere,
-  }));
-  const select = vi.fn(() => ({
-    from: selectFrom,
-  }));
+  const selectInnerJoin = vi.fn(() => ({ innerJoin: selectInnerJoin, where: selectWhere }));
+  const selectFrom = vi.fn(() => ({ innerJoin: selectInnerJoin, where: selectWhere }));
+  const select = vi.fn(() => ({ from: selectFrom }));
   const tenantWriteTx = {
+    execute: txExecute,
     insert: txInsert,
     select,
     update: txUpdate,
@@ -32,11 +22,7 @@ const mocks = vi.hoisted(() => {
   const transaction = vi.fn(
     async (
       callback: (tx: { insert: typeof txInsert; update: typeof txUpdate }) => Promise<unknown>
-    ) =>
-      callback({
-        insert: txInsert,
-        update: txUpdate,
-      })
+    ) => callback({ insert: txInsert, update: txUpdate })
   );
 
   const updateReturning = vi.fn();
@@ -67,6 +53,7 @@ const mocks = vi.hoisted(() => {
     txInsert,
     txInsertOnConflictDoNothing,
     txInsertValues,
+    txExecute,
     txUpdate,
     txUpdateReturning,
     txUpdateSet,
@@ -94,6 +81,7 @@ vi.mock('@/lib/storage/evidence-bucket', () => ({
 }));
 
 vi.mock('@interdomestik/database', () => ({
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
   withTenantContext: mocks.withTenantContext,
 }));
 
@@ -237,6 +225,7 @@ describe('processClaimDocumentWorkflowRunService', () => {
     mocks.txInsertValues.mockImplementation(() => ({
       onConflictDoNothing: mocks.txInsertOnConflictDoNothing,
     }));
+    mocks.txExecute.mockResolvedValue([{ id: 'doc-1' }]);
     mocks.txUpdateReturning.mockResolvedValue([{ id: 'run-1' }]);
   });
 

--- a/apps/web/src/lib/ai/claim-workflows.test.ts
+++ b/apps/web/src/lib/ai/claim-workflows.test.ts
@@ -3,9 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => {
   const txInsertOnConflictDoNothing = vi.fn().mockResolvedValue(undefined);
   const txInsertValues = vi.fn();
-  const txInsert = vi.fn(() => ({
-    values: txInsertValues,
-  }));
+  const txInsert = vi.fn(() => ({ values: txInsertValues }));
   const txUpdateReturning = vi.fn();
   const txUpdateWhere = vi.fn(() => ({
     returning: txUpdateReturning,
@@ -13,23 +11,7 @@ const mocks = vi.hoisted(() => {
   const txUpdateSet = vi.fn(() => ({
     where: txUpdateWhere,
   }));
-  const txUpdate = vi.fn(() => ({
-    set: txUpdateSet,
-  }));
-  const tenantWriteTx = {
-    insert: txInsert,
-    update: txUpdate,
-  };
-  const transaction = vi.fn(
-    async (
-      callback: (tx: { insert: typeof txInsert; update: typeof txUpdate }) => Promise<unknown>
-    ) =>
-      callback({
-        insert: txInsert,
-        update: txUpdate,
-      })
-  );
-
+  const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
   const selectWhere = vi.fn();
   const selectInnerJoin = vi.fn(() => ({
     innerJoin: selectInnerJoin,
@@ -42,6 +24,21 @@ const mocks = vi.hoisted(() => {
   const select = vi.fn(() => ({
     from: selectFrom,
   }));
+  const tenantWriteTx = {
+    insert: txInsert,
+    select,
+    update: txUpdate,
+  };
+  const transaction = vi.fn(
+    async (
+      callback: (tx: { insert: typeof txInsert; update: typeof txUpdate }) => Promise<unknown>
+    ) =>
+      callback({
+        insert: txInsert,
+        update: txUpdate,
+      })
+  );
+
   const updateReturning = vi.fn();
   const updateWhere = vi.fn(() => ({
     returning: updateReturning,
@@ -107,12 +104,12 @@ vi.mock('@interdomestik/database/schema', () => ({
     __name: 'document_extractions',
     sourceRunId: { __name: 'document_extractions.source_run_id' },
   },
-  documents: { __name: 'documents', id: { __name: 'documents.id' } },
+  documents: { __name: 'documents', deletedAt: {}, id: { __name: 'documents.id' } },
 }));
-
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ __op: 'and', args })),
   eq: vi.fn((left: unknown, right: unknown) => ({ __op: 'eq', left, right })),
+  isNull: vi.fn((field: unknown) => ({ __op: 'isNull', field })),
 }));
 
 vi.mock('nanoid', () => ({

--- a/apps/web/src/lib/ai/claim-workflows.ts
+++ b/apps/web/src/lib/ai/claim-workflows.ts
@@ -10,7 +10,8 @@ import {
   validateClaimAiCandidate,
   type ClaimPipelineDeps,
 } from './claim-pipeline-input';
-import { markClaimAiRunFailed, persistClaimAiExtraction } from './claim-pipeline-persist';
+import { markClaimAiRunFailed } from './claim-pipeline-failure';
+import { persistClaimAiExtraction } from './claim-pipeline-persist';
 import { claimClaimAiRun, type ClaimAiWorkflow } from './claim-pipeline-run';
 
 type QueuedClaimAiRun = {

--- a/apps/web/src/lib/ai/document-run-lifecycle.ts
+++ b/apps/web/src/lib/ai/document-run-lifecycle.ts
@@ -1,0 +1,56 @@
+import { ExtractionPipelineError } from '@/lib/ai/extraction-pipeline';
+import { db } from '@/lib/db.server';
+import { aiRuns, documents } from '@interdomestik/database/schema';
+import { and, eq, isNull } from 'drizzle-orm';
+
+export type DeletedDocumentFailure = {
+  errorCode: string;
+  errorMessage: string;
+};
+
+type ProcessingRunDocument = {
+  runId: string;
+  tenantId: string;
+  documentId: string;
+};
+
+export function buildDeletedDocumentFailure(completedAt: Date, failure: DeletedDocumentFailure) {
+  return {
+    status: 'failed' as const,
+    completedAt,
+    errorCode: failure.errorCode,
+    errorMessage: failure.errorMessage,
+    requestJson: {},
+    outputJson: null,
+    responseJson: null,
+  };
+}
+
+export function throwDeletedDocumentError(failure: DeletedDocumentFailure): never {
+  throw new ExtractionPipelineError(failure.errorCode, failure.errorMessage);
+}
+
+export async function assertProcessingRunHasActiveDocument(
+  run: ProcessingRunDocument,
+  failure: DeletedDocumentFailure
+) {
+  // db-access-guard: tenant-scoped -- reason: pre-download liveness check is constrained by exact runId, tenantId, and documentId before AI document processing
+  const [activeRun] = await db
+    .select({ id: aiRuns.id })
+    .from(aiRuns)
+    .innerJoin(
+      documents,
+      and(eq(documents.id, aiRuns.documentId), eq(documents.tenantId, aiRuns.tenantId))
+    )
+    .where(
+      and(
+        eq(aiRuns.id, run.runId),
+        eq(aiRuns.status, 'processing'),
+        eq(documents.id, run.documentId),
+        eq(documents.tenantId, run.tenantId),
+        isNull(documents.deletedAt)
+      )
+    );
+
+  if (!activeRun) throwDeletedDocumentError(failure);
+}

--- a/packages/domain-documents/src/document-lifecycle.test.ts
+++ b/packages/domain-documents/src/document-lifecycle.test.ts
@@ -28,6 +28,7 @@ vi.mock('@interdomestik/database/schema', () => ({
   aiRuns: {
     completedAt: 'ai_runs.completed_at',
     documentId: 'ai_runs.document_id',
+    entityType: 'ai_runs.entity_type',
     errorCode: 'ai_runs.error_code',
     errorMessage: 'ai_runs.error_message',
     outputJson: 'ai_runs.output_json',
@@ -84,6 +85,7 @@ describe('softDeleteDocument', () => {
     expect(mocks.updateSet).toHaveBeenNthCalledWith(2, {
       requestJson: {},
       outputJson: null,
+      requestJson: {},
       responseJson: null,
     });
     expect(mocks.updateSet).toHaveBeenNthCalledWith(
@@ -93,9 +95,11 @@ describe('softDeleteDocument', () => {
         errorCode: 'claim_ai_document_deleted',
         requestJson: {},
         outputJson: null,
+        requestJson: {},
         responseJson: null,
       })
     );
+    expect(mocks.eq).toHaveBeenCalledWith('ai_runs.entity_type', 'claim');
     expect(mocks.inArray).toHaveBeenCalledWith('ai_runs.status', [
       'queued',
       'processing',

--- a/packages/domain-documents/src/document-lifecycle.test.ts
+++ b/packages/domain-documents/src/document-lifecycle.test.ts
@@ -31,6 +31,7 @@ vi.mock('@interdomestik/database/schema', () => ({
     errorCode: 'ai_runs.error_code',
     errorMessage: 'ai_runs.error_message',
     outputJson: 'ai_runs.output_json',
+    requestJson: 'ai_runs.request_json',
     responseJson: 'ai_runs.response_json',
     status: 'ai_runs.status',
     tenantId: 'ai_runs.tenant_id',
@@ -81,6 +82,7 @@ describe('softDeleteDocument', () => {
       expect.objectContaining({ documentId: 'ai_runs.document_id' })
     );
     expect(mocks.updateSet).toHaveBeenNthCalledWith(2, {
+      requestJson: {},
       outputJson: null,
       responseJson: null,
     });
@@ -89,6 +91,7 @@ describe('softDeleteDocument', () => {
       expect.objectContaining({
         status: 'failed',
         errorCode: 'claim_ai_document_deleted',
+        requestJson: {},
         outputJson: null,
         responseJson: null,
       })

--- a/packages/domain-documents/src/document-lifecycle.test.ts
+++ b/packages/domain-documents/src/document-lifecycle.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => {
   const deleteWhere = vi.fn();
   const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
+  const updateReturning = vi.fn();
   const updateWhere = vi.fn();
-  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const updateWhereReturning = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhereReturning }));
   const update = vi.fn(() => ({ set: updateSet }));
   const tx = { delete: deleteFrom, update };
 
@@ -18,8 +20,10 @@ const mocks = vi.hoisted(() => {
     logAuditEvent: vi.fn(),
     tx,
     update,
+    updateReturning,
     updateSet,
     updateWhere,
+    updateWhereReturning,
   };
 });
 
@@ -44,8 +48,17 @@ vi.mock('@interdomestik/database/schema', () => ({
   documents: {
     deletedAt: 'documents.deleted_at',
     deletedBy: 'documents.deleted_by',
+    entityId: 'documents.entity_id',
+    entityType: 'documents.entity_type',
     id: 'documents.id',
     tenantId: 'documents.tenant_id',
+  },
+  policies: {
+    analysisJson: 'policies.analysis_json',
+    id: 'policies.id',
+    policyNumber: 'policies.policy_number',
+    provider: 'policies.provider',
+    tenantId: 'policies.tenant_id',
   },
 }));
 vi.mock('drizzle-orm', () => ({
@@ -61,6 +74,8 @@ describe('softDeleteDocument', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('soft-deletes the document and clears AI-derived data for the tenant document', async () => {
+    mocks.updateReturning.mockResolvedValue([{ entityType: 'policy', entityId: 'policy-1' }]);
+
     await softDeleteDocument({
       tenantId: 'tenant-1',
       documentId: 'doc-1',
@@ -68,21 +83,24 @@ describe('softDeleteDocument', () => {
     });
 
     expect(mocks.db.transaction).toHaveBeenCalledTimes(1);
-    expect(mocks.update).toHaveBeenNthCalledWith(1, {
-      deletedAt: 'documents.deleted_at',
-      deletedBy: 'documents.deleted_by',
-      id: 'documents.id',
-      tenantId: 'documents.tenant_id',
-    });
-    expect(mocks.deleteFrom).toHaveBeenCalledWith({
-      documentId: 'document_extractions.document_id',
-      tenantId: 'document_extractions.tenant_id',
-    });
+    expect(mocks.update).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        deletedAt: 'documents.deleted_at',
+        deletedBy: 'documents.deleted_by',
+        id: 'documents.id',
+        tenantId: 'documents.tenant_id',
+      })
+    );
     expect(mocks.update).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ documentId: 'ai_runs.document_id' })
     );
     expect(mocks.updateSet).toHaveBeenNthCalledWith(2, {
+      status: 'failed',
+      completedAt: expect.any(Date),
+      errorCode: 'document_ai_document_deleted',
+      errorMessage: 'AI run skipped because the source document was deleted.',
       requestJson: {},
       outputJson: null,
       responseJson: null,
@@ -90,19 +108,29 @@ describe('softDeleteDocument', () => {
     expect(mocks.updateSet).toHaveBeenNthCalledWith(
       3,
       expect.objectContaining({
-        status: 'failed',
         errorCode: 'claim_ai_document_deleted',
-        requestJson: {},
-        outputJson: null,
-        responseJson: null,
       })
     );
+    expect(mocks.updateSet).toHaveBeenNthCalledWith(4, {
+      requestJson: {},
+      outputJson: null,
+      responseJson: null,
+    });
     expect(mocks.eq).toHaveBeenCalledWith('ai_runs.entity_type', 'claim');
     expect(mocks.inArray).toHaveBeenCalledWith('ai_runs.status', [
       'queued',
       'processing',
       'in_progress',
     ]);
+    expect(mocks.deleteFrom).toHaveBeenCalledWith({
+      documentId: 'document_extractions.document_id',
+      tenantId: 'document_extractions.tenant_id',
+    });
+    expect(mocks.updateSet).toHaveBeenLastCalledWith({
+      analysisJson: {},
+      provider: null,
+      policyNumber: null,
+    });
     expect(mocks.logAuditEvent).toHaveBeenCalledWith({
       tenantId: 'tenant-1',
       documentId: 'doc-1',

--- a/packages/domain-documents/src/document-lifecycle.test.ts
+++ b/packages/domain-documents/src/document-lifecycle.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const deleteWhere = vi.fn();
+  const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
+  const updateWhere = vi.fn();
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+  const tx = { delete: deleteFrom, update };
+
+  return {
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, op: 'and' })),
+    db: { transaction: vi.fn(async (callback: (txArg: typeof tx) => unknown) => callback(tx)) },
+    deleteFrom,
+    deleteWhere,
+    eq: vi.fn((left: unknown, right: unknown) => ({ left, right, op: 'eq' })),
+    inArray: vi.fn((field: unknown, values: unknown[]) => ({ field, op: 'inArray', values })),
+    logAuditEvent: vi.fn(),
+    tx,
+    update,
+    updateSet,
+    updateWhere,
+  };
+});
+
+vi.mock('@interdomestik/database/db', () => ({ db: mocks.db }));
+vi.mock('@interdomestik/database/schema', () => ({
+  aiRuns: {
+    completedAt: 'ai_runs.completed_at',
+    documentId: 'ai_runs.document_id',
+    errorCode: 'ai_runs.error_code',
+    errorMessage: 'ai_runs.error_message',
+    outputJson: 'ai_runs.output_json',
+    responseJson: 'ai_runs.response_json',
+    status: 'ai_runs.status',
+    tenantId: 'ai_runs.tenant_id',
+  },
+  documentExtractions: {
+    documentId: 'document_extractions.document_id',
+    tenantId: 'document_extractions.tenant_id',
+  },
+  documents: {
+    deletedAt: 'documents.deleted_at',
+    deletedBy: 'documents.deleted_by',
+    id: 'documents.id',
+    tenantId: 'documents.tenant_id',
+  },
+}));
+vi.mock('drizzle-orm', () => ({
+  and: mocks.and,
+  eq: mocks.eq,
+  inArray: mocks.inArray,
+}));
+vi.mock('./audit', () => ({ logAuditEvent: mocks.logAuditEvent }));
+
+import { softDeleteDocument } from './document-lifecycle';
+
+describe('softDeleteDocument', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('soft-deletes the document and clears AI-derived data for the tenant document', async () => {
+    await softDeleteDocument({
+      tenantId: 'tenant-1',
+      documentId: 'doc-1',
+      deletedBy: 'admin-1',
+    });
+
+    expect(mocks.db.transaction).toHaveBeenCalledTimes(1);
+    expect(mocks.update).toHaveBeenNthCalledWith(1, {
+      deletedAt: 'documents.deleted_at',
+      deletedBy: 'documents.deleted_by',
+      id: 'documents.id',
+      tenantId: 'documents.tenant_id',
+    });
+    expect(mocks.deleteFrom).toHaveBeenCalledWith({
+      documentId: 'document_extractions.document_id',
+      tenantId: 'document_extractions.tenant_id',
+    });
+    expect(mocks.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ documentId: 'ai_runs.document_id' })
+    );
+    expect(mocks.updateSet).toHaveBeenNthCalledWith(2, {
+      outputJson: null,
+      responseJson: null,
+    });
+    expect(mocks.updateSet).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        status: 'failed',
+        errorCode: 'claim_ai_document_deleted',
+        outputJson: null,
+        responseJson: null,
+      })
+    );
+    expect(mocks.inArray).toHaveBeenCalledWith('ai_runs.status', [
+      'queued',
+      'processing',
+      'in_progress',
+    ]);
+    expect(mocks.logAuditEvent).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      documentId: 'doc-1',
+      accessType: 'delete',
+      accessedBy: 'admin-1',
+    });
+  });
+});

--- a/packages/domain-documents/src/document-lifecycle.test.ts
+++ b/packages/domain-documents/src/document-lifecycle.test.ts
@@ -85,7 +85,6 @@ describe('softDeleteDocument', () => {
     expect(mocks.updateSet).toHaveBeenNthCalledWith(2, {
       requestJson: {},
       outputJson: null,
-      requestJson: {},
       responseJson: null,
     });
     expect(mocks.updateSet).toHaveBeenNthCalledWith(
@@ -95,7 +94,6 @@ describe('softDeleteDocument', () => {
         errorCode: 'claim_ai_document_deleted',
         requestJson: {},
         outputJson: null,
-        requestJson: {},
         responseJson: null,
       })
     );

--- a/packages/domain-documents/src/document-lifecycle.ts
+++ b/packages/domain-documents/src/document-lifecycle.ts
@@ -1,0 +1,70 @@
+import { db } from '@interdomestik/database/db';
+import * as schema from '@interdomestik/database/schema';
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { logAuditEvent } from './audit';
+
+const DELETED_DOCUMENT_RUN_STATUSES = ['queued', 'processing', 'in_progress'];
+
+/**
+ * Soft delete a document and purge AI-derived document payloads.
+ * The source file remains in storage but database reads must no longer expose it.
+ */
+export async function softDeleteDocument(params: {
+  tenantId: string;
+  documentId: string;
+  deletedBy: string;
+}): Promise<void> {
+  const { tenantId, documentId, deletedBy } = params;
+  const deletedAt = new Date();
+
+  await db.transaction(async tx => {
+    // db-access-guard: tenant-scoped -- reason: document soft-delete is constrained by exact tenantId and documentId.
+    await tx
+      .update(schema.documents)
+      .set({ deletedAt, deletedBy })
+      .where(and(eq(schema.documents.id, documentId), eq(schema.documents.tenantId, tenantId)));
+
+    // db-access-guard: tenant-scoped -- reason: derived extraction purge is constrained by exact tenantId and documentId.
+    await tx
+      .delete(schema.documentExtractions)
+      .where(
+        and(
+          eq(schema.documentExtractions.documentId, documentId),
+          eq(schema.documentExtractions.tenantId, tenantId)
+        )
+      );
+
+    // db-access-guard: tenant-scoped -- reason: AI output redaction is constrained by exact tenantId and documentId.
+    await tx
+      .update(schema.aiRuns)
+      .set({ outputJson: null, responseJson: null })
+      .where(and(eq(schema.aiRuns.documentId, documentId), eq(schema.aiRuns.tenantId, tenantId)));
+
+    // db-access-guard: tenant-scoped -- reason: non-terminal AI run failure is constrained by exact tenantId, documentId, and status.
+    await tx
+      .update(schema.aiRuns)
+      .set({
+        status: 'failed',
+        completedAt: deletedAt,
+        errorCode: 'claim_ai_document_deleted',
+        errorMessage: 'Claim AI run skipped because the source document was deleted.',
+        outputJson: null,
+        responseJson: null,
+      })
+      .where(
+        and(
+          eq(schema.aiRuns.documentId, documentId),
+          eq(schema.aiRuns.tenantId, tenantId),
+          inArray(schema.aiRuns.status, DELETED_DOCUMENT_RUN_STATUSES)
+        )
+      );
+  });
+
+  await logAuditEvent({
+    tenantId,
+    documentId,
+    accessType: 'delete',
+    accessedBy: deletedBy,
+  });
+}

--- a/packages/domain-documents/src/document-lifecycle.ts
+++ b/packages/domain-documents/src/document-lifecycle.ts
@@ -38,7 +38,7 @@ export async function softDeleteDocument(params: {
     // db-access-guard: tenant-scoped -- reason: AI output redaction is constrained by exact tenantId and documentId.
     await tx
       .update(schema.aiRuns)
-      .set({ outputJson: null, responseJson: null })
+      .set({ requestJson: {}, outputJson: null, responseJson: null })
       .where(and(eq(schema.aiRuns.documentId, documentId), eq(schema.aiRuns.tenantId, tenantId)));
 
     // db-access-guard: tenant-scoped -- reason: non-terminal AI run failure is constrained by exact tenantId, documentId, and status.
@@ -49,6 +49,7 @@ export async function softDeleteDocument(params: {
         completedAt: deletedAt,
         errorCode: 'claim_ai_document_deleted',
         errorMessage: 'Claim AI run skipped because the source document was deleted.',
+        requestJson: {},
         outputJson: null,
         responseJson: null,
       })

--- a/packages/domain-documents/src/document-lifecycle.ts
+++ b/packages/domain-documents/src/document-lifecycle.ts
@@ -41,7 +41,7 @@ export async function softDeleteDocument(params: {
       .set({ requestJson: {}, outputJson: null, responseJson: null })
       .where(and(eq(schema.aiRuns.documentId, documentId), eq(schema.aiRuns.tenantId, tenantId)));
 
-    // db-access-guard: tenant-scoped -- reason: non-terminal AI run failure is constrained by exact tenantId, documentId, and status.
+    // db-access-guard: tenant-scoped -- reason: non-terminal claim AI run failure is constrained by exact tenantId, documentId, entity type, and status.
     await tx
       .update(schema.aiRuns)
       .set({
@@ -57,6 +57,7 @@ export async function softDeleteDocument(params: {
         and(
           eq(schema.aiRuns.documentId, documentId),
           eq(schema.aiRuns.tenantId, tenantId),
+          eq(schema.aiRuns.entityType, 'claim'),
           inArray(schema.aiRuns.status, DELETED_DOCUMENT_RUN_STATUSES)
         )
       );

--- a/packages/domain-documents/src/document-lifecycle.ts
+++ b/packages/domain-documents/src/document-lifecycle.ts
@@ -5,6 +5,8 @@ import { and, eq, inArray } from 'drizzle-orm';
 import { logAuditEvent } from './audit';
 
 const DELETED_DOCUMENT_RUN_STATUSES = ['queued', 'processing', 'in_progress'];
+const DOCUMENT_AI_DELETED_CODE = 'document_ai_document_deleted';
+const DOCUMENT_AI_DELETED_MESSAGE = 'AI run skipped because the source document was deleted.';
 
 /**
  * Soft delete a document and purge AI-derived document payloads.
@@ -20,18 +22,47 @@ export async function softDeleteDocument(params: {
 
   await db.transaction(async tx => {
     // db-access-guard: tenant-scoped -- reason: document soft-delete is constrained by exact tenantId and documentId.
-    await tx
+    const [deletedDocument] = await tx
       .update(schema.documents)
       .set({ deletedAt, deletedBy })
-      .where(and(eq(schema.documents.id, documentId), eq(schema.documents.tenantId, tenantId)));
+      .where(and(eq(schema.documents.id, documentId), eq(schema.documents.tenantId, tenantId)))
+      .returning({
+        entityId: schema.documents.entityId,
+        entityType: schema.documents.entityType,
+      });
 
-    // db-access-guard: tenant-scoped -- reason: derived extraction purge is constrained by exact tenantId and documentId.
+    // db-access-guard: tenant-scoped -- reason: non-terminal AI run failure is constrained by exact tenantId, documentId, and status.
     await tx
-      .delete(schema.documentExtractions)
+      .update(schema.aiRuns)
+      .set({
+        status: 'failed',
+        completedAt: deletedAt,
+        errorCode: DOCUMENT_AI_DELETED_CODE,
+        errorMessage: DOCUMENT_AI_DELETED_MESSAGE,
+        requestJson: {},
+        outputJson: null,
+        responseJson: null,
+      })
       .where(
         and(
-          eq(schema.documentExtractions.documentId, documentId),
-          eq(schema.documentExtractions.tenantId, tenantId)
+          eq(schema.aiRuns.documentId, documentId),
+          eq(schema.aiRuns.tenantId, tenantId),
+          inArray(schema.aiRuns.status, DELETED_DOCUMENT_RUN_STATUSES)
+        )
+      );
+
+    // db-access-guard: tenant-scoped -- reason: claim run error-code compatibility is constrained by exact tenantId, documentId, and entity type.
+    await tx
+      .update(schema.aiRuns)
+      .set({
+        errorCode: 'claim_ai_document_deleted',
+        errorMessage: 'Claim AI run skipped because the source document was deleted.',
+      })
+      .where(
+        and(
+          eq(schema.aiRuns.documentId, documentId),
+          eq(schema.aiRuns.tenantId, tenantId),
+          eq(schema.aiRuns.entityType, 'claim')
         )
       );
 
@@ -41,26 +72,28 @@ export async function softDeleteDocument(params: {
       .set({ requestJson: {}, outputJson: null, responseJson: null })
       .where(and(eq(schema.aiRuns.documentId, documentId), eq(schema.aiRuns.tenantId, tenantId)));
 
-    // db-access-guard: tenant-scoped -- reason: non-terminal claim AI run failure is constrained by exact tenantId, documentId, entity type, and status.
+    // db-access-guard: tenant-scoped -- reason: derived extraction purge is constrained by exact tenantId and documentId after in-flight runs are failed.
     await tx
-      .update(schema.aiRuns)
-      .set({
-        status: 'failed',
-        completedAt: deletedAt,
-        errorCode: 'claim_ai_document_deleted',
-        errorMessage: 'Claim AI run skipped because the source document was deleted.',
-        requestJson: {},
-        outputJson: null,
-        responseJson: null,
-      })
+      .delete(schema.documentExtractions)
       .where(
         and(
-          eq(schema.aiRuns.documentId, documentId),
-          eq(schema.aiRuns.tenantId, tenantId),
-          eq(schema.aiRuns.entityType, 'claim'),
-          inArray(schema.aiRuns.status, DELETED_DOCUMENT_RUN_STATUSES)
+          eq(schema.documentExtractions.documentId, documentId),
+          eq(schema.documentExtractions.tenantId, tenantId)
         )
       );
+
+    if (deletedDocument?.entityType === 'policy' && deletedDocument.entityId) {
+      // db-access-guard: tenant-scoped -- reason: policy AI projection redaction is constrained by exact tenantId and policy id.
+      await tx
+        .update(schema.policies)
+        .set({ analysisJson: {}, provider: null, policyNumber: null })
+        .where(
+          and(
+            eq(schema.policies.id, deletedDocument.entityId),
+            eq(schema.policies.tenantId, tenantId)
+          )
+        );
+    }
   });
 
   await logAuditEvent({

--- a/packages/domain-documents/src/upload.test.ts
+++ b/packages/domain-documents/src/upload.test.ts
@@ -8,14 +8,10 @@ const mocks = vi.hoisted(() => {
   const selectFrom = vi.fn(() => ({ where: selectWhere }));
   const select = vi.fn(() => ({ from: selectFrom }));
 
-  const updateWhere = vi.fn();
-  const updateSet = vi.fn(() => ({ where: updateWhere }));
-  const update = vi.fn(() => ({ set: updateSet }));
-
   return {
     and: vi.fn((...conditions: unknown[]) => ({ conditions, op: 'and' })),
     captureAudit: vi.fn(),
-    db: { insert, select, update },
+    db: { insert, select },
     eq: vi.fn((left: unknown, right: unknown) => ({ left, right, op: 'eq' })),
     insert,
     insertValues,
@@ -25,9 +21,6 @@ const mocks = vi.hoisted(() => {
     select,
     selectFrom,
     selectWhere,
-    update,
-    updateSet,
-    updateWhere,
   };
 });
 
@@ -60,7 +53,7 @@ vi.mock('./audit', () => ({
   logAuditEvent: mocks.logAuditEvent,
 }));
 
-import { getDocumentsForEntity, recordUpload, softDeleteDocument } from './upload';
+import { getDocumentsForEntity, recordUpload } from './upload';
 
 describe('document upload helpers', () => {
   beforeEach(() => {
@@ -145,32 +138,5 @@ describe('document upload helpers', () => {
       tenantId: 'documents.tenantId',
     });
     expect(mocks.selectWhere).toHaveBeenCalledTimes(1);
-  });
-
-  it('soft-deletes tenant-scoped documents and logs the deletion', async () => {
-    await softDeleteDocument({
-      tenantId: 'tenant-1',
-      documentId: 'doc-1',
-      deletedBy: 'admin-1',
-    });
-
-    expect(mocks.update).toHaveBeenCalledWith({
-      deletedAt: 'documents.deletedAt',
-      entityId: 'documents.entityId',
-      entityType: 'documents.entityType',
-      id: 'documents.id',
-      tenantId: 'documents.tenantId',
-    });
-    expect(mocks.updateSet).toHaveBeenCalledWith({
-      deletedAt: expect.any(Date),
-      deletedBy: 'admin-1',
-    });
-    expect(mocks.updateWhere).toHaveBeenCalledTimes(1);
-    expect(mocks.logAuditEvent).toHaveBeenCalledWith({
-      tenantId: 'tenant-1',
-      documentId: 'doc-1',
-      accessType: 'delete',
-      accessedBy: 'admin-1',
-    });
   });
 });

--- a/packages/domain-documents/src/upload.ts
+++ b/packages/domain-documents/src/upload.ts
@@ -1,9 +1,3 @@
-/**
- * Document Upload - M3.1
- *
- * Upload handler that stores documents with tenant isolation
- * and emits audit events for all uploads.
- */
 import { db } from '@interdomestik/database/db';
 import * as schema from '@interdomestik/database/schema';
 import { and, eq, isNull } from 'drizzle-orm';
@@ -11,6 +5,8 @@ import { nanoid } from 'nanoid';
 
 import { captureAudit, logAuditEvent } from './audit';
 import { buildStoragePath, validateTenantOwnership } from './storage';
+
+export { softDeleteDocument } from './document-lifecycle';
 
 export interface UploadParams {
   tenantId: string;
@@ -147,33 +143,4 @@ export async function getDocumentsForEntity(params: {
     );
 
   return docs;
-}
-
-/**
- * Soft delete a document.
- * The file remains in storage but is marked as deleted.
- */
-export async function softDeleteDocument(params: {
-  tenantId: string;
-  documentId: string;
-  deletedBy: string;
-}): Promise<void> {
-  const { tenantId, documentId, deletedBy } = params;
-
-  // Update MUST include tenantId for isolation
-  await db
-    .update(schema.documents)
-    .set({
-      deletedAt: new Date(),
-      deletedBy,
-    })
-    .where(and(eq(schema.documents.id, documentId), eq(schema.documents.tenantId, tenantId)));
-
-  // Log deletion
-  await logAuditEvent({
-    tenantId,
-    documentId,
-    accessType: 'delete',
-    accessedBy: deletedBy,
-  });
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35640999,
-  "maxTrackedFiles": 4637,
+  "maxTrackedBytes": 35650320,
+  "maxTrackedFiles": 4640,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
-    "source/scripts": 7105033,
+    "source/scripts": 7106688,
     "docs/text": 5723328,
-    "tests/e2e": 5065631,
+    "tests/e2e": 5073297,
     "config/data/messages": 1558543,
     "other": 129555
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35640529,
+  "maxTrackedBytes": 35640999,
   "maxTrackedFiles": 4637,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
-    "source/scripts": 7104879,
+    "source/scripts": 7105033,
     "docs/text": 5723328,
-    "tests/e2e": 5065315,
+    "tests/e2e": 5065631,
     "config/data/messages": 1558543,
     "other": 129555
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35650320,
-  "maxTrackedFiles": 4640,
+  "maxTrackedBytes": 35659735,
+  "maxTrackedFiles": 4641,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
-    "source/scripts": 7106688,
+    "source/scripts": 7112348,
     "docs/text": 5723328,
-    "tests/e2e": 5073297,
+    "tests/e2e": 5077052,
     "config/data/messages": 1558543,
     "other": 129555
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35660865,
-  "maxTrackedFiles": 4641,
+  "maxTrackedBytes": 35662126,
+  "maxTrackedFiles": 4642,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
-    "source/scripts": 7113337,
+    "source/scripts": 7111839,
     "docs/text": 5723328,
-    "tests/e2e": 5077193,
+    "tests/e2e": 5079952,
     "config/data/messages": 1558543,
     "other": 129555
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35614822,
-  "maxTrackedFiles": 4629,
+  "maxTrackedBytes": 35640529,
+  "maxTrackedFiles": 4637,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
-    "source/scripts": 7100473,
+    "source/scripts": 7104879,
     "docs/text": 5723328,
-    "tests/e2e": 5043164,
-    "config/data/messages": 1559393,
+    "tests/e2e": 5065315,
+    "config/data/messages": 1558543,
     "other": 129555
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 35659735,
+  "maxTrackedBytes": 35660865,
   "maxTrackedFiles": 4641,
   "maxCategoryBytes": {
     "large support/generated-ish": 16058909,
-    "source/scripts": 7112348,
+    "source/scripts": 7113337,
     "docs/text": 5723328,
-    "tests/e2e": 5077052,
+    "tests/e2e": 5077193,
     "config/data/messages": 1558543,
     "other": 129555
   },


### PR DESCRIPTION
## Summary
- Prevent queued AI claim and policy document processing from reaching soft-deleted documents.
- Re-check source-document liveness before AI file download and before persistence, then fail/redact affected AI runs instead of retaining request/output payloads.
- Purge derived extraction rows and clear AI-derived policy fields on document soft-delete.
- Dedupe shared AI document lifecycle guard logic to clear the Sonar new-code duplication gate.

## Classification
- Classified as AI-affected implementation because this touches queued AI document processing, extraction persistence, document lifecycle retention, and PII-bearing AI run payloads.
- Risk tier: Tier 3 because the changed surfaces include AI production behavior, privacy/PII retention, tenant-scoped persistence, and E2E gate infrastructure.

## Changed Areas
- Claim AI pipeline: active-document claim/load/persist guards, deleted-document failure fallback, redacted failure payloads, and regression tests.
- Policy AI pipeline: active-document pre-download and persist-time guards, deleted-document failure/redaction, and regression tests.
- Document lifecycle: tenant-scoped soft-delete cleanup for extraction rows, policy AI outputs, and AI run payload JSON.
- E2E gate: scoped privacy-copy assertion to avoid duplicate navigation-feedback text collisions.
- Sonar cleanup: shared `document-run-lifecycle` helper removes duplicated guard/failure code.

## Verification
- Focused AI/document lifecycle tests: passed, 6 files / 15 tests.
- `pnpm --filter @interdomestik/web type-check`: passed.
- `pnpm security:guard`: passed.
- `pnpm repo:size:check`: passed after generated budget sync.
- `git diff --check`: passed.
- `pnpm pr:verify`: passed after the Sonar-dedupe patch; coverage gate 84.65% lines, embedded E2E gate 134 passed / 8 skipped, final smoke 13 passed / 9 skipped.
- `pnpm e2e:gate`: passed after the Sonar-dedupe patch, 134 passed / 8 skipped.

## Review / Security
- Codex Security deep scan completed: `b15e3738-a92e-4bf0-ad51-a3a880a24e8a`.
- Scan finding was remediated by guarding policy AI downloads after post-claim deletion.
- Copilot review was requested and previously re-reviewed the AI document lifecycle remediation.
- PR feedback intake reported the remaining hosted blocker as Sonar new-code duplication; commit `61d9a1f3` addresses that by extracting shared guard logic.
- Hosted CI/Sonar are rerunning on the latest head after this push.

## Residual Risk
- Merge should wait for hosted checks on latest head `61d9a1f3`, including SonarCloud, to turn green.
- This Tier 3 AI/security PR still needs normal human merge approval/waiver after hosted checks complete.
