### PR TITLE
docs: add mobile UI/UX static board

### DIFF
--- a/docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
+++ b/docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
@@ -1,0 +1,109 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: product-design
+last_reviewed: 2026-07-05
+related:
+  - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
+  - docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
+  - docs/product/2026-07-05-mobile-uiux-review-input-package.md
+  - docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
+---
+
+# Mobile UI/UX Static Storyboard Board Contract
+
+> Status: **static board contract only.** This is not an implemented UI, a
+> browser prototype, an exported Figma/PDF board, a Figma approval, or runtime
+> authority. It defines the board humans must create and review before any UI
+> package is installed.
+
+## Board Contract
+
+Create a print/PDF board or Figma page named:
+`MOB Step 3 Storyboard - Pre-Implementation`.
+
+Use this layout:
+
+| Column       | Content                                                    |
+| ------------ | ---------------------------------------------------------- |
+| Flow lane    | One horizontal lane per row below                          |
+| Frame cards  | One card per frame ID from the frame inventory             |
+| State badge  | `default`, `risk`, `offline`, `decision`, `artifact`       |
+| Footer strip | data dependency, unresolved decision, reviewer mark        |
+| Review mark  | `pass`, `pass_with_changes`, `blocker`, or `missing_frame` |
+
+## Frame Card Template
+
+Every card must use the same structure:
+
+```text
+[Frame ID] [State badge]
+Primary user question
+Main screen hierarchy
+Trust / legal / data boundary
+Reviewer mark: _____
+Notes: _____________
+```
+
+## Board Lanes
+
+| Lane | Frame IDs                 | Reviewer focus                                  |
+| ---- | ------------------------- | ----------------------------------------------- |
+| HN   | `HN-1` to `HN-6`          | Help Now clarity, country trust, no upsell      |
+| IG   | `IG-1` to `IG-5`          | Crisis choices, safety boundaries, permissions  |
+| EC   | `EC-1` to `EC-5`          | Evidence custody, camera fallback, deletion     |
+| TM   | `TM-1` to `TM-6`          | Offline readiness, stale packs, integrity fail  |
+| CP   | `CP-1` to `CP-5`          | Claim basis, deadlines, equal-dignity fork      |
+| FM   | `FM-1` to `FM-4C`         | Net outcome, loss edge, Memo 1 variants         |
+| HM   | `HM-1A`, `HM-1B`, `HM-1C` | Handler promise honesty, Memo 2 variants        |
+| AC   | `AC-1` to `AC-4`          | Signing hierarchy, errors, 135% dynamic type    |
+| PDF  | `PDF-1`, `PDF-2`, `PDF-3` | Filing seriousness and sponsor privacy boundary |
+
+## Must-Show Global Elements
+
+Each mobile frame must reserve space for:
+
+- country and verified-date line;
+- emergency-first instruction where relevant;
+- human-review boundary for preliminary outputs;
+- no-sales area for Help Now and crisis states;
+- signed/unsigned decision marker for Memo 1 and Memo 2 variants;
+- accessible action labels, not icon-only controls;
+- footer note: `Review grants no runtime authority`.
+
+## Reviewer Pass
+
+Reviewers inspect the board in this order:
+
+1. Scan all `HN` and `IG` frames for crisis trust failures.
+2. Scan `EC` and `TM` for privacy, offline, stale-pack, and integrity failures.
+3. Scan `CP`, `FM`, and `AC` for legal/final-output overclaim.
+4. Scan `HM` for handler-promise mismatch.
+5. Scan `PDF` for professional seriousness and privacy.
+6. Mark any missing frame ID as `missing_frame`.
+
+## Human Output Form
+
+Each reviewer returns one note using this format:
+
+| Field                 | Value                                      |
+| --------------------- | ------------------------------------------ |
+| Reviewer              | `TBD`                                      |
+| Role / qualification  | `TBD`                                      |
+| Board reviewed        | `TBD`                                      |
+| Date                  | `TBD`                                      |
+| Missing frames        | `TBD`                                      |
+| Blockers              | `TBD`                                      |
+| Copy needing review   | `TBD`                                      |
+| Accessibility concern | `TBD`                                      |
+| Runtime authority     | `This review grants no runtime authority.` |
+
+## Completion Rule
+
+The static board is ready only after every frame ID in
+`docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md` exists in a
+Figma/PDF/exported board and every card includes a reviewer-mark field that is
+still unfilled.
+
+Step 3 is still not complete until dated human findings are returned and stored.

--- a/docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
+++ b/docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
@@ -5,6 +5,7 @@ source_of_truth: false
 owner: product-design
 last_reviewed: 2026-07-05
 related:
+  - docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
   - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
   - docs/product/2026-07-05-mobile-uiux-review-input-package.md
 ---

--- a/docs/product/2026-07-05-mobile-uiux-storyboard-package.md
+++ b/docs/product/2026-07-05-mobile-uiux-storyboard-package.md
@@ -5,6 +5,7 @@ source_of_truth: false
 owner: product-design
 last_reviewed: 2026-07-05
 related:
+  - docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
   - docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
   - docs/product/2026-07-05-mobile-uiux-review-input-package.md
   - docs/product/mobile-experience-blueprint.md
@@ -32,8 +33,9 @@ flow order, trust hierarchy, crisis-state copy, legal/commercial boundaries,
 accessibility intent, and whether unresolved business decisions require visible
 variants.
 
-Use this package to create a Figma board or equivalent static storyboard. Do not
-use it as proof that the app works in a browser.
+Use this package and the static board companion to create a Figma board or
+equivalent storyboard. Do not use either as proof that the app works in a
+browser.
 
 ## Reviewer Boundary
 

--- a/docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
+++ b/docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
@@ -11,6 +11,7 @@ related:
   - docs/plans/2026-07-05-b2-staging-rbac-residual-check.md
   - docs/plans/2026-07-05-rbac-01-current-authority.md
   - docs/product/2026-07-05-mobile-uiux-review-input-package.md
+  - docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
   - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
   - docs/product/2026-07-05-business-memo-signing-packet.md
 ---
@@ -32,17 +33,17 @@ local proof as staging proof.
 
 ## Sequence
 
-| Step | Work                          | Current status   | Evidence / next action                                                                                                                                                                           | Advancement rule                                                                       |
-| ---- | ----------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| 1    | Verify ENT-A01 / RBAC-01      | Closed, caveated | PR `#1299` fixed the narrow release-gate stabilization path; PR `#1300` recorded two consecutive green staging jobs after one post-deploy P0.1 staff miss.                                       | Reopen/freeze if any future current-main staging P0.1 agent/staff marker miss appears. |
-| 2    | Appoint country reviewer      | In progress      | MK signature package sent to `Interdomestik@gmail.com`; wait for named professional signatures and preserve returned PDFs.                                                                       | Required before L2 review can complete for the selected country.                       |
-| 3    | UI/UX design preparation only | Storyboard ready | Review input package plus storyboard package: `docs/product/2026-07-05-mobile-uiux-review-input-package.md`, `docs/product/2026-07-05-mobile-uiux-storyboard-package.md`; no shipped UI changes. | Allowed in parallel, but cannot promote runtime.                                       |
-| 4    | Sign business memos           | Ready to sign    | Signing packet plus decision records: `docs/product/2026-07-05-business-memo-signing-packet.md`; records still unsigned.                                                                         | Required before MOB-05a and MOB-02 gates.                                              |
-| 5    | Complete B6/B7                | In progress      | B6 runbook and B7 alert-coverage contract are drafted; staging hotfix exercise and synthetic alert proof are still required.                                                                     | Required before non-dark Help Now exposure.                                            |
-| 6    | Draft MOB-01b gate            | Not started      | Draft only after Step 1 path is clear enough to cite entry evidence; keep it docs-only.                                                                                                          | Drafting is allowed; promotion is not.                                                 |
-| 7    | Implement MOB-01b             | Blocked          | Requires ENT-A01 closed, L2 MK signed, B6 done, B7 done, and a later `MOB-DG01B` authority record.                                                                                               | No flag flip or runtime config until CA+DG.                                            |
-| 8    | Prepare MOB-05a               | Blocked          | Start gate prep after Memo 1 and fee-wording review kickoff.                                                                                                                                     | Runtime waits for CA+DG.                                                               |
-| 9    | Prepare MOB-02                | Blocked          | Start design prep after Memo 2 and ops-SLA reconciliation inputs.                                                                                                                                | Runtime waits for CA+DG.                                                               |
+| Step | Work                          | Current status       | Evidence / next action                                                                                                                                     | Advancement rule                                                                       |
+| ---- | ----------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1    | Verify ENT-A01 / RBAC-01      | Closed, caveated     | PR `#1299` fixed the narrow release-gate stabilization path; PR `#1300` recorded two consecutive green staging jobs after one post-deploy P0.1 staff miss. | Reopen/freeze if any future current-main staging P0.1 agent/staff marker miss appears. |
+| 2    | Appoint country reviewer      | In progress          | MK signature package sent to `Interdomestik@gmail.com`; wait for named professional signatures and preserve returned PDFs.                                 | Required before L2 review can complete for the selected country.                       |
+| 3    | UI/UX design preparation only | Board contract ready | Review input, storyboard, and static-board contract exist; Figma/PDF board export and human findings still pending.                                        | Allowed in parallel, but cannot promote runtime.                                       |
+| 4    | Sign business memos           | Ready to sign        | Signing packet plus decision records: `docs/product/2026-07-05-business-memo-signing-packet.md`; records still unsigned.                                   | Required before MOB-05a and MOB-02 gates.                                              |
+| 5    | Complete B6/B7                | In progress          | B6 runbook and B7 alert-coverage contract are drafted; staging hotfix exercise and synthetic alert proof are still required.                               | Required before non-dark Help Now exposure.                                            |
+| 6    | Draft MOB-01b gate            | Not started          | Draft only after Step 1 path is clear enough to cite entry evidence; keep it docs-only.                                                                    | Drafting is allowed; promotion is not.                                                 |
+| 7    | Implement MOB-01b             | Blocked              | Requires ENT-A01 closed, L2 MK signed, B6 done, B7 done, and a later `MOB-DG01B` authority record.                                                         | No flag flip or runtime config until CA+DG.                                            |
+| 8    | Prepare MOB-05a               | Blocked              | Start gate prep after Memo 1 and fee-wording review kickoff.                                                                                               | Runtime waits for CA+DG.                                                               |
+| 9    | Prepare MOB-02                | Blocked              | Start design prep after Memo 2 and ops-SLA reconciliation inputs.                                                                                          | Runtime waits for CA+DG.                                                               |
 
 ## Step 1 State
 
@@ -66,9 +67,8 @@ current-authority/design-gate are complete.
    qualification, date, and scope.
 2. Choose owners for B6 hotfix runbook and B7 alert catalog.
 3. Decide who signs Memo 1 and Memo 2 if not Arben.
-4. Assign the UI/UX review and storyboard packages to the design reviewers,
-   create the Figma/static board, and collect dated findings before runtime
-   decisions.
+4. Create/export the Figma/PDF board from the static-board contract, then assign
+   it to design reviewers and collect dated findings before runtime decisions.
 5. Fill and sign both business-memo decision records, then commit the signed
    files.
 6. Draft the MOB-01b gate only after the entry evidence can be cited.

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54953396,
-  "maxTrackedFiles": 4766,
+  "maxTrackedBytes": 54957822,
+  "maxTrackedFiles": 4767,
   "maxCategoryBytes": {
     "other": 18821537,
     "large support/generated-ish": 16077049,
     "source/scripts": 7152638,
-    "docs/text": 6233052,
+    "docs/text": 6237478,
     "tests/e2e": 5106882,
     "config/data/messages": 1562238
   },


### PR DESCRIPTION
## Summary
- add a static mobile UI/UX storyboard board for Step 3 review
- link the board from the storyboard package and frame inventory
- update the nine-step sequence so Step 3 is `Static board ready`
- sync repo-size budget for the added tracked doc

## Authority boundary
- docs-only Tier 0 work
- no UI package installed
- no browser prototype or shipped UI
- no runtime behavior, route/auth/tenancy/billing change, flag flip, or `MOB-*` promotion
- Figma MCP creation was not available in this session; the exposed Figma tool only supports library lookup, so this PR provides the static board fallback

## Verification
- `git diff --check HEAD~1..HEAD`
- `pnpm docs:verify`
- `pnpm plan:audit`
- `pnpm track:audit`
- `pnpm security:guard`
- `pnpm repo:size:check`
- resolver check returned expected supervisor block: `blocked_requires_current_authority`, `activeSlice=null`

## Human next step
Use `docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md` to create/export the Figma or PDF board, then collect dated reviewer findings.