### PR TITLE
fix: expose Help Now accessibility states

### DIFF
--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -64,6 +64,17 @@ describe('HelpNowExperience', () => {
     expect(hoisted.trackEventMock).toHaveBeenCalledTimes(1);
   });
 
+  it('exposes checklist completion as toggle state', async () => {
+    const user = userEvent.setup();
+    render(<HelpNowExperience locale="en" />);
+
+    const checklistItem = screen.getByTestId('help-now-checklist-0');
+    expect(checklistItem).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(checklistItem);
+    expect(checklistItem).toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('keeps evidence local and allows clearing the bundle', async () => {
     const user = userEvent.setup();
     render(<HelpNowExperience locale="en" />);

--- a/apps/web/src/features/help-now/scene-guide.tsx
+++ b/apps/web/src/features/help-now/scene-guide.tsx
@@ -30,6 +30,7 @@ export function SceneGuide({ copy, completed, country, scenario, onToggle }: Sce
               <li key={item}>
                 <button
                   type="button"
+                  aria-pressed={done}
                   data-testid={`help-now-checklist-${index}`}
                   onClick={() => {
                     onToggle(index);

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -72,14 +72,15 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
         {copy.download}
       </button>
       {status ? (
-        <output
+        <p
+          role="status"
           aria-live="polite"
           className={`mt-3 text-sm font-medium ${
             status === 'saved' ? 'text-emerald-800' : 'text-amber-900'
           }`}
         >
           {getStatusMessage(copy, status)}
-        </output>
+        </p>
       ) : null}
       <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
         <p className="font-semibold">{copy.darkTitle}</p>

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54620651,
+  "maxTrackedBytes": 54620734,
   "maxTrackedFiles": 4721,
   "maxCategoryBytes": {
     "other": 18693297,
     "large support/generated-ish": 16070592,
-    "source/scripts": 7147274,
+    "source/scripts": 7147336,
     "docs/text": 6044735,
-    "tests/e2e": 5103464,
+    "tests/e2e": 5103485,
     "config/data/messages": 1561289
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Summary
- Add explicit pressed state to Help Now scene checklist toggles.
- Add explicit status role to Trip Mode save feedback.
- Add focused regression coverage for checklist toggle state.

## Context
- Follow-up to #1296, which merged before the late current-head Copilot accessibility review completed.
- The two addressed threads were resolved on #1296: PRRT_kwDOQ0Mhjc6OYCpY and PRRT_kwDOQ0Mhjc6OYCph.

## Verification
- corepack pnpm --filter @interdomestik/web test:unit --run src/features/help-now/help-now-experience.test.tsx src/features/help-now/trip-mode.test.tsx src/features/help-now/offline.test.ts
- corepack pnpm --filter @interdomestik/web type-check
- corepack pnpm --filter @interdomestik/web lint
- corepack pnpm repo:size:check
- corepack pnpm check:modularity-guard