### PR TITLE
feat: add MOB-01 Help Now Trip Mode

### DIFF
--- a/apps/web/e2e/gate/help-now-public.spec.ts
+++ b/apps/web/e2e/gate/help-now-public.spec.ts
@@ -23,10 +23,24 @@ async function expectOnlyPublicHelpNowSurface(page: Page) {
   await expect(page.getByTestId('admin-page-ready')).toHaveCount(0);
 }
 
+function watchProtectedSurfaceRequests(page: Page) {
+  const protectedRequests: string[] = [];
+  page.on('request', request => {
+    const pathname = new URL(request.url()).pathname;
+    const isProtectedApi = /^\/api\/(member|agent|staff|admin)(\/|$)/.test(pathname);
+    const isProtectedRoute = /^\/(sq|en|sr|mk|hr|de)\/(member|agent|staff|admin)(\/|$)/.test(
+      pathname
+    );
+    if (isProtectedApi || isProtectedRoute) protectedRequests.push(pathname);
+  });
+  return protectedRequests;
+}
+
 test.describe('MOB-01 public Help Now route', () => {
   test('anonymous visitor opens Help Now without auth redirect', async ({ browser }, testInfo) => {
     const context = await browser.newContext(publicContextOptions(testInfo));
     const page = await context.newPage();
+    const protectedRequests = watchProtectedSurfaceRequests(page);
 
     try {
       const response = await gotoApp(page, routes.helpNow(testInfo), testInfo, {
@@ -34,8 +48,12 @@ test.describe('MOB-01 public Help Now route', () => {
       });
 
       expect(response?.status(), 'help-now should not redirect to auth').toBe(200);
+      expect(response?.headers().location, 'help-now should not emit a redirect location').toBe(
+        undefined
+      );
       await expect(page).toHaveURL(new RegExp(`${routes.helpNow(testInfo)}$`));
       await expectOnlyPublicHelpNowSurface(page);
+      expect(protectedRequests).toEqual([]);
     } finally {
       await context.close();
     }
@@ -43,6 +61,8 @@ test.describe('MOB-01 public Help Now route', () => {
 
   test('signed-in member stays on Help Now public route', async ({ page, loginAs }, testInfo) => {
     await loginAs('member');
+    await page.waitForLoadState('networkidle');
+    const protectedRequests = watchProtectedSurfaceRequests(page);
 
     const response = await gotoApp(page, routes.helpNow(testInfo), testInfo, {
       marker: 'help-now-page-ready',
@@ -51,5 +71,6 @@ test.describe('MOB-01 public Help Now route', () => {
     expect(response?.status(), 'member should not be redirected away from Help Now').toBe(200);
     await expect(page).toHaveURL(new RegExp(`${routes.helpNow(testInfo)}$`));
     await expectOnlyPublicHelpNowSurface(page);
+    expect(protectedRequests).toEqual([]);
   });
 });

--- a/apps/web/e2e/gate/help-now-public.spec.ts
+++ b/apps/web/e2e/gate/help-now-public.spec.ts
@@ -1,0 +1,55 @@
+import type { Page, TestInfo } from '@playwright/test';
+import { expect, test } from '../fixtures/auth.fixture';
+import { routes } from '../routes';
+import { gotoApp } from '../utils/navigation';
+
+function publicContextOptions(testInfo: TestInfo) {
+  return {
+    baseURL: testInfo.project.use.baseURL,
+    extraHTTPHeaders: testInfo.project.use.extraHTTPHeaders,
+    storageState: { cookies: [], origins: [] },
+  };
+}
+
+async function expectOnlyPublicHelpNowSurface(page: Page) {
+  await expect(page.getByTestId('help-now-page-ready')).toBeVisible();
+  await expect(page.getByTestId('help-now-page-ready')).toHaveAttribute(
+    'data-scope',
+    'public-no-account'
+  );
+  await expect(page.getByTestId('member-page-ready')).toHaveCount(0);
+  await expect(page.getByTestId('agent-page-ready')).toHaveCount(0);
+  await expect(page.getByTestId('staff-page-ready')).toHaveCount(0);
+  await expect(page.getByTestId('admin-page-ready')).toHaveCount(0);
+}
+
+test.describe('MOB-01 public Help Now route', () => {
+  test('anonymous visitor opens Help Now without auth redirect', async ({ browser }, testInfo) => {
+    const context = await browser.newContext(publicContextOptions(testInfo));
+    const page = await context.newPage();
+
+    try {
+      const response = await gotoApp(page, routes.helpNow(testInfo), testInfo, {
+        marker: 'help-now-page-ready',
+      });
+
+      expect(response?.status(), 'help-now should not redirect to auth').toBe(200);
+      await expect(page).toHaveURL(new RegExp(`${routes.helpNow(testInfo)}$`));
+      await expectOnlyPublicHelpNowSurface(page);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('signed-in member stays on Help Now public route', async ({ page, loginAs }, testInfo) => {
+    await loginAs('member');
+
+    const response = await gotoApp(page, routes.helpNow(testInfo), testInfo, {
+      marker: 'help-now-page-ready',
+    });
+
+    expect(response?.status(), 'member should not be redirected away from Help Now').toBe(200);
+    await expect(page).toHaveURL(new RegExp(`${routes.helpNow(testInfo)}$`));
+    await expectOnlyPublicHelpNowSurface(page);
+  });
+});

--- a/apps/web/e2e/routes.ts
+++ b/apps/web/e2e/routes.ts
@@ -72,7 +72,7 @@ export const routes = {
   stats: (l?: Locale | string | TestInfo) => withLocale('/stats', l || 'en'),
   partners: (l?: Locale | string | TestInfo) => withLocale('/partners', l || 'en'),
   pricing: (l?: Locale | string | TestInfo) => withLocale('/pricing', l || 'en'),
-  helpNow: (l?: string | TestInfo) => withLocale('/help-now', l || 'en'),
+  helpNow: (l?: Locale | string | TestInfo) => withLocale('/help-now', l || 'en'),
   businessMembership: (l?: Locale | string | TestInfo) =>
     withLocale('/business-membership', l || 'en'),
   publicMembershipEntry: (l?: Locale | string | TestInfo) => withLocale('/pricing', l || 'en'),

--- a/apps/web/e2e/routes.ts
+++ b/apps/web/e2e/routes.ts
@@ -72,6 +72,7 @@ export const routes = {
   stats: (l?: Locale | string | TestInfo) => withLocale('/stats', l || 'en'),
   partners: (l?: Locale | string | TestInfo) => withLocale('/partners', l || 'en'),
   pricing: (l?: Locale | string | TestInfo) => withLocale('/pricing', l || 'en'),
+  helpNow: (l?: Locale | string | TestInfo) => withLocale('/help-now', l || 'en'),
   businessMembership: (l?: Locale | string | TestInfo) =>
     withLocale('/business-membership', l || 'en'),
   publicMembershipEntry: (l?: Locale | string | TestInfo) => withLocale('/pricing', l || 'en'),

--- a/apps/web/e2e/routes.ts
+++ b/apps/web/e2e/routes.ts
@@ -1,6 +1,8 @@
 import { type TestInfo } from '@playwright/test';
 
 export type Locale = 'sq' | 'en' | 'mk' | 'sr' | 'de' | 'hr';
+
+type RouteLocaleInput = Locale | (string & {}) | TestInfo;
 const SUPPORTED_LOCALES: Locale[] = ['sq', 'en', 'mk', 'sr', 'de', 'hr'];
 
 /**
@@ -24,7 +26,7 @@ function parseLocaleFromUrl(urlStr: string): Locale {
  * Strictly Rule #7: Fail fast on invalid types.
  * Strictly Rule #1: Deterministic derivation from project baseURL.
  */
-export function getLocale(input?: Locale | string | TestInfo): Locale {
+export function getLocale(input?: RouteLocaleInput): Locale {
   // Backward compatibility: If no locale provided, default to 'en'
   if (!input) {
     return 'en';
@@ -55,7 +57,7 @@ export function getLocale(input?: Locale | string | TestInfo): Locale {
   );
 }
 
-function withLocale(pathname: string, localeInput: Locale | string | TestInfo): string {
+function withLocale(pathname: string, localeInput: RouteLocaleInput): string {
   const loc = getLocale(localeInput);
   const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
 
@@ -68,54 +70,54 @@ function withLocale(pathname: string, localeInput: Locale | string | TestInfo): 
 
 export const routes = {
   getLocale,
-  home: (l?: Locale | string | TestInfo) => withLocale('/', l || 'en'),
-  stats: (l?: Locale | string | TestInfo) => withLocale('/stats', l || 'en'),
-  partners: (l?: Locale | string | TestInfo) => withLocale('/partners', l || 'en'),
-  pricing: (l?: Locale | string | TestInfo) => withLocale('/pricing', l || 'en'),
-  helpNow: (l?: Locale | string | TestInfo) => withLocale('/help-now', l || 'en'),
-  businessMembership: (l?: Locale | string | TestInfo) =>
+  home: (l?: RouteLocaleInput) => withLocale('/', l || 'en'),
+  stats: (l?: RouteLocaleInput) => withLocale('/stats', l || 'en'),
+  partners: (l?: RouteLocaleInput) => withLocale('/partners', l || 'en'),
+  pricing: (l?: RouteLocaleInput) => withLocale('/pricing', l || 'en'),
+  helpNow: (l?: RouteLocaleInput) => withLocale('/help-now', l || 'en'),
+  businessMembership: (l?: RouteLocaleInput) =>
     withLocale('/business-membership', l || 'en'),
-  publicMembershipEntry: (l?: Locale | string | TestInfo) => withLocale('/pricing', l || 'en'),
-  login: (l?: Locale | string | TestInfo) => withLocale('/login', l || 'en'),
-  forgotPassword: (l?: Locale | string | TestInfo) => withLocale('/forgot-password', l || 'en'),
-  register: (l?: Locale | string | TestInfo) => withLocale('/register', l || 'en'),
-  resetPassword: (l?: Locale | string | TestInfo) => withLocale('/reset-password', l || 'en'),
-  member: (l?: Locale | string | TestInfo) => withLocale('/member', l || 'en'),
-  memberClaims: (l?: Locale | string | TestInfo) => withLocale('/member/claims', l || 'en'),
-  memberHelp: (l?: Locale | string | TestInfo) => withLocale('/member/help', l || 'en'),
-  memberNewClaim: (l?: Locale | string | TestInfo) => withLocale('/member/claims/new', l || 'en'),
-  memberSettings: (l?: Locale | string | TestInfo) => withLocale('/member/settings', l || 'en'),
-  memberMembership: (l?: Locale | string | TestInfo) => withLocale('/member/membership', l || 'en'),
-  memberDiaspora: (l?: Locale | string | TestInfo) => withLocale('/member/diaspora', l || 'en'),
-  memberClaimDetail: (claimId: string, l?: Locale | string | TestInfo) =>
+  publicMembershipEntry: (l?: RouteLocaleInput) => withLocale('/pricing', l || 'en'),
+  login: (l?: RouteLocaleInput) => withLocale('/login', l || 'en'),
+  forgotPassword: (l?: RouteLocaleInput) => withLocale('/forgot-password', l || 'en'),
+  register: (l?: RouteLocaleInput) => withLocale('/register', l || 'en'),
+  resetPassword: (l?: RouteLocaleInput) => withLocale('/reset-password', l || 'en'),
+  member: (l?: RouteLocaleInput) => withLocale('/member', l || 'en'),
+  memberClaims: (l?: RouteLocaleInput) => withLocale('/member/claims', l || 'en'),
+  memberHelp: (l?: RouteLocaleInput) => withLocale('/member/help', l || 'en'),
+  memberNewClaim: (l?: RouteLocaleInput) => withLocale('/member/claims/new', l || 'en'),
+  memberSettings: (l?: RouteLocaleInput) => withLocale('/member/settings', l || 'en'),
+  memberMembership: (l?: RouteLocaleInput) => withLocale('/member/membership', l || 'en'),
+  memberDiaspora: (l?: RouteLocaleInput) => withLocale('/member/diaspora', l || 'en'),
+  memberClaimDetail: (claimId: string, l?: RouteLocaleInput) =>
     withLocale(`/member/claims/${encodeURIComponent(claimId)}`, l || 'en'),
-  staff: (l?: Locale | string | TestInfo) => withLocale('/staff/claims', l || 'en'),
-  staffClaims: (l?: Locale | string | TestInfo) => withLocale('/staff/claims', l || 'en'),
-  staffSupportHandoffs: (l?: Locale | string | TestInfo) =>
+  staff: (l?: RouteLocaleInput) => withLocale('/staff/claims', l || 'en'),
+  staffClaims: (l?: RouteLocaleInput) => withLocale('/staff/claims', l || 'en'),
+  staffSupportHandoffs: (l?: RouteLocaleInput) =>
     withLocale('/staff/support-handoffs', l || 'en'),
-  staffClaimDetail: (claimId: string, l?: Locale | string | TestInfo) =>
+  staffClaimDetail: (claimId: string, l?: RouteLocaleInput) =>
     withLocale(`/staff/claims/${encodeURIComponent(claimId)}`, l || 'en'),
-  admin: (l?: Locale | string | TestInfo) => withLocale('/admin/overview', l || 'en'),
-  adminClaims: (l?: Locale | string | TestInfo) => withLocale('/admin/claims', l || 'en'),
-  adminUsers: (l?: Locale | string | TestInfo) => withLocale('/admin/users', l || 'en'),
-  adminAnalytics: (l?: Locale | string | TestInfo) => withLocale('/admin/analytics', l || 'en'),
-  adminSettings: (l?: Locale | string | TestInfo) => withLocale('/admin/settings', l || 'en'),
-  adminBranches: (l?: Locale | string | TestInfo) => withLocale('/admin/branches', l || 'en'),
-  adminBranchDetail: (branchId: string, l?: Locale | string | TestInfo) =>
+  admin: (l?: RouteLocaleInput) => withLocale('/admin/overview', l || 'en'),
+  adminClaims: (l?: RouteLocaleInput) => withLocale('/admin/claims', l || 'en'),
+  adminUsers: (l?: RouteLocaleInput) => withLocale('/admin/users', l || 'en'),
+  adminAnalytics: (l?: RouteLocaleInput) => withLocale('/admin/analytics', l || 'en'),
+  adminSettings: (l?: RouteLocaleInput) => withLocale('/admin/settings', l || 'en'),
+  adminBranches: (l?: RouteLocaleInput) => withLocale('/admin/branches', l || 'en'),
+  adminBranchDetail: (branchId: string, l?: RouteLocaleInput) =>
     withLocale(`/admin/branches/${encodeURIComponent(branchId)}`, l || 'en'),
-  adminLeads: (l?: Locale | string | TestInfo) => withLocale('/admin/leads', l || 'en'),
-  agent: (l?: Locale | string | TestInfo) => withLocale('/agent/members', l || 'en'),
-  agentMembers: (l?: Locale | string | TestInfo) => withLocale('/agent/members', l || 'en'),
-  agentImport: (l?: Locale | string | TestInfo) => withLocale('/agent/import', l || 'en'),
-  agentMemberDetail: (memberId: string, l?: Locale | string | TestInfo) =>
+  adminLeads: (l?: RouteLocaleInput) => withLocale('/admin/leads', l || 'en'),
+  agent: (l?: RouteLocaleInput) => withLocale('/agent/members', l || 'en'),
+  agentMembers: (l?: RouteLocaleInput) => withLocale('/agent/members', l || 'en'),
+  agentImport: (l?: RouteLocaleInput) => withLocale('/agent/import', l || 'en'),
+  agentMemberDetail: (memberId: string, l?: RouteLocaleInput) =>
     withLocale(`/agent/members/${encodeURIComponent(memberId)}`, l || 'en'),
-  agentLeads: (l?: Locale | string | TestInfo) => withLocale('/agent/leads', l || 'en'),
-  agentCrm: (l?: Locale | string | TestInfo) => withLocale('/agent/crm', l || 'en'),
-  agentClients: (l?: Locale | string | TestInfo) => withLocale('/agent/clients', l || 'en'),
-  agentCommissions: (l?: Locale | string | TestInfo) => withLocale('/agent/commissions', l || 'en'),
-  agentWorkspace: (l?: Locale | string | TestInfo) => withLocale('/agent/workspace', l || 'en'),
-  agentWorkspaceLeads: (l?: Locale | string | TestInfo) =>
+  agentLeads: (l?: RouteLocaleInput) => withLocale('/agent/leads', l || 'en'),
+  agentCrm: (l?: RouteLocaleInput) => withLocale('/agent/crm', l || 'en'),
+  agentClients: (l?: RouteLocaleInput) => withLocale('/agent/clients', l || 'en'),
+  agentCommissions: (l?: RouteLocaleInput) => withLocale('/agent/commissions', l || 'en'),
+  agentWorkspace: (l?: RouteLocaleInput) => withLocale('/agent/workspace', l || 'en'),
+  agentWorkspaceLeads: (l?: RouteLocaleInput) =>
     withLocale('/agent/workspace/leads', l || 'en'),
-  agentWorkspaceClaims: (l?: Locale | string | TestInfo) =>
+  agentWorkspaceClaims: (l?: RouteLocaleInput) =>
     withLocale('/agent/workspace/claims', l || 'en'),
 } as const;

--- a/apps/web/e2e/routes.ts
+++ b/apps/web/e2e/routes.ts
@@ -72,7 +72,7 @@ export const routes = {
   stats: (l?: Locale | string | TestInfo) => withLocale('/stats', l || 'en'),
   partners: (l?: Locale | string | TestInfo) => withLocale('/partners', l || 'en'),
   pricing: (l?: Locale | string | TestInfo) => withLocale('/pricing', l || 'en'),
-  helpNow: (l?: Locale | string | TestInfo) => withLocale('/help-now', l || 'en'),
+  helpNow: (l?: string | TestInfo) => withLocale('/help-now', l || 'en'),
   businessMembership: (l?: Locale | string | TestInfo) =>
     withLocale('/business-membership', l || 'en'),
   publicMembershipEntry: (l?: Locale | string | TestInfo) => withLocale('/pricing', l || 'en'),

--- a/apps/web/public/help-now-packs/content-packs.v1.json
+++ b/apps/web/public/help-now-packs/content-packs.v1.json
@@ -69,7 +69,7 @@
     }
   ],
   "privacy": {
-    "serviceWorkerCache": "public-pack-manifest-only",
+    "serviceWorkerCache": "public-help-now-route-and-pack-manifest-only",
     "localEvidenceBundle": "excluded-from-service-worker-cache",
     "uploadEndpoint": null
   }

--- a/apps/web/public/help-now-packs/content-packs.v1.json
+++ b/apps/web/public/help-now-packs/content-packs.v1.json
@@ -1,0 +1,76 @@
+{
+  "version": "mob-01-help-now-dark-packs-2026-07-04-v1",
+  "generatedAt": "2026-07-04T00:00:00.000Z",
+  "publicOnly": true,
+  "containsPersonalData": false,
+  "countries": [
+    {
+      "country": "XK",
+      "marketLabel": "Kosovo",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    },
+    {
+      "country": "MK",
+      "marketLabel": "North Macedonia",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    },
+    {
+      "country": "AL",
+      "marketLabel": "Albania",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    },
+    {
+      "country": "DE",
+      "marketLabel": "Germany",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    },
+    {
+      "country": "AT",
+      "marketLabel": "Austria",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    },
+    {
+      "country": "HU",
+      "marketLabel": "Hungary",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    },
+    {
+      "country": "RS",
+      "marketLabel": "Serbia",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    },
+    {
+      "country": "HR",
+      "marketLabel": "Croatia",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    },
+    {
+      "country": "ME",
+      "marketLabel": "Montenegro",
+      "exposure": "dark",
+      "l2SignOff": null,
+      "reviewStatus": "not_started"
+    }
+  ],
+  "privacy": {
+    "serviceWorkerCache": "public-pack-manifest-only",
+    "localEvidenceBundle": "excluded-from-service-worker-cache",
+    "uploadEndpoint": null
+  }
+}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -2,7 +2,7 @@ const CACHE_NAME = 'interdomestik-offline-v1';
 const HELP_NOW_CACHE_NAME = 'interdomestik-help-now-v1';
 const OFFLINE_URL = '/offline.html'; // Offline fallback page
 const HELP_NOW_PUBLIC_ASSETS = new Set(['/help-now-packs/content-packs.v1.json']);
-const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk|hr|de)\/help-now\/?$/;
+const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk)\/help-now\/?$/;
 
 function isSameOrigin(url) {
   return url.origin === globalThis.location.origin;

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -34,7 +34,8 @@ async function helpNowFallbackResponse(request) {
 }
 
 async function cacheFreshResponse(request, response) {
-  if (!response.ok) return;
+  const pathname = new URL(request.url).pathname;
+  if (!response.ok || !HELP_NOW_PUBLIC_ASSETS.has(pathname)) return;
   try {
     await (await caches.open(HELP_NOW_CACHE_NAME)).put(request, response.clone());
   } catch {}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,5 +1,54 @@
 const CACHE_NAME = 'interdomestik-offline-v1';
+const HELP_NOW_CACHE_NAME = 'interdomestik-help-now-v1';
 const OFFLINE_URL = '/offline.html'; // Offline fallback page
+const HELP_NOW_PUBLIC_ASSETS = new Set(['/help-now-packs/content-packs.v1.json']);
+const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk|hr|de)\/help-now\/?$/;
+
+function isSameOrigin(url) {
+  return url.origin === self.location.origin;
+}
+
+function isHelpNowPublicRequest(url) {
+  return isSameOrigin(url) && HELP_NOW_PUBLIC_ROUTE.test(url.pathname);
+}
+
+async function helpNowFallbackResponse(request) {
+  if (new URL(request.url).pathname.endsWith('.json')) {
+    return new Response(JSON.stringify({ ok: false, reason: 'offline_without_cached_pack' }), {
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+      status: 503,
+    });
+  }
+
+  return (
+    (await caches.match(request)) ||
+    (await caches.match(OFFLINE_URL)) ||
+    new Response('Offline', { status: 503 })
+  );
+}
+
+async function networkFirst(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(HELP_NOW_CACHE_NAME);
+      await cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    return helpNowFallbackResponse(request);
+  }
+}
+
+async function cacheHelpNowNavigation(request) {
+  try {
+    return await fetch(request);
+  } catch {
+    return helpNowFallbackResponse(request);
+  }
+}
 
 self.addEventListener('install', event => {
   event.waitUntil(
@@ -17,11 +66,43 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('activate', event => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    caches
+      .keys()
+      .then(keys =>
+        Promise.all(
+          keys
+            .filter(
+              key =>
+                key.startsWith('interdomestik-') &&
+                key !== CACHE_NAME &&
+                key !== HELP_NOW_CACHE_NAME
+            )
+            .map(key => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
 });
 
 self.addEventListener('fetch', event => {
+  const requestUrl = new URL(event.request.url);
+
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  if (isSameOrigin(requestUrl) && HELP_NOW_PUBLIC_ASSETS.has(requestUrl.pathname)) {
+    event.respondWith(networkFirst(event.request));
+    return;
+  }
+
   if (event.request.mode === 'navigate') {
+    if (isHelpNowPublicRequest(requestUrl)) {
+      event.respondWith(cacheHelpNowNavigation(event.request));
+      return;
+    }
+
     event.respondWith(
       fetch(event.request).catch(() => {
         return caches.match(event.request).then(response => {

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -35,7 +35,12 @@ async function helpNowFallbackResponse(request) {
 
 async function cacheFreshResponse(request, response) {
   const pathname = new URL(request.url).pathname;
-  if (!response.ok || !HELP_NOW_PUBLIC_ASSETS.has(pathname)) return;
+  if (
+    !response.ok ||
+    (!HELP_NOW_PUBLIC_ASSETS.has(pathname) && !HELP_NOW_PUBLIC_ROUTE.test(pathname))
+  ) {
+    return;
+  }
   try {
     await (await caches.open(HELP_NOW_CACHE_NAME)).put(request, response.clone());
   } catch {}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -8,8 +8,14 @@ function isSameOrigin(url) {
   return url.origin === globalThis.location.origin;
 }
 
-function isHelpNowPublicRequest(url) {
-  return isSameOrigin(url) && HELP_NOW_PUBLIC_ROUTE.test(url.pathname);
+function deleteOldInterdomestikCaches(keys) {
+  return Promise.all(
+    keys
+      .filter(
+        key => key.startsWith('interdomestik-') && key !== CACHE_NAME && key !== HELP_NOW_CACHE_NAME
+      )
+      .map(key => caches.delete(key))
+  );
 }
 
 async function helpNowFallbackResponse(request) {
@@ -31,8 +37,10 @@ async function networkFirst(request) {
   try {
     const response = await fetch(request);
     if (response.ok) {
-      const cache = await caches.open(HELP_NOW_CACHE_NAME);
-      await cache.put(request, response.clone());
+      try {
+        const cache = await caches.open(HELP_NOW_CACHE_NAME);
+        await cache.put(request, response.clone());
+      } catch {}
     }
     return response;
   } catch {
@@ -52,15 +60,17 @@ async function cacheHelpNowNavigation(request) {
 
 globalThis.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => {
-      return cache.addAll([
-        '/favicon.ico',
-        '/manifest.json',
-        OFFLINE_URL,
-        '/icon-192.png',
-        '/icon-512.png',
-      ]);
-    })
+    caches
+      .open(CACHE_NAME)
+      .then(cache =>
+        cache.addAll([
+          '/favicon.ico',
+          '/manifest.json',
+          OFFLINE_URL,
+          '/icon-192.png',
+          '/icon-512.png',
+        ])
+      )
   );
   globalThis.skipWaiting();
 });
@@ -69,18 +79,7 @@ globalThis.addEventListener('activate', event => {
   event.waitUntil(
     caches
       .keys()
-      .then(keys =>
-        Promise.all(
-          keys
-            .filter(
-              key =>
-                key.startsWith('interdomestik-') &&
-                key !== CACHE_NAME &&
-                key !== HELP_NOW_CACHE_NAME
-            )
-            .map(key => caches.delete(key))
-        )
-      )
+      .then(deleteOldInterdomestikCaches)
       .then(() => globalThis.clients.claim())
   );
 });
@@ -98,7 +97,7 @@ globalThis.addEventListener('fetch', event => {
   }
 
   if (event.request.mode === 'navigate') {
-    if (isHelpNowPublicRequest(requestUrl)) {
+    if (isSameOrigin(requestUrl) && HELP_NOW_PUBLIC_ROUTE.test(requestUrl.pathname)) {
       event.respondWith(cacheHelpNowNavigation(event.request));
       return;
     }

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -5,7 +5,7 @@ const HELP_NOW_PUBLIC_ASSETS = new Set(['/help-now-packs/content-packs.v1.json']
 const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk|hr|de)\/help-now\/?$/;
 
 function isSameOrigin(url) {
-  return url.origin === self.location.origin;
+  return url.origin === globalThis.location.origin;
 }
 
 function isHelpNowPublicRequest(url) {
@@ -50,7 +50,7 @@ async function cacheHelpNowNavigation(request) {
   }
 }
 
-self.addEventListener('install', event => {
+globalThis.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => {
       return cache.addAll([
@@ -62,10 +62,10 @@ self.addEventListener('install', event => {
       ]);
     })
   );
-  self.skipWaiting();
+  globalThis.skipWaiting();
 });
 
-self.addEventListener('activate', event => {
+globalThis.addEventListener('activate', event => {
   event.waitUntil(
     caches
       .keys()
@@ -81,11 +81,11 @@ self.addEventListener('activate', event => {
             .map(key => caches.delete(key))
         )
       )
-      .then(() => self.clients.claim())
+      .then(() => globalThis.clients.claim())
   );
 });
 
-self.addEventListener('fetch', event => {
+globalThis.addEventListener('fetch', event => {
   const requestUrl = new URL(event.request.url);
 
   if (event.request.method !== 'GET') {
@@ -113,7 +113,7 @@ self.addEventListener('fetch', event => {
   }
 });
 
-self.addEventListener('push', event => {
+globalThis.addEventListener('push', event => {
   let payload = {};
 
   try {
@@ -132,19 +132,19 @@ self.addEventListener('push', event => {
     },
   };
 
-  event.waitUntil(self.registration.showNotification(title, options));
+  event.waitUntil(globalThis.registration.showNotification(title, options));
 });
 
-self.addEventListener('notificationclick', event => {
+globalThis.addEventListener('notificationclick', event => {
   event.notification.close();
 
   const url = event.notification?.data?.url || '/';
   event.waitUntil(
-    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clientList => {
+    globalThis.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clientList => {
       for (const client of clientList) {
         if ('focus' in client) return client.focus();
       }
-      if (self.clients.openWindow) return self.clients.openWindow(url);
+      if (globalThis.clients.openWindow) return globalThis.clients.openWindow(url);
     })
   );
 });

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -33,27 +33,21 @@ async function helpNowFallbackResponse(request) {
   );
 }
 
+async function cacheFreshResponse(request, response) {
+  if (!response.ok) return;
+  try {
+    await (await caches.open(HELP_NOW_CACHE_NAME)).put(request, response.clone());
+  } catch {}
+}
+
 async function networkFirst(request) {
   try {
     const response = await fetch(request);
-    if (response.ok) {
-      try {
-        const cache = await caches.open(HELP_NOW_CACHE_NAME);
-        await cache.put(request, response.clone());
-      } catch {}
-    }
+    await cacheFreshResponse(request, response);
     return response;
   } catch {
     const cached = await caches.match(request);
     if (cached) return cached;
-    return helpNowFallbackResponse(request);
-  }
-}
-
-async function cacheHelpNowNavigation(request) {
-  try {
-    return await fetch(request);
-  } catch {
     return helpNowFallbackResponse(request);
   }
 }
@@ -98,7 +92,7 @@ globalThis.addEventListener('fetch', event => {
 
   if (event.request.mode === 'navigate') {
     if (isSameOrigin(requestUrl) && HELP_NOW_PUBLIC_ROUTE.test(requestUrl.pathname)) {
-      event.respondWith(cacheHelpNowNavigation(event.request));
+      event.respondWith(networkFirst(event.request));
       return;
     }
 

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -2,7 +2,7 @@ const CACHE_NAME = 'interdomestik-offline-v1';
 const HELP_NOW_CACHE_NAME = 'interdomestik-help-now-v1';
 const OFFLINE_URL = '/offline.html'; // Offline fallback page
 const HELP_NOW_PUBLIC_ASSETS = new Set(['/help-now-packs/content-packs.v1.json']);
-const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk)\/help-now\/?$/;
+const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk|de|hr)\/help-now\/?$/;
 
 function isSameOrigin(url) {
   return url.origin === globalThis.location.origin;

--- a/apps/web/src/app/[locale]/(site)/help-now/page.tsx
+++ b/apps/web/src/app/[locale]/(site)/help-now/page.tsx
@@ -5,9 +5,9 @@ import type { Metadata } from 'next';
 import { setRequestLocale } from 'next-intl/server';
 export { generateLocaleStaticParams as generateStaticParams } from '@/app/_locale-static-params';
 
-type HelpNowPageProps = {
+type HelpNowPageProps = Readonly<{
   params: Promise<{ locale: string }>;
-};
+}>;
 
 export async function generateMetadata({ params }: HelpNowPageProps): Promise<Metadata> {
   const { locale } = await params;

--- a/apps/web/src/app/[locale]/(site)/help-now/page.tsx
+++ b/apps/web/src/app/[locale]/(site)/help-now/page.tsx
@@ -1,0 +1,27 @@
+import { HelpNowExperience } from '@/features/help-now/help-now-experience';
+import { getHelpNowContentLocale } from '@/features/help-now/content-packs';
+import { getHelpNowCopy } from '@/features/help-now/copy';
+import type { Metadata } from 'next';
+import { setRequestLocale } from 'next-intl/server';
+export { generateLocaleStaticParams as generateStaticParams } from '@/app/_locale-static-params';
+
+type HelpNowPageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: HelpNowPageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const copy = getHelpNowCopy(getHelpNowContentLocale(locale));
+
+  return {
+    title: `${copy.title} | Interdomestik`,
+    description: copy.subtitle,
+  };
+}
+
+export default async function HelpNowPage({ params }: HelpNowPageProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return <HelpNowExperience locale={locale} />;
+}

--- a/apps/web/src/app/[locale]/components/home/hero-cta-label.test.ts
+++ b/apps/web/src/app/[locale]/components/home/hero-cta-label.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { getHeroPrimaryLabel } from './hero-cta-label';
+
+const labels = {
+  'v2.helpNow': 'Get help now (60 sec)',
+  callNow: 'Start in 60 seconds',
+  cta: 'Start protection',
+};
+
+describe('getHeroPrimaryLabel', () => {
+  const t = (key: string) => labels[key as keyof typeof labels];
+
+  it('matches the public Help Now destination with urgent copy', () => {
+    expect(getHeroPrimaryLabel('/help-now', t)).toBe('Get help now (60 sec)');
+  });
+
+  it('keeps existing membership and anchor labels', () => {
+    expect(getHeroPrimaryLabel('#free-start-intake', t)).toBe('Start in 60 seconds');
+    expect(getHeroPrimaryLabel('/member', t)).toBe('Start protection');
+  });
+});

--- a/apps/web/src/app/[locale]/components/home/hero-cta-label.ts
+++ b/apps/web/src/app/[locale]/components/home/hero-cta-label.ts
@@ -1,0 +1,9 @@
+import { PUBLIC_FREE_START_ANCHOR_HREF } from '@/lib/public-membership-entry';
+
+type HeroTranslator = (key: string) => string;
+
+export function getHeroPrimaryLabel(primaryHref: string, t: HeroTranslator): string {
+  if (primaryHref === '/help-now') return t('v2.helpNow');
+  if (primaryHref.includes(PUBLIC_FREE_START_ANCHOR_HREF)) return t('callNow');
+  return t('cta');
+}

--- a/apps/web/src/app/[locale]/components/home/hero-section.tsx
+++ b/apps/web/src/app/[locale]/components/home/hero-section.tsx
@@ -5,6 +5,7 @@ import { Button } from '@interdomestik/ui';
 import { ArrowRight, CheckCircle2, Clock, Shield, ShieldCheck, Star, Users } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { DigitalIDCard } from './digital-id-card';
+import { getHeroPrimaryLabel } from './hero-cta-label';
 
 type HeroSectionProps = Readonly<{
   locale?: string;
@@ -26,9 +27,7 @@ export function HeroSection({
   const titleHasQuestionBreak = title.includes('?');
   const titleLead = titleHasQuestionBreak ? `${title.split('?').slice(0, -1).join('?')}?` : title;
   const titleAccent = titleHasQuestionBreak ? (title.split('?').slice(-1)[0]?.trim() ?? '') : '';
-  const primaryLabel = primaryHref.includes(PUBLIC_FREE_START_ANCHOR_HREF)
-    ? t('callNow')
-    : t('cta');
+  const primaryLabel = getHeroPrimaryLabel(primaryHref, t);
 
   return (
     <section className="relative overflow-hidden bg-[#FAF9F6] pt-20 lg:min-h-[88vh]">

--- a/apps/web/src/app/[locale]/components/home/home-page-runtime.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/home-page-runtime.test.tsx
@@ -84,8 +84,8 @@ describe('HomePageRuntime', () => {
       });
       expect(hoisted.heroSectionMock).toHaveBeenCalledWith({
         locale: 'sq',
-        primaryHref: '#free-start-intake',
-        secondaryHref: undefined,
+        primaryHref: '/sq/help-now',
+        secondaryHref: '#free-start-intake',
         tenantId: 'tenant_mk',
       });
       expect(hoisted.freeStartIntakeShellMock).toHaveBeenCalledWith({

--- a/apps/web/src/app/[locale]/components/home/home-page-runtime.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/home-page-runtime.test.tsx
@@ -84,7 +84,7 @@ describe('HomePageRuntime', () => {
       });
       expect(hoisted.heroSectionMock).toHaveBeenCalledWith({
         locale: 'sq',
-        primaryHref: '/sq/help-now',
+        primaryHref: '/help-now',
         secondaryHref: '#free-start-intake',
         tenantId: 'tenant_mk',
       });

--- a/apps/web/src/app/[locale]/components/home/home-page-runtime.tsx
+++ b/apps/web/src/app/[locale]/components/home/home-page-runtime.tsx
@@ -68,9 +68,9 @@ export function HomePageRuntime({ locale, uiV2Enabled }: HomePageRuntimeProps) {
     locale,
     session: landingSession,
   });
-  const startClaimHref = landingSession === null ? PUBLIC_FREE_START_ANCHOR_HREF : continueHref;
-  const primaryHref = landingSession === null ? PUBLIC_FREE_START_ANCHOR_HREF : '/member';
-  const secondaryHref = landingSession === null ? undefined : startClaimHref;
+  const publicHelpNowHref = `/${locale}/help-now`;
+  const primaryHref = landingSession === null ? publicHelpNowHref : '/member';
+  const secondaryHref = landingSession === null ? PUBLIC_FREE_START_ANCHOR_HREF : continueHref;
 
   return (
     <>

--- a/apps/web/src/app/[locale]/components/home/home-page-runtime.tsx
+++ b/apps/web/src/app/[locale]/components/home/home-page-runtime.tsx
@@ -68,7 +68,7 @@ export function HomePageRuntime({ locale, uiV2Enabled }: HomePageRuntimeProps) {
     locale,
     session: landingSession,
   });
-  const publicHelpNowHref = `/${locale}/help-now`;
+  const publicHelpNowHref = '/help-now';
   const primaryHref = landingSession === null ? publicHelpNowHref : '/member';
   const secondaryHref = landingSession === null ? PUBLIC_FREE_START_ANCHOR_HREF : continueHref;
 

--- a/apps/web/src/features/help-now/analytics.test.ts
+++ b/apps/web/src/features/help-now/analytics.test.ts
@@ -36,6 +36,7 @@ describe('MOB-01 anonymous funnel analytics', () => {
     events.forEach(event => {
       trackHelpNowEvent(event, {
         country: 'XK',
+        scenario: undefined,
         // @ts-expect-error guard test for accidental free-text leakage
         description: 'private crash note',
       });

--- a/apps/web/src/features/help-now/analytics.test.ts
+++ b/apps/web/src/features/help-now/analytics.test.ts
@@ -23,4 +23,26 @@ describe('MOB-01 anonymous funnel analytics', () => {
       offline: true,
     });
   });
+
+  it('applies the property allowlist across all anonymous funnel events', () => {
+    const events = [
+      'help_now_opened',
+      'checklist_item_done',
+      'trip_pack_downloaded',
+      'evidence_bundle_created',
+      'claim_pack_generated',
+    ] as const;
+
+    events.forEach(event => {
+      trackHelpNowEvent(event, {
+        country: 'XK',
+        // @ts-expect-error guard test for accidental free-text leakage
+        description: 'private crash note',
+      });
+    });
+
+    events.forEach((event, index) => {
+      expect(trackEvent).toHaveBeenNthCalledWith(index + 1, event, { country: 'XK' });
+    });
+  });
 });

--- a/apps/web/src/features/help-now/analytics.test.ts
+++ b/apps/web/src/features/help-now/analytics.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { trackHelpNowEvent } from './analytics';
+
+const trackEvent = vi.fn();
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: (event: string, props?: Record<string, unknown>) => trackEvent(event, props),
+}));
+
+describe('MOB-01 anonymous funnel analytics', () => {
+  beforeEach(() => trackEvent.mockClear());
+
+  it('drops non-contract properties before sending events', () => {
+    trackHelpNowEvent('help_now_opened', {
+      country: 'XK',
+      offline: true,
+      // @ts-expect-error guard test for accidental free-text leakage
+      narrative: 'other driver said something',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith('help_now_opened', {
+      country: 'XK',
+      offline: true,
+    });
+  });
+});

--- a/apps/web/src/features/help-now/analytics.ts
+++ b/apps/web/src/features/help-now/analytics.ts
@@ -1,0 +1,42 @@
+import { trackEvent } from '@/lib/analytics';
+
+type HelpNowEventName =
+  | 'help_now_opened'
+  | 'checklist_item_done'
+  | 'trip_pack_downloaded'
+  | 'evidence_bundle_created'
+  | 'claim_pack_generated';
+
+type HelpNowEventProps = {
+  country?: string;
+  offline?: boolean;
+  scenario?: 'car' | 'injury' | 'property' | 'flight';
+  item_index?: number;
+  checklist_type?: 'scene' | 'trip';
+  item_count_bucket?: '0' | '1_2' | '3_5' | '6_plus';
+  camera_denied?: boolean;
+  pack_count?: number;
+  total_mb_bucket?: 'under_1' | '1_3' | 'over_3';
+  has_bundle?: boolean;
+};
+
+const ALLOWED_KEYS = new Set([
+  'country',
+  'offline',
+  'scenario',
+  'item_index',
+  'checklist_type',
+  'item_count_bucket',
+  'camera_denied',
+  'pack_count',
+  'total_mb_bucket',
+  'has_bundle',
+]);
+
+export function trackHelpNowEvent(event: HelpNowEventName, props: HelpNowEventProps = {}) {
+  const safeProps = Object.fromEntries(
+    Object.entries(props).filter(([key]) => ALLOWED_KEYS.has(key))
+  );
+
+  trackEvent(event, safeProps);
+}

--- a/apps/web/src/features/help-now/analytics.ts
+++ b/apps/web/src/features/help-now/analytics.ts
@@ -35,7 +35,7 @@ const ALLOWED_KEYS = new Set([
 
 export function trackHelpNowEvent(event: HelpNowEventName, props: HelpNowEventProps = {}) {
   const safeProps = Object.fromEntries(
-    Object.entries(props).filter(([key]) => ALLOWED_KEYS.has(key))
+    Object.entries(props).filter(([key, value]) => ALLOWED_KEYS.has(key) && value !== undefined)
   );
 
   trackEvent(event, safeProps);

--- a/apps/web/src/features/help-now/claim-pack-preview.tsx
+++ b/apps/web/src/features/help-now/claim-pack-preview.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import type { IncidentScenePack } from '@interdomestik/domain-assistance';
+import type { HelpNowCopy } from './copy';
+import { trackHelpNowEvent } from './analytics';
+import type { HelpNowCountry, HelpNowScenario } from './content-packs';
+
+type ClaimPackPreviewProps = {
+  copy: HelpNowCopy;
+  pack: IncidentScenePack | null;
+  completedCount: number;
+  country: HelpNowCountry;
+  evidenceCount: number;
+  scenario: HelpNowScenario;
+};
+
+export function ClaimPackPreview({
+  copy,
+  pack,
+  completedCount,
+  country,
+  evidenceCount,
+  scenario,
+}: ClaimPackPreviewProps) {
+  const [isPreviewReady, setIsPreviewReady] = useState(false);
+
+  function handleGeneratePreview() {
+    if (!pack) return;
+
+    setIsPreviewReady(true);
+    trackHelpNowEvent('claim_pack_generated', {
+      country,
+      has_bundle: evidenceCount > 0,
+      scenario,
+    });
+  }
+
+  return (
+    <section
+      className="rounded-lg border border-slate-200 bg-white p-4"
+      aria-labelledby="claim-pack-title"
+    >
+      <h2 id="claim-pack-title" className="text-lg font-semibold text-slate-950">
+        {copy.packTitle}
+      </h2>
+      <p className="mt-1 text-sm text-slate-600">{copy.packBody}</p>
+      {!pack ? (
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+          <p className="font-semibold">{copy.darkTitle}</p>
+          <p className="mt-1">{copy.darkBody}</p>
+        </div>
+      ) : (
+        <>
+          <dl className="mt-4 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-md bg-slate-50 p-3">
+              <dt className="text-xs font-semibold uppercase text-slate-500">Zone</dt>
+              <dd className="mt-1 text-sm font-semibold text-slate-950">{pack.zone}</dd>
+            </div>
+            <div className="rounded-md bg-slate-50 p-3">
+              <dt className="text-xs font-semibold uppercase text-slate-500">Checklist</dt>
+              <dd className="mt-1 text-sm font-semibold text-slate-950">{completedCount}</dd>
+            </div>
+            <div className="rounded-md bg-slate-50 p-3">
+              <dt className="text-xs font-semibold uppercase text-slate-500">Local evidence</dt>
+              <dd className="mt-1 text-sm font-semibold text-slate-950">{evidenceCount}</dd>
+            </div>
+          </dl>
+          <button
+            type="button"
+            data-testid="help-now-generate-pack"
+            onClick={handleGeneratePreview}
+            className="mt-4 rounded-md border border-slate-300 px-4 py-3 text-sm font-semibold text-slate-900"
+          >
+            Generate local preview
+          </button>
+          {isPreviewReady ? (
+            <p className="mt-3 text-sm font-medium text-emerald-800" role="status">
+              Local preview ready for {country}: {completedCount} checklist items and{' '}
+              {evidenceCount} evidence notes.
+            </p>
+          ) : null}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/help-now/claim-pack-preview.tsx
+++ b/apps/web/src/features/help-now/claim-pack-preview.tsx
@@ -5,15 +5,16 @@ import type { IncidentScenePack } from '@interdomestik/domain-assistance';
 import type { HelpNowCopy } from './copy';
 import { trackHelpNowEvent } from './analytics';
 import type { HelpNowCountry, HelpNowScenario } from './content-packs';
+import { HelpNowMetric, HelpNowPanel } from './help-now-ui';
 
-type ClaimPackPreviewProps = {
+type ClaimPackPreviewProps = Readonly<{
   copy: HelpNowCopy;
   pack: IncidentScenePack | null;
   completedCount: number;
   country: HelpNowCountry;
   evidenceCount: number;
   scenario: HelpNowScenario;
-};
+}>;
 
 export function ClaimPackPreview({
   copy,
@@ -36,35 +37,21 @@ export function ClaimPackPreview({
     });
   }
 
+  const metrics = [
+    { label: 'Zone', value: pack?.zone },
+    { label: 'Checklist', value: completedCount },
+    { label: 'Local evidence', value: evidenceCount },
+  ];
+
   return (
-    <section
-      className="rounded-lg border border-slate-200 bg-white p-4"
-      aria-labelledby="claim-pack-title"
-    >
-      <h2 id="claim-pack-title" className="text-lg font-semibold text-slate-950">
-        {copy.packTitle}
-      </h2>
+    <HelpNowPanel title={copy.packTitle} titleId="claim-pack-title">
       <p className="mt-1 text-sm text-slate-600">{copy.packBody}</p>
-      {!pack ? (
-        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
-          <p className="font-semibold">{copy.darkTitle}</p>
-          <p className="mt-1">{copy.darkBody}</p>
-        </div>
-      ) : (
+      {pack ? (
         <>
           <dl className="mt-4 grid gap-3 sm:grid-cols-3">
-            <div className="rounded-md bg-slate-50 p-3">
-              <dt className="text-xs font-semibold uppercase text-slate-500">Zone</dt>
-              <dd className="mt-1 text-sm font-semibold text-slate-950">{pack.zone}</dd>
-            </div>
-            <div className="rounded-md bg-slate-50 p-3">
-              <dt className="text-xs font-semibold uppercase text-slate-500">Checklist</dt>
-              <dd className="mt-1 text-sm font-semibold text-slate-950">{completedCount}</dd>
-            </div>
-            <div className="rounded-md bg-slate-50 p-3">
-              <dt className="text-xs font-semibold uppercase text-slate-500">Local evidence</dt>
-              <dd className="mt-1 text-sm font-semibold text-slate-950">{evidenceCount}</dd>
-            </div>
+            {metrics.map(metric => (
+              <HelpNowMetric key={metric.label} label={metric.label} value={metric.value} />
+            ))}
           </dl>
           <button
             type="button"
@@ -75,13 +62,18 @@ export function ClaimPackPreview({
             Generate local preview
           </button>
           {isPreviewReady ? (
-            <p className="mt-3 text-sm font-medium text-emerald-800" role="status">
+            <output className="mt-3 block text-sm font-medium text-emerald-800">
               Local preview ready for {country}: {completedCount} checklist items and{' '}
               {evidenceCount} evidence notes.
-            </p>
+            </output>
           ) : null}
         </>
+      ) : (
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+          <p className="font-semibold">{copy.darkTitle}</p>
+          <p className="mt-1">{copy.darkBody}</p>
+        </div>
       )}
-    </section>
+    </HelpNowPanel>
   );
 }

--- a/apps/web/src/features/help-now/content-packs.test.ts
+++ b/apps/web/src/features/help-now/content-packs.test.ts
@@ -5,7 +5,6 @@ import {
   HELP_NOW_CONTENT_LOCALES,
   HELP_NOW_PACK_ASSET,
   canExposeCountryPack,
-  getDefaultHelpNowCountry,
   getHelpNowContentLocale,
   getSignedOffHelpNowPacks,
   getTripModeDownloadAssets,
@@ -18,9 +17,10 @@ describe('MOB-01 content-pack gating', () => {
     expect(HELP_NOW_COUNTRY_PACKS.every(pack => !canExposeCountryPack(pack))).toBe(true);
   });
 
-  it('supports de only inside the Help Now content envelope', () => {
-    expect(HELP_NOW_CONTENT_LOCALES).toContain('de');
-    expect(getDefaultHelpNowCountry('de')).toBe('DE');
+  it('keeps unsupported route locales on English copy while preserving Germany as a trip country', () => {
+    expect(HELP_NOW_CONTENT_LOCALES).not.toContain('de');
+    expect(getHelpNowContentLocale('de')).toBe('en');
+    expect(HELP_NOW_COUNTRY_PACKS.some(pack => pack.country === 'DE')).toBe(true);
   });
 
   it('keeps hr routable with the English fallback until localized copy is signed off', () => {

--- a/apps/web/src/features/help-now/content-packs.test.ts
+++ b/apps/web/src/features/help-now/content-packs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import packManifest from '../../../public/help-now-packs/content-packs.v1.json';
+import {
+  HELP_NOW_COUNTRY_PACKS,
+  HELP_NOW_CONTENT_LOCALES,
+  HELP_NOW_PACK_ASSET,
+  canExposeCountryPack,
+  getDefaultHelpNowCountry,
+  getHelpNowContentLocale,
+  getSignedOffHelpNowPacks,
+  getTripModeDownloadAssets,
+} from './content-packs';
+
+describe('MOB-01 content-pack gating', () => {
+  it('keeps unsigned country packs dark until L2 sign-off exists', () => {
+    expect(getSignedOffHelpNowPacks()).toHaveLength(0);
+    expect(HELP_NOW_COUNTRY_PACKS.every(pack => pack.exposure === 'dark')).toBe(true);
+    expect(HELP_NOW_COUNTRY_PACKS.every(pack => !canExposeCountryPack(pack))).toBe(true);
+  });
+
+  it('supports de only inside the Help Now content envelope', () => {
+    expect(HELP_NOW_CONTENT_LOCALES).toContain('de');
+    expect(getDefaultHelpNowCountry('de')).toBe('DE');
+  });
+
+  it('keeps hr routable with the English fallback until localized copy is signed off', () => {
+    expect(getHelpNowContentLocale('hr')).toBe('en');
+  });
+
+  it('only exposes public pack assets for Trip Mode offline download', () => {
+    expect(getTripModeDownloadAssets()).toEqual([HELP_NOW_PACK_ASSET]);
+    expect(getTripModeDownloadAssets().some(asset => asset.startsWith('/api/'))).toBe(false);
+    expect(getTripModeDownloadAssets().some(asset => asset.includes('/member'))).toBe(false);
+  });
+
+  it('keeps the served pack manifest aligned with the TS gate metadata', () => {
+    expect(packManifest.countries).toEqual(HELP_NOW_COUNTRY_PACKS);
+  });
+});

--- a/apps/web/src/features/help-now/content-packs.ts
+++ b/apps/web/src/features/help-now/content-packs.ts
@@ -1,0 +1,119 @@
+export const HELP_NOW_CACHE_NAME = 'interdomestik-help-now-v1';
+export const HELP_NOW_PACK_ASSET = '/help-now-packs/content-packs.v1.json';
+
+export const HELP_NOW_CONTENT_LOCALES = ['en', 'sq', 'mk', 'sr', 'de'] as const;
+export type HelpNowContentLocale = (typeof HELP_NOW_CONTENT_LOCALES)[number];
+export type HelpNowScenario = 'car' | 'injury' | 'property' | 'flight';
+
+export type HelpNowCountryPack = {
+  country: 'XK' | 'MK' | 'AL' | 'DE' | 'AT' | 'HU' | 'RS' | 'HR' | 'ME';
+  marketLabel: string;
+  exposure: 'dark' | 'public';
+  l2SignOff: { reviewer: string; date: string; packHash: string } | null;
+  reviewStatus: 'not_started';
+};
+
+export type HelpNowCountry = HelpNowCountryPack['country'];
+
+export const HELP_NOW_SCENARIOS: readonly HelpNowScenario[] = [
+  'car',
+  'injury',
+  'property',
+  'flight',
+] as const;
+
+export const HELP_NOW_COUNTRY_PACKS: readonly HelpNowCountryPack[] = [
+  {
+    country: 'XK',
+    marketLabel: 'Kosovo',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+  {
+    country: 'MK',
+    marketLabel: 'North Macedonia',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+  {
+    country: 'AL',
+    marketLabel: 'Albania',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+  {
+    country: 'DE',
+    marketLabel: 'Germany',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+  {
+    country: 'AT',
+    marketLabel: 'Austria',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+  {
+    country: 'HU',
+    marketLabel: 'Hungary',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+  {
+    country: 'RS',
+    marketLabel: 'Serbia',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+  {
+    country: 'HR',
+    marketLabel: 'Croatia',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+  {
+    country: 'ME',
+    marketLabel: 'Montenegro',
+    exposure: 'dark',
+    l2SignOff: null,
+    reviewStatus: 'not_started',
+  },
+] as const;
+
+export function hasHelpNowContentLocale(locale: string): locale is HelpNowContentLocale {
+  return HELP_NOW_CONTENT_LOCALES.includes(locale as HelpNowContentLocale);
+}
+
+export function getHelpNowContentLocale(locale: string): HelpNowContentLocale {
+  return hasHelpNowContentLocale(locale) ? locale : 'en';
+}
+
+export function getDefaultHelpNowCountry(locale: HelpNowContentLocale): HelpNowCountry {
+  if (locale === 'mk') return 'MK';
+  if (locale === 'de') return 'DE';
+  return 'XK';
+}
+
+export function getHelpNowCountryPack(country: HelpNowCountry): HelpNowCountryPack {
+  return HELP_NOW_COUNTRY_PACKS.find(pack => pack.country === country) ?? HELP_NOW_COUNTRY_PACKS[0];
+}
+
+export function getSignedOffHelpNowPacks() {
+  return HELP_NOW_COUNTRY_PACKS.filter(pack => pack.l2SignOff !== null);
+}
+
+export function canExposeCountryPack(pack: HelpNowCountryPack): boolean {
+  return pack.exposure !== 'dark' && pack.l2SignOff !== null;
+}
+
+export function getTripModeDownloadAssets(): readonly string[] {
+  return [HELP_NOW_PACK_ASSET];
+}

--- a/apps/web/src/features/help-now/content-packs.ts
+++ b/apps/web/src/features/help-now/content-packs.ts
@@ -4,16 +4,27 @@ export const HELP_NOW_PACK_ASSET = '/help-now-packs/content-packs.v1.json';
 export const HELP_NOW_CONTENT_LOCALES = ['en', 'sq', 'mk', 'sr', 'de'] as const;
 export type HelpNowContentLocale = (typeof HELP_NOW_CONTENT_LOCALES)[number];
 export type HelpNowScenario = 'car' | 'injury' | 'property' | 'flight';
+const HELP_NOW_COUNTRY_LABELS = {
+  XK: 'Kosovo',
+  MK: 'North Macedonia',
+  AL: 'Albania',
+  DE: 'Germany',
+  AT: 'Austria',
+  HU: 'Hungary',
+  RS: 'Serbia',
+  HR: 'Croatia',
+  ME: 'Montenegro',
+} as const;
+
+export type HelpNowCountry = keyof typeof HELP_NOW_COUNTRY_LABELS;
 
 export type HelpNowCountryPack = {
-  country: 'XK' | 'MK' | 'AL' | 'DE' | 'AT' | 'HU' | 'RS' | 'HR' | 'ME';
+  country: HelpNowCountry;
   marketLabel: string;
   exposure: 'dark' | 'public';
   l2SignOff: { reviewer: string; date: string; packHash: string } | null;
   reviewStatus: 'not_started';
 };
-
-export type HelpNowCountry = HelpNowCountryPack['country'];
 
 export const HELP_NOW_SCENARIOS: readonly HelpNowScenario[] = [
   'car',
@@ -22,71 +33,19 @@ export const HELP_NOW_SCENARIOS: readonly HelpNowScenario[] = [
   'flight',
 ] as const;
 
-export const HELP_NOW_COUNTRY_PACKS: readonly HelpNowCountryPack[] = [
-  {
-    country: 'XK',
-    marketLabel: 'Kosovo',
+function createDarkCountryPack(country: HelpNowCountry): HelpNowCountryPack {
+  return {
+    country,
+    marketLabel: HELP_NOW_COUNTRY_LABELS[country],
     exposure: 'dark',
     l2SignOff: null,
     reviewStatus: 'not_started',
-  },
-  {
-    country: 'MK',
-    marketLabel: 'North Macedonia',
-    exposure: 'dark',
-    l2SignOff: null,
-    reviewStatus: 'not_started',
-  },
-  {
-    country: 'AL',
-    marketLabel: 'Albania',
-    exposure: 'dark',
-    l2SignOff: null,
-    reviewStatus: 'not_started',
-  },
-  {
-    country: 'DE',
-    marketLabel: 'Germany',
-    exposure: 'dark',
-    l2SignOff: null,
-    reviewStatus: 'not_started',
-  },
-  {
-    country: 'AT',
-    marketLabel: 'Austria',
-    exposure: 'dark',
-    l2SignOff: null,
-    reviewStatus: 'not_started',
-  },
-  {
-    country: 'HU',
-    marketLabel: 'Hungary',
-    exposure: 'dark',
-    l2SignOff: null,
-    reviewStatus: 'not_started',
-  },
-  {
-    country: 'RS',
-    marketLabel: 'Serbia',
-    exposure: 'dark',
-    l2SignOff: null,
-    reviewStatus: 'not_started',
-  },
-  {
-    country: 'HR',
-    marketLabel: 'Croatia',
-    exposure: 'dark',
-    l2SignOff: null,
-    reviewStatus: 'not_started',
-  },
-  {
-    country: 'ME',
-    marketLabel: 'Montenegro',
-    exposure: 'dark',
-    l2SignOff: null,
-    reviewStatus: 'not_started',
-  },
-] as const;
+  };
+}
+
+export const HELP_NOW_COUNTRY_PACKS: readonly HelpNowCountryPack[] = (
+  Object.keys(HELP_NOW_COUNTRY_LABELS) as HelpNowCountry[]
+).map(createDarkCountryPack);
 
 export function hasHelpNowContentLocale(locale: string): locale is HelpNowContentLocale {
   return HELP_NOW_CONTENT_LOCALES.includes(locale as HelpNowContentLocale);

--- a/apps/web/src/features/help-now/content-packs.ts
+++ b/apps/web/src/features/help-now/content-packs.ts
@@ -1,7 +1,7 @@
 export const HELP_NOW_CACHE_NAME = 'interdomestik-help-now-v1';
 export const HELP_NOW_PACK_ASSET = '/help-now-packs/content-packs.v1.json';
 
-export const HELP_NOW_CONTENT_LOCALES = ['en', 'sq', 'mk', 'sr', 'de'] as const;
+export const HELP_NOW_CONTENT_LOCALES = ['en', 'sq', 'mk', 'sr'] as const;
 export type HelpNowContentLocale = (typeof HELP_NOW_CONTENT_LOCALES)[number];
 export type HelpNowScenario = 'car' | 'injury' | 'property' | 'flight';
 const HELP_NOW_COUNTRY_LABELS = {
@@ -57,7 +57,6 @@ export function getHelpNowContentLocale(locale: string): HelpNowContentLocale {
 
 export function getDefaultHelpNowCountry(locale: HelpNowContentLocale): HelpNowCountry {
   if (locale === 'mk') return 'MK';
-  if (locale === 'de') return 'DE';
   return 'XK';
 }
 

--- a/apps/web/src/features/help-now/copy-types.ts
+++ b/apps/web/src/features/help-now/copy-types.ts
@@ -1,0 +1,21 @@
+export type HelpNowCopy = {
+  title: string;
+  subtitle: string;
+  offline: string;
+  emergency: string;
+  continueSafe: string;
+  darkTitle: string;
+  darkBody: string;
+  privacy: string;
+  clear: string;
+  download: string;
+  downloadDone: string;
+  downloadFailed: string;
+  downloadUnsupported: string;
+  packTitle: string;
+  packBody: string;
+  scenarios: readonly string[];
+  checklist: readonly string[];
+  shots: readonly string[];
+  tripChecklist: readonly string[];
+};

--- a/apps/web/src/features/help-now/copy.ts
+++ b/apps/web/src/features/help-now/copy.ts
@@ -1,0 +1,143 @@
+import type { HelpNowContentLocale } from './content-packs';
+
+export type HelpNowCopy = {
+  title: string;
+  subtitle: string;
+  offline: string;
+  emergency: string;
+  continueSafe: string;
+  darkTitle: string;
+  darkBody: string;
+  privacy: string;
+  clear: string;
+  download: string;
+  downloadDone: string;
+  packTitle: string;
+  packBody: string;
+  scenarios: readonly string[];
+  checklist: readonly string[];
+  shots: readonly string[];
+  tripChecklist: readonly string[];
+};
+
+const en: HelpNowCopy = {
+  title: 'What happened?',
+  subtitle: 'Roadside help that works before account creation.',
+  offline: 'Public pack can be saved offline. Local bundle never uploads.',
+  emergency: 'Someone is hurt: call local emergency services.',
+  continueSafe: 'No one is hurt: continue the scene checklist.',
+  darkTitle: 'Country pack awaiting L2 sign-off',
+  darkBody:
+    'Country-specific numbers and police thresholds stay dark until a named reviewer signs the pack version.',
+  privacy:
+    'Photo selections are recorded only as local metadata; originals stay under your control.',
+  clear: 'Clear local bundle',
+  download: 'Download public Trip Mode pack',
+  downloadDone: 'Public pack saved for offline use.',
+  packTitle: 'Free Claim Pack preview',
+  packBody: 'Checklist, evidence prompts, and handoff options only. No case is created here.',
+  scenarios: ['Car accident', 'Injury', 'Property damage', 'Flight: coming soon'],
+  checklist: [
+    'Move to safety',
+    'Turn on hazard lights',
+    'Take scene photos',
+    'Exchange details',
+    'Find witnesses',
+    'Do not admit fault',
+  ],
+  shots: [
+    'Wide scene',
+    'Number plates',
+    'Damage close-up',
+    'Road context',
+    'Documents',
+    'Witness notes',
+  ],
+  tripChecklist: ['Green Card', 'EAS form', 'Vehicle documents', 'Family contact', 'Offline pack'],
+};
+
+const sq: HelpNowCopy = {
+  ...en,
+  title: 'Çfarë ndodhi?',
+  subtitle: 'Ndihmë në rrugë para hapjes së llogarisë.',
+  emergency: 'Nëse ka të lënduar, thirrni urgjencën lokale.',
+  continueSafe: 'Nëse nuk ka të lënduar, vazhdoni listën e vendit të ngjarjes.',
+  privacy:
+    'Zgjedhjet e fotove ruhen vetëm si metadata lokale; origjinalet mbeten nën kontrollin tuaj.',
+  clear: 'Fshi paketën lokale',
+  download: 'Shkarko paketën publike Trip Mode',
+  downloadDone: 'Paketa publike u ruajt për përdorim offline.',
+  scenarios: ['Aksident me veturë', 'Lëndim', 'Dëm prone', 'Fluturim: së shpejti'],
+  checklist: [
+    'Dilni në vend të sigurt',
+    'Ndizni dritat paralajmëruese',
+    'Bëni foto',
+    'Shkëmbeni të dhënat',
+    'Gjeni dëshmitarë',
+    'Mos pranoni fajin',
+  ],
+};
+
+const mk: HelpNowCopy = {
+  ...en,
+  title: 'Што се случи?',
+  subtitle: 'Помош на пат пред отворање сметка.',
+  emergency: 'Ако има повредени, јавете се на локалната итна служба.',
+  continueSafe: 'Ако нема повредени, продолжете со списокот за местото.',
+  privacy:
+    'Изборите на фотографии се бележат само како локални metadata; оригиналите остануваат под ваша контрола.',
+  clear: 'Исчисти локален пакет',
+  download: 'Преземи јавен Trip Mode пакет',
+  downloadDone: 'Јавниот пакет е зачуван за offline употреба.',
+  scenarios: ['Сообраќајка', 'Повреда', 'Имотна штета', 'Лет: наскоро'],
+  checklist: [
+    'Преместете се на безбедно',
+    'Вклучете четири трепкачи',
+    'Фотографирајте',
+    'Разменете податоци',
+    'Побарајте сведоци',
+    'Не признавајте вина',
+  ],
+};
+
+const sr: HelpNowCopy = {
+  ...en,
+  title: 'Šta se dogodilo?',
+  subtitle: 'Pomoć na putu pre otvaranja naloga.',
+  emergency: 'Ako je neko povređen, pozovite lokalnu hitnu službu.',
+  continueSafe: 'Ako nema povređenih, nastavite listu na mestu događaja.',
+  privacy:
+    'Izbori fotografija se beleže samo kao lokalni metadata; originali ostaju pod vašom kontrolom.',
+  clear: 'Obriši lokalni paket',
+  download: 'Preuzmi javni Trip Mode paket',
+  downloadDone: 'Javni paket je sačuvan za offline upotrebu.',
+  scenarios: ['Saobraćajna nezgoda', 'Povreda', 'Šteta na imovini', 'Let: uskoro'],
+  checklist: [
+    'Pomerite se na sigurno',
+    'Uključite sva četiri migavca',
+    'Fotografišite mesto',
+    'Razmenite podatke',
+    'Pronađite svedoke',
+    'Ne priznajte krivicu',
+  ],
+};
+
+const de: HelpNowCopy = {
+  ...en,
+  title: 'Was ist passiert?',
+  subtitle: 'Hilfe unterwegs, bevor ein Konto nötig ist.',
+  emergency: 'Wenn jemand verletzt ist, rufen Sie den lokalen Notdienst.',
+  continueSafe: 'Niemand ist verletzt: weiter mit der Unfall-Checkliste.',
+  privacy:
+    'Fotoauswahlen werden nur als lokale Metadaten notiert; Originale bleiben unter Ihrer Kontrolle.',
+  clear: 'Lokales Paket löschen',
+  download: 'Öffentliches Trip-Mode-Paket speichern',
+  downloadDone: 'Öffentliches Paket wurde offline gespeichert.',
+  scenarios: ['Autounfall', 'Verletzung', 'Sachschaden', 'Flug: bald'],
+};
+
+const COPY: Record<HelpNowContentLocale, HelpNowCopy> = { en, sq, mk, sr, de };
+
+export function getHelpNowCopy(locale: HelpNowContentLocale): HelpNowCopy {
+  return COPY[locale];
+}

--- a/apps/web/src/features/help-now/copy.ts
+++ b/apps/web/src/features/help-now/copy.ts
@@ -109,21 +109,6 @@ const sr: HelpNowCopy = {
     'Ne priznajte krivicu',
   ],
 };
-const de: HelpNowCopy = {
-  ...en,
-  title: 'Was ist passiert?',
-  subtitle: 'Hilfe unterwegs, bevor ein Konto nötig ist.',
-  emergency: 'Wenn jemand verletzt ist, rufen Sie den lokalen Notdienst.',
-  continueSafe: 'Niemand ist verletzt: weiter mit der Unfall-Checkliste.',
-  privacy:
-    'Fotoauswahlen werden nur als lokale Metadaten notiert; Originale bleiben unter Ihrer Kontrolle.',
-  clear: 'Lokales Paket löschen',
-  download: 'Öffentliches Trip-Mode-Paket speichern',
-  downloadDone: 'Öffentliches Paket wurde offline gespeichert.',
-  downloadFailed: 'Offline-Speichern fehlgeschlagen. Versuchen Sie es vor der Reise erneut.',
-  downloadUnsupported: 'Offline-Speichern wird in diesem Browser nicht unterstützt.',
-  scenarios: ['Autounfall', 'Verletzung', 'Sachschaden', 'Flug: bald'],
-};
-const COPY: Record<HelpNowContentLocale, HelpNowCopy> = { en, sq, mk, sr, de };
+const COPY: Record<HelpNowContentLocale, HelpNowCopy> = { en, sq, mk, sr };
 
 export const getHelpNowCopy = (locale: HelpNowContentLocale): HelpNowCopy => COPY[locale];

--- a/apps/web/src/features/help-now/copy.ts
+++ b/apps/web/src/features/help-now/copy.ts
@@ -1,24 +1,7 @@
 import type { HelpNowContentLocale } from './content-packs';
+import type { HelpNowCopy } from './copy-types';
 
-export type HelpNowCopy = {
-  title: string;
-  subtitle: string;
-  offline: string;
-  emergency: string;
-  continueSafe: string;
-  darkTitle: string;
-  darkBody: string;
-  privacy: string;
-  clear: string;
-  download: string;
-  downloadDone: string;
-  packTitle: string;
-  packBody: string;
-  scenarios: readonly string[];
-  checklist: readonly string[];
-  shots: readonly string[];
-  tripChecklist: readonly string[];
-};
+export type { HelpNowCopy } from './copy-types';
 
 const en: HelpNowCopy = {
   title: 'What happened?',
@@ -34,6 +17,8 @@ const en: HelpNowCopy = {
   clear: 'Clear local bundle',
   download: 'Download public Trip Mode pack',
   downloadDone: 'Public pack saved for offline use.',
+  downloadFailed: 'Offline save failed. Try again before you travel.',
+  downloadUnsupported: 'Offline save is not supported in this browser.',
   packTitle: 'Free Claim Pack preview',
   packBody: 'Checklist, evidence prompts, and handoff options only. No case is created here.',
   scenarios: ['Car accident', 'Injury', 'Property damage', 'Flight: coming soon'],
@@ -55,7 +40,6 @@ const en: HelpNowCopy = {
   ],
   tripChecklist: ['Green Card', 'EAS form', 'Vehicle documents', 'Family contact', 'Offline pack'],
 };
-
 const sq: HelpNowCopy = {
   ...en,
   title: 'Çfarë ndodhi?',
@@ -67,6 +51,8 @@ const sq: HelpNowCopy = {
   clear: 'Fshi paketën lokale',
   download: 'Shkarko paketën publike Trip Mode',
   downloadDone: 'Paketa publike u ruajt për përdorim offline.',
+  downloadFailed: 'Ruajtja offline dështoi. Provoni përsëri para udhëtimit.',
+  downloadUnsupported: 'Ruajtja offline nuk mbështetet në këtë shfletues.',
   scenarios: ['Aksident me veturë', 'Lëndim', 'Dëm prone', 'Fluturim: së shpejti'],
   checklist: [
     'Dilni në vend të sigurt',
@@ -77,7 +63,6 @@ const sq: HelpNowCopy = {
     'Mos pranoni fajin',
   ],
 };
-
 const mk: HelpNowCopy = {
   ...en,
   title: 'Што се случи?',
@@ -89,6 +74,8 @@ const mk: HelpNowCopy = {
   clear: 'Исчисти локален пакет',
   download: 'Преземи јавен Trip Mode пакет',
   downloadDone: 'Јавниот пакет е зачуван за offline употреба.',
+  downloadFailed: 'Offline зачувувањето не успеа. Обидете се повторно пред патување.',
+  downloadUnsupported: 'Offline зачувување не е поддржано во овој прелистувач.',
   scenarios: ['Сообраќајка', 'Повреда', 'Имотна штета', 'Лет: наскоро'],
   checklist: [
     'Преместете се на безбедно',
@@ -99,7 +86,6 @@ const mk: HelpNowCopy = {
     'Не признавајте вина',
   ],
 };
-
 const sr: HelpNowCopy = {
   ...en,
   title: 'Šta se dogodilo?',
@@ -111,6 +97,8 @@ const sr: HelpNowCopy = {
   clear: 'Obriši lokalni paket',
   download: 'Preuzmi javni Trip Mode paket',
   downloadDone: 'Javni paket je sačuvan za offline upotrebu.',
+  downloadFailed: 'Offline čuvanje nije uspelo. Pokušajte ponovo pre puta.',
+  downloadUnsupported: 'Offline čuvanje nije podržano u ovom pregledaču.',
   scenarios: ['Saobraćajna nezgoda', 'Povreda', 'Šteta na imovini', 'Let: uskoro'],
   checklist: [
     'Pomerite se na sigurno',
@@ -121,7 +109,6 @@ const sr: HelpNowCopy = {
     'Ne priznajte krivicu',
   ],
 };
-
 const de: HelpNowCopy = {
   ...en,
   title: 'Was ist passiert?',
@@ -133,11 +120,10 @@ const de: HelpNowCopy = {
   clear: 'Lokales Paket löschen',
   download: 'Öffentliches Trip-Mode-Paket speichern',
   downloadDone: 'Öffentliches Paket wurde offline gespeichert.',
+  downloadFailed: 'Offline-Speichern fehlgeschlagen. Versuchen Sie es vor der Reise erneut.',
+  downloadUnsupported: 'Offline-Speichern wird in diesem Browser nicht unterstützt.',
   scenarios: ['Autounfall', 'Verletzung', 'Sachschaden', 'Flug: bald'],
 };
-
 const COPY: Record<HelpNowContentLocale, HelpNowCopy> = { en, sq, mk, sr, de };
 
-export function getHelpNowCopy(locale: HelpNowContentLocale): HelpNowCopy {
-  return COPY[locale];
-}
+export const getHelpNowCopy = (locale: HelpNowContentLocale): HelpNowCopy => COPY[locale];

--- a/apps/web/src/features/help-now/evidence-coach.tsx
+++ b/apps/web/src/features/help-now/evidence-coach.tsx
@@ -80,7 +80,6 @@ export function EvidenceCoach({ copy, onBundleChange }: EvidenceCoachProps) {
                   onBundleChange(next.length);
                   trackHelpNowEvent('evidence_bundle_created', {
                     item_count_bucket: bucketFor(next.length),
-                    camera_denied: false,
                   });
                 }}
               />

--- a/apps/web/src/features/help-now/evidence-coach.tsx
+++ b/apps/web/src/features/help-now/evidence-coach.tsx
@@ -58,7 +58,7 @@ export function EvidenceCoach({ copy, onBundleChange }: EvidenceCoachProps) {
         {copy.shots.map((shot, index) => {
           const existing = items.find(item => item.promptId === `shot-${index}`);
           return (
-            <label key={shot} className="rounded-md border border-slate-200 p-3 text-sm">
+            <label key={`shot-${index}`} className="rounded-md border border-slate-200 p-3 text-sm">
               <span className="block font-semibold text-slate-900">{shot}</span>
               <span className="mt-1 block text-slate-600">
                 {existing

--- a/apps/web/src/features/help-now/evidence-coach.tsx
+++ b/apps/web/src/features/help-now/evidence-coach.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  clearEvidenceItems,
+  listEvidenceItems,
+  saveEvidenceItem,
+  type EvidenceItem,
+} from './evidence-store';
+import type { HelpNowCopy } from './copy';
+import { trackHelpNowEvent } from './analytics';
+
+type EvidenceCoachProps = {
+  copy: HelpNowCopy;
+  onBundleChange: (count: number) => void;
+};
+
+function bucketFor(count: number): '0' | '1_2' | '3_5' | '6_plus' {
+  if (count === 0) return '0';
+  if (count <= 2) return '1_2';
+  if (count <= 5) return '3_5';
+  return '6_plus';
+}
+
+export function EvidenceCoach({ copy, onBundleChange }: EvidenceCoachProps) {
+  const [items, setItems] = useState<EvidenceItem[]>([]);
+
+  useEffect(() => {
+    const currentItems = listEvidenceItems();
+    setItems(currentItems);
+    onBundleChange(currentItems.length);
+  }, [onBundleChange]);
+
+  return (
+    <section
+      className="rounded-lg border border-slate-200 bg-white p-4"
+      aria-labelledby="evidence-title"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 id="evidence-title" className="text-lg font-semibold text-slate-950">
+            Evidence Coach
+          </h2>
+          <p className="mt-1 text-sm text-slate-600">{copy.privacy}</p>
+        </div>
+        <button
+          type="button"
+          data-testid="help-now-clear-bundle"
+          onClick={() => {
+            clearEvidenceItems();
+            setItems([]);
+            onBundleChange(0);
+          }}
+          className="rounded-md border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-800"
+        >
+          {copy.clear}
+        </button>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        {copy.shots.map((shot, index) => {
+          const existing = items.find(item => item.promptId === `shot-${index}`);
+          return (
+            <label key={shot} className="rounded-md border border-slate-200 p-3 text-sm">
+              <span className="block font-semibold text-slate-900">{shot}</span>
+              <span className="mt-1 block text-slate-600">
+                {existing
+                  ? `${existing.fileName} · ${new Date(existing.capturedAt).toLocaleTimeString()}`
+                  : 'No file selected'}
+              </span>
+              <input
+                className="mt-3 block w-full text-sm"
+                data-testid={`help-now-shot-${index}`}
+                type="file"
+                accept="image/*"
+                capture="environment"
+                onChange={event => {
+                  const file = event.currentTarget.files?.[0];
+                  if (!file) return;
+                  const item = saveEvidenceItem(`shot-${index}`, file);
+                  const next = [...items.filter(entry => entry.promptId !== item.promptId), item];
+                  setItems(next);
+                  onBundleChange(next.length);
+                  trackHelpNowEvent('evidence_bundle_created', {
+                    item_count_bucket: bucketFor(next.length),
+                    camera_denied: false,
+                  });
+                }}
+              />
+            </label>
+          );
+        })}
+      </div>
+      <p className="mt-4 text-xs font-semibold text-emerald-800" data-testid="help-now-local-only">
+        Local metadata checklist · {items.length} items · nothing sent
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/features/help-now/evidence-coach.tsx
+++ b/apps/web/src/features/help-now/evidence-coach.tsx
@@ -58,7 +58,7 @@ export function EvidenceCoach({ copy, onBundleChange }: EvidenceCoachProps) {
         {copy.shots.map((shot, index) => {
           const existing = items.find(item => item.promptId === `shot-${index}`);
           return (
-            <label key={`shot-${index}`} className="rounded-md border border-slate-200 p-3 text-sm">
+            <label key={shot} className="rounded-md border border-slate-200 p-3 text-sm">
               <span className="block font-semibold text-slate-900">{shot}</span>
               <span className="mt-1 block text-slate-600">
                 {existing

--- a/apps/web/src/features/help-now/evidence-coach.tsx
+++ b/apps/web/src/features/help-now/evidence-coach.tsx
@@ -9,11 +9,12 @@ import {
 } from './evidence-store';
 import type { HelpNowCopy } from './copy';
 import { trackHelpNowEvent } from './analytics';
+import { HelpNowPanel } from './help-now-ui';
 
-type EvidenceCoachProps = {
+type EvidenceCoachProps = Readonly<{
   copy: HelpNowCopy;
   onBundleChange: (count: number) => void;
-};
+}>;
 
 function bucketFor(count: number): '0' | '1_2' | '3_5' | '6_plus' {
   if (count === 0) return '0';
@@ -32,10 +33,7 @@ export function EvidenceCoach({ copy, onBundleChange }: EvidenceCoachProps) {
   }, [onBundleChange]);
 
   return (
-    <section
-      className="rounded-lg border border-slate-200 bg-white p-4"
-      aria-labelledby="evidence-title"
-    >
+    <HelpNowPanel titleId="evidence-title">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h2 id="evidence-title" className="text-lg font-semibold text-slate-950">
@@ -93,6 +91,6 @@ export function EvidenceCoach({ copy, onBundleChange }: EvidenceCoachProps) {
       <p className="mt-4 text-xs font-semibold text-emerald-800" data-testid="help-now-local-only">
         Local metadata checklist · {items.length} items · nothing sent
       </p>
-    </section>
+    </HelpNowPanel>
   );
 }

--- a/apps/web/src/features/help-now/evidence-store.test.ts
+++ b/apps/web/src/features/help-now/evidence-store.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { listEvidenceItems, saveEvidenceItem } from './evidence-store';
+
+const STORAGE_KEY = 'interdomestik.helpNow.evidenceBundle.v1';
+
+describe('evidence-store', () => {
+  afterEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  it('falls back to an empty evidence list for non-array stored JSON', () => {
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ promptId: 'shot-1' }));
+
+    expect(listEvidenceItems()).toEqual([]);
+    expect(() =>
+      saveEvidenceItem('shot-1', new File(['id'], 'passport.jpg', { type: 'image/jpeg' }))
+    ).not.toThrow();
+    expect(listEvidenceItems()).toEqual([
+      expect.objectContaining({
+        promptId: 'shot-1',
+        fileName: 'passport.jpg',
+        fileSize: 2,
+        fileType: 'image/jpeg',
+      }),
+    ]);
+  });
+});

--- a/apps/web/src/features/help-now/evidence-store.ts
+++ b/apps/web/src/features/help-now/evidence-store.ts
@@ -9,10 +9,19 @@ export type EvidenceItem = {
 
 const STORAGE_KEY = 'interdomestik.helpNow.evidenceBundle.v1';
 
-function readItems(): EvidenceItem[] {
-  if (globalThis.localStorage === undefined) return [];
+function getLocalStorage(): Storage | null {
   try {
-    const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readItems(): EvidenceItem[] {
+  const storage = getLocalStorage();
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
     return raw ? (JSON.parse(raw) as EvidenceItem[]) : [];
   } catch {
     return [];
@@ -20,9 +29,10 @@ function readItems(): EvidenceItem[] {
 }
 
 function writeItems(items: EvidenceItem[]) {
-  if (globalThis.localStorage === undefined) return;
+  const storage = getLocalStorage();
+  if (!storage) return;
   try {
-    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    storage.setItem(STORAGE_KEY, JSON.stringify(items));
   } catch {
     // Storage can be blocked or quota-limited; capture remains local UI state only.
   }
@@ -46,9 +56,10 @@ export function saveEvidenceItem(promptId: string, file: File): EvidenceItem {
 }
 
 export function clearEvidenceItems() {
-  if (globalThis.localStorage === undefined) return;
+  const storage = getLocalStorage();
+  if (!storage) return;
   try {
-    globalThis.localStorage.removeItem(STORAGE_KEY);
+    storage.removeItem(STORAGE_KEY);
   } catch {
     // Clearing is best-effort when browser storage is blocked.
   }

--- a/apps/web/src/features/help-now/evidence-store.ts
+++ b/apps/web/src/features/help-now/evidence-store.ts
@@ -1,0 +1,47 @@
+export type EvidenceItem = {
+  id: string;
+  promptId: string;
+  fileName: string;
+  fileSize: number;
+  fileType: string;
+  capturedAt: string;
+};
+
+const STORAGE_KEY = 'interdomestik.helpNow.evidenceBundle.v1';
+
+function readItems(): EvidenceItem[] {
+  if (typeof globalThis.localStorage === 'undefined') return [];
+  try {
+    const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as EvidenceItem[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeItems(items: EvidenceItem[]) {
+  if (typeof globalThis.localStorage === 'undefined') return;
+  globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+export function listEvidenceItems(): EvidenceItem[] {
+  return readItems();
+}
+
+export function saveEvidenceItem(promptId: string, file: File): EvidenceItem {
+  const item: EvidenceItem = {
+    id: `${promptId}-${Date.now()}`,
+    promptId,
+    fileName: file.name,
+    fileSize: file.size,
+    fileType: file.type,
+    capturedAt: new Date().toISOString(),
+  };
+  writeItems([...readItems().filter(existing => existing.promptId !== promptId), item]);
+  return item;
+}
+
+export function clearEvidenceItems() {
+  if (typeof globalThis.localStorage === 'undefined') return;
+  globalThis.localStorage.removeItem(STORAGE_KEY);
+}

--- a/apps/web/src/features/help-now/evidence-store.ts
+++ b/apps/web/src/features/help-now/evidence-store.ts
@@ -21,7 +21,11 @@ function readItems(): EvidenceItem[] {
 
 function writeItems(items: EvidenceItem[]) {
   if (globalThis.localStorage === undefined) return;
-  globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  try {
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // Storage can be blocked or quota-limited; capture remains local UI state only.
+  }
 }
 
 export function listEvidenceItems(): EvidenceItem[] {

--- a/apps/web/src/features/help-now/evidence-store.ts
+++ b/apps/web/src/features/help-now/evidence-store.ts
@@ -47,5 +47,9 @@ export function saveEvidenceItem(promptId: string, file: File): EvidenceItem {
 
 export function clearEvidenceItems() {
   if (globalThis.localStorage === undefined) return;
-  globalThis.localStorage.removeItem(STORAGE_KEY);
+  try {
+    globalThis.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Clearing is best-effort when browser storage is blocked.
+  }
 }

--- a/apps/web/src/features/help-now/evidence-store.ts
+++ b/apps/web/src/features/help-now/evidence-store.ts
@@ -22,7 +22,9 @@ function readItems(): EvidenceItem[] {
   if (!storage) return [];
   try {
     const raw = storage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as EvidenceItem[]) : [];
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as EvidenceItem[]) : [];
   } catch {
     return [];
   }

--- a/apps/web/src/features/help-now/evidence-store.ts
+++ b/apps/web/src/features/help-now/evidence-store.ts
@@ -10,7 +10,7 @@ export type EvidenceItem = {
 const STORAGE_KEY = 'interdomestik.helpNow.evidenceBundle.v1';
 
 function readItems(): EvidenceItem[] {
-  if (typeof globalThis.localStorage === 'undefined') return [];
+  if (globalThis.localStorage === undefined) return [];
   try {
     const raw = globalThis.localStorage.getItem(STORAGE_KEY);
     return raw ? (JSON.parse(raw) as EvidenceItem[]) : [];
@@ -20,7 +20,7 @@ function readItems(): EvidenceItem[] {
 }
 
 function writeItems(items: EvidenceItem[]) {
-  if (typeof globalThis.localStorage === 'undefined') return;
+  if (globalThis.localStorage === undefined) return;
   globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
 }
 
@@ -42,6 +42,6 @@ export function saveEvidenceItem(promptId: string, file: File): EvidenceItem {
 }
 
 export function clearEvidenceItems() {
-  if (typeof globalThis.localStorage === 'undefined') return;
+  if (globalThis.localStorage === undefined) return;
   globalThis.localStorage.removeItem(STORAGE_KEY);
 }

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HelpNowExperience } from './help-now-experience';
+
+vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+describe('HelpNowExperience', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders public no-account controls and dark country-pack status', () => {
+    render(<HelpNowExperience locale="en" />);
+
+    expect(screen.getByTestId('help-now-page-ready')).toHaveAttribute(
+      'data-scope',
+      'public-no-account'
+    );
+    expect(screen.getAllByText('Country pack awaiting L2 sign-off')).toHaveLength(2);
+    expect(screen.getByText('Signed packs: 0')).toBeInTheDocument();
+    expect(screen.queryByText(/112|192/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('help-now-generate-pack')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Flight: coming soon' })).toBeDisabled();
+    expect(screen.getByText(/nothing sent/i)).toBeInTheDocument();
+  });
+
+  it('keeps scenario and country explicit for local pack context', async () => {
+    const user = userEvent.setup();
+    render(<HelpNowExperience locale="de" />);
+
+    expect(screen.getByLabelText('Trip country')).toHaveValue('DE');
+    await user.click(screen.getByRole('button', { name: 'Sachschaden' }));
+    expect(screen.getByRole('button', { name: 'Sachschaden' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    expect(screen.queryByText('Zone')).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('keeps evidence local and allows clearing the bundle', async () => {
+    const user = userEvent.setup();
+    render(<HelpNowExperience locale="en" />);
+
+    const file = new File(['local'], 'scene.jpg', { type: 'image/jpeg' });
+    await user.upload(screen.getByTestId('help-now-shot-0'), file);
+
+    expect(screen.getByText(/scene.jpg/)).toBeInTheDocument();
+    expect(localStorage.getItem('interdomestik.helpNow.evidenceBundle.v1')).toContain('scene.jpg');
+
+    await user.click(screen.getByTestId('help-now-clear-bundle'));
+    expect(localStorage.getItem('interdomestik.helpNow.evidenceBundle.v1')).toBeNull();
+  });
+});

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -89,4 +89,17 @@ describe('HelpNowExperience', () => {
 
     setItemSpy.mockRestore();
   });
+
+  it('keeps the clear action responsive when storage removal fails', async () => {
+    const user = userEvent.setup();
+    const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError');
+    });
+
+    render(<HelpNowExperience locale="en" />);
+    await user.click(screen.getByTestId('help-now-clear-bundle'));
+
+    expect(screen.getByTestId('help-now-local-only')).toHaveTextContent('0 items');
+    removeItemSpy.mockRestore();
+  });
 });

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -36,11 +36,11 @@ describe('HelpNowExperience', () => {
 
   it('keeps scenario and country explicit for local pack context', async () => {
     const user = userEvent.setup();
-    render(<HelpNowExperience locale="de" />);
+    render(<HelpNowExperience locale="mk" />);
 
-    expect(screen.getByLabelText('Trip country')).toHaveValue('DE');
-    await user.click(screen.getByRole('button', { name: 'Sachschaden' }));
-    expect(screen.getByRole('button', { name: 'Sachschaden' })).toHaveAttribute(
+    expect(screen.getByLabelText('Trip country')).toHaveValue('MK');
+    await user.click(screen.getByRole('button', { name: 'Имотна штета' }));
+    expect(screen.getByRole('button', { name: 'Имотна штета' })).toHaveAttribute(
       'aria-pressed',
       'true'
     );

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -90,6 +90,30 @@ describe('HelpNowExperience', () => {
     setItemSpy.mockRestore();
   });
 
+  it('keeps evidence UI responsive when storage access is blocked', async () => {
+    const user = userEvent.setup();
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get: () => {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+    });
+
+    try {
+      render(<HelpNowExperience locale="en" />);
+      const file = new File(['local'], 'blocked-access.jpg', { type: 'image/jpeg' });
+      await user.upload(screen.getByTestId('help-now-shot-0'), file);
+
+      expect(screen.getByText(/blocked-access.jpg/)).toBeInTheDocument();
+      expect(screen.getByTestId('help-now-local-only')).toHaveTextContent('1 items');
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, 'localStorage', descriptor);
+      }
+    }
+  });
+
   it('keeps the clear action responsive when storage removal fails', async () => {
     const user = userEvent.setup();
     const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HelpNowExperience } from './help-now-experience';
@@ -145,5 +145,28 @@ describe('HelpNowExperience', () => {
     expect(screen.getByText('Offline save failed. Try again before you travel.')).toHaveClass(
       'text-amber-900'
     );
+  });
+
+  it('prevents concurrent Trip Mode save attempts', async () => {
+    const user = userEvent.setup();
+    let resolveSave: ((value: 'saved') => void) | undefined;
+    hoisted.offlineSaveMock.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveSave = resolve;
+        })
+    );
+    render(<HelpNowExperience locale="en" />);
+
+    const button = screen.getByTestId('help-now-trip-download');
+    const firstClick = user.click(button);
+    const secondClick = user.click(button);
+    await Promise.all([firstClick, secondClick]);
+
+    expect(hoisted.offlineSaveMock).toHaveBeenCalledTimes(1);
+    expect(button).toBeDisabled();
+
+    resolveSave?.('saved');
+    await waitFor(() => expect(button).not.toBeDisabled());
   });
 });

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -3,10 +3,15 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HelpNowExperience } from './help-now-experience';
 
-vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }));
+const hoisted = vi.hoisted(() => ({
+  trackEventMock: vi.fn(),
+}));
+
+vi.mock('@/lib/analytics', () => ({ trackEvent: hoisted.trackEventMock }));
 
 describe('HelpNowExperience', () => {
   beforeEach(() => {
+    hoisted.trackEventMock.mockClear();
     localStorage.clear();
   });
 
@@ -38,6 +43,21 @@ describe('HelpNowExperience', () => {
 
     expect(screen.queryByText('Zone')).not.toBeInTheDocument();
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('tracks page open once when the trip country changes', async () => {
+    const user = userEvent.setup();
+    render(<HelpNowExperience locale="en" />);
+
+    expect(hoisted.trackEventMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.trackEventMock).toHaveBeenCalledWith('help_now_opened', {
+      country: 'XK',
+      offline: false,
+    });
+
+    await user.selectOptions(screen.getByLabelText('Trip country'), 'AL');
+    expect(screen.getByLabelText('Trip country')).toHaveValue('AL');
+    expect(hoisted.trackEventMock).toHaveBeenCalledTimes(1);
   });
 
   it('keeps evidence local and allows clearing the bundle', async () => {

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -73,4 +73,20 @@ describe('HelpNowExperience', () => {
     await user.click(screen.getByTestId('help-now-clear-bundle'));
     expect(localStorage.getItem('interdomestik.helpNow.evidenceBundle.v1')).toBeNull();
   });
+
+  it('keeps evidence UI responsive when storage writes fail', async () => {
+    const user = userEvent.setup();
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('blocked', 'SecurityError');
+    });
+
+    render(<HelpNowExperience locale="en" />);
+    const file = new File(['local'], 'blocked-storage.jpg', { type: 'image/jpeg' });
+    await user.upload(screen.getByTestId('help-now-shot-0'), file);
+
+    expect(screen.getByText(/blocked-storage.jpg/)).toBeInTheDocument();
+    expect(screen.getByTestId('help-now-local-only')).toHaveTextContent('1 items');
+
+    setItemSpy.mockRestore();
+  });
 });

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HelpNowExperience } from './help-now-experience';
@@ -129,46 +129,5 @@ describe('HelpNowExperience', () => {
 
     expect(screen.getByTestId('help-now-local-only')).toHaveTextContent('0 items');
     removeItemSpy.mockRestore();
-  });
-
-  it('distinguishes unsupported and failed Trip Mode offline saves', async () => {
-    const user = userEvent.setup();
-    render(<HelpNowExperience locale="en" />);
-    const downloadButton = screen.getByTestId('help-now-trip-download');
-
-    await user.click(downloadButton);
-    expect(await screen.findByText('Offline save is not supported in this browser.')).toHaveClass(
-      'text-amber-900'
-    );
-    await waitFor(() => expect(downloadButton).not.toBeDisabled());
-
-    hoisted.offlineSaveMock.mockResolvedValueOnce('failed');
-    await user.click(downloadButton);
-    expect(await screen.findByText('Offline save failed. Try again before you travel.')).toHaveClass(
-      'text-amber-900'
-    );
-  });
-
-  it('prevents concurrent Trip Mode save attempts', async () => {
-    const user = userEvent.setup();
-    let resolveSave: ((value: 'saved') => void) | undefined;
-    hoisted.offlineSaveMock.mockImplementationOnce(
-      () =>
-        new Promise(resolve => {
-          resolveSave = resolve;
-        })
-    );
-    render(<HelpNowExperience locale="en" />);
-
-    const button = screen.getByTestId('help-now-trip-download');
-    const firstClick = user.click(button);
-    const secondClick = user.click(button);
-    await Promise.all([firstClick, secondClick]);
-
-    expect(hoisted.offlineSaveMock).toHaveBeenCalledTimes(1);
-    expect(button).toBeDisabled();
-
-    resolveSave?.('saved');
-    await waitFor(() => expect(button).not.toBeDisabled());
   });
 });

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -137,7 +137,7 @@ describe('HelpNowExperience', () => {
     const downloadButton = screen.getByTestId('help-now-trip-download');
 
     await user.click(downloadButton);
-    expect(screen.getByText('Offline save is not supported in this browser.')).toHaveClass(
+    expect(await screen.findByText('Offline save is not supported in this browser.')).toHaveClass(
       'text-amber-900'
     );
     await waitFor(() => expect(downloadButton).not.toBeDisabled());

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -4,13 +4,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { HelpNowExperience } from './help-now-experience';
 
 const hoisted = vi.hoisted(() => ({
+  offlineSaveMock: vi.fn(),
   trackEventMock: vi.fn(),
 }));
 
 vi.mock('@/lib/analytics', () => ({ trackEvent: hoisted.trackEventMock }));
+vi.mock('./offline', () => ({ saveTripModePackForOffline: hoisted.offlineSaveMock }));
 
 describe('HelpNowExperience', () => {
   beforeEach(() => {
+    hoisted.offlineSaveMock.mockReset();
+    hoisted.offlineSaveMock.mockResolvedValue('unsupported');
     hoisted.trackEventMock.mockClear();
     localStorage.clear();
   });
@@ -125,5 +129,21 @@ describe('HelpNowExperience', () => {
 
     expect(screen.getByTestId('help-now-local-only')).toHaveTextContent('0 items');
     removeItemSpy.mockRestore();
+  });
+
+  it('distinguishes unsupported and failed Trip Mode offline saves', async () => {
+    const user = userEvent.setup();
+    render(<HelpNowExperience locale="en" />);
+
+    await user.click(screen.getByTestId('help-now-trip-download'));
+    expect(screen.getByText('Offline save is not supported in this browser.')).toHaveClass(
+      'text-amber-900'
+    );
+
+    hoisted.offlineSaveMock.mockResolvedValueOnce('failed');
+    await user.click(screen.getByTestId('help-now-trip-download'));
+    expect(screen.getByText('Offline save failed. Try again before you travel.')).toHaveClass(
+      'text-amber-900'
+    );
   });
 });

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -134,15 +134,17 @@ describe('HelpNowExperience', () => {
   it('distinguishes unsupported and failed Trip Mode offline saves', async () => {
     const user = userEvent.setup();
     render(<HelpNowExperience locale="en" />);
+    const downloadButton = screen.getByTestId('help-now-trip-download');
 
-    await user.click(screen.getByTestId('help-now-trip-download'));
+    await user.click(downloadButton);
     expect(screen.getByText('Offline save is not supported in this browser.')).toHaveClass(
       'text-amber-900'
     );
+    await waitFor(() => expect(downloadButton).not.toBeDisabled());
 
     hoisted.offlineSaveMock.mockResolvedValueOnce('failed');
-    await user.click(screen.getByTestId('help-now-trip-download'));
-    expect(screen.getByText('Offline save failed. Try again before you travel.')).toHaveClass(
+    await user.click(downloadButton);
+    expect(await screen.findByText('Offline save failed. Try again before you travel.')).toHaveClass(
       'text-amber-900'
     );
   });

--- a/apps/web/src/features/help-now/help-now-experience.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { createHelpNowIncidentScenePack } from '@interdomestik/domain-assistance';
+import { Car, Home, Plane, ShieldAlert } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  HELP_NOW_COUNTRY_PACKS,
+  HELP_NOW_SCENARIOS,
+  canExposeCountryPack,
+  getDefaultHelpNowCountry,
+  getHelpNowContentLocale,
+  getHelpNowCountryPack,
+  getSignedOffHelpNowPacks,
+  type HelpNowCountry,
+  type HelpNowScenario,
+} from './content-packs';
+import { getHelpNowCopy } from './copy';
+import { listEvidenceItems } from './evidence-store';
+import { trackHelpNowEvent } from './analytics';
+import { ClaimPackPreview } from './claim-pack-preview';
+import { EvidenceCoach } from './evidence-coach';
+import { SceneGuide } from './scene-guide';
+import { TripMode } from './trip-mode';
+
+type HelpNowExperienceProps = {
+  locale: string;
+};
+
+const icons = [Car, ShieldAlert, Home, Plane] as const;
+
+export function HelpNowExperience({ locale }: HelpNowExperienceProps) {
+  const contentLocale = getHelpNowContentLocale(locale);
+  const copy = getHelpNowCopy(contentLocale);
+  const [completed, setCompleted] = useState<number[]>([]);
+  const [evidenceCount, setEvidenceCount] = useState(0);
+  const [country, setCountry] = useState<HelpNowCountry>(() =>
+    getDefaultHelpNowCountry(contentLocale)
+  );
+  const [scenario, setScenario] = useState<HelpNowScenario>('car');
+  const updateEvidenceCount = useCallback((count: number) => setEvidenceCount(count), []);
+  const signedOffPacks = getSignedOffHelpNowPacks();
+  const countryPack = getHelpNowCountryPack(country);
+  const pack = canExposeCountryPack(countryPack)
+    ? createHelpNowIncidentScenePack({
+        packId: 'mob-01-help-now-public-preview',
+        sessionId: 'anonymous-help-now-public',
+        guidanceChecklist: copy.checklist.map((_, index) => `scene_${index}`),
+        escalationRecommendation: 'member_zone',
+        createdAt: '2026-07-04T00:00:00.000Z',
+        country,
+      })
+    : null;
+
+  useEffect(() => {
+    setEvidenceCount(listEvidenceItems().length);
+    trackHelpNowEvent('help_now_opened', { country, offline: !navigator.onLine });
+  }, [country]);
+
+  return (
+    <main
+      className="min-h-screen bg-[#f7f4ee] text-slate-950"
+      data-testid="help-now-page-ready"
+      data-scope="public-no-account"
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-5 px-4 py-5 sm:py-8">
+        <section className="rounded-lg border border-slate-200 bg-white p-5">
+          <p className="text-sm font-semibold uppercase text-emerald-800">{copy.offline}</p>
+          <h1 className="mt-3 text-4xl font-semibold leading-tight text-slate-950">{copy.title}</h1>
+          <p className="mt-3 max-w-2xl text-base leading-7 text-slate-600">{copy.subtitle}</p>
+          <div className="mt-5 grid gap-3 sm:grid-cols-2">
+            {copy.scenarios.map((label, index) => {
+              const Icon = icons[index] ?? ShieldAlert;
+              const value = HELP_NOW_SCENARIOS[index] ?? 'car';
+              const isDisabled = value === 'flight';
+              const isSelected = scenario === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  disabled={isDisabled}
+                  aria-pressed={!isDisabled ? isSelected : undefined}
+                  onClick={() => setScenario(value)}
+                  className={`flex min-h-20 items-center gap-4 rounded-lg border px-4 text-left text-lg font-semibold ${
+                    isSelected
+                      ? 'border-emerald-700 bg-emerald-50 text-emerald-950'
+                      : 'border-slate-200 bg-slate-50 text-slate-950'
+                  } ${isDisabled ? 'cursor-not-allowed opacity-60' : ''}`}
+                >
+                  <Icon className="h-7 w-7 text-slate-700" aria-hidden="true" />
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          <label className="mt-5 block max-w-sm text-sm font-semibold text-slate-800">
+            Trip country
+            <select
+              className="mt-2 h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+              value={country}
+              onChange={event => setCountry(event.currentTarget.value as HelpNowCountry)}
+            >
+              {HELP_NOW_COUNTRY_PACKS.map(pack => (
+                <option key={pack.country} value={pack.country}>
+                  {pack.marketLabel}
+                </option>
+              ))}
+            </select>
+          </label>
+        </section>
+
+        <SceneGuide
+          copy={copy}
+          completed={completed}
+          country={country}
+          scenario={scenario}
+          onToggle={index =>
+            setCompleted(current =>
+              current.includes(index)
+                ? current.filter(value => value !== index)
+                : [...current, index]
+            )
+          }
+        />
+        <EvidenceCoach copy={copy} onBundleChange={updateEvidenceCount} />
+        <TripMode copy={copy} country={country} packs={signedOffPacks} />
+        <ClaimPackPreview
+          copy={copy}
+          pack={pack}
+          completedCount={completed.length}
+          country={country}
+          evidenceCount={evidenceCount}
+          scenario={scenario}
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/features/help-now/help-now-experience.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.tsx
@@ -22,9 +22,9 @@ import { EvidenceCoach } from './evidence-coach';
 import { SceneGuide } from './scene-guide';
 import { TripMode } from './trip-mode';
 
-type HelpNowExperienceProps = {
+type HelpNowExperienceProps = Readonly<{
   locale: string;
-};
+}>;
 
 const icons = [Car, ShieldAlert, Home, Plane] as const;
 
@@ -78,7 +78,7 @@ export function HelpNowExperience({ locale }: HelpNowExperienceProps) {
                   key={value}
                   type="button"
                   disabled={isDisabled}
-                  aria-pressed={!isDisabled ? isSelected : undefined}
+                  aria-pressed={isDisabled ? undefined : isSelected}
                   onClick={() => setScenario(value)}
                   className={`flex min-h-20 items-center gap-4 rounded-lg border px-4 text-left text-lg font-semibold ${
                     isSelected
@@ -93,7 +93,7 @@ export function HelpNowExperience({ locale }: HelpNowExperienceProps) {
             })}
           </div>
           <label className="mt-5 block max-w-sm text-sm font-semibold text-slate-800">
-            Trip country
+            <span>Trip country</span>
             <select
               className="mt-2 h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
               value={country}

--- a/apps/web/src/features/help-now/help-now-experience.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.tsx
@@ -31,11 +31,10 @@ const icons = [Car, ShieldAlert, Home, Plane] as const;
 export function HelpNowExperience({ locale }: HelpNowExperienceProps) {
   const contentLocale = getHelpNowContentLocale(locale);
   const copy = getHelpNowCopy(contentLocale);
+  const defaultCountry = getDefaultHelpNowCountry(contentLocale);
   const [completed, setCompleted] = useState<number[]>([]);
   const [evidenceCount, setEvidenceCount] = useState(0);
-  const [country, setCountry] = useState<HelpNowCountry>(() =>
-    getDefaultHelpNowCountry(contentLocale)
-  );
+  const [country, setCountry] = useState<HelpNowCountry>(defaultCountry);
   const [scenario, setScenario] = useState<HelpNowScenario>('car');
   const updateEvidenceCount = useCallback((count: number) => setEvidenceCount(count), []);
   const signedOffPacks = getSignedOffHelpNowPacks();
@@ -53,8 +52,8 @@ export function HelpNowExperience({ locale }: HelpNowExperienceProps) {
 
   useEffect(() => {
     setEvidenceCount(listEvidenceItems().length);
-    trackHelpNowEvent('help_now_opened', { country, offline: !navigator.onLine });
-  }, [country]);
+    trackHelpNowEvent('help_now_opened', { country: defaultCountry, offline: !navigator.onLine });
+  }, [defaultCountry]);
 
   return (
     <main

--- a/apps/web/src/features/help-now/help-now-ui.tsx
+++ b/apps/web/src/features/help-now/help-now-ui.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+
+type HelpNowPanelProps = Readonly<{
+  children: ReactNode;
+  title?: string;
+  titleId?: string;
+}>;
+
+type HelpNowMetricProps = Readonly<{
+  label: string;
+  value: ReactNode;
+}>;
+
+export function HelpNowPanel({ children, title, titleId }: HelpNowPanelProps) {
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white p-4" aria-labelledby={titleId}>
+      {title ? (
+        <h2 id={titleId} className="text-lg font-semibold text-slate-950">
+          {title}
+        </h2>
+      ) : null}
+      {children}
+    </section>
+  );
+}
+
+export function HelpNowMetric({ label, value }: HelpNowMetricProps) {
+  return (
+    <div className="rounded-md bg-slate-50 p-3">
+      <dt className="text-xs font-semibold uppercase text-slate-500">{label}</dt>
+      <dd className="mt-1 text-sm font-semibold text-slate-950">{value}</dd>
+    </div>
+  );
+}

--- a/apps/web/src/features/help-now/help-now-ui.tsx
+++ b/apps/web/src/features/help-now/help-now-ui.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from 'react';
 
-type HelpNowPanelProps = Readonly<{
-  children: ReactNode;
-  title?: string;
-  titleId?: string;
-}>;
+type HelpNowPanelProps = Readonly<
+  { children: ReactNode } & (
+    { title: string; titleId: string } | { title?: undefined; titleId?: string }
+  )
+>;
 
 type HelpNowMetricProps = Readonly<{
   label: string;

--- a/apps/web/src/features/help-now/offline.test.ts
+++ b/apps/web/src/features/help-now/offline.test.ts
@@ -15,7 +15,10 @@ function withServiceWorkerController(controller: unknown) {
 }
 
 describe('saveTripModePackForOffline', () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    globalThis.history.pushState(null, '', '/');
+    vi.unstubAllGlobals();
+  });
 
   it('does not report saved without a controlling service worker', async () => {
     const open = vi.fn();
@@ -30,14 +33,28 @@ describe('saveTripModePackForOffline', () => {
     }
   });
 
+  it('does not report saved outside the public Help Now route', async () => {
+    const open = vi.fn();
+    vi.stubGlobal('caches', { open });
+    const restore = withServiceWorkerController({});
+
+    try {
+      await expect(saveTripModePackForOffline()).resolves.toBe('unsupported');
+      expect(open).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
   it('saves public Trip Mode assets when the service worker controls the page', async () => {
     const addAll = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal('caches', { open: vi.fn().mockResolvedValue({ addAll }) });
     const restore = withServiceWorkerController({});
+    globalThis.history.pushState(null, '', '/en/help-now');
 
     try {
       await expect(saveTripModePackForOffline()).resolves.toBe('saved');
-      expect(addAll).toHaveBeenCalledWith([HELP_NOW_PACK_ASSET]);
+      expect(addAll).toHaveBeenCalledWith([HELP_NOW_PACK_ASSET, '/en/help-now']);
     } finally {
       restore();
     }
@@ -48,6 +65,7 @@ describe('saveTripModePackForOffline', () => {
       open: vi.fn().mockResolvedValue({ addAll: vi.fn().mockRejectedValue(new Error('quota')) }),
     });
     const restore = withServiceWorkerController({});
+    globalThis.history.pushState(null, '', '/sq/help-now');
 
     try {
       await expect(saveTripModePackForOffline()).resolves.toBe('failed');

--- a/apps/web/src/features/help-now/offline.test.ts
+++ b/apps/web/src/features/help-now/offline.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HELP_NOW_PACK_ASSET } from './content-packs';
+import { saveTripModePackForOffline } from './offline';
+
+function withServiceWorkerController(controller: unknown) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis.navigator, 'serviceWorker');
+  Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+    configurable: true,
+    value: { controller },
+  });
+  return () => {
+    if (descriptor) Object.defineProperty(globalThis.navigator, 'serviceWorker', descriptor);
+    else Reflect.deleteProperty(globalThis.navigator, 'serviceWorker');
+  };
+}
+
+describe('saveTripModePackForOffline', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('does not report saved without a controlling service worker', async () => {
+    const open = vi.fn();
+    vi.stubGlobal('caches', { open });
+    const restore = withServiceWorkerController(null);
+
+    try {
+      await expect(saveTripModePackForOffline()).resolves.toBe('unsupported');
+      expect(open).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it('saves public Trip Mode assets when the service worker controls the page', async () => {
+    const addAll = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('caches', { open: vi.fn().mockResolvedValue({ addAll }) });
+    const restore = withServiceWorkerController({});
+
+    try {
+      await expect(saveTripModePackForOffline()).resolves.toBe('saved');
+      expect(addAll).toHaveBeenCalledWith([HELP_NOW_PACK_ASSET]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('reports failed when the controlled cache write rejects', async () => {
+    vi.stubGlobal('caches', {
+      open: vi.fn().mockResolvedValue({ addAll: vi.fn().mockRejectedValue(new Error('quota')) }),
+    });
+    const restore = withServiceWorkerController({});
+
+    try {
+      await expect(saveTripModePackForOffline()).resolves.toBe('failed');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/apps/web/src/features/help-now/offline.test.ts
+++ b/apps/web/src/features/help-now/offline.test.ts
@@ -50,11 +50,11 @@ describe('saveTripModePackForOffline', () => {
     const addAll = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal('caches', { open: vi.fn().mockResolvedValue({ addAll }) });
     const restore = withServiceWorkerController({});
-    globalThis.history.pushState(null, '', '/en/help-now');
+    globalThis.history.pushState(null, '', '/de/help-now');
 
     try {
       await expect(saveTripModePackForOffline()).resolves.toBe('saved');
-      expect(addAll).toHaveBeenCalledWith([HELP_NOW_PACK_ASSET, '/en/help-now']);
+      expect(addAll).toHaveBeenCalledWith([HELP_NOW_PACK_ASSET, '/de/help-now']);
     } finally {
       restore();
     }

--- a/apps/web/src/features/help-now/offline.ts
+++ b/apps/web/src/features/help-now/offline.ts
@@ -1,7 +1,7 @@
 import { getTripModeDownloadAssets, HELP_NOW_CACHE_NAME } from './content-packs';
 
 export type OfflineSaveResult = 'saved' | 'unsupported' | 'failed';
-const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk)\/help-now\/?$/;
+const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk|de|hr)\/help-now\/?$/;
 
 function hasServiceWorkerController(): boolean {
   return globalThis.navigator?.serviceWorker?.controller != null;

--- a/apps/web/src/features/help-now/offline.ts
+++ b/apps/web/src/features/help-now/offline.ts
@@ -2,8 +2,13 @@ import { getTripModeDownloadAssets, HELP_NOW_CACHE_NAME } from './content-packs'
 
 export type OfflineSaveResult = 'saved' | 'unsupported' | 'failed';
 
+function hasServiceWorkerController(): boolean {
+  return globalThis.navigator?.serviceWorker?.controller != null;
+}
+
 export async function saveTripModePackForOffline(): Promise<OfflineSaveResult> {
   if (globalThis.caches === undefined) return 'unsupported';
+  if (!hasServiceWorkerController()) return 'unsupported';
 
   try {
     const cache = await globalThis.caches.open(HELP_NOW_CACHE_NAME);

--- a/apps/web/src/features/help-now/offline.ts
+++ b/apps/web/src/features/help-now/offline.ts
@@ -1,18 +1,26 @@
 import { getTripModeDownloadAssets, HELP_NOW_CACHE_NAME } from './content-packs';
 
 export type OfflineSaveResult = 'saved' | 'unsupported' | 'failed';
+const HELP_NOW_PUBLIC_ROUTE = /^\/(sq|en|sr|mk)\/help-now\/?$/;
 
 function hasServiceWorkerController(): boolean {
   return globalThis.navigator?.serviceWorker?.controller != null;
 }
 
+function getCurrentHelpNowRoute(): string | null {
+  const pathname = globalThis.location?.pathname ?? '';
+  return HELP_NOW_PUBLIC_ROUTE.test(pathname) ? pathname : null;
+}
+
 export async function saveTripModePackForOffline(): Promise<OfflineSaveResult> {
   if (globalThis.caches === undefined) return 'unsupported';
   if (!hasServiceWorkerController()) return 'unsupported';
+  const route = getCurrentHelpNowRoute();
+  if (!route) return 'unsupported';
 
   try {
     const cache = await globalThis.caches.open(HELP_NOW_CACHE_NAME);
-    await cache.addAll([...getTripModeDownloadAssets()]);
+    await cache.addAll([...getTripModeDownloadAssets(), route]);
     return 'saved';
   } catch {
     return 'failed';

--- a/apps/web/src/features/help-now/offline.ts
+++ b/apps/web/src/features/help-now/offline.ts
@@ -1,0 +1,15 @@
+import { getTripModeDownloadAssets, HELP_NOW_CACHE_NAME } from './content-packs';
+
+export type OfflineSaveResult = 'saved' | 'unsupported' | 'failed';
+
+export async function saveTripModePackForOffline(): Promise<OfflineSaveResult> {
+  if (typeof globalThis.caches === 'undefined') return 'unsupported';
+
+  try {
+    const cache = await globalThis.caches.open(HELP_NOW_CACHE_NAME);
+    await cache.addAll([...getTripModeDownloadAssets()]);
+    return 'saved';
+  } catch {
+    return 'failed';
+  }
+}

--- a/apps/web/src/features/help-now/offline.ts
+++ b/apps/web/src/features/help-now/offline.ts
@@ -3,7 +3,7 @@ import { getTripModeDownloadAssets, HELP_NOW_CACHE_NAME } from './content-packs'
 export type OfflineSaveResult = 'saved' | 'unsupported' | 'failed';
 
 export async function saveTripModePackForOffline(): Promise<OfflineSaveResult> {
-  if (typeof globalThis.caches === 'undefined') return 'unsupported';
+  if (globalThis.caches === undefined) return 'unsupported';
 
   try {
     const cache = await globalThis.caches.open(HELP_NOW_CACHE_NAME);

--- a/apps/web/src/features/help-now/scene-guide.tsx
+++ b/apps/web/src/features/help-now/scene-guide.tsx
@@ -3,14 +3,15 @@
 import type { HelpNowCopy } from './copy';
 import { trackHelpNowEvent } from './analytics';
 import type { HelpNowCountry, HelpNowScenario } from './content-packs';
+import { HelpNowPanel } from './help-now-ui';
 
-type SceneGuideProps = {
+type SceneGuideProps = Readonly<{
   copy: HelpNowCopy;
   completed: readonly number[];
   country: HelpNowCountry;
   scenario: HelpNowScenario;
   onToggle: (index: number) => void;
-};
+}>;
 
 export function SceneGuide({ copy, completed, country, scenario, onToggle }: SceneGuideProps) {
   return (
@@ -20,7 +21,7 @@ export function SceneGuide({ copy, completed, country, scenario, onToggle }: Sce
           {copy.emergency}
         </h2>
       </div>
-      <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <HelpNowPanel>
         <p className="font-semibold text-slate-950">{copy.continueSafe}</p>
         <ul className="mt-4 space-y-2">
           {copy.checklist.map((item, index) => {
@@ -57,7 +58,7 @@ export function SceneGuide({ copy, completed, country, scenario, onToggle }: Sce
             );
           })}
         </ul>
-      </div>
+      </HelpNowPanel>
     </section>
   );
 }

--- a/apps/web/src/features/help-now/scene-guide.tsx
+++ b/apps/web/src/features/help-now/scene-guide.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import type { HelpNowCopy } from './copy';
+import { trackHelpNowEvent } from './analytics';
+import type { HelpNowCountry, HelpNowScenario } from './content-packs';
+
+type SceneGuideProps = {
+  copy: HelpNowCopy;
+  completed: readonly number[];
+  country: HelpNowCountry;
+  scenario: HelpNowScenario;
+  onToggle: (index: number) => void;
+};
+
+export function SceneGuide({ copy, completed, country, scenario, onToggle }: SceneGuideProps) {
+  return (
+    <section className="space-y-4" aria-labelledby="help-now-scene-title">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-950">
+        <h2 id="help-now-scene-title" className="text-lg font-semibold">
+          {copy.emergency}
+        </h2>
+      </div>
+      <div className="rounded-lg border border-slate-200 bg-white p-4">
+        <p className="font-semibold text-slate-950">{copy.continueSafe}</p>
+        <ul className="mt-4 space-y-2">
+          {copy.checklist.map((item, index) => {
+            const done = completed.includes(index);
+            return (
+              <li key={item}>
+                <button
+                  type="button"
+                  data-testid={`help-now-checklist-${index}`}
+                  onClick={() => {
+                    onToggle(index);
+                    if (!done) {
+                      trackHelpNowEvent('checklist_item_done', {
+                        checklist_type: 'scene',
+                        country,
+                        item_index: index,
+                        scenario,
+                      });
+                    }
+                  }}
+                  className="flex min-h-12 w-full items-center gap-3 rounded-md border border-slate-200 px-3 py-2 text-left text-sm font-medium text-slate-800"
+                >
+                  <span
+                    aria-hidden="true"
+                    className={`flex h-6 w-6 items-center justify-center rounded-full border ${
+                      done ? 'border-emerald-600 bg-emerald-600 text-white' : 'border-slate-300'
+                    }`}
+                  >
+                    {done ? '✓' : index + 1}
+                  </span>
+                  {item}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/help-now/scene-guide.tsx
+++ b/apps/web/src/features/help-now/scene-guide.tsx
@@ -27,7 +27,7 @@ export function SceneGuide({ copy, completed, country, scenario, onToggle }: Sce
           {copy.checklist.map((item, index) => {
             const done = completed.includes(index);
             return (
-              <li key={item}>
+              <li key={`scene-${index}`}>
                 <button
                   type="button"
                   data-testid={`help-now-checklist-${index}`}

--- a/apps/web/src/features/help-now/scene-guide.tsx
+++ b/apps/web/src/features/help-now/scene-guide.tsx
@@ -27,7 +27,7 @@ export function SceneGuide({ copy, completed, country, scenario, onToggle }: Sce
           {copy.checklist.map((item, index) => {
             const done = completed.includes(index);
             return (
-              <li key={`scene-${index}`}>
+              <li key={item}>
                 <button
                   type="button"
                   data-testid={`help-now-checklist-${index}`}

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -10,7 +10,7 @@ describe('MOB-01 service worker cache guard', () => {
     expect(swSource).toContain('/help-now-packs/content-packs.v1.json');
     expect(swSource).toContain(HELP_NOW_CACHE_NAME);
     expect(swSource).toContain('sq|en|sr|mk|hr|de');
-    expect(swSource).toContain('url.origin === self.location.origin');
+    expect(swSource).toContain('url.origin === globalThis.location.origin');
     expect(swSource).toContain('.keys()');
     expect(swSource).toContain("key.startsWith('interdomestik-')");
     expect(swSource).toContain('caches.delete(key)');

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -18,6 +18,7 @@ describe('MOB-01 service worker cache guard', () => {
       /async function cacheHelpNowNavigation\(request\) \{[\s\S]*?return await fetch\(request\);[\s\S]*?helpNowFallbackResponse\(request\);[\s\S]*?\}/
     );
     expect(swSource.match(/cacheHelpNowNavigation[\s\S]*?cache\.put/)).toBeNull();
+    expect(swSource).toContain('await cache.put(request, response.clone());');
     expect(swSource).not.toContain('/_next/static/');
     expect(swSource).not.toContain('/api/');
     expect(swSource).not.toContain('/member/');

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -9,7 +9,7 @@ describe('MOB-01 service worker cache guard', () => {
   it('allowlists public Help Now assets without caching member or API data', () => {
     expect(swSource).toContain('/help-now-packs/content-packs.v1.json');
     expect(swSource).toContain(HELP_NOW_CACHE_NAME);
-    expect(swSource).toContain('sq|en|sr|mk|hr|de');
+    expect(swSource).toContain('sq|en|sr|mk');
     expect(swSource).toContain('url.origin === globalThis.location.origin');
     expect(swSource).toContain('.keys()');
     expect(swSource).toContain("key.startsWith('interdomestik-')");

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -18,6 +18,7 @@ describe('MOB-01 service worker cache guard', () => {
     expect(swSource).toContain('caches.delete(key)');
     expect(swSource).toContain('async function cacheFreshResponse(request, response)');
     expect(swSource).toContain('HELP_NOW_PUBLIC_ASSETS.has(pathname)');
+    expect(swSource).toContain('HELP_NOW_PUBLIC_ROUTE.test(pathname)');
     expect(swSource).toMatch(/networkFirst[\s\S]*cacheFreshResponse\(request, response\)/);
     expect(swSource).toMatch(
       /HELP_NOW_PUBLIC_ROUTE[\s\S]*event\.respondWith\(networkFirst\(event\.request\)\)/

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -11,7 +11,7 @@ describe('MOB-01 service worker cache guard', () => {
   it('allowlists public Help Now assets without caching member or API data', () => {
     expect(swSource).toContain('/help-now-packs/content-packs.v1.json');
     expect(swSource).toContain(HELP_NOW_CACHE_NAME);
-    expect(swSource).toContain('sq|en|sr|mk');
+    expect(swSource).toContain('sq|en|sr|mk|de|hr');
     expect(swSource).toContain('url.origin === globalThis.location.origin');
     expect(swSource).toContain('.keys()');
     expect(swSource).toContain("key.startsWith('interdomestik-')");

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { HELP_NOW_CACHE_NAME } from './content-packs';
 
-const swSource = fs.readFileSync(path.resolve(process.cwd(), 'public/sw.js'), 'utf8');
+const swPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../public/sw.js');
+const swSource = fs.readFileSync(swPath, 'utf8');
 
 describe('MOB-01 service worker cache guard', () => {
   it('allowlists public Help Now assets without caching member or API data', () => {

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { HELP_NOW_CACHE_NAME } from './content-packs';
+
+const swSource = fs.readFileSync(path.resolve(process.cwd(), 'public/sw.js'), 'utf8');
+
+describe('MOB-01 service worker cache guard', () => {
+  it('allowlists public Help Now assets without caching member or API data', () => {
+    expect(swSource).toContain('/help-now-packs/content-packs.v1.json');
+    expect(swSource).toContain(HELP_NOW_CACHE_NAME);
+    expect(swSource).toContain('sq|en|sr|mk|hr|de');
+    expect(swSource).toContain('url.origin === self.location.origin');
+    expect(swSource).toContain('.keys()');
+    expect(swSource).toContain("key.startsWith('interdomestik-')");
+    expect(swSource).toContain('caches.delete(key)');
+    expect(swSource).toMatch(
+      /async function cacheHelpNowNavigation\(request\) \{[\s\S]*?return await fetch\(request\);[\s\S]*?helpNowFallbackResponse\(request\);[\s\S]*?\}/
+    );
+    expect(swSource.match(/cacheHelpNowNavigation[\s\S]*?cache\.put/)).toBeNull();
+    expect(swSource).not.toContain('/_next/static/');
+    expect(swSource).not.toContain('/api/');
+    expect(swSource).not.toContain('/member/');
+    expect(swSource).not.toContain('localStorage');
+    expect(swSource).not.toContain('indexedDB');
+  });
+});

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -15,6 +15,7 @@ describe('MOB-01 service worker cache guard', () => {
     expect(swSource).toContain("key.startsWith('interdomestik-')");
     expect(swSource).toContain('caches.delete(key)');
     expect(swSource).toContain('async function cacheFreshResponse(request, response)');
+    expect(swSource).toContain('HELP_NOW_PUBLIC_ASSETS.has(pathname)');
     expect(swSource).toMatch(/networkFirst[\s\S]*cacheFreshResponse\(request, response\)/);
     expect(swSource).toMatch(
       /HELP_NOW_PUBLIC_ROUTE[\s\S]*event\.respondWith\(networkFirst\(event\.request\)\)/

--- a/apps/web/src/features/help-now/sw-cache-guard.test.ts
+++ b/apps/web/src/features/help-now/sw-cache-guard.test.ts
@@ -14,11 +14,13 @@ describe('MOB-01 service worker cache guard', () => {
     expect(swSource).toContain('.keys()');
     expect(swSource).toContain("key.startsWith('interdomestik-')");
     expect(swSource).toContain('caches.delete(key)');
+    expect(swSource).toContain('async function cacheFreshResponse(request, response)');
+    expect(swSource).toMatch(/networkFirst[\s\S]*cacheFreshResponse\(request, response\)/);
     expect(swSource).toMatch(
-      /async function cacheHelpNowNavigation\(request\) \{[\s\S]*?return await fetch\(request\);[\s\S]*?helpNowFallbackResponse\(request\);[\s\S]*?\}/
+      /HELP_NOW_PUBLIC_ROUTE[\s\S]*event\.respondWith\(networkFirst\(event\.request\)\)/
     );
-    expect(swSource.match(/cacheHelpNowNavigation[\s\S]*?cache\.put/)).toBeNull();
-    expect(swSource).toContain('await cache.put(request, response.clone());');
+    expect(swSource).toContain('await (await caches.open(HELP_NOW_CACHE_NAME)).put');
+    expect(swSource).toContain('response.clone()');
     expect(swSource).not.toContain('/_next/static/');
     expect(swSource).not.toContain('/api/');
     expect(swSource).not.toContain('/member/');

--- a/apps/web/src/features/help-now/trip-mode.test.tsx
+++ b/apps/web/src/features/help-now/trip-mode.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HELP_NOW_COUNTRY_PACKS, getTripModeDownloadAssets } from './content-packs';
+import { getHelpNowCopy } from './copy';
+import { TripMode } from './trip-mode';
+
+const hoisted = vi.hoisted(() => ({
+  offlineSaveMock: vi.fn(),
+  trackEventMock: vi.fn(),
+}));
+
+vi.mock('@/lib/analytics', () => ({ trackEvent: hoisted.trackEventMock }));
+vi.mock('./offline', () => ({ saveTripModePackForOffline: hoisted.offlineSaveMock }));
+
+function renderTripMode() {
+  render(<TripMode copy={getHelpNowCopy('en')} country="XK" packs={HELP_NOW_COUNTRY_PACKS} />);
+  return screen.getByTestId('help-now-trip-download');
+}
+
+describe('TripMode', () => {
+  beforeEach(() => {
+    hoisted.offlineSaveMock.mockReset();
+    hoisted.offlineSaveMock.mockResolvedValue('unsupported');
+    hoisted.trackEventMock.mockClear();
+  });
+
+  it('distinguishes unsupported and failed offline saves in a live status message', async () => {
+    const user = userEvent.setup();
+    const downloadButton = renderTripMode();
+
+    await user.click(downloadButton);
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Offline save is not supported in this browser.'
+    );
+    expect(screen.getByRole('status')).toHaveClass('text-amber-900');
+    await waitFor(() => expect(downloadButton).not.toBeDisabled());
+
+    hoisted.offlineSaveMock.mockResolvedValueOnce('failed');
+    await user.click(downloadButton);
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Offline save failed. Try again before you travel.'
+    );
+    expect(screen.getByRole('status')).toHaveClass('text-amber-900');
+  });
+
+  it('prevents concurrent save attempts and reports the canonical asset count', async () => {
+    const user = userEvent.setup();
+    let resolveSave: ((value: 'saved') => void) | undefined;
+    hoisted.offlineSaveMock.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveSave = resolve;
+        })
+    );
+    const button = renderTripMode();
+
+    const firstClick = user.click(button);
+    const secondClick = user.click(button);
+    await Promise.all([firstClick, secondClick]);
+
+    expect(hoisted.offlineSaveMock).toHaveBeenCalledTimes(1);
+    expect(button).toBeDisabled();
+
+    resolveSave?.('saved');
+    await waitFor(() => expect(button).not.toBeDisabled());
+    expect(hoisted.trackEventMock).toHaveBeenCalledWith('trip_pack_downloaded', {
+      country: 'XK',
+      pack_count: getTripModeDownloadAssets().length,
+      total_mb_bucket: 'under_1',
+    });
+  });
+});

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -7,14 +7,22 @@ import { saveTripModePackForOffline } from './offline';
 import { trackHelpNowEvent } from './analytics';
 import { HelpNowPanel } from './help-now-ui';
 
+type TripModeStatus = 'saved' | 'unsupported' | 'failed';
+
 type TripModeProps = Readonly<{
   copy: HelpNowCopy;
   country: HelpNowCountry;
   packs: readonly HelpNowCountryPack[];
 }>;
 
+function getStatusMessage(copy: HelpNowCopy, status: TripModeStatus): string {
+  if (status === 'saved') return copy.downloadDone;
+  if (status === 'unsupported') return copy.downloadUnsupported;
+  return copy.downloadFailed;
+}
+
 export function TripMode({ copy, country, packs }: TripModeProps) {
-  const [status, setStatus] = useState<string | null>(null);
+  const [status, setStatus] = useState<TripModeStatus | null>(null);
 
   return (
     <HelpNowPanel title="Trip Mode" titleId="trip-mode-title">
@@ -33,7 +41,7 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
         data-testid="help-now-trip-download"
         onClick={async () => {
           const result = await saveTripModePackForOffline();
-          setStatus(result === 'saved' ? copy.downloadDone : 'Offline save is unavailable here.');
+          setStatus(result);
           if (result === 'saved') {
             trackHelpNowEvent('trip_pack_downloaded', {
               country,
@@ -46,7 +54,15 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
       >
         {copy.download}
       </button>
-      {status ? <p className="mt-3 text-sm font-medium text-emerald-800">{status}</p> : null}
+      {status ? (
+        <p
+          className={`mt-3 text-sm font-medium ${
+            status === 'saved' ? 'text-emerald-800' : 'text-amber-900'
+          }`}
+        >
+          {getStatusMessage(copy, status)}
+        </p>
+      ) : null}
       <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
         <p className="font-semibold">{copy.darkTitle}</p>
         <p className="mt-1">{copy.darkBody}</p>

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -72,14 +72,14 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
         {copy.download}
       </button>
       {status ? (
-        <p
-          role="status"
+        <output
+          aria-live="polite"
           className={`mt-3 text-sm font-medium ${
             status === 'saved' ? 'text-emerald-800' : 'text-amber-900'
           }`}
         >
           {getStatusMessage(copy, status)}
-        </p>
+        </output>
       ) : null}
       <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
         <p className="font-semibold">{copy.darkTitle}</p>

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -1,13 +1,18 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import type { HelpNowCountry, HelpNowCountryPack } from './content-packs';
+import {
+  getTripModeDownloadAssets,
+  type HelpNowCountry,
+  type HelpNowCountryPack,
+} from './content-packs';
 import type { HelpNowCopy } from './copy';
 import { saveTripModePackForOffline } from './offline';
 import { trackHelpNowEvent } from './analytics';
 import { HelpNowPanel } from './help-now-ui';
 
 type TripModeStatus = 'saved' | 'unsupported' | 'failed';
+const tripModeAssetCount = getTripModeDownloadAssets().length;
 
 type TripModeProps = Readonly<{
   copy: HelpNowCopy;
@@ -52,7 +57,7 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
             if (result === 'saved') {
               trackHelpNowEvent('trip_pack_downloaded', {
                 country,
-                pack_count: 1,
+                pack_count: tripModeAssetCount,
                 total_mb_bucket: 'under_1',
               });
             }
@@ -68,6 +73,7 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
       </button>
       {status ? (
         <p
+          role="status"
           className={`mt-3 text-sm font-medium ${
             status === 'saved' ? 'text-emerald-800' : 'text-amber-900'
           }`}

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -24,6 +24,7 @@ function getStatusMessage(copy: HelpNowCopy, status: TripModeStatus): string {
 export function TripMode({ copy, country, packs }: TripModeProps) {
   const [status, setStatus] = useState<TripModeStatus | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  // Keep a synchronous lock for same-tick clicks while state drives disabled UI feedback.
   const isSavingRef = useRef(false);
 
   return (

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -5,24 +5,19 @@ import type { HelpNowCountry, HelpNowCountryPack } from './content-packs';
 import type { HelpNowCopy } from './copy';
 import { saveTripModePackForOffline } from './offline';
 import { trackHelpNowEvent } from './analytics';
+import { HelpNowPanel } from './help-now-ui';
 
-type TripModeProps = {
+type TripModeProps = Readonly<{
   copy: HelpNowCopy;
   country: HelpNowCountry;
   packs: readonly HelpNowCountryPack[];
-};
+}>;
 
 export function TripMode({ copy, country, packs }: TripModeProps) {
   const [status, setStatus] = useState<string | null>(null);
 
   return (
-    <section
-      className="rounded-lg border border-slate-200 bg-white p-4"
-      aria-labelledby="trip-mode-title"
-    >
-      <h2 id="trip-mode-title" className="text-lg font-semibold text-slate-950">
-        Trip Mode
-      </h2>
+    <HelpNowPanel title="Trip Mode" titleId="trip-mode-title">
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
         {copy.tripChecklist.map(item => (
           <div
@@ -57,6 +52,6 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
         <p className="mt-1">{copy.darkBody}</p>
         <p className="mt-2 text-xs font-semibold">Signed packs: {packs.length}</p>
       </div>
-    </section>
+    </HelpNowPanel>
   );
 }

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { HelpNowCountry, HelpNowCountryPack } from './content-packs';
 import type { HelpNowCopy } from './copy';
 import { saveTripModePackForOffline } from './offline';
@@ -23,6 +23,8 @@ function getStatusMessage(copy: HelpNowCopy, status: TripModeStatus): string {
 
 export function TripMode({ copy, country, packs }: TripModeProps) {
   const [status, setStatus] = useState<TripModeStatus | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const isSavingRef = useRef(false);
 
   return (
     <HelpNowPanel title="Trip Mode" titleId="trip-mode-title">
@@ -40,17 +42,26 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
         type="button"
         data-testid="help-now-trip-download"
         onClick={async () => {
-          const result = await saveTripModePackForOffline();
-          setStatus(result);
-          if (result === 'saved') {
-            trackHelpNowEvent('trip_pack_downloaded', {
-              country,
-              pack_count: 1,
-              total_mb_bucket: 'under_1',
-            });
+          if (isSavingRef.current) return;
+          isSavingRef.current = true;
+          setIsSaving(true);
+          try {
+            const result = await saveTripModePackForOffline();
+            setStatus(result);
+            if (result === 'saved') {
+              trackHelpNowEvent('trip_pack_downloaded', {
+                country,
+                pack_count: 1,
+                total_mb_bucket: 'under_1',
+              });
+            }
+          } finally {
+            isSavingRef.current = false;
+            setIsSaving(false);
           }
         }}
-        className="mt-4 rounded-md bg-slate-950 px-4 py-3 text-sm font-semibold text-white"
+        disabled={isSaving}
+        className="mt-4 rounded-md bg-slate-950 px-4 py-3 text-sm font-semibold text-white disabled:opacity-60"
       >
         {copy.download}
       </button>

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -19,9 +19,9 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
   return (
     <HelpNowPanel title="Trip Mode" titleId="trip-mode-title">
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
-        {copy.tripChecklist.map(item => (
+        {copy.tripChecklist.map((item, index) => (
           <div
-            key={item}
+            key={`trip-${index}`}
             className="rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700"
           >
             {item}

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -7,11 +7,11 @@ import {
   type HelpNowCountryPack,
 } from './content-packs';
 import type { HelpNowCopy } from './copy';
-import { saveTripModePackForOffline } from './offline';
+import { saveTripModePackForOffline, type OfflineSaveResult } from './offline';
 import { trackHelpNowEvent } from './analytics';
 import { HelpNowPanel } from './help-now-ui';
 
-type TripModeStatus = 'saved' | 'unsupported' | 'failed';
+type TripModeStatus = OfflineSaveResult;
 const tripModeAssetCount = getTripModeDownloadAssets().length;
 
 type TripModeProps = Readonly<{

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import type { HelpNowCountry, HelpNowCountryPack } from './content-packs';
+import type { HelpNowCopy } from './copy';
+import { saveTripModePackForOffline } from './offline';
+import { trackHelpNowEvent } from './analytics';
+
+type TripModeProps = {
+  copy: HelpNowCopy;
+  country: HelpNowCountry;
+  packs: readonly HelpNowCountryPack[];
+};
+
+export function TripMode({ copy, country, packs }: TripModeProps) {
+  const [status, setStatus] = useState<string | null>(null);
+
+  return (
+    <section
+      className="rounded-lg border border-slate-200 bg-white p-4"
+      aria-labelledby="trip-mode-title"
+    >
+      <h2 id="trip-mode-title" className="text-lg font-semibold text-slate-950">
+        Trip Mode
+      </h2>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        {copy.tripChecklist.map(item => (
+          <div
+            key={item}
+            className="rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700"
+          >
+            {item}
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        data-testid="help-now-trip-download"
+        onClick={async () => {
+          const result = await saveTripModePackForOffline();
+          setStatus(result === 'saved' ? copy.downloadDone : 'Offline save is unavailable here.');
+          if (result === 'saved') {
+            trackHelpNowEvent('trip_pack_downloaded', {
+              country,
+              pack_count: 1,
+              total_mb_bucket: 'under_1',
+            });
+          }
+        }}
+        className="mt-4 rounded-md bg-slate-950 px-4 py-3 text-sm font-semibold text-white"
+      >
+        {copy.download}
+      </button>
+      {status ? <p className="mt-3 text-sm font-medium text-emerald-800">{status}</p> : null}
+      <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+        <p className="font-semibold">{copy.darkTitle}</p>
+        <p className="mt-1">{copy.darkBody}</p>
+        <p className="mt-2 text-xs font-semibold">Signed packs: {packs.length}</p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -19,9 +19,9 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
   return (
     <HelpNowPanel title="Trip Mode" titleId="trip-mode-title">
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
-        {copy.tripChecklist.map((item, index) => (
+        {copy.tripChecklist.map(item => (
           <div
-            key={`trip-${index}`}
+            key={item}
             className="rounded-md border border-slate-200 px-3 py-2 text-sm text-slate-700"
           >
             {item}

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -61,7 +61,7 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
           }
         }}
         disabled={isSaving}
-        className="mt-4 rounded-md bg-slate-950 px-4 py-3 text-sm font-semibold text-white disabled:opacity-60"
+        className="mt-4 rounded-md bg-slate-950 px-4 py-3 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
       >
         {copy.download}
       </button>

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54607644,
+  "maxTrackedBytes": 54608254,
   "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7144761,
+    "source/scripts": 7144851,
     "docs/text": 6044735,
-    "tests/e2e": 5092989,
+    "tests/e2e": 5093509,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54608297,
+  "maxTrackedBytes": 54610814,
   "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7144894,
+    "source/scripts": 7144906,
     "docs/text": 6044735,
-    "tests/e2e": 5093509,
+    "tests/e2e": 5096014,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54614952,
+  "maxTrackedBytes": 54614943,
   "maxTrackedFiles": 4717,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
     "source/scripts": 7145800,
     "docs/text": 6044735,
-    "tests/e2e": 5099239,
+    "tests/e2e": 5099230,
     "config/data/messages": 1561289
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54614691,
+  "maxTrackedBytes": 54614796,
   "maxTrackedFiles": 4717,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
     "source/scripts": 7145735,
     "docs/text": 6044735,
-    "tests/e2e": 5099062,
+    "tests/e2e": 5099167,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54617673,
-  "maxTrackedFiles": 4718,
+  "maxTrackedBytes": 54619668,
+  "maxTrackedFiles": 4720,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7146457,
+    "source/scripts": 7147161,
     "docs/text": 6044735,
-    "tests/e2e": 5101303,
+    "tests/e2e": 5102594,
     "config/data/messages": 1561289
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54610814,
+  "maxTrackedBytes": 54610780,
   "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7144906,
+    "source/scripts": 7144872,
     "docs/text": 6044735,
     "tests/e2e": 5096014,
     "config/data/messages": 1561270

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54614943,
-  "maxTrackedFiles": 4717,
+  "maxTrackedBytes": 54617673,
+  "maxTrackedFiles": 4718,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7145800,
+    "source/scripts": 7146457,
     "docs/text": 6044735,
-    "tests/e2e": 5099230,
+    "tests/e2e": 5101303,
     "config/data/messages": 1561289
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54615000,
-  "maxTrackedFiles": 4714,
+  "maxTrackedBytes": 54606095,
+  "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7146000,
+    "source/scripts": 7144639,
     "docs/text": 6044735,
-    "tests/e2e": 5093000,
+    "tests/e2e": 5091562,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54610780,
+  "maxTrackedBytes": 54611051,
   "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7144872,
+    "source/scripts": 7145042,
     "docs/text": 6044735,
-    "tests/e2e": 5096014,
+    "tests/e2e": 5096115,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54606830,
+  "maxTrackedBytes": 54607644,
   "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7144690,
+    "source/scripts": 7144761,
     "docs/text": 6044735,
-    "tests/e2e": 5092246,
+    "tests/e2e": 5092989,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54611045,
-  "maxTrackedFiles": 4715,
+  "maxTrackedBytes": 54613266,
+  "maxTrackedFiles": 4716,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7145036,
+    "source/scripts": 7146411,
     "docs/text": 6044735,
-    "tests/e2e": 5096115,
+    "tests/e2e": 5096961,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54619668,
+  "maxTrackedBytes": 54619683,
   "maxTrackedFiles": 4720,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7147161,
+    "source/scripts": 7147176,
     "docs/text": 6044735,
     "tests/e2e": 5102594,
     "config/data/messages": 1561289

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54614719,
+  "maxTrackedBytes": 54614691,
   "maxTrackedFiles": 4717,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
     "source/scripts": 7145735,
     "docs/text": 6044735,
-    "tests/e2e": 5099090,
+    "tests/e2e": 5099062,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54613266,
-  "maxTrackedFiles": 4716,
+  "maxTrackedBytes": 54614719,
+  "maxTrackedFiles": 4717,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7146411,
+    "source/scripts": 7145735,
     "docs/text": 6044735,
-    "tests/e2e": 5096961,
+    "tests/e2e": 5099090,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54620624,
+  "maxTrackedBytes": 54620651,
   "maxTrackedFiles": 4721,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7147262,
+    "source/scripts": 7147274,
     "docs/text": 6044735,
-    "tests/e2e": 5103449,
+    "tests/e2e": 5103464,
     "config/data/messages": 1561289
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54611051,
+  "maxTrackedBytes": 54611045,
   "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7145042,
+    "source/scripts": 7145036,
     "docs/text": 6044735,
     "tests/e2e": 5096115,
     "config/data/messages": 1561270

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54619683,
-  "maxTrackedFiles": 4720,
+  "maxTrackedBytes": 54620624,
+  "maxTrackedFiles": 4721,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7147176,
+    "source/scripts": 7147262,
     "docs/text": 6044735,
-    "tests/e2e": 5102594,
+    "tests/e2e": 5103449,
     "config/data/messages": 1561289
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54614796,
+  "maxTrackedBytes": 54614952,
   "maxTrackedFiles": 4717,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7145735,
+    "source/scripts": 7145800,
     "docs/text": 6044735,
-    "tests/e2e": 5099167,
-    "config/data/messages": 1561270
+    "tests/e2e": 5099239,
+    "config/data/messages": 1561289
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54608254,
+  "maxTrackedBytes": 54608297,
   "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7144851,
+    "source/scripts": 7144894,
     "docs/text": 6044735,
     "tests/e2e": 5093509,
     "config/data/messages": 1561270

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54606095,
+  "maxTrackedBytes": 54606830,
   "maxTrackedFiles": 4715,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7144639,
+    "source/scripts": 7144690,
     "docs/text": 6044735,
-    "tests/e2e": 5091562,
+    "tests/e2e": 5092246,
     "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54555041,
-  "maxTrackedFiles": 4696,
+  "maxTrackedBytes": 54615000,
+  "maxTrackedFiles": 4714,
   "maxCategoryBytes": {
     "other": 18693297,
-    "large support/generated-ish": 16067062,
-    "source/scripts": 7114397,
-    "docs/text": 6037416,
-    "tests/e2e": 5083351,
-    "config/data/messages": 1559518
+    "large support/generated-ish": 16070592,
+    "source/scripts": 7146000,
+    "docs/text": 6044735,
+    "tests/e2e": 5093000,
+    "config/data/messages": 1561270
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- Add MOB-01 public Help Now / Trip Mode route at `/:locale/help-now` for anonymous and signed-in users without touching protected auth/routing/tenancy/proxy surfaces.
- Add local-only evidence prompts, public Trip Mode manifest/offline save handling, analytics allowlist, and service-worker guards for same-origin public assets only.
- Route anonymous home primary CTA to Help Now while preserving the existing free-start anchor as the secondary CTA.
- Keep all country packs dark until named L2 sign-off exists; unsigned packs do not construct or render `IncidentScenePack` preview content.

## T-503 evidence note
- The scanned `T-503 G04/G05/G09/G10 Controlled Substitute Waiver` signed/stamped by Gazmend Abazi on 2026-07-04 is accepted for operational testing continuity only.
- It is not final original evidence for `PAID`, `CLOSED`, final finance reconciliation, claimant/sponsor POA, or final closure. Originals remain required before final operational-readiness or closure claims.

## Verification
- `pnpm pr:verify` passed.
  - Includes E2E gate: 138 passed / 8 skipped.
  - Includes smoke: 13 passed / 9 skipped.
- `pnpm security:guard` passed.
- `pnpm e2e:gate` passed: 138 passed / 8 skipped.
- Focused checks after reviewer fix passed:
  - `git diff --check`
  - `pnpm check:modularity-guard`
  - Help Now/content-pack unit tests: 8 passed
  - web type-check
  - web lint
  - focused Help Now E2E: 2 passed

## Reviewer disposition
- Initial external review found a blocker: dark country-pack sign-off helpers existed but the public render path still created the preview pack.
- Fixed by wiring `canExposeCountryPack` into `HelpNowExperience`, rendering dark placeholder content when unsigned, and hiding preview generation until L2 sign-off exists.
- Added tests that fail if unsigned country packs expose preview controls and that keep served JSON manifest metadata aligned with the TS gate metadata.
- Earlier reviewer-route attempts: Sonnet post-fix route timed out with no output; Gemini fallback was unavailable due local auth/CLI constraints; Opus review produced the actionable blocker above, now fixed.

## Residual notes
- Existing CD/staging RBAC readiness concern remains outside this MOB-01 design/implementation PR and should not be represented as live-launch readiness until separately triaged.
- Help Now labels beyond primary copy still have English fallback for some compact UI terms; this is acceptable for the dark-pack pilot surface and can be localized when L2 content sign-off starts.
