### PR TITLE
docs: add mobile UI/UX storyboard package

### DIFF
--- a/docs/product/2026-07-05-mobile-uiux-review-input-package.md
+++ b/docs/product/2026-07-05-mobile-uiux-review-input-package.md
@@ -5,6 +5,8 @@ source_of_truth: false
 owner: product-design
 last_reviewed: 2026-07-05
 related:
+  - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
+  - docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
   - docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
   - docs/product/mobile-experience-blueprint.md
   - docs/product/2026-07-03-mobile-excellence-dossier.md
@@ -20,6 +22,10 @@ related:
 > authority, promotes no `MOB-*` slice, changes no runtime behavior, and does
 > not approve any public exposure. It is a handoff checklist for product design,
 > Figma, accessibility, legal-copy, and commercial reviewers.
+> The storyboard companion in
+> `docs/product/2026-07-05-mobile-uiux-storyboard-package.md` defines the first
+> Figma/static-board pass reviewers should inspect before any UI package is
+> installed.
 
 ## Purpose
 
@@ -43,6 +49,7 @@ or legal-copy reviewer to inspect the mobile lane.
 
 | Source                                                               | Why reviewer needs it                                                   |
 | -------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `docs/product/2026-07-05-mobile-uiux-storyboard-package.md`          | Required Figma rows, frame IDs, variants, and review procedure          |
 | `docs/product/mobile-experience-blueprint.md`                        | Screen inventory, IA, primary mobile flows                              |
 | `docs/product/2026-07-03-mobile-excellence-dossier.md`               | Product principles, performance budgets, measurement, red-team critique |
 | `docs/product/2026-07-03-mobile-design-review-enterprise.md`         | Existing enterprise UX critique and missing artifacts                   |
@@ -66,17 +73,8 @@ implementation details unless they expose a defect in the component contracts.
 
 ## Required Figma Frames
 
-The first Figma pass is useful only if it includes these states.
-
-| Flow               | Required frames                                                                                   |
-| ------------------ | ------------------------------------------------------------------------------------------------- |
-| Help Now           | default, country detected, offline, stale pack, emergency-number hotfix, dark country placeholder |
-| Scene guide        | car accident, medical/injury, property/home, flight disruption, permission denied                 |
-| Evidence coach     | camera allowed, camera denied, low light, saved locally, clear/delete confirmation                |
-| Trip Mode          | download ready, downloading, verified road-ready, pack stale/needs refresh, storage unavailable   |
-| Claim Pack         | read-back, deadlines, documents needed, free-pack path, handle-it path                            |
-| Fee Math Sheet     | three recovery amounts, zero recovery, member discount, expert-cost-on-loss edge                  |
-| Agreement Ceremony | service agreement, POA/e-sign, signature error, 135% dynamic type                                 |
+Use the storyboard package and frame inventory for the exact row and frame IDs.
+The first Figma pass is incomplete if any required frame is missing.
 
 ## Artifact Templates
 
@@ -145,6 +143,8 @@ Each reviewer returns one dated note with:
 
 ## Done Definition For Step 3
 
-Step 3 is complete when this package is merged and assigned to the design
-reviewers. The actual Figma frames, accessibility scripts, and artifact template
-files are follow-on design deliverables; they authorize no runtime work.
+Step 3 is reviewable when this package and the storyboard companion are merged
+and assigned to the design reviewers. Step 3 is complete only after dated human
+findings return for the storyboard/Figma board. The actual Figma frames,
+accessibility scripts, and artifact template files are design deliverables; they
+authorize no runtime work.

--- a/docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
+++ b/docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
@@ -1,0 +1,63 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: product-design
+last_reviewed: 2026-07-05
+related:
+  - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
+  - docs/product/2026-07-05-mobile-uiux-review-input-package.md
+---
+
+# Mobile UI/UX Storyboard Frame Inventory
+
+> Status: **frame inventory only.** This file defines static storyboard frames
+> for Step 3 review. It grants no runtime authority.
+
+## Required Frames
+
+| Frame ID | State                    | Must show                                                       | Review question                                                |
+| -------- | ------------------------ | --------------------------------------------------------------- | -------------------------------------------------------------- |
+| `HN-1`   | Help Now default         | Country, verified date, emergency number area, situation list   | Can the user act without reading marketing copy?               |
+| `HN-2`   | Country detected         | Detected country, confidence, manual change affordance          | Is the country assumption visible and correctable?             |
+| `HN-3`   | Offline                  | Last verified pack, offline limits, emergency-first instruction | Is the offline limit honest without causing panic?             |
+| `HN-4`   | Stale pack               | Refresh need, last verified date, blocked/allowed actions       | Is stale content visibly different from verified content?      |
+| `HN-5`   | Emergency hotfix         | Updated number, timestamp, source note                          | Would a reviewer catch a wrong-number hotfix before exposure?  |
+| `HN-6`   | Dark country placeholder | Unavailable country copy and no broken-looking empty state      | Does this read as intentionally not launched yet?              |
+| `IG-1`   | Car accident             | Triage steps, evidence prompts, police/medical boundary         | Are steps short enough for roadside use?                       |
+| `IG-2`   | Medical or injury        | Emergency-first posture and non-diagnostic language             | Does anything imply medical advice?                            |
+| `IG-3`   | Property/home            | Safety, photo evidence, document checklist                      | Does it avoid false urgency?                                   |
+| `IG-4`   | Flight disruption        | Timing, evidence capture, airline boundary                      | Are deadlines and evidence prompts visible?                    |
+| `IG-5`   | Permission denied        | Manual fallback and permission recovery                         | Can the user continue without changing settings immediately?   |
+| `EC-1`   | Camera allowed           | Capture instruction, local-save note, privacy copy              | Does the user know where evidence goes?                        |
+| `EC-2`   | Camera denied            | Manual upload/notes fallback                                    | Can the user continue without granting camera access?          |
+| `EC-3`   | Low light                | Quality warning and recapture guidance                          | Is weak evidence clearly marked without shaming the user?      |
+| `EC-4`   | Saved locally            | Local-only state, sync limits, delete path                      | Is local custody understandable?                               |
+| `EC-5`   | Delete confirmation      | Consequence, cancel, confirm                                    | Is destructive action unmistakable?                            |
+| `TM-1`   | Download ready           | Country pack, size, verified date                               | Is the value clear without sounding like a subscription pitch? |
+| `TM-2`   | Downloading              | Progress, cancel, network/storage status                        | Does progress avoid false readiness?                           |
+| `TM-3`   | Road-ready verified      | Pack hash/version, offline availability                         | Does readiness feel proven rather than decorative?             |
+| `TM-4`   | Pack stale               | Refresh requirement and unsafe-content boundary                 | Does the design refuse stale guidance when needed?             |
+| `TM-5`   | Storage unavailable      | What cannot download and how to recover                         | Is the failure actionable?                                     |
+| `TM-6`   | Integrity failure        | Blocked use, retry, support path                                | Does the design refuse unsafe guidance clearly?                |
+| `CP-1`   | Claim Pack read-back     | Basis, summary, human-review boundary                           | Does preliminary output avoid looking legally final?           |
+| `CP-2`   | Deadlines                | Dates, source lines, confidence                                 | Are timing risks impossible to miss?                           |
+| `CP-3`   | Documents needed         | Required/optional evidence and missing items                    | Can the user see what to gather next?                          |
+| `CP-4`   | Free pack fork           | User keeps package without paid handling                        | Is the unpaid path equally dignified?                          |
+| `CP-5`   | Handle-it fork           | Paid handling offer, no emergency-context sales pressure        | Is the sales prompt limited to the approved moment?            |
+| `FM-1`   | Three recovery amounts   | Low/base/high recovery and member net amount                    | Is user outcome more prominent than platform fee?              |
+| `FM-2`   | Zero recovery            | No recovery, no success fee, any third-party cost caveat        | Is the loss outcome honest before signature?                   |
+| `FM-3`   | Member discount          | Discounted fee and user receives amount                         | Is the discount useful without hiding the fee base?            |
+| `FM-4A`  | Memo 1 option A          | Interdomestik absorbs approved expert/court costs on loss       | Does "recover nothing, pay nothing" remain visibly qualified?  |
+| `FM-4B`  | Memo 1 option B          | Success fee waived, approved third-party costs member-payable   | Is the member's possible loss-side cost impossible to miss?    |
+| `FM-4C`  | Memo 1 option C          | Cap, above-cap approval, at-risk amount                         | Does the cap appear before signature, not after?               |
+| `HM-1A`  | Memo 2 option A          | Named handler from launch                                       | Does the layout support stable handover and absence states?    |
+| `HM-1B`  | Memo 2 option B          | Case team from launch                                           | Does no surface imply one stable named person?                 |
+| `HM-1C`  | Memo 2 option C          | Case team now, branch-earned named-handler later                | Are branch thresholds copy-ready before runtime?               |
+| `AC-1`   | Service agreement        | Service, fee, handler model, document list                      | Can the member understand the commitment before signing?       |
+| `AC-2`   | POA/e-sign action        | Signature action, legal copy, disabled/loading states           | Is the signature action visually dominant but not coercive?    |
+| `AC-3`   | Signature error          | Retry, support, no duplicate-submit confusion                   | Can the user recover without wondering whether they signed?    |
+| `AC-4`   | 135% dynamic type        | Fee, signature, deadline, emergency/help hierarchy              | Does the critical hierarchy survive large text?                |
+| `PDF-1`  | Claim Pack PDF           | Reference, source lines, document checklist                     | Would a professional forward or file it?                       |
+| `PDF-2`  | Signed pack PDF          | Signature evidence, policy versions, exhibit manifest           | Is audit evidence clear enough without internal jargon?        |
+| `PDF-3`  | Sponsor aggregate report | Aggregate-only metrics, no case/member detail                   | Does the design reinforce that sponsor case access is blocked? |

--- a/docs/product/2026-07-05-mobile-uiux-storyboard-package.md
+++ b/docs/product/2026-07-05-mobile-uiux-storyboard-package.md
@@ -1,0 +1,148 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: product-design
+last_reviewed: 2026-07-05
+related:
+  - docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
+  - docs/product/2026-07-05-mobile-uiux-review-input-package.md
+  - docs/product/mobile-experience-blueprint.md
+  - docs/product/2026-07-03-mobile-excellence-dossier.md
+  - docs/product/2026-07-03-mobile-component-contracts.md
+  - docs/product/2026-07-03-mobile-copy-system.md
+  - docs/product/2026-07-03-mobile-error-taxonomy.md
+  - docs/product/2026-07-05-memo1-expert-cost-on-loss-decision-record.md
+  - docs/product/2026-07-05-memo2-handler-model-decision-record.md
+  - docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
+---
+
+# Mobile UI/UX Storyboard Package
+
+> Status: **Figma/storyboard preparation only.** This package installs no UI
+> package, ships no prototype, promotes no `MOB-*` slice, and grants no runtime
+> authority. It exists so human reviewers can inspect the intended mobile
+> experience before implementation.
+
+## Why This Comes First
+
+A human cannot review implemented UI behavior before the UI package exists.
+They can still review the most expensive UX decisions before engineering starts:
+flow order, trust hierarchy, crisis-state copy, legal/commercial boundaries,
+accessibility intent, and whether unresolved business decisions require visible
+variants.
+
+Use this package to create a Figma board or equivalent static storyboard. Do not
+use it as proof that the app works in a browser.
+
+## Reviewer Boundary
+
+Reviewers may approve, reject, or annotate:
+
+- frame sequence and information hierarchy;
+- copy clarity for Help Now, Trip Mode, Claim Pack, Fee Math, and Agreement
+  Ceremony;
+- dark-country, stale-pack, offline, camera-denied, and signature-error states;
+- accessibility reading order, focus order, and dynamic-type resilience;
+- artifact seriousness for PDFs and partner-facing documents.
+
+Reviewers cannot approve:
+
+- shipped UI, routing, auth, session, tenancy, or billing behavior;
+- non-dark country exposure;
+- emergency-number correctness without signed country evidence;
+- fee promises before Memo 1 is signed;
+- handler promises before Memo 2 is signed;
+- `MOB-01b`, `MOB-05a`, or `MOB-02` promotion.
+
+## Board Setup
+
+Create one Figma page named `MOB Step 3 Storyboard - Pre-Implementation`.
+
+| Board rule       | Requirement                                                                 |
+| ---------------- | --------------------------------------------------------------------------- |
+| Device frames    | `390 x 844` primary, `360 x 800` compact, plus one `135%` dynamic-type lane |
+| Layout grouping  | One horizontal row per flow; one vertical column per state                  |
+| Annotation style | Short side notes for intent, data dependency, and unresolved decision       |
+| Visual tone      | Calm institutional, not sales-led; Help Now must feel operational           |
+| Variant handling | Show unsigned Memo 1 and Memo 2 options as separate frames, not hidden text |
+
+## Storyboard Rows
+
+| Row | Flow                     | Purpose                                                                 |
+| --- | ------------------------ | ----------------------------------------------------------------------- |
+| 1   | Help Now entry           | Prove a stressed user can get country-specific guidance without upsell  |
+| 2   | Incident guide           | Prove crisis choices are scannable, non-legalistic, and recoverable     |
+| 3   | Trip Mode                | Prove offline preparedness, pack freshness, and integrity failure copy  |
+| 4   | Evidence Coach           | Prove camera permission, local-save, and delete choices are trustworthy |
+| 5   | Claim Pack read-back     | Prove the user understands basis, deadline, documents, and next fork    |
+| 6   | Fee Math Sheet           | Prove member net outcome is clearer than platform fee                   |
+| 7   | Handler / member support | Prove the support promise matches the unsigned handler decision         |
+| 8   | Agreement Ceremony       | Prove signing hierarchy survives errors and 135% type                   |
+| 9   | Artifact templates       | Prove PDFs look serious enough for lawyers, insurers, and partners      |
+
+## Required Frames
+
+Use `docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md` as the
+frame-level checklist. The Figma board is incomplete if any listed frame ID is
+missing.
+
+## Copy Constraints
+
+- Help Now copy must never sell handling services.
+- Dark-country copy must say the country is not yet available, not that the app
+  is broken.
+- Stale-pack copy must block or qualify unsafe guidance instead of hiding risk.
+- Claim Pack copy must say initial assessment / human review where applicable.
+- Fee Math copy must put the user's net amount before the platform fee.
+- Handler copy must match Memo 2 exactly; if Memo 2 is unsigned, all three
+  variants remain visible in the board.
+- Signature copy must not bury loss-side expert/court-cost exposure.
+
+## Accessibility Script Deliverables
+
+Create one text script per flow row. Each script must include:
+
+- first focus target;
+- reading order;
+- control name and state announcement;
+- error-state announcement;
+- keyboard/focus recovery path;
+- what changes in the `135%` dynamic-type lane.
+
+Minimum scripts: Help Now car accident, Trip Mode stale pack, Evidence Coach
+camera denied, Claim Pack read-back, Fee Math option B, Agreement Ceremony
+signature error.
+
+## Human Review Procedure
+
+1. Reviewer reads the input package and this storyboard package.
+2. Designer creates the Figma page with every frame ID in the inventory.
+3. Reviewer marks each frame `pass`, `pass_with_changes`, or `blocker`.
+4. Reviewer records blocking findings with frame ID, issue, risk, and required
+   change.
+5. Product-design owner updates the review input package with a dated link to
+   the returned notes.
+6. No runtime work starts until a later current-authority/design-gate record
+   explicitly cites the accepted storyboard evidence.
+
+## Output Required From Reviewers
+
+Each reviewer returns a dated note containing:
+
+- Figma file/page name or exported PDF name reviewed;
+- frames reviewed and frames missing;
+- blockers by frame ID;
+- copy strings requiring legal/language approval;
+- accessibility issues by script;
+- one explicit sentence: "This review grants no runtime authority."
+
+## Step 3 Done Definition
+
+Step 3 becomes reviewable when this package and the existing review input package
+are merged. Step 3 becomes complete only after human reviewers return dated
+findings for the storyboard/Figma board.
+
+Completion does not install the UI package, prove browser behavior, or unblock
+runtime exposure. It only reduces product-design uncertainty before `MOB-01b`,
+`MOB-05a`, or `MOB-02` gate work.

--- a/docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
+++ b/docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
@@ -11,6 +11,7 @@ related:
   - docs/plans/2026-07-05-b2-staging-rbac-residual-check.md
   - docs/plans/2026-07-05-rbac-01-current-authority.md
   - docs/product/2026-07-05-mobile-uiux-review-input-package.md
+  - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
   - docs/product/2026-07-05-business-memo-signing-packet.md
 ---
 
@@ -31,17 +32,17 @@ local proof as staging proof.
 
 ## Sequence
 
-| Step | Work                          | Current status   | Evidence / next action                                                                                                                                     | Advancement rule                                                                       |
-| ---- | ----------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| 1    | Verify ENT-A01 / RBAC-01      | Closed, caveated | PR `#1299` fixed the narrow release-gate stabilization path; PR `#1300` recorded two consecutive green staging jobs after one post-deploy P0.1 staff miss. | Reopen/freeze if any future current-main staging P0.1 agent/staff marker miss appears. |
-| 2    | Appoint country reviewer      | In progress      | MK signature package sent to `Interdomestik@gmail.com`; wait for named professional signatures and preserve returned PDFs.                                 | Required before L2 review can complete for the selected country.                       |
-| 3    | UI/UX design preparation only | Prepared         | Review input package: `docs/product/2026-07-05-mobile-uiux-review-input-package.md`; no shipped UI changes.                                                | Allowed in parallel, but cannot promote runtime.                                       |
-| 4    | Sign business memos           | Ready to sign    | Signing packet plus decision records: `docs/product/2026-07-05-business-memo-signing-packet.md`; records still unsigned.                                   | Required before MOB-05a and MOB-02 gates.                                              |
-| 5    | Complete B6/B7                | In progress      | B6 runbook and B7 alert-coverage contract are drafted; staging hotfix exercise and synthetic alert proof are still required.                               | Required before non-dark Help Now exposure.                                            |
-| 6    | Draft MOB-01b gate            | Not started      | Draft only after Step 1 path is clear enough to cite entry evidence; keep it docs-only.                                                                    | Drafting is allowed; promotion is not.                                                 |
-| 7    | Implement MOB-01b             | Blocked          | Requires ENT-A01 closed, L2 MK signed, B6 done, B7 done, and a later `MOB-DG01B` authority record.                                                         | No flag flip or runtime config until CA+DG.                                            |
-| 8    | Prepare MOB-05a               | Blocked          | Start gate prep after Memo 1 and fee-wording review kickoff.                                                                                               | Runtime waits for CA+DG.                                                               |
-| 9    | Prepare MOB-02                | Blocked          | Start design prep after Memo 2 and ops-SLA reconciliation inputs.                                                                                          | Runtime waits for CA+DG.                                                               |
+| Step | Work                          | Current status   | Evidence / next action                                                                                                                                                                           | Advancement rule                                                                       |
+| ---- | ----------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| 1    | Verify ENT-A01 / RBAC-01      | Closed, caveated | PR `#1299` fixed the narrow release-gate stabilization path; PR `#1300` recorded two consecutive green staging jobs after one post-deploy P0.1 staff miss.                                       | Reopen/freeze if any future current-main staging P0.1 agent/staff marker miss appears. |
+| 2    | Appoint country reviewer      | In progress      | MK signature package sent to `Interdomestik@gmail.com`; wait for named professional signatures and preserve returned PDFs.                                                                       | Required before L2 review can complete for the selected country.                       |
+| 3    | UI/UX design preparation only | Storyboard ready | Review input package plus storyboard package: `docs/product/2026-07-05-mobile-uiux-review-input-package.md`, `docs/product/2026-07-05-mobile-uiux-storyboard-package.md`; no shipped UI changes. | Allowed in parallel, but cannot promote runtime.                                       |
+| 4    | Sign business memos           | Ready to sign    | Signing packet plus decision records: `docs/product/2026-07-05-business-memo-signing-packet.md`; records still unsigned.                                                                         | Required before MOB-05a and MOB-02 gates.                                              |
+| 5    | Complete B6/B7                | In progress      | B6 runbook and B7 alert-coverage contract are drafted; staging hotfix exercise and synthetic alert proof are still required.                                                                     | Required before non-dark Help Now exposure.                                            |
+| 6    | Draft MOB-01b gate            | Not started      | Draft only after Step 1 path is clear enough to cite entry evidence; keep it docs-only.                                                                                                          | Drafting is allowed; promotion is not.                                                 |
+| 7    | Implement MOB-01b             | Blocked          | Requires ENT-A01 closed, L2 MK signed, B6 done, B7 done, and a later `MOB-DG01B` authority record.                                                                                               | No flag flip or runtime config until CA+DG.                                            |
+| 8    | Prepare MOB-05a               | Blocked          | Start gate prep after Memo 1 and fee-wording review kickoff.                                                                                                                                     | Runtime waits for CA+DG.                                                               |
+| 9    | Prepare MOB-02                | Blocked          | Start design prep after Memo 2 and ops-SLA reconciliation inputs.                                                                                                                                | Runtime waits for CA+DG.                                                               |
 
 ## Step 1 State
 
@@ -65,8 +66,9 @@ current-authority/design-gate are complete.
    qualification, date, and scope.
 2. Choose owners for B6 hotfix runbook and B7 alert catalog.
 3. Decide who signs Memo 1 and Memo 2 if not Arben.
-4. Assign the UI/UX review package to the design reviewers and collect dated
-   findings before Figma/runtime decisions.
+4. Assign the UI/UX review and storyboard packages to the design reviewers,
+   create the Figma/static board, and collect dated findings before runtime
+   decisions.
 5. Fill and sign both business-memo decision records, then commit the signed
    files.
 6. Draft the MOB-01b gate only after the entry evidence can be cited.

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54938362,
-  "maxTrackedFiles": 4764,
+  "maxTrackedBytes": 54953396,
+  "maxTrackedFiles": 4766,
   "maxCategoryBytes": {
     "other": 18821537,
     "large support/generated-ish": 16077049,
     "source/scripts": 7152638,
-    "docs/text": 6218018,
+    "docs/text": 6233052,
     "tests/e2e": 5106882,
     "config/data/messages": 1562238
   },


### PR DESCRIPTION
## Summary
- add a pre-implementation mobile UI/UX storyboard package for Step 3
- link it from the existing UI/UX review input package
- update the nine-step sequence to mark Step 3 as storyboard-ready, not runtime-ready
- sync the repo-size budget for the added tracked doc

## Authority boundary
- docs-only Tier 0 work
- no UI package installed
- no shipped prototype or runtime behavior
- no `MOB-*` promotion, flag flip, route/auth/tenancy/billing change, or public exposure approval
- canonical resolver remains blocked pending fresh current authority (`blocked_requires_current_authority`, `activeSlice=null`)

## Verification
- `git diff --check HEAD~1..HEAD`
- `pnpm docs:verify`
- `pnpm plan:status`
- `pnpm plan:audit`
- `pnpm track:audit`
- `pnpm repo:size:check`
- `node /Users/arbenlila/.codex/skills/interdomestik-slice-runner/scripts/next-slice.mjs /Users/arbenlila/development/interdomestik-crystal-home` returned expected supervisor block: `blocked_requires_current_authority`, `activeSlice=null`

## Notes
- Also added an advisory Obsidian note outside this repo at `Notes/decisions/2026-07-05-interdomestik-storyboard-before-ui-package.md`.