### PR TITLE
docs(product): add Fable enterprise readiness inputs

### DIFF
--- a/docs/product/2026-07-04-fable-enterprise-red-team-audit.md
+++ b/docs/product/2026-07-04-fable-enterprise-red-team-audit.md
@@ -1,0 +1,149 @@
+---
+plan_role: input
+status: draft
+source_of_truth: false
+owner: product-design
+last_reviewed: 2026-07-04
+related:
+  - docs/product/2026-07-03-mobile-program-authority-packet.md
+  - docs/product/2026-07-03-mob-execution-sequence.md
+  - docs/product/2026-07-03-mobile-copy-system.md
+  - docs/product/2026-07-03-mobile-design-review-enterprise.md
+---
+
+# Fable Enterprise Red-Team Audit
+
+> Status: **Fable 5 advisory audit only - no execution authority.** Findings are
+> input for future product/design/legal cleanup. This document promotes no slice
+> and authorizes no runtime, tracker, routing, auth, session, tenancy, proxy,
+> schema, billing, VONESA, SVC, or CQRS work.
+
+## Scope
+
+Fable reviewed the merged pre-gate mobile/product package at a package level,
+with emphasis on enterprise credibility, legal seriousness, claims operations,
+artifact consistency, and governance drift. Findings below are condensed and
+must be checked against live tracker/current-authority state before any edit.
+
+## Priority Findings
+
+### F1 - Fee Promise Is Ahead Of The Expert-Cost Decision
+
+The package repeats "recover nothing -> pay nothing" as a structural promise,
+while the expert-cost-on-loss decision remains a blocker for money surfaces.
+Future MOB-05a/MOB-05b gates should treat the promise line as conditional until
+the business/legal memo is decided and L5-reviewed.
+
+Class: business/legal input. Maps to future money-surface gates.
+
+### F2 - "Zero Server-Side PII" Is Too Absolute With Instrumentation
+
+MOB-01's safety posture is sound, but "zero server-side PII" can over-claim if
+anonymous funnel events use IP/device/browser signals. Safer wording: "no
+identity data, no case content, and no account data server-side before explicit
+handoff; instrumentation uses a defined minimal event schema."
+
+Class: legal/design wording input. Maps to MOB-DG01 acceptance wording.
+
+### F3 - Missing Service-Authorization Legal Input
+
+The L-list covers e-signature, content, DPIA, cession, fee display, tax, and
+reconciliation. It does not explicitly cover whether Interdomestik may perform
+claims-recovery or legal-service activity per market, including diaspora
+cross-border service into DE/CH/AT.
+
+Suggested input: service-authorization / claims-management licensing matrix.
+
+Class: legal input only. Blocks commercial launch confidence, not design prep.
+
+### F4 - Missing Membership Regulatory Classification
+
+The annual membership may raise consumer, insurance-like, or claims-management
+classification questions depending on market and promise wording. Treat this as
+its own legal input, not a fee-copy subquestion.
+
+Class: legal input only. Blocks public commercial language.
+
+### F5 - Named Handler Copy Depends On Handler-Model Decision
+
+The copy system leans toward named humans, while the enterprise review keeps
+named handler vs case team open. Copy keys should mark handler naming as
+conditional until that memo is decided.
+
+Class: business/design input. Maps to future case-status copy and MOB-02.
+
+### F6 - Input Docs Use Too Much Binding Language
+
+Several docs say `source_of_truth: false` but use phrases such as "binding",
+"authority", "governance violation", and "board verdict". Future cleanup should
+use "candidate", "proposed", or "becomes binding only if adopted by a gate."
+
+Class: governance wording input only.
+
+### F7 - Package Manifest Drift
+
+Different docs imply different package sizes and document sets. A single
+canonical package manifest would help future gate runners know which input docs
+belong together and which are superseded.
+
+Class: doc-hygiene input only.
+
+### F8 - AI/Human ReviewBadge Needs Timing Honesty
+
+ReviewBadge should distinguish "will be reviewed", "under review", and
+"reviewed". If AI-generated or automated output appears before human review,
+the wording must not imply a human has already approved it. AI transparency
+obligations may require legal review.
+
+Class: legal/component-contract input. Maps to future component adoption.
+
+### F9 - Impressum/Company Info Is Legal, Not Just Trust Grammar
+
+German-market diaspora surfaces likely need provider-identification content.
+Treat this as legal/company-information input, not only brand credibility.
+
+Class: legal/content input. Maps to future member shell content.
+
+### F10 - Local Evidence Bundles Need A Privacy Memo
+
+Photos may include third-party personal data, plates, faces, and sometimes
+injury-adjacent context. MOB-01 should have a memo on pre-handoff controller
+posture and member guidance for photographing scenes without over-collecting.
+
+Class: privacy/legal input. Maps to MOB-DG01 copy and evidence coach.
+
+### F11 - Offline Write Copy Must Match The Rule
+
+The error taxonomy rejects silent queues for legal writes. Any copy saying "we
+will hold this" can sound like a queue. Use "this was not sent; try again when
+back online" for legally meaningful writes unless a future gate defines an
+explicit held-item system.
+
+Class: design/copy input. Maps to MOB-03/MOB-05.
+
+### F12 - Stale Repo-State Statements Need Day-Of-Use Verification
+
+Fable flagged possible drift in statements about T-503 and M0-M5 status. This
+finding is a hypothesis because Fable had no repository tools in that pass.
+Before any docs are edited for state, compare with `current-program.md`,
+`current-tracker.md`, and live git history.
+
+Class: verification note only.
+
+## Highest-Value Corrections Before Future Gates
+
+1. Add service-authorization and membership-classification legal inputs.
+2. Make fee-promise usage conditional on the expert-cost decision.
+3. Replace absolute PII wording with a defined minimal-instrumentation posture.
+4. Mark named-handler copy as contingent.
+5. Create or designate one package manifest.
+6. Add local-evidence privacy memo and ReviewBadge timing states.
+
+## Red Flags For More Fable Work
+
+- Do not let advisory docs become hidden execution authority.
+- Do not let Fable invent jurisdictional facts; use `UNVERIFIED`.
+- Do not create screens for unpromoted slices.
+- Do not turn legal questions into copy fixes when the activity itself may need
+  authorization.
+- Do not expand artifacts without assigning counsel/reviewer ownership.

--- a/docs/product/2026-07-04-fable-evidence-custody-specification.md
+++ b/docs/product/2026-07-04-fable-evidence-custody-specification.md
@@ -1,0 +1,137 @@
+---
+plan_role: input
+status: draft
+source_of_truth: false
+owner: product-design
+last_reviewed: 2026-07-04
+related:
+  - docs/product/2026-07-03-artifact-pdf-template-specs.md
+  - docs/product/2026-07-03-mobile-legal-compliance-input-templates.md
+  - docs/product/2026-07-03-mobile-error-taxonomy.md
+  - docs/product/2026-07-03-mob-execution-sequence.md
+---
+
+# Fable Evidence Custody Specification
+
+> Status: **Fable 5 advisory input only - no execution authority.** This document
+> authorizes no runtime work, no slice promotion, and no changes to routing,
+> auth, session, tenancy, proxy, schema, billing, VONESA, SVC, or CQRS. Any future
+> implementation implication must be separately promoted through current
+> authority. Paddle-only billing remains fixed.
+
+## Purpose
+
+Enterprise trust for Interdomestik depends on whether evidence can be explained
+to members, branch staff, lawyers, insurers, sponsors, and auditors without
+over-claiming. This spec gives future gates a shared custody vocabulary. It is a
+contract-input document, not a data model, event model, or migration proposal.
+
+## Principles
+
+1. **Member custody by default:** before explicit handoff, local incident bundles
+   remain member-controlled. Do not imply Interdomestik possesses evidence it has
+   not received.
+2. **Declaration before possession:** a Claim Pack may list member-declared
+   evidence before upload, but must label it as declared, not held.
+3. **Integrity without theatrics:** use reference numbers, timestamps, versions,
+   and manifests. Do not claim notarization, forensic proof, or court-grade
+   custody unless counsel approves the exact claim.
+4. **Multilingual dignity:** custody wording must work in sq/de/en/mk without
+   sounding evasive, bureaucratic, or like insurance small print.
+5. **Sponsors see aggregates only:** sponsor credibility never depends on access
+   to member evidence or case-level facts.
+
+## Custody State Vocabulary
+
+| State                | Meaning                                                     | Permitted wording                |
+| -------------------- | ----------------------------------------------------------- | -------------------------------- |
+| `member_device`      | Evidence exists only on the member device.                  | "Saved on this phone."           |
+| `declared`           | The member has listed an item in a pack or form.            | "Declared by the member."        |
+| `submitted_vault`    | Evidence was explicitly sent into Interdomestik custody.    | "Received by Interdomestik."     |
+| `review_pending`     | A human review is required but not complete.                | "Waiting for review."            |
+| `reviewed`           | A qualified reviewer has checked usability or completeness. | "Reviewed on {date}."            |
+| `sealed_manifest`    | Manifest and versions are fixed for a disclosure packet.    | "Packet version fixed."          |
+| `disclosed`          | Shared with a named counterparty.                           | "Sent to {party} on {date}."     |
+| `retained`           | Held after active use under a retention rule.               | "Kept under the retention rule." |
+| `erasure_pending`    | Deletion/destruction requested or scheduled.                | "Deletion requested."            |
+| `crypto_shredded`    | Digital erasure completed through the approved chain.       | "Digital deletion completed."    |
+| `physical_destroyed` | Paper original or copy destroyed under policy.              | "Physical destruction recorded." |
+
+All retention periods and destruction procedures are **UNVERIFIED** until the
+data and consent map plus counsel review set them.
+
+## Transition Rules
+
+1. `member_device` -> `declared`: allowed without account if the pack clearly
+   states the content is member-provided and locally held.
+2. `declared` -> `submitted_vault`: requires explicit handoff. No silent upload,
+   retry, or background sync for evidence.
+3. `submitted_vault` -> `review_pending` -> `reviewed`: reviewer identity,
+   role, timestamp, and reviewed artifact version must be recorded by the future
+   implementation slice.
+4. `reviewed` -> `sealed_manifest`: only after the artifact reference, pack
+   version, legal marker version, and included items are fixed.
+5. `sealed_manifest` -> `disclosed`: disclose only to a named party for a named
+   purpose. Sponsors are excluded.
+6. `retained` -> `erasure_pending` -> `crypto_shredded` or
+   `physical_destroyed`: depends on **UNVERIFIED** retention and legal-hold
+   rules.
+
+## Actor Matrix
+
+| Actor                    | May do                                                         | Must not do                                               |
+| ------------------------ | -------------------------------------------------------------- | --------------------------------------------------------- |
+| Member                   | Create, declare, delete local bundle; initiate handoff.        | Be surprised by upload or disclosure.                     |
+| Branch staff             | Scan paper, issue intake receipt, return originals by default. | Hold originals without a counsel-approved bailment rule.  |
+| Case team or handler     | Request review, prepare packets, communicate status.           | Claim legal review before it happened.                    |
+| Legal reviewer           | Approve legal instruments and reviewed wording.                | Approve unverified jurisdiction facts silently.           |
+| Medical reviewer         | Review medical evidence only after DPIA/consent path.          | Touch MOB-01 car/property evidence by default.            |
+| Partner lawyer           | Receive scoped disclosed packets.                              | Browse vault contents.                                    |
+| Insurer/recovery partner | Receive named disclosed artifacts.                             | Receive sponsor-level aggregate reports with case detail. |
+| Sponsor                  | Receive aggregate, privacy-safe reporting only.                | Access member, case, evidence, or document-level data.    |
+| Support                  | Use reference numbers to help the member.                      | View contents unless an authorized support path exists.   |
+| DPO/compliance           | Audit custody, retention, and erasure evidence.                | Change case facts.                                        |
+
+## Branch Handoff
+
+Paper-to-digital branch intake needs a bilingual receipt before branch launch:
+
+- proposed artifact type: `IDA-IR-{YYYYMMDD}-{shortid}` (design input only)
+- list every received item, scan status, returned/held status, and staff name
+- default: scan and return same visit
+- exceptional holds: **blocked until counsel reviews bailment, liability, storage,
+  and destruction rules**
+- non-member family presenters: allowed only when the future gate defines proof
+  of authority and member notification
+
+## Contract Clauses For Counsel
+
+All clauses are **COUNSEL-REVIEW REQUIRED**:
+
+- C1: "Before you send evidence to us, it stays on your device."
+- C2: "A Claim Pack may list evidence you told us about, even before we hold it."
+- C3: "We record when a packet version is fixed and when it is disclosed."
+- C4: "Sponsors cannot access individual cases or evidence."
+- C5: "We do not call evidence notarized, forensic, or court-certified unless a
+  separate approved process says so."
+- C6: "Deletion can be limited by legal retention or legal hold duties."
+- C7: "Physical paper handling follows the branch intake receipt."
+
+## Future-Slice Mapping
+
+| Future surface               | Mapping                                               |
+| ---------------------------- | ----------------------------------------------------- |
+| MOB-01 Help Now / Claim Pack | May use `member_device` and `declared`; no uploads.   |
+| MOB-03 Vault / consent       | First likely `submitted_vault` and retention surface. |
+| MOB-05b Agreement Ceremony   | Signature evidence and sealed signed packs.           |
+| MOB-06 under OMG             | Branch intake receipt and branch custody workflow.    |
+| WS-F / VONESA                | Own authority; may reuse disclosed packet vocabulary. |
+| Sponsor reporting            | Legal/marketing input only until separately promoted. |
+
+## Open Board Decisions
+
+1. Is Interdomestik willing to hold original paper at branches?
+2. Should destruction certificates be member-visible trust artifacts?
+3. What exact sponsor visibility line is commercially usable and legally safe?
+4. Which party owns liability for branch scanning failures?
+5. Can branch launch precede OMG, or does custody make OMG a hard gate?

--- a/docs/product/2026-07-04-fable-legal-artifact-registry.md
+++ b/docs/product/2026-07-04-fable-legal-artifact-registry.md
@@ -1,0 +1,89 @@
+---
+plan_role: input
+status: draft
+source_of_truth: false
+owner: product-design
+last_reviewed: 2026-07-04
+related:
+  - docs/product/2026-07-03-artifact-pdf-template-specs.md
+  - docs/product/2026-07-03-business-decision-memos.md
+  - docs/product/2026-07-03-mobile-legal-compliance-input-templates.md
+  - docs/product/2026-07-04-fable-evidence-custody-specification.md
+---
+
+# Fable Legal Artifact Registry
+
+> Status: **Fable 5 advisory input only - no execution authority.** This registry
+> is not a template library, schema, writer, or slice promotion. It names the
+> legal and trust artifacts future gates may adopt after current authority
+> permits them. Any legal character stated here is **UNVERIFIED** unless counsel
+> signs the relevant L-input.
+
+## Registry Rules
+
+- Each artifact has one purpose, one reference identity, and one owning review
+  lane.
+- Blank fields are not allowed in filed artifacts; use "not provided" as already
+  specified in the PDF template spec.
+- Member-facing PDFs must survive print, grayscale, forwarding, and lawyer use.
+- Legal instruments and marker translations are documents, not casual message
+  keys.
+- Generated artifacts may be regenerated idempotently, but identity must not
+  multiply on retry.
+
+## Artifact Registry
+
+| ID     | Artifact                         | Legal character                               | Custody states                          | Review lane          | Future mapping      |
+| ------ | -------------------------------- | --------------------------------------------- | --------------------------------------- | -------------------- | ------------------- |
+| LAR-01 | Claim Pack PDF `IDA-CP-*`        | Starting file, not legal advice               | `declared`, later `sealed_manifest`     | L2/L5 copy markers   | MOB-01              |
+| LAR-02 | Bilingual EAS PDF `IDA-EAS-*`    | Form companion, official semantics UNVERIFIED | `member_device`                         | L2 country sign-off  | MOB-01              |
+| LAR-03 | Signed Pack PDF `IDA-SP-*`       | Signed-document bundle                        | `sealed_manifest`, `disclosed`          | L1/L5                | MOB-05b             |
+| LAR-04 | Evidence Manifest annex          | Evidence list, not possession proof           | `declared` or `submitted_vault`         | custody + L5 wording | MOB-01/MOB-03       |
+| LAR-05 | Signature Evidence block         | Method/timestamp/version record               | `reviewed`, `sealed_manifest`           | L1                   | MOB-05b             |
+| LAR-06 | Consent Record                   | Data-processing proof                         | `submitted_vault`, `retained`           | L3/L5                | MOB-03              |
+| LAR-07 | Power of Attorney                | Legal instrument, UNVERIFIED by country       | `sealed_manifest`                       | L1                   | MOB-05b             |
+| LAR-08 | Assignment / cession             | Legal instrument, UNVERIFIED by country       | `sealed_manifest`                       | L4/L5                | WS-F only           |
+| LAR-09 | Fee Disclosure                   | Commercial/consumer information               | `reviewed`, `sealed_manifest`           | L5                   | MOB-05a/MOB-05b     |
+| LAR-10 | Demand Letter                    | Recovery document                             | `sealed_manifest`, `disclosed`          | counsel              | Future case ops     |
+| LAR-11 | Settlement Confirmation          | Recovery closing document                     | `sealed_manifest`, `retained`           | counsel/finance      | Future case ops     |
+| LAR-12 | Branch Intake Receipt `IDA-IR-*` | Proposed custody receipt                      | `submitted_vault`, `retained`           | counsel + ops        | MOB-06 under OMG    |
+| LAR-13 | Custody Record                   | Internal audit record                         | all post-handoff states                 | compliance           | Future runtime only |
+| LAR-14 | Erasure/Destruction Record       | Deletion/destruction evidence                 | `crypto_shredded`, `physical_destroyed` | DPO/counsel          | Future privacy work |
+| LAR-15 | Sponsor Credibility Pack         | Aggregate proof only                          | no member custody state                 | legal/marketing      | Input only          |
+| LAR-16 | Legal Input Matrix L1-L7         | Counsel evidence artifacts                    | `retained`                              | legal/compliance     | Input only          |
+| LAR-17 | Business Decision Memos          | Board/product decisions                       | `retained`                              | product/legal        | Input only          |
+| LAR-18 | Partner Release Terms            | Disclosure conditions                         | `disclosed`                             | counsel              | Future partner path |
+
+## Counsel Review Queue
+
+1. **CRQ-1:** custody limitation sentence for Claim Pack and local bundle.
+2. **CRQ-2:** POA/e-sign matrix by country and diaspora jurisdiction.
+3. **CRQ-3:** fee promise including expert-cost-on-loss treatment.
+4. **CRQ-4:** service-authorization / claims-management licensing matrix.
+5. **CRQ-5:** membership regulatory classification.
+6. **CRQ-6:** sponsor visibility and aggregate-report wording.
+7. **CRQ-7:** branch paper holding, bailment, and liability position.
+8. **CRQ-8:** retention, erasure, legal hold, and physical destruction.
+9. **CRQ-9:** official EAS, Green Card, and country content terms.
+
+CRQ-2 and CRQ-9 do not replace existing L1/L2 long poles; they make the same
+work visible inside the artifact system.
+
+## Entry Criteria Suggestions
+
+| Future gate        | Suggested artifact entry criteria                          |
+| ------------------ | ---------------------------------------------------------- |
+| MOB-DG01           | LAR-01/LAR-02 designs plus CRQ-1/CRQ-9 for public wording. |
+| MOB-DG02 / MOB-05a | CRQ-3 and fee disclosure wording before money surfaces.    |
+| MOB-DG03 / MOB-03  | LAR-06 plus retention and consent answers before uploads.  |
+| MOB-DG05 / MOB-05b | LAR-03/LAR-05/LAR-07 plus L1 country matrix.               |
+| OMG branch work    | LAR-12 and CRQ-7 before branch evidence intake.            |
+
+## Registry Red Flags
+
+- Do not let a PDF template imply counsel sign-off before counsel signs.
+- Do not let Claim Pack evidence lists imply Interdomestik holds local photos.
+- Do not create sponsor proof by weakening sponsor privacy boundaries.
+- Do not mix WS-F cession artifacts into MOB authority.
+- Do not treat proposed artifacts (`IDA-IR-*`, custody record, destruction
+  record) as implementation scope without a future gate.

--- a/docs/product/2026-07-04-fable-terminology-register-base.md
+++ b/docs/product/2026-07-04-fable-terminology-register-base.md
@@ -1,0 +1,117 @@
+---
+plan_role: input
+status: draft
+source_of_truth: false
+owner: product-design
+last_reviewed: 2026-07-04
+related:
+  - docs/product/2026-07-03-mobile-copy-system.md
+  - docs/product/2026-07-03-ks-help-now-content-dossier-draft.md
+  - docs/product/2026-07-03-artifact-pdf-template-specs.md
+  - docs/product/2026-07-03-screen-reader-flow-scripts.md
+---
+
+# Fable Terminology And Register Base
+
+> Status: **Fable 5 advisory input only - no implementation authority.** This is
+> a draft termbase for reviewer correction, not a linguistic or legal source of
+> truth. All sq/de/mk terms are `[NATIVE]` until signed by qualified reviewers.
+> Jurisdictional or legal terms are `[UNVERIFIED]` until L2/L5 review.
+
+## Foundations
+
+| Locale | Register rule                                                                                 |
+| ------ | --------------------------------------------------------------------------------------------- |
+| sq     | Use formal `ju`. Written artifacts use standard Albanian with Kosovo-transparent vocabulary.  |
+| de     | Use formal `Sie`. Sound like competent consumer-protection language, not translated legalese. |
+| en     | Pivot/reference locale; do not let English idioms drive legal meaning.                        |
+| mk     | Cyrillic-only placeholder policy; public mk content remains dark until native legal review.   |
+
+Locale follows the user, not the incident country. A `de` user reading a Kosovo
+pack gets German chrome plus country-specific bilingual content.
+
+## Term Families
+
+| Concept        | en                             | sq draft                                         | de draft                                             | Flags                  |
+| -------------- | ------------------------------ | ------------------------------------------------ | ---------------------------------------------------- | ---------------------- |
+| recover        | recover                        | `kthej` / document: `rikuperim`                  | `zurueckholen` / document: `Durchsetzung`            | `[NATIVE]`             |
+| success fee    | success fee                    | `tarifa e suksesit`                              | `Erfolgshonorar`                                     | `[L5][UNVERIFIED]`     |
+| no win, no fee | recover nothing -> pay nothing | `Nese nuk kthejme asgje, ju nuk paguani asgje.`  | `Holen wir nichts zurueck, zahlen Sie nichts.`       | `[L5]`                 |
+| membership     | membership                     | `anetaresia`                                     | `Mitgliedschaft`                                     | never insurance policy |
+| annual fee     | annual fee                     | `anetaresia vjetore`                             | `Jahresbeitrag`                                      | never premium          |
+| case           | your case                      | `rasti juaj`                                     | `Ihr Fall`                                           | never `Prozess`        |
+| claim          | claim                          | `kerkesa` / document: `kerkesa per demshperblim` | `Forderung` / document: `Schadenersatzanspruch`      | `[NATIVE]`             |
+| insurer        | insurer                        | `sigurimi` / document: `siguruesi`               | `Versicherung` / document: `Versicherer`             | we are never this      |
+| police report  | police report                  | `raporti i policise`                             | `Polizeibericht`                                     | `[L2]`                 |
+| EAS            | European Accident Statement    | `Raporti Evropian i Aksidentit`                  | `Europaeischer Unfallbericht`                        | `[L2][UNVERIFIED]`     |
+| Green Card     | Green Card                     | `Kartoni i Gjelber`                              | `Gruene Karte`                                       | `[L2][UNVERIFIED]`     |
+| evidence       | evidence                       | `provat`                                         | member: `Fotos und Belege`; document: `Beweismittel` | tiered                 |
+| vehicle        | vehicle/car                    | member: `vetura`; document: `automjeti`          | member: `Auto`; document: `Fahrzeug`                 | `[NATIVE]`             |
+| POA            | power of attorney              | member: `autorizimi`; document: `prokura`        | `Vollmacht`                                          | `[L1][L5]`             |
+| consent        | consent                        | `pelqimi`                                        | `Einwilligung`                                       | data context           |
+| handler        | handler                        | prefer verb: `Ana ndjek rastin tuaj`             | `Ansprechpartner/in`                                 | `[UPL]`                |
+
+Note: accented spellings above are draft-normalized to ASCII for this input
+file. Native review owns final diacritics and orthography; shipped sq strings
+must keep correct diacritics.
+
+## Surface Registers
+
+| Surface                        | Register                                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| Help Now                       | Triage nurse: verb first, one instruction per sentence, no sales language.     |
+| Claim Pack / EAS / Signed Pack | Filing-grade document: precise, printable, grayscale-safe, no chat tone.       |
+| SMS / WhatsApp                 | One calm line; no marketing add-on; artifact reference included when useful.   |
+| Legal agreement                | Document register; summaries use member terms with one legal bridge.           |
+| Branch script                  | Capable relative: warm speech, fixed nouns, no improvising fee or legal lines. |
+
+## Forbidden Terms
+
+- Do not call membership a policy, premium, insurance, `polica`, `Police`, or
+  `Praemie`.
+- Do not call non-lawyer staff `lawyer`, `avokat`, `Anwalt`, or imply legal
+  representation before licensing is confirmed.
+- Do not use outcome guarantees except the reviewed fee-promise sentence after
+  the expert-cost decision is resolved.
+- Do not use legalese on emergency screens: `pursuant to`, `gemäß`,
+  `diesbezueglich`, `parashtroni`, or bare statutory citations.
+- Do not use `Prozess` for a case in German; it implies a lawsuit/trial.
+- Do not strip sq or mk diacritics in shipped strings; this ASCII draft is not a
+  localization payload.
+
+## False-Friend Risks
+
+1. German `Prozess` and Albanian `proces` can imply court process, not a case.
+2. `eventuell` / `eventualisht` means possibly, not eventually.
+3. `kontrollieren` / `kontrolloj` means inspect/check, not control or decide.
+4. Albanian `pretendim` can sound like pretending on member surfaces; prefer
+   `kerkesa` unless document register requires otherwise.
+5. German `erholen` means recover health; never use it for money recovery.
+6. German `Provision` means commission, not a contract provision.
+7. Albanian `sigurim` can mean insurance or security; context must disambiguate.
+
+## QA Checklist
+
+- Every launch locale has complete full-sentence keys; no fragments assembled in
+  code.
+- Forbidden-term scan passes per locale.
+- Surface register matches namespace and artifact type.
+- `@legal-reviewed` keys have review references before public exposure.
+- Stress strings fit after translation, not only in English.
+- Screen-reader scripts are read aloud per locale before gate closure.
+- SMS budget accounts for sq/mk encoding; never remove diacritics to fit.
+- Bilingual EAS field labels follow official semantics, not brand preference.
+
+## Reviewer Questions
+
+1. Does formal `ju` feel natural for Kosovo emergency copy?
+2. Should KS member surfaces use `vetura`, `makina`, or another vehicle term?
+3. What is the accepted sq name for the EAS in insurer practice?
+4. What is the official and colloquial Green Card terminology?
+5. Is `tarifa e suksesit` acceptable in KS consumer contracts?
+6. Does KS POA practice require `prokura`, `autorizim`, or a notarized term?
+7. Does German `Erfolgshonorar` or `Rechtsdienstleistung` trigger regulated
+   framing for diaspora surfaces?
+8. Is there a safe sq noun for handler, or should the verb form remain the rule?
+9. Who owns mk legal-language review before MK country content leaves dark mode?
+10. Do target iOS/Android builds have acceptable sq/mk screen-reader voices?

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54516499,
-  "maxTrackedFiles": 4692,
+  "maxTrackedBytes": 54555041,
+  "maxTrackedFiles": 4696,
   "maxCategoryBytes": {
     "other": 18693297,
-    "large support/generated-ish": 16066450,
+    "large support/generated-ish": 16067062,
     "source/scripts": 7114397,
-    "docs/text": 5999486,
+    "docs/text": 6037416,
     "tests/e2e": 5083351,
     "config/data/messages": 1559518
   },


### PR DESCRIPTION
## Summary

Adds four Fable 5 advisory product/legal/design input documents under `docs/product/`:

- `2026-07-04-fable-evidence-custody-specification.md`
- `2026-07-04-fable-legal-artifact-registry.md`
- `2026-07-04-fable-terminology-register-base.md`
- `2026-07-04-fable-enterprise-red-team-audit.md`

Also updates `scripts/repo-size-budget.json` with the required repo-size budget sync for the added tracked docs.

## Governance / Scope

Docs-only Tier 0 input. This PR grants no execution authority, promotes no slice, and changes no runtime code. It does not touch routing, auth, session, tenancy, proxy, schema, billing, VONESA, SVC, CQRS, trackers, or current-program authority. Paddle-only remains fixed.

## Verification

- `git diff --check HEAD~1..HEAD`
- `pnpm docs:verify`
- `pnpm repo:size:check`
- `pnpm security:guard`
- `pnpm exec prettier --check docs/product/2026-07-04-fable-enterprise-red-team-audit.md docs/product/2026-07-04-fable-evidence-custody-specification.md docs/product/2026-07-04-fable-legal-artifact-registry.md docs/product/2026-07-04-fable-terminology-register-base.md scripts/repo-size-budget.json`

## Notes

Fable was used as an advisory reviewer/authoring aid. The resulting docs mark legal and jurisdictional items as `UNVERIFIED`, `COUNSEL-REVIEW REQUIRED`, or reviewer-routed input where appropriate.
