### PR TITLE
docs: add mobile UI/UX PDF board

### DIFF
--- a/docs/product/2026-07-05-mobile-uiux-review-input-package.md
+++ b/docs/product/2026-07-05-mobile-uiux-review-input-package.md
@@ -32,8 +32,7 @@ related:
 Convert the existing mobile dossier into a reviewer-ready work package before
 the next governed runtime decision. The goal is to make the UI/UX review
 answerable without reopening the whole strategy conversation.
-Use it when asking a product designer, Figma designer, accessibility reviewer,
-or legal-copy reviewer to inspect the mobile lane.
+Use it when asking reviewers to inspect the mobile lane.
 
 ## Authority Boundary
 
@@ -47,17 +46,18 @@ or legal-copy reviewer to inspect the mobile lane.
 
 ## Source Pack To Give Reviewers
 
-| Source                                                               | Why reviewer needs it                                                   |
-| -------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `docs/product/2026-07-05-mobile-uiux-storyboard-package.md`          | Required Figma rows, frame IDs, variants, and review procedure          |
-| `docs/product/mobile-experience-blueprint.md`                        | Screen inventory, IA, primary mobile flows                              |
-| `docs/product/2026-07-03-mobile-excellence-dossier.md`               | Product principles, performance budgets, measurement, red-team critique |
-| `docs/product/2026-07-03-mobile-design-review-enterprise.md`         | Existing enterprise UX critique and missing artifacts                   |
-| `docs/product/2026-07-03-mobile-component-contracts.md`              | Component API/state contracts for design consistency                    |
-| `docs/product/2026-07-03-mobile-copy-system.md`                      | Tone, boundary copy, trust language                                     |
-| `docs/product/2026-07-03-mobile-error-taxonomy.md`                   | Error-state grammar to keep flows consistent                            |
-| `docs/product/2026-07-03-mobile-visual-benchmark-moodboard-brief.md` | Visual direction for calm institutional mobile UI                       |
-| `docs/product/2026-07-05-mk-help-now-signature-package/README.md`    | MK country-content sign-off context                                     |
+| Source                                                                                                            | Why reviewer needs it                                                        |
+| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `docs/product/2026-07-05-mobile-uiux-storyboard-package.md`                                                       | Required Figma rows, frame IDs, variants, and review procedure               |
+| `output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/interdomestik-mobile-uiux-static-storyboard-board.pdf` | Current static board export with all 43 frame cards and blank reviewer marks |
+| `docs/product/mobile-experience-blueprint.md`                                                                     | Screen inventory, IA, primary mobile flows                                   |
+| `docs/product/2026-07-03-mobile-excellence-dossier.md`                                                            | Product principles, performance budgets, measurement, red-team critique      |
+| `docs/product/2026-07-03-mobile-design-review-enterprise.md`                                                      | Existing enterprise UX critique and missing artifacts                        |
+| `docs/product/2026-07-03-mobile-component-contracts.md`                                                           | Component API/state contracts for design consistency                         |
+| `docs/product/2026-07-03-mobile-copy-system.md`                                                                   | Tone, boundary copy, trust language                                          |
+| `docs/product/2026-07-03-mobile-error-taxonomy.md`                                                                | Error-state grammar to keep flows consistent                                 |
+| `docs/product/2026-07-03-mobile-visual-benchmark-moodboard-brief.md`                                              | Visual direction for calm institutional mobile UI                            |
+| `docs/product/2026-07-05-mk-help-now-signature-package/README.md`                                                 | MK country-content sign-off context                                          |
 
 ## Review Scope
 
@@ -143,8 +143,8 @@ Each reviewer returns one dated note with:
 
 ## Done Definition For Step 3
 
-Step 3 is reviewable when this package and the storyboard companion are merged
-and assigned to the design reviewers. Step 3 is complete only after dated human
-findings return for the storyboard/Figma board. The actual Figma frames,
-accessibility scripts, and artifact template files are design deliverables; they
-authorize no runtime work.
+Step 3 is reviewable from this package, the storyboard companion, and the
+generated PDF board. Step 3 is complete only after dated human findings return
+for the storyboard/Figma/PDF board. The actual Figma frames, accessibility
+scripts, and artifact template files are design deliverables; they authorize no
+runtime work.

--- a/docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
+++ b/docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
@@ -8,15 +8,19 @@ related:
   - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
   - docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
   - docs/product/2026-07-05-mobile-uiux-review-input-package.md
+  - output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/interdomestik-mobile-uiux-static-storyboard-board.pdf
   - docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
 ---
 
 # Mobile UI/UX Static Storyboard Board Contract
 
-> Status: **static board contract only.** This is not an implemented UI, a
-> browser prototype, an exported Figma/PDF board, a Figma approval, or runtime
-> authority. It defines the board humans must create and review before any UI
+> Status: **static board contract plus generated PDF export.** This is not an
+> implemented UI, browser prototype, Figma approval, human review finding, or
+> runtime authority. It defines the board humans must review before any UI
 > package is installed.
+
+Current generated PDF export:
+`output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/interdomestik-mobile-uiux-static-storyboard-board.pdf`.
 
 ## Board Contract
 
@@ -101,9 +105,10 @@ Each reviewer returns one note using this format:
 
 ## Completion Rule
 
-The static board is ready only after every frame ID in
+The static board export is ready only after every frame ID in
 `docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md` exists in a
 Figma/PDF/exported board and every card includes a reviewer-mark field that is
-still unfilled.
+still unfilled. The generated PDF export currently satisfies this export-level
+condition for all 43 inventory frame IDs.
 
 Step 3 is still not complete until dated human findings are returned and stored.

--- a/docs/product/2026-07-05-mobile-uiux-storyboard-package.md
+++ b/docs/product/2026-07-05-mobile-uiux-storyboard-package.md
@@ -20,10 +20,10 @@ related:
 
 # Mobile UI/UX Storyboard Package
 
-> Status: **Figma/storyboard preparation only.** This package installs no UI
-> package, ships no prototype, promotes no `MOB-*` slice, and grants no runtime
-> authority. It exists so human reviewers can inspect the intended mobile
-> experience before implementation.
+> Status: **storyboard preparation plus generated PDF board.** This package
+> installs no UI package, ships no prototype, promotes no `MOB-*` slice, and
+> grants no runtime authority. It exists so human reviewers can inspect the
+> intended mobile experience before implementation.
 
 ## Why This Comes First
 
@@ -141,9 +141,8 @@ Each reviewer returns a dated note containing:
 
 ## Step 3 Done Definition
 
-Step 3 becomes reviewable when this package and the existing review input package
-are merged. Step 3 becomes complete only after human reviewers return dated
-findings for the storyboard/Figma board.
+Step 3 is reviewable from the generated PDF board and complete only after dated
+human findings return for the storyboard/Figma/PDF board.
 
 Completion does not install the UI package, prove browser behavior, or unblock
 runtime exposure. It only reduces product-design uncertainty before `MOB-01b`,

--- a/docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
+++ b/docs/reviews/2026-07-05-nine-step-enterprise-sequence.md
@@ -13,6 +13,7 @@ related:
   - docs/product/2026-07-05-mobile-uiux-review-input-package.md
   - docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
   - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
+  - output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/interdomestik-mobile-uiux-static-storyboard-board.pdf
   - docs/product/2026-07-05-business-memo-signing-packet.md
 ---
 
@@ -33,17 +34,17 @@ local proof as staging proof.
 
 ## Sequence
 
-| Step | Work                          | Current status       | Evidence / next action                                                                                                                                     | Advancement rule                                                                       |
-| ---- | ----------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| 1    | Verify ENT-A01 / RBAC-01      | Closed, caveated     | PR `#1299` fixed the narrow release-gate stabilization path; PR `#1300` recorded two consecutive green staging jobs after one post-deploy P0.1 staff miss. | Reopen/freeze if any future current-main staging P0.1 agent/staff marker miss appears. |
-| 2    | Appoint country reviewer      | In progress          | MK signature package sent to `Interdomestik@gmail.com`; wait for named professional signatures and preserve returned PDFs.                                 | Required before L2 review can complete for the selected country.                       |
-| 3    | UI/UX design preparation only | Board contract ready | Review input, storyboard, and static-board contract exist; Figma/PDF board export and human findings still pending.                                        | Allowed in parallel, but cannot promote runtime.                                       |
-| 4    | Sign business memos           | Ready to sign        | Signing packet plus decision records: `docs/product/2026-07-05-business-memo-signing-packet.md`; records still unsigned.                                   | Required before MOB-05a and MOB-02 gates.                                              |
-| 5    | Complete B6/B7                | In progress          | B6 runbook and B7 alert-coverage contract are drafted; staging hotfix exercise and synthetic alert proof are still required.                               | Required before non-dark Help Now exposure.                                            |
-| 6    | Draft MOB-01b gate            | Not started          | Draft only after Step 1 path is clear enough to cite entry evidence; keep it docs-only.                                                                    | Drafting is allowed; promotion is not.                                                 |
-| 7    | Implement MOB-01b             | Blocked              | Requires ENT-A01 closed, L2 MK signed, B6 done, B7 done, and a later `MOB-DG01B` authority record.                                                         | No flag flip or runtime config until CA+DG.                                            |
-| 8    | Prepare MOB-05a               | Blocked              | Start gate prep after Memo 1 and fee-wording review kickoff.                                                                                               | Runtime waits for CA+DG.                                                               |
-| 9    | Prepare MOB-02                | Blocked              | Start design prep after Memo 2 and ops-SLA reconciliation inputs.                                                                                          | Runtime waits for CA+DG.                                                               |
+| Step | Work                          | Current status   | Evidence / next action                                                                                                                                     | Advancement rule                                                                       |
+| ---- | ----------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1    | Verify ENT-A01 / RBAC-01      | Closed, caveated | PR `#1299` fixed the narrow release-gate stabilization path; PR `#1300` recorded two consecutive green staging jobs after one post-deploy P0.1 staff miss. | Reopen/freeze if any future current-main staging P0.1 agent/staff marker miss appears. |
+| 2    | Appoint country reviewer      | In progress      | MK signature package sent to `Interdomestik@gmail.com`; wait for named professional signatures and preserve returned PDFs.                                 | Required before L2 review can complete for the selected country.                       |
+| 3    | UI/UX design preparation only | PDF board ready  | Review input, storyboard, static-board contract, and generated 43-frame PDF board exist; human findings are still pending.                                 | Allowed in parallel, but cannot promote runtime.                                       |
+| 4    | Sign business memos           | Ready to sign    | Signing packet plus decision records: `docs/product/2026-07-05-business-memo-signing-packet.md`; records still unsigned.                                   | Required before MOB-05a and MOB-02 gates.                                              |
+| 5    | Complete B6/B7                | In progress      | B6 runbook and B7 alert-coverage contract are drafted; staging hotfix exercise and synthetic alert proof are still required.                               | Required before non-dark Help Now exposure.                                            |
+| 6    | Draft MOB-01b gate            | Not started      | Draft only after Step 1 path is clear enough to cite entry evidence; keep it docs-only.                                                                    | Drafting is allowed; promotion is not.                                                 |
+| 7    | Implement MOB-01b             | Blocked          | Requires ENT-A01 closed, L2 MK signed, B6 done, B7 done, and a later `MOB-DG01B` authority record.                                                         | No flag flip or runtime config until CA+DG.                                            |
+| 8    | Prepare MOB-05a               | Blocked          | Start gate prep after Memo 1 and fee-wording review kickoff.                                                                                               | Runtime waits for CA+DG.                                                               |
+| 9    | Prepare MOB-02                | Blocked          | Start design prep after Memo 2 and ops-SLA reconciliation inputs.                                                                                          | Runtime waits for CA+DG.                                                               |
 
 ## Step 1 State
 
@@ -67,8 +68,8 @@ current-authority/design-gate are complete.
    qualification, date, and scope.
 2. Choose owners for B6 hotfix runbook and B7 alert catalog.
 3. Decide who signs Memo 1 and Memo 2 if not Arben.
-4. Create/export the Figma/PDF board from the static-board contract, then assign
-   it to design reviewers and collect dated findings before runtime decisions.
+4. Assign the generated PDF board or a derived Figma board to design reviewers
+   and collect dated findings before runtime decisions.
 5. Fill and sign both business-memo decision records, then commit the signed
    files.
 6. Draft the MOB-01b gate only after the entry evidence can be cited.

--- a/output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/artifact-metadata.md
+++ b/output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/artifact-metadata.md
@@ -1,0 +1,34 @@
+---
+plan_role: artifact
+status: active
+source_of_truth: false
+owner: product-design
+last_reviewed: 2026-07-05
+related:
+  - docs/product/2026-07-05-mobile-uiux-static-storyboard-board.md
+  - docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md
+  - docs/product/2026-07-05-mobile-uiux-storyboard-package.md
+---
+
+# Mobile UI/UX Static Storyboard Board PDF
+
+This folder contains the generated Step 3 review board export:
+
+`interdomestik-mobile-uiux-static-storyboard-board.pdf`
+
+## Scope
+
+- 17-page static PDF board.
+- 43 frame cards generated from
+  `docs/product/2026-07-05-mobile-uiux-storyboard-frame-inventory.md`.
+- One reviewer-return form.
+- Blank reviewer-mark fields for human review.
+
+## Boundary
+
+This PDF is a review artifact only. It is not an implemented UI, Figma approval,
+browser proof, country exposure approval, or current-authority/design-gate
+record. It grants no runtime authority.
+
+Step 3 remains incomplete until dated human reviewer findings are returned and
+stored.

--- a/output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/interdomestik-mobile-uiux-static-storyboard-board.pdf
+++ b/output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/interdomestik-mobile-uiux-static-storyboard-board.pdf
@@ -1,0 +1,379 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 26 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 27 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 28 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 29 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 30 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 31 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 32 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/Contents 33 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/Contents 34 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/Contents 35 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+16 0 obj
+<<
+/Contents 36 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+17 0 obj
+<<
+/Contents 37 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+18 0 obj
+<<
+/Contents 38 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+19 0 obj
+<<
+/Contents 39 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+20 0 obj
+<<
+/Contents 40 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 23 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+21 0 obj
+<<
+/PageMode /UseNone /Pages 23 0 R /Type /Catalog
+>>
+endobj
+22 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260705235007+02'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260705235007+02'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+23 0 obj
+<<
+/Count 17 /Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 
+  14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R ] /Type /Pages
+>>
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1239
+>>
+stream
+Gatm:?$"^\&:N_Clsjo\(:%aZp?beB>M@j]]kKiHqNaup!GZG/b(c.1IojKH-D-hU0GpUN<p-R0mLfT?GNbZE"`Q5LnK`dL_/'Ti9OaB;K(lV!cV\<ecB.bk,g'61"d#+l).c'Xb\<Ap?+:>Pk<6sYP&_HCj+N1r)T&S-UT\F-eI=(2XP3qo"*RtZ\l'[&mF#+mD@)j51P%&$D#rqRb1IJ'?#JQ2`Q_;a<iU[gB?+n7A^*rE/?Gp-F$Gj-FD&(3A$`W-G(mqq/BM6QqZ4#^%fZO)81C5`'SdgWj[)6mf^T,TZ/62S%V3m/(+BhHN\Q9L/DssOi9,pCN.tI:,\.`M+RDk9-uaD*Gf#",Rpa+P4/==I,3J6u!fkRk<nY>hWbM,`9[/hT'o$5rm5nR[ZILsa)8"^Yn&.B`1kJ(jT%1`_=Z1qmpWL-pNr82amYGu+;+&k3Ft.ObR>B6hQupuYs.(8n[=W&t14XGHK!T2lW_1g%K;j4ALE<&&9Eh,p@!D&`N+9_g,_HAbm2$nECo:Bu,ugZpIZ#HeTjq-`^._oi#f:j&6@]0fdJV7FHCm:i40G/(la*E('r2F5]9@[o=7ASOrTtsXgZ=q!I.Y^mH7ng_5`Q'hUNd#$AL.*=94RiL'/$KOOR:Knk[*i)NJ6K*P'&-.lSJ<51]e:k6!fEGKj!/84\n4t#^\<!_W8rYb=/\]gG,HS$)e+X%k=2__-4$l"\gZ*?uBPP!aT_@[5^aXiea>Hr3\jHEQ@JSh=GWCDh[uLEJ^G<Lgf79?AmMDOt*9`50o/CC@'8lI=@jdpb">LMb<]Fj.Oq-WMSB`e+K6/ZCi#pMo2jdR<U\lJO+:'4?EDZTp\N"%8,bUaB^5saeh)lcc[9`/hcgmX;;5AY"Fmb.sh[AO\.QlXr!Eg0-1,h07JA/#Yum="A%P3K'a,m43%F$otq&hFL/0c'l_HS5WWd^_M'qqiB08jVRPjq/+1"m_Uj/XBuF//V*@[W`$9aqiuJ+C&BeIb+7E"cmTp)e5Md?S'GG@lo]*V>FQ"5WrHMuAqi/MK%m%pA*c$*R'dODKI.T&t6f_CZi'i7]2<[GY[p:EZ2gkNc55P>jeW"I>[Hj\QLA.V+fbCb[De-Qc=VkK.o2=0I)ECkO_+r=sPNhku.?nQj9>;`2<MaN7EG.9*UQi>NL6#7uSJA!,!G3:n9>T'+ps029\2GYFc3Tf)g8l5M2;VWF13MVue>".1`!E.<!J:EOBE~>endstream
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1789
+>>
+stream
+Gb"/(?!#c?&:N_CbTkk:KI)+$%sqt]96P#_6eFPMi[D7*\96l6AAe!,G@\`h!Yj(hS3@L>"*(-A1iqhpjuQ>Cn:t%oUBSHf#opXV5T*6.TFPsLEXm`D_*81*);e*jm5V@<7U7*lj#WmQJ@LVTK`S-?\Ugna[mT-YY2oY)M+_PJ@BtF$Z+*BE/^+oqKa*rt.V4_p"Rr^ak:/(O#^e[]&(@&L(rX24>SW@Dm-`LClZp'HMAWLN4nEZnnlm[[/6/8heOYqbEpBg=;3qWV?/joScc@anq$N<E`r?JqrP0TmU].]cTD2([gUQ9"@aWuji#NZJ$a(K].s,%7&?#'HU7hgF1.29O]*F)pN`l8C4Tjse4IKd=4?OS!3L9gDE$hk:N:L2/12_X+[F#\ge3t*Z\^VhH[QJol2s(Zim2P2DX`@uSY6W@Xg,VR>UcF"1cM!q:M;jno#h,IRXO>.qX<%BpA&nef&YQ-QU&#/"^-Rp>%&^!@Qf#TS3.lLei,WBuFpNYFKSGe*6?q"q7tS9(ZF5Y<Wi#*d.Q1KGRp!qrNE@(TBmKCZS.N5h1aQST@M67Yi)L%S@r-E9A0LNs`fgu;%/MPWOC-,!h04$mL9t9'72Zon_jt#sG`Igchp2`X5t`5VYk@9PSj***P"7tR";h^[?,G1);EVT51=Z#5VE01af^t;3>Jg6TXt,$0n(J=1('uY#iqp7hlD)8HDkPsdE1!cpAnqOahRX3lds1ZXAGcV6/dGn]Ho8F($nk(3+Fn@V[2Z3-\2ar8_)]hi`!s19'qS!JEPns7G_\[>joS.RI<\`,D2QlE/<CH+:?;o.)%_M4MXolbmnY*;H\>POHRXV3Sd\,.q//;3N8SM3(nZcESUK/l+`r@>h>%!UeYT;O2aX?C$t>$<+aP7H6Ht1BmQd(rWBh%<l[_fhOr%gb+\VK,KF2Z#lFG3$_%ekW5(IE(^:M6m$g3-Q-g18RH87Kp[Qf.dEA]dG\igQGetQQiX^0ln#^mUUppC:0DZE1MUc;\UfM>DAOa_AF9Ei_[%JJ?42Lqggp?Rm"/[^ft=&gX8CRthAWGK2l;5@*\C=!-%UXr0&F='G(<6G%=c[:ChR&Go%8fo;X,GB6@c-SO9'q'NF\:_]'BEub2.CtQFIglX4@kkd)nE9Cg_A^]X[bif8@8h[uUhRrY7b3s9CJt><UH+Ys@E,0I*[*dn[7ClN3P2FTl#//Zf8mS9.MN@JhfPD*6>gm")-f@dQqKcP.t&kb*fKmjf8kOW#QB08+DtR1:-^po(,f:0DLLOU#K28LmJah%GPH>4K?MEYg75RZL9:@()g:+CP5(_`q'\*%gLVN8!48t9]CLlj/&r3C6l14$`[^@XirO:!YF2]0C"/*L7[?htXA2thbueK:g*EUl`eI>Peekg;B/?i*X>WCf;%q!'hgX2bs78CVfre,Niq]U-)>j6HXD&TX-q%$jGlNHM:fk60H#UX+>V;>-Y..'h(1eOhU0K,MLu[Y]P\-gDFu1V8k=h;>1$T&ZBIF]iN_ak!*s8)[\V`DmFIK;[A=Y(51g-`up-Ou%0@J@iX^6\uZ[]\+]1<R`)"q!_j`ULR*>`Djo3;X9rgk\#V('/]Uh(J3Ta!UA#Y+^AfTJb^HJ<u7h?-'+8mSAN12=62A"=J&`)nD,3\e&Z@]]N[lr@aTkN?Wdb6"_jeSb+ZQK]ms.$oXL`TeDI4,D?2_=!+(M96WM<O/pb6Zk:&M%Y+E;M_i<4aU,.ec3XjHWPU5ZRil1;-q@"h<D4?QZ]m@dq,(&He#^/IYWRU!$IHHW;~>endstream
+endobj
+26 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1417
+>>
+stream
+Gb"/&968fX&AJ$Co[0-c@u[;3@suuR[N)X>?lR%]EcMUu5`-kI1(kr3qe\nq#fdHRle4^8\M2CZe,Aqu4l$PN%KC,75=be2qf$pXJa21>JXXL[rt7Hoi9S3k`@_ss<_a')Vp#?S1=Ocq+O"Abl[W0')sG;Qi=a=BRL)#"N)GF_T>9DVgdbfW$cUR=LK&k/VF?^Ti6*=/.Os!PY0YC%._2"!pm+KOJ5#"r8ZA58;3m%V9En#Kf;Xq6>U[[XPk.K[82R6qe]*!9ctnGppH0e;Jc>oOG:!4u8DDOJVGhgXj>C9M0KM:5OGd_/M*!D;"pRQ\ka$i@ij)T:f+_2#C)*4ab9_".Vj&$Q__rHjMqfIM`3!/f0!cP@-r$P:XD8SkFVjj1n73M/LL,lRj.!g<hm3X=V7!S^Zc:?5HIc>\\eYilRC6]j3(J?.VkiGL>Y!O:hc`7W)"uSl9jOJAicH0!Lq8Q/>H\a)a)Z_J[Z:09=_'Uk5p,W32I:60e/;q$?G/b*Kh-hRKX-t8hk!5d!S[mIg;_/*?AVmt2B(1<IdO]Vpj+dlfH5Nrak.QKc,:RuK<*rP$m5tiKq[*1@ht:>_SJ*f4T^8d0IXeWC)BDDj-*`f1Z4W#j__jR&F^kL;6WqR?1cQV1.>Wr%SXiH@\tt`im6fO1+]/8e9W^X55#4K(nZgND[7-]Dq#l"?@:U^/qcO"0`Ek6PAJ5H//pH"7o0tk]\lA)"M%d;5[`h)`&#%cBSfp:r%VO5#1.S,pnPqJ0.U:R+8V?!Ib+8jNVgWf=-MS\-J?R)fiWbcYkI2#+nQ)8:,h;+GISG=RR^i</")#L9#V*mk2,dnOie&6K`^j<M-/PC2*YdW#aYinHZa48+^_*&Y,_?SbBYXZLf1_oE<\e@3Y#,R7lfLA'I)G'aJ20RB#i*%rW"_dTUnh#iTa1:quh6ULcg`q0r!],&a/5Co.tMu0h8][/$DJ"56L?fQ2iH?J%pA+=Ln*bq`W9ID9D9ja-?*Va/g`IDHB[Ih?G-!(S[-g@i6CTpaM&]Soes6=$.(E[*7AjniTtc9[*F?f=V`;_^jU`^W[N>DX!G#(1WCorUTQTV#?"N0*d.j)Y+$L.bV\IC=`o5o\k=&YhJL0agSC^Z5CTHP1EphG/W*%m>g%%-Ah+nRZ.E(@kc`X[Z;=21FcWjgAjUhO^7<Q*@n7n5sS/6Qt:^6.Q+M48[F85eS.OQOYobT+AR&83_HNU;/59bDIea.<l19!:7O*;p<-5+2\0rR?oG!Ak>*sq=o\L]G(q<R*PA_G#9oE&9W2<:/3B%tK8U<<R1^M&Za/*r!e9+KPfN=*S2.<O/^ki\QF7RJY;hE9r16F2Z*A4+3>9JM%6U1uIa[&/ZklA\LWp2sNiZ@7e%sd`p,8MUNG!1ig"UcF;ibSa3un/+\2<<J~>endstream
+endobj
+27 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1784
+>>
+stream
+Gb"/(>?BiC&:WeDbTkpV@JT?^d$'0fRhf*a$16CnNj+d:]=q:N6hBb.Z=>9;6M?Y]"5'.%A2KTa^)>1C[OE'g8#uYu!q:12LSkib$'Qf7S(KDTK>D*eT=rd2V[*-#:9;7,NX*LGm(b<+34<<"500/+J?ELn!oj':@>!eULJjb],_>n+?O2)g1We'36(3?Udm><"=BWj(.>fF&bEGl7adA$;s-mZ,J1Q\H7p9'?7@s)VY(d2XkDd]''pk$*/=T\'0Z3/9ZFWkt&uWuoE5?#S$V\:PjFamj_ar*4Lga3MY*#&e`kgNAi[\Kc>[l_.ke.(YjV&lC*Q/MEnZ+qX(C2l1'd2X%3"3%agkVdS:fl[k)B-p"i?pTp.>Jra9;.#jE1VoJWrl17b)7Pi;5Oqh6Aok:';:Z3;K^$ka6b["ii_[d316gl=k3&X5dN?[;:2)/6;U1"hgqb;(nqR/U'RheaPs^q!)"Pm3EpHaeI\(\KZP;i'g0LpS!^$:5_h@SH'tmYV+,WIJ\$L=L9"U)<5HHtEu`EZb"&3FY2-*5g8Hd\D"Dqi<thbo>\aL<JGG,&8qK*f8`7+m>9T5GA]#gF).63D\3#)qKO1-$Qt+SU]<?#Q%;7oX.W$/q%p*Yta0e'PpjR$-n_<[jLq0)t'<"En6kY]Gpca!l",E90<@Mfn(UMW^l>3jkhmV_nX0tUc&Z`&9?FB&QPJG%36p*&mN[%@2NMTq`o1k!,05EGg,4P92[Bl3piH]qF%Bd^'&U_81N$lLr(HZl&B$dq'B'jHA%u?3TY4IGe:9u0M%DOg=Wm'[:e5a>+Kb[/q.%Y&4C_"ofK$7>m&/HZ/s*YhAQ:jo(\hAc]H%1&>j5\NpDulSdK2I,?r;#(WaIjDmD8uTFAg2p]SeX3iJGU<",ilO'-[DC9=;GCh4%slE65DN!D7Kfu+/c!=A,dNF6"AjUTI-G70lBlK)gpqCiVB96kr6fSJ,F>0EInMj4E+DJr!fuU"jSLf$07+JXm9%jE%/#77_OTm*+G'$,N&lp1PBf%RgQ,%\=I]?lYXi^fL_--#H@j[Ws`a%Y3qiD`F>u8V!sem3F$+(LLK"X<.W5kob:$B;B?jEC&J2Z*X^_D5SnPqeWJ_`*4sQlN7P6Q*iglh*,H9]Zu:7DQ0>!Z?c0_;\G`ZDr:t`1Y[X(@bO6:GTII>\_NZjQ0Pg=FqGn=%lYt.t):u0`3"$<@r)P]>FEUs_c/2]8Y9,d5PmA<b?h]p(6LNjVA2&HR0o#mX<VfUL4m)G/a3TA2#CaDU&]ZgA-QoQ]$eqX^2nID74lX?Gh/8gcqfs]M@9b6!S"mtDZ#O,t6gq!'M&3[VLW%'=*&GBRNuF<o<HaeUatNr=dD[`G0hX$4/>+o,1L74DPo<f+A9c&1l?#OqOYoak7Jpn5Cac]s7]GK0S";LC=p_`-SN,@%p;\3J^Y[-kbOJ,'4Pph^1LHc/SZhl<&eC+R0=Njf2p0*719PO]QGjgo/r1d6QdF(e(+kVb]L*Sq\47A)DRcW_L[eCsc-fpO/1j;Y#dK#[ZP#9&8&74nekrZ3Joqdo>u36Q@%(9/e=5B&f'@C\9:=mH(<aU@Q>GlYDjbg+!n\\1&PQ?/30\Q<I#!Aj>Wo/QJ:*q'=o7"?!2;"q':osNc?]10(2DUQdZ.s_4KILF*RF"qf%].dmA$gC7CVX8Vd$((R*?"pKT]nQ@$,nfPY8c7N&Z`;T<)D3hg`HH$W/d^GK@QH,/HIMn]ik"\UN[`!),qC=SK,+@pg;ZlPNaE^to:uX3\$E+26@*jT~>endstream
+endobj
+28 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1281
+>>
+stream
+Gatm:?$G!^&:N_Cb[]@4'M5_a\Tugp'9]ShO9Eeqku3Ts!o3X)asJ\>I`F?)VTf?/)fl"+1n(srFYtoVMB>mu"u3o+%o+bq0FlqZQq_DdDP6H@^3=`FZ5?DtSQILW63=EGm8=E^fRg[AbbCK?G0qn.3(d!d\0-AX`P@DjA>Gha]n(n-P<=IC"g^tp0\50co4;[RHqWDsiY&,fDe>[B?)8m'1l8YRKla[2="?Fdal)pQEGEorV@BV#Ra+Q!OCC2U/LP.GK4.h@puFs+"*e1hqcMcpJWu$)b*b?pH1*CCLt7LijJ&5Tis`"qJ;"^fmO7--LM8bR;,FPi9/_(5-#6UqN*)AY]8=HpmZ8dT<\+kb36JL`:^K1(l4B;oaJX_BUD/K$K,*^AIlop$%ErB`YUVFD(_8E$QSR.n_AlcXkD+2u02Vm)VjAB5'>BNV1:ZTjdaTV$+\nl<,3B6LpK8Aka)QZ4P,!J&78heSHR>e!B9gE8'I_/+pY*PoQA'#S1S'2Fp*'X@=<_3$X^1@iP[!4WlJ0I0Q+O'kIPeS%NP<2=g`OAMUd+PWGJbXR5T";JK3'@o%#PGOi0Ya\JKZK[$t6(AL/l)MpCkW7)V0W?K+tdkZIZ5dE=]0m#aTqF#a5F&3ld@O#%8M;=m5$0gA^U\>F%W9A^5Y-Fk[iD@=19(pP3]Nk`:%boBS&"Y_=d`*le4lldek_IKX^VMPbjl%K'`@X1a=J%al_A[]^7;0GJS]rG0?]256_!nOA]smT-j^?hJ=+s.\]LlLZHrmj>p['\V5/8aJ\o=N;&N#^]-E]DhUF+<f\`pJuKmWduQloGQjpRtXUhD0I%i/;MJJ@gb%QdSJN@c^Fp$le#"EVJ>d&$p!oRftb4f+)+\a!nTJ:_(a]8"t%R2%'gl%AGZp@\4H8YFIcAi\C#r5>ccR:hmCMN^^gL+lSje7SNkY%7UB4^RhJ:?0&K=SU]0/'r]f$:YSmB3p,ZXJk,n8GY*3)ah4L!Ij_#I2VYGKh2Z7-rj)ne"7VRAUiE[o$AFVW<I]PakbW\43^"*g4<.8i>]G#A(40LktRk[4a+tJ!n`h'7-mH[hFq\-_O4%(KS499F/[d[OeeVQ5rl4=1YLW=_R5M-oZ"QRpe[R]S5RJuF+np;f2Ofh%t^0rE_E#6iKoWX!Kio4DP$qWs4nYBngBl#X.AkQSL%D(q+gDVFhM8\h(i)JHG-XdTemYmH1A#l/h(S5e][B4JdQ\nBp7JY3G62;&QVu;?",Up>QVl3?\b!J2%(&bjfLX(Akj/Cf~>endstream
+endobj
+29 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1777
+>>
+stream
+Gb"/)>BALX'RnB3302a1:b:AlAb3-i-F@>C9cG4ee#///"h69BQ#'S%r>sYEO>Ib7S*A3$P9GHu/=lCsdlF$R'J00Wjo8uun9,)XmjM!OL1?l/EFF(mh;Q2ZK6<5n3eF6"32''7&&`$sB\>Y<bH*At2),?_p#o.A]RX-;fShLV!t)p`*;7>q&PJK>/oqIW"'*E)R0he?50[&iY6]M>Ig;a-Wu/c>o1\8-a`MZ7N:f#qcUA8o]d*,iUp?g4$K`h]`aqf-iG`O3*iKI#_p5N._,Kn4%)9[KNU_MA8O'G8AQ/W3PFqY=J@B[>'k1#^io1Oe4TjgL`!Te)(h,FQ[:nb)Tf/VH`4cJ3"g/a?pmhlD1O.W>Jb-*m"rCMOkWj?S`'QopU-e$G]K1Y#c\1:3k%Qm9dHqOa+r,BdaZHXgm%!GUDrVfiP.b0QVgNpUSR$MrOI1/36Wbr7+bR$d2p`?UCBEhp6]\5_i%g$dn:^jBFpZ]eEHMZL7&8Hu9"DS<Zc4FfM]%js1U9@Re0?fW4;5Sa#!Of$0r/Y(UK)J=@?krC8ik]9RC?Y5nOUiEf&23P?K<OA.iOV5H%B$@,`T(jOjFT#cjjrQ+L%QgO9GqKI^Apq0$o\\K<7/OE'0Z$iK!*t)"@L3Td4<]@hF&D3jPYN+%6g18:ggdU*1cTAlaf$f0bEVIRR8g%pXlR0PeR.T/]gXnB4t\.UF;*ZDE@!?V-nS\kDu?kah:!RFnJd7d-n0X)L;tHQQ&\?f67WmDIIsG;/B3]%eHXFG"JdYcE$7SNpHHo@O._Y^0)iAc[i0:?fcD-8ad^!JSWZ[k_1)E[m.ZU>Ea#[.sSK?lY6[(A1u@R#e/Y9,O2l]A6-Td-LC$qe%"bli7I*5rW]ZB40$[4?$D%OZHQ4A5^qiUfkXbN]&=QB"9n<FIat-[)-?:?Tis;J>6#'\NbgG=?H6t7`55u!&l<2FPi]si90q#n?eednEm.>bB'K1o9`t;$+AXC'siG;a$<k\XC#BZ<.]BOm_h4(O=!kqJAA9F5u+OCj$`-Z9f.QX@"BWrU^<\fY+7&Q@eD9_bZ.e&&c!.*RRm2rdQ(QEbMu,>3mjUAS47FOd)e\5ppcF9(T]M,g1:mj65N7d!08=tFYZS:4$F:VINjc(CL_Z#D#^=khXCHoli)k_+&ftIc`\!oCO9jn*S2aA;seeP2!8$eCWsiD1<HFQd?Mh20Pr&13!+cjAdQ=!-T>V]r2i9Yk(2,_ftg,>S,2\BaBa65FpH><`^jcTV([PT6W$)JqGGW=_"ZF__?(*b!ob*)Ya"uaOmBbH+<E*&<q=q@Q8`Y0$q_a[]@XXCCu)SWZ?pCYieO,eUSnG<AqsLRdDB<el'KZGNZmVB0%Qr&;4=rI"6uU91V%hdW,?C0/>)^)SaI?FD7'ss85S`5/Yf2F2JP(oG%>`"AV<+=,)uuEq/Ie[X*\)mQqtlcq5P^-rP(oX<#`qC.^1]kO_=l"Pi:k\/-M?IS/$<lG)9qC5(T`VefO+]O'EG_KjpWc4?b[g9/gLIXn$4l=0&u;jjbia]hi&17[c@teZ4d:cHhh^(YKEO_do5)TA8^G=:0Mh\\8fTJu`uneYfnh?@'b,7X*D2C_%iD'ah)h?bqmUBqR03a-DJ3(WIdj&p"2['jn*<C;j7)^0:'7(ZML+m.IA8R/?J4fRPV/6^N"]d\lLR]j;^[`a1kR!*J]o6KKUN3*)q?PZnscbsh5S86+9&5d+^O,%?l!HMtX4_!71\>KPDfY#]SNP,jjQY?GsHT5a9Q8Z/?:~>endstream
+endobj
+30 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1259
+>>
+stream
+Gatm:?$G!^&:N_Cb[\(#'MGkcH1S7q-;Hoe,mfspe#+0q"Lp<IOUQ(*rJk`29UcQ=2YI0hBJaenl=si:(>cFrNg9Ye"$!oe5T'\\TFPra\,ehX4EblmU)8uOS_,!Y>QAcRj&lcrGIZa+d.:]Jh*ne9i_")K^c:;;8d`BI:53KsX"DP<R-"V$%.lU*j/%?HSM)`=k>)6K0!AZGKmF*khc6OpaO9/6]PoceGdUFJ)#$ga^D!/TNRG&Z=Z.c^;24'%;`W7,225Dqi$M.=D\.;Ki'W(1"]@mL=H&,)OE]YgJS<<<7kX'U%aMlT3S7H-A?J<1ES)ar.gem,XccE0E(M#".4)DSq/.DHO?97pGSQ.Tj0!Lk,#jHFb]8Q\4QOu2Q'%4q\&!spbs!,>f`CBc.ThthiYW1^>Fn8H(C5.(@C\V(,CYG"BK<\6(n7aXoFq8!b7A9$'1EM2PZSOj3+;]c'ZK*Y5]"855H#bL*Lf6VeZ#k^@TNmNA_'M>W*J:bVmBJY_`Z5m(I;HR!\mV^n$4%3h'0I:B1Ms%lrD;S_u?"Zn10GfrXeM<r[@!f%ZVY4@F..G<Y^T\-n^1*@kN68#-VE2KHVi_FpXp^@&co'f23T-;!1\A"0Bs_D"@(B3(_VlYE<;+KNZfQ02fOVq?%R?%"3U*f6r/$)dZd!4b=B$62*)42^oPGC=M9IV3*fm.)\Vr>3k5a2C-SG/pDc(%BkNV'-"c,4Mnc;2u]`3%6cFl6*F%5o'plc\3pA2c&TU=dXlTm4-Ir,l)D8Sn$#YMT#GHuSVFY<OuQJ)TU&3rOh.GCdUdIO/eg2\NLOd;c2,(%@'O$mBieAqI"EN>Te>)@f7\u9&>sKLOqeD2m9-5p',s2.k0!$XR!>4&l.J,"I\;iKoL&R06iC;)F,kR,PVFo8(m8j4&jou.5DKi;9.&LgbsVO"^Ae^]DqsQ+]tI1nQrts<OmD)Y?1k+,>(sthC5U'L2U3*Ld3;9IWj#3\/4+sX([c>XVt5\3%[ZIAL=q>pY1NN#K?>j-P':AQE#\SI[i+5E/$dUt@dLY*hnFQ)[*SOCefe:%a:f,o?jfb);4V@;:EAH3p@-F8mZ6bTQGBG@ZJ)))J_BnI]B/cb80U1J');GKD9b7+e^;:sG);.I*AA`Zfu6mg'rA1c#cJu(;fq-0;f-<?/3sD^VZWjN<]b;jaDtq#S/PW!e@a)6/$!NP'>?5$_C<WGrZ%/P?f(2E:G,2k4dh#hFG2-MZWkhtSNCrm"&='0Wr~>endstream
+endobj
+31 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1799
+>>
+stream
+Gb"/)?$"^Z'Re<2\<#<\:b;Eho<:S$g="4n+hQ4$N3Hki@r*V4f^,g!.iTFjV?rg<FD$3I&0'k;](bFPhI?Wk$iao95FMYd*Q$c^$C&@\!U:4$L*t=emX<nqp%YC/B\J:`1@"^$*7kKK#/kXh.h"\&blr2H\fDD:E%M<^93b'k$H"=Z&&^el-&`Sb$4U,JC7Z/\.Y,j'8ZlTD8)WD%4cFEa@M"%8E`GArV0>GL=AS!o-=XLQ+./*6PqTOA0N37gPV#am_l:9=69SC0ljPrl4=.bXn-]Z^)#lOboE1"RN;E:>]\m9#_8[4VLdc`KK3)IQ0"?'iXO(r!6gVfkMhW8aaq,:1liA(A3+hNppC+!5n77i9F+8EA-Ti'hJb(-Y-(ZR%@m"LS!4q*fJ/ODcnUo$m0fB;'_I\&>]>sk[%e8-LiB"6oHJ.EG)[BO-+JN>23e=M=nU1o\`Gp_Y>S9b=[=gY:WtsVr%&r.mj1=IfW\`c%((r&ollMuc]*5Ob.88l&Sup5X(*QM8d*V>W#`fo!82Adck*@`*ATnkia_7_c1i)m!&M(aL/^IaS'-_pgW[+[59L@>=]Fpp^(gA$f=brTVEH_NdK20<#jB1tbqjAIt+ftrQdDj/qE9;m=T&X=r&(cQ!TV7E8fQqWb:ksK98L,Me!fVqi/n+'K.;iN(=_dgK>9,qID#25S%;C6"='<<lB0FP,=dnrlAF&(G<t_HmmS^e(HE5P(-FW5s&c-8%.boqJs0Ol_%+eRo!F/t*Y(loHZRt0,2sAs)<lJ;3"QEg]k<@m[>OMmE/:_`X0&>`,-mf!LZcmE!+Sum)-"aB,!?-"jDW!7FneMlMkkRb>9$Rd3B/#N<2#7)!]PNW_Mg@%1f4h^D#$:6t^"sWSm.U_?_7Pc#\%iC-TPHLc1LBNNM:prFb\QbkE<$B?,j'n"@U=j<+:2uulFG3$5n_b_HiqK0E.*Gp'M`rr\gM_bmLHl%o_WRQYKr5k@*_2n\L6$KCKlSr6D)*Xf*7Y'5mC"_3!(fLC+Q[SY*2DQ$Wp/W1)W"c$`p0p9`Sa^m8PMMb:%CnX0R%p1_paaAHY2SF9ZCRndoN7V)Dn^&:-KmQK(ZWL\%T.JQP<RL[6m4>pt+(4Gp@.aUqROP`J54T1J,&0MKmqo3[C'KAN7!hI!ek0bO?Rr&S93AfK3;\P?S(E5,PQ):od0@h(G0ceh,(SrJG<)l7h5!9)U1,!=QRVQ?<&29=W:np2c'366JGAR5YQZh%Vol?U<Q&t2tf9-O"2eBbmY'XU[2rj#&L^d=QAGQo`NW.%b3"s<Pp#L!#;I(HKE9j7s+V3/1=CY`d7*a3L7I;_[9LS!V&Zj:K7Kimil_KP=p0BTDW6dQENXAU"41i9W*e3SLp;Y-b_h:<EG54L?hh(u(cC*V=W6+Jd0N1.3/W)5UFOk"<6&ZU\F3%"Rc_nGOm+)oJJI8VE<=!bf;s!P`=g$G:;43fSJiXOaH@5S,#aCU;h8#b@TM:t7tFg2#/!:S7>8>LKC/;e#AD@^lP.s#WE$N=;>P,jjQXlO4C="Ch)6?;$(Bkl[-Y<m$X5@818:hOpn#@:-8fMToDa=Bf78<!aVL^XtNYX1[-ak7@^e/F$GLg<tf4M$4Qf98S_M(.HiOKY8Do*(I_^L\mQV]M>9!j!,EXT3,?==_0nNrWseH+b[Jk59TI<gMA.]C?o,?fnE0=I;^7'M.@iXF;TPT$,bKnhGhRK1q)'`&fB^"sQo2:Cs#!F/_u(A4?;="YB((&Y1>r$I_r^KiWr919?aLXUJuVfW1<HeIhNS"YuaRm/~>endstream
+endobj
+32 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1371
+>>
+stream
+Gb"/fh/hR6&A[2p=6sFC%>n_$[bNue84"r9#t_qsbroVP>C`nHjs1&RJ)@YnNQL:7RqDM9(GfH\<r;F9HF6SRn3tOHBEiDq_Vl@9C-srbl4OoM$g<:k?h`,-IPJ[.ET.*ZANgZl\Ue;o@4nkf%XM#(TPNpi5Wm=C(MlPXV49k3KDhKK-?98'/Q?UQAY9hh:M(6X,+iI.aWCdnT:WlI-?K[eT6[;TaAi"T<!\t-17u`,DYj[Xc[24bN79Q5=Z.m&U(#T:LN9(kBN.(6ae_PM0+`S`n3c/ab=S=1`3QAWmGt[B8-iBLDNI<#`5NH.4Tbp6jL3*k+\l8'FG6B`BpCOBL*^]8;bA$bZh6Wt+?RM0Jr1`YR)_@f:o."@[QG2T!V1>OB/mAoe+egjNBccIf``;@8m,`Y@]0eh>Cf3F%g_i5hsqiU,JFI;YT07fW12EYmJGjRLM^I7K;.QWk84d?(pQ##.41)l!-*B*o*;VCkH71EYj0e?IH"3Dka,=?H)?K?=t$Wi8Lj.,q5b5HZ]@:KhcX1@.<c0c:2M$I=4XF>YD<)"mdN$fNd=(&\a>BnrmbB]#j;KK\7&H)@j2U'\q>&FHbp4m\O"UP?Ff$ZDY+D!;quj*;!*%f-^cG\r;I<:a!8#]]shHjg$K;XF>E4U#&rGf%D0NAo?TM&5W@oHNW75^do>B>$)OpIibYI>9Z/&Q%+B"r3S##bAP9"0!5hYKopGW)@"R+-Dnq%DgCZW/E7+R8]tjMZ2sf,XpQ)Lq#H*qUYClDN_R/+P'bi%f),_jJqY2Q`O(=d%\.ad*6CK<J"EGj^7&oIE1JY=!@5X=;>$@eDM<4T4$"1?3$.[F'.DJB<Z-['5mMM'Y",VVNREf6&XUZSHR)FNsd>ZbW0Zc`)pi)q,0+c;4jY?uqU&UG4*+;<,d[1.n)Xn?*W?Eq]T5,+$ESGuD`#eXOlM!L$"-/H=T<I\sQ=da?I`HjDlFQi:2U-q1Qo2kMDO';3]4`\D6l';,Bbhj7r&.1ZO.+j`[@#(n)R=Q_>VD?F(Gifc9\tT\i%")Q?73``:fsQ47I7"P?ba;kg)p+hZ:>b@O:r2/TS;R+?_(lJO*efteb672gDo"n=:1g$aD0%)>Jo$%l'C+G.Z#6lQB*$hGF0E/\W.:4F%X2`[WW(Q,@*Ee>$@B"g&pX:`%;=<>GrTYKIibj=IlmRlEONK3J<_p7SBZtX+d!sVB&f&<XE3`:aJjKIe.&"r0p3ejtNEl`UelM\%MaUhs.7I:5[W8mP]O.DX0-C<PK9likWE)(b\S1JJp8/0Nf[+:m$DZPsVAZ5@FqC>TQNm+I*&)K0@3TR)Q`9q_f8doY(!Fn%IS)YP6o>^%_AsH`u]EHiF/C29]>~>endstream
+endobj
+33 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1784
+>>
+stream
+Gb"/)gJZcs&:N^lqN9%BK1:&:%pKO2NHY[P`p?`tW3J1f($jlC!o`VBN+C%b(iX5hC_b#?@X4h.ds_'dpHb11L4?l4hiEWNNToAS'A$q\-#PK%`htX1msX"rbrBITD9&('l.g<8R?m)O3\egb1s`"7VJb=meI@SmY,.P^>Kl*^jYW!3IjD3bGseo3,XkI"8m.Pr@4Y!7`B;D^ig/!fnHhofOTd#F/^peo1l6)\Q#StuQV/4Cjm]DK36BU<>\:@edWAZPpaMNPDQ=`J1;gCj9O<X5rBfNt1k)4thf."`CrUVD\a/=eQq?;k`\!e_7WXWi0b*)GA/R#K4OX@fR)YuB4e&Ys?m2E)_a>YI/UhZ5'=S^L\u+uP5<>]@O\"cb;'a#G-6`ul[hM@F6t%9Z.DM/ml36,t!B`25Zc*s2[elqkb[11$,jD@?):e%7kOdIg5bdg3-*L)<^.$LE+?r'\OY^2&:IJ&C66Z^aP2]YC<_^];(Q3)qdniN$SjXc*ONMQ2o.h*'b)G^!!_7,jbuQ!(2/p>bb5uO](q"+i%]c>1<mb&gah/4dN]T,Q=FoL`]\k71C)SnSZ<b(/-rJ!QbrjeaTa_tNf@?kPOp(uX^=dpIPIS[!`E&5.YT@t*WFMD-!kt9GcJ4^H)Um<=K02<r+HdikF'V2P4cARj>rbZ`%>GcrbuE/39nRB;[3_olN4K-Oor]$,c\9+6![?i&E:n06M*#[F3t9t,<=cLNd;4jHeD&S@T9"^KqP2AYGqg/`VouoqGkgfF#8H)#?b<#`;)dZhR@(=_/T+\8afnb`PT**R`c3JLPTC]rEL7"GS[9r6AO5<:%<3`CF:fiUS;eBr$]ZfTU>I%[afq29EVm:CqTp=UdDaLH0K>j%_ni993dUgO#F+-N?b>j#;0l<1Zb25o(2i$\7A*]u!EAkM#r)8_/1q^t[UoFT/7.A_GHd#rQPVWYF?92lIu=!\rj^j%^]3`^jk2Aeoe]@@4mn&/]>EVarW#\`X3UAg?-=ceoaH.t-mYc5E(DaMfh<alD/U>)GsOB1RAl&_a_N`]_`!%Ikc34eb=)QFL'bP[d?;f'Rfbk_OW)@MCm2&haO+X2E)7nS"WEL6]/1[2en(-hP43mfkM[\<G@Dbkr/kG`VN)kflHXIuH8PDD3;<^`+!ojKVt5S1X`&$jA"L?1i-q#iV9!_^7_N*`KZ3l3T8R5,e^u->I/nr$3!;@cm&K?@^U;-hD0\9F&54cbFdZl/md/tYE:Gbo(A$%Yr4*Bn(A6.[*sM%-r-[1-QE($6@^\T2%FqF^h<9n_B%,#\ING[SH92ni7:i93c>%QX[JSMoFq61H*7*1U8.4%RF:Sg&(5?C"Id,G+0n9aUd@W<tBu_,&\-[S\b4DK-1Y*IY%WbI;mMIfkNKId+[lPBG7dX;fe1.$6aI9Bf#\p(\NXEQ"E$tQZpUFg;%]bKMM\9LqcPL'2bqBC,:OVnunj4e/)53*Cd+Vt,b#`e`,-=K,.o]`nWg?(iV.Jf@g&[iD1ms(!e:[+0<i<8bS^lu+:1q6ISV804eA,*<6=:]2K>:+X17$IcC+06&]KVm/,SDThP"PD?4dQd5;%uW2blibWi:=!pKgKQ#^Qr;_rgbYL1i3g:Zp:ImW[Hf,c9u(aj2])`Vn+q>eZ#]HF`j_Mjf#?Ul.1b*?foZN?RH`P`_uc#naXA>^JsGTb\Q=*/4CBULgj\?'d1)alH91-NP7aDFfCVh6HWkGO[FOu6hRId/>rUW/PA5@STV6=P?jaGl=<sD]3_l2Wo%OZ?aK-jA,~>endstream
+endobj
+34 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1277
+>>
+stream
+Gatn%>BcPr&BE],.HWA>>q;('88K@@\;A\ERlV$+];JFb(s=fh(K]P)q=Zn#_77b/4W?Ap+:U.,q.U\^JE"\Nmk=cen&+B9"3//a!4.Lkr\Y,_hRD?Z7[=^f*@I/rR?0[M@Cqa+&[n@8!jaFr?p!hC9,o7V%9sI\Qt"u$E8p,;88hpNK!`TBc+n/D,"aZpRpqYNW-BRA\[[;q(77,Gn*A13OJVL-=_XD0U@h^9iGS9XGr[\62V//a-Hd1T8=6)4o2sh9D[a3_j5`Q=PMa1U!rff0In-<!%Un.XLE\+^;?LF">Ab$BF,s$%`Uj=9R%iT#6ARTqX6H'=Kp,OsGmfhDfGPp"V8VdkiZ^MG7,/\*EJ:/-X)sW$0rGM$\Vi^)>T0FuoNSSfi8WS_O_nJYX.@e'WBbqMRC\Wn%M7dTOubfY,^tP!\XZuHoM,,;qoSZ00+K[Y5r$lg'P>9g623Vn_s25H+I;(j5ZgKRfbSoYWng(.`2ZI,<`-&PF<9as<59\6?_<==kt72`UpUSX<8EjkXX5`rY63D@:;"uPJbL&MVF(l3mtObjF>H*)J!@eC13f?Cej+MR*1V)g'/Ds-K:r]RbHNH6UE#/VL-197?5A$r/g-1;W5(ouaJue^mdW?[&tKef]`cGt#cGml.nH9:UG5Hg^#<o==/2HJnBS4$*ru[ZYe?"q%;?GCF'+]m&uA7B((4uZ(82CYQ9#HsqdGd+qKpV1e9T_&?6H)k2fjZNCS]`Ti_Q@tmr"#D/6i]M%'K-p@c.ccn0d[Cm`$&FCp0%dfS2GmN[:S/HNr=%Y)E8h&)'F08C.2)T[6eNWBTVJ>XTnl@(Xk>LQ%8d"#fhY2M'C*$.?Pe)u^7Oc3%"QnU:p09&WC_CD^^=e'LL.PXAbbR!e?HO-Zc:T5N*R&'T0PG$,/D@(pB>T0X$C\89PD7WlO@a#SERrG54KTt#KN9)")?N/%@A/&8%OpZq-urL8#J+1Y-adsQXKVKJ!`=>f3drAH-+pE>k";O:n"3"$<0r_"HRP:l;?-:md$/_U"KNgG'FNKml=3,_3&I,ba8Y7hSf/YfV\,5,!eY91Ldm3@(ooS?<X3<=+l>.D,cHJA$ToS<V(_nA4dn*]RF%+E@TG%^'U0`BD1A+uKd,$fsrI*GKRi%ApHBOM4Jd`'1#(d^a(\79ZoZt#'sAkQU"*P6+:N3u,S&rGH/^o/,dN.aW!oji0'g9JYrII$-0er8-Kph!A>:76QXEKL0:F`uY@Kd9[mj:nZDOg;'Zh26[9R7$F-W+)a?~>endstream
+endobj
+35 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1835
+>>
+stream
+Gb"/)?$"^h'Rf_Z\C2fa22bMmWZO8I`X/bA&rbR:?T\]ITL9l4-#i\S4Y%\,*Ij0M-_7Mra%#E%mG:##m(Go)3#VMM`SYZ/oQj'q;bl,DiKUjsC`8mBGBiWM@+40#%_lmo<a]sg,A'#\@$nkPgG&c%e4ec82ksRXF+)*5a`Nof\^+t,e)<Qp6?u9]-'CBc,UKilnh?@TQMEXC@D6@GiT-4mWDF7ks"%'5;jp,?@r7a\_o4r;kd#E.5E8]hSOl6XQ)<$)AXm3h[4Z@@Q3tM^d('c$qjE22C%t<t^Z2-Q\W!#/GLOYE@O;,rc7L+=7Wjc/0E]LBaK^,)"L\CDd>^eO#;0FI^d?8XKnht&*kZo9&pH4+VP3NB4?]SuO[s4a?Xg"XI%84ILnZ`L85<d,4I:&F!EMO@)RUN%h<gSD1O&.%,%PR8AJMCe4>TXVJ;4X*P_([ALFu;d5]F^K7`K*T4:t"n$]/C\OVB<;Wp#VG'as\gVP/sq4c2YuKlhhiRP/05Cs:NQ9Ag(L@(:LhG8b_!QfEV&`>X`1]3JCQAY\1h=Yk>9XX<Hm>\aF:!9Sm//1<O&!lsui!hi"$)_MNB!,T*J07;ZQ<m;>_C\hfGR;Lpa0*g8$`PHed\`SleHW]e)fPp!)]J5ea*?E@<nU$B$$^pHn76GOV\Xf!qlaiaejcq[14l<^C*OF=5opAbIJ$55^3*0"uH^q5aG++6[Q@".H`'(WT]aF8BP)"4rWZ4808dELMIi.h'4+g=NH-mYZa33niYkPlH#7b^*Dr!+jF]UYVg$!LJ45=eT^#A6ABK*$0NF#(ISU<=WQJrU35dH6a6maqUF3o=IM0tblR&3d\p(0WXb=mQ#:Bf-kVq7i)2hQ"W:[`Vc6"f]Lh5<CYJfB+'`d`a,/A5q^6mg[[E&QUI%'i>Rit9("ORc!J4b/QRn[Ro;hhOs'\b-Cm_nkF<2Ck>@hfd<7IaT*WWp(%$^VB--J6n;3Kad&2\@!tn53)CQok%.8INcK@,)8os'9PqF^o1b+YuENIN7Y1GW3Vqrk>LPm(s*Mm_K!8>,13jA7#Nh39I<(@e[(Nt87iP_oM.j`l6A8u'kUlD=cR4%m1<D[9B;n^9Zda3a>*&0KQM7$.Q\t3*m6)B7hNBI,8k&'Ui`n:Uh\fZSr2?Vm[q2\?eG9I"+NES-Y.+9BDOdO'NAf@RkQDs.W_*OgXUG6c`b@@l8,Eo7Su2N5e)\=^m!!FMYd-aNU519YD;\#%Hct[o0g[mh[d=8O!Eek5gRTF$F.3DrV5]*62M\;T+@=L)o.;tX3j7:ou_kFG^I52]"V=tj)&)*gEO3WN/ZS!j$p@pgNpp.^*/m\\:t6>iEM<[T^9S5Eid,2e(H\bd"*faeBTIb>NGmpU!e%KhDM=eC*UW+*jX6(UT1FOE\->h4(H=0DQA_2]sG>VWi\+0VC7:rQX>6PZ2BZl\7R`B/!B)%P%3X8QXbM<Q.Df)7B3S>0$C/h8r:gA7%ur,jA\c-?,K'jB>GB4_"q8M'T^;fZDcM]NZLK@XascV-EVtuq&7T)!,[[M3RNYf7Z936X:\s%(jd-0%)8I7KrLYt$F>2o$9Ko%1F?NgIcN3CH0_[A!.?[^>t1Vg11V9I_[-rp@05g^qG?AZb-@->3iM$V"apk]*$IYDa`)s.eJs9#lDmchNV[D>f*bJ`ohjAJ&n,tHIo0YN+6D`2f,=F6#G/%)4%YQ]J(bn<T[)Y?,i0d,kB6IV-]fPg."&'lf;piX?&GR/YV/h6ocV6',`QB$LL3T2Z;cghbu[AFna.!hnhqb_b)=`RN'JnAeCZ1V7\M[HX\ibk6@78jXaI%!IfY[G^GP~>endstream
+endobj
+36 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1401
+>>
+stream
+Gb"/&D0+\p&H88.Z/;!V&&j\`>AcWH84"r9#t_pHk<<G[#k/j`3QZsFn%6$50tFr9e')n\`Jh(8>4"NNBY@SJYjb/@s%ro<'#;mT"j.sT!-O)"_'O2TK5V"\&MG4;[@Gl5UYGt2E6#F)&FOM\(SI]%"M2$Zqns6)Ee&/H.2<PK#S-as+]M+%C)LXgiWSltcGE,'>\(0/LY7R#c.P)c'<0$Fr_=,t5n_LFa18LDKk[R,E7b&U57VhA1eL-8P@RQ^7L>O4X(%f+BJc4<i.IP`T-<t2_1s"["/P+jKJMH>#'hGk$E2dJEf4I-Eu^*?(d80D6PR`Z80SOJ`Gipb6)R`0a_ESF9fo2i[KU#6,X.BH4;#?(Ond]HY+;&>;41Q>nX5Gkg:/t+0PK!E0u1ndh*!hbI9IO>4^/onTkDQXW:'e]Y2`[QUP6XMLn'g,F,%+0gK6[&^M5bV><Fd2U'O^(%#OhNY`2kEl/VV*Cl`!/@30^2Z0;p>S]\')lnSgZ_X3VG&l_HN/50Mt*WQE2+^jTgCX5(RDXQ2\4<sZuk;(tbIeTkursX+(:*4BB3eO)Ph:mJ\KL%ON=;`f)6%0pr*-:oh0R*nV+q.>cYR;:R"5-@6UnXR258h7Q2rS_Y@#d/t'93gA$7:BZW^j>tU<o:b?6[R9$+$T-<b,LD]0."$p,efd>]`(+G5q3oo+#:S%(_#[YK7\67O)IQ9U(.*$m4!oj16jN.EQ1q*k,%HZW0;Z=d+`;PsjJ8TM(p[l>l(.kjg6ohpE22mfrOk_e&"0q\$)Fm@[aq5<QKjl^_JH]hY2T<N-"7=8E&ncgZ.i/ul\%K@8^(<9)P3Asd@BXH#S88l&GL>.#]N`fs]Q'UC&Ik3;t_r,EamC_=e!V9A^"7$D,[MlPVhEioh(0jLZ&$GBtq1t&'(%@@R[R#MCc:1H.F>/]M3N7A4,YQ@3jIoY2BK.L'7HkYR;bmer,r>\:3/suB6l/(n,g$S]kFTF#2+0Vj]Q?1Vr^Z.BN<A"2fR8Sl%IK]K.IMlb(qpA*W;jGO\o43LWiE]ak_K^Akd5"V7f$)u8EP,7!*6e>."*u3SHIkGqn2b'LppjK&<fB0Vp$9YZP4gu/?Od>X(@hUHc.TtIegi\qrhfkX_K("(O#EJU/XsYN:pQObes=s7XPM6Mc6Vq-fCH03&2n/bp&_1$F1]6,p_k!4NpPd!eZ_rp.Kn8kLm+1mVG\_@Pq7u@=Ilmb.TrUdD'FirUS1Z1.]']_C.;7G8gWg[b/DE>Y913i^O;>^2YTa>4Ps5$G5>S?B[6d*[lrGJU<5**,h'E`:f>2-9bL-UI/f?II\5[C/K)W$VY'nm0ftXLG%*i*_cgi9MJkA:AM*6K^4M=7emmThm9?fC$asuip+=q/DSaIG*;fn*8`,1~>endstream
+endobj
+37 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1659
+>>
+stream
+Gb"/(D,VW=&H;+$k`=Sl`(=Pr0B\*@<*\*T<5?-":KDuGZTHC8aT0Ar^WsIm.a$=F[8dPLDb3aQrUc<ALQR1BIl)N>:B4/%E-ss&1?]4!3lHU;'f<K,57WPgcV4,a33`QT\Hg(3:1,e!gu2;lK,U-cBX,,h&D-*2",mmgWDB3LJ]"pdLN3D?-/qlkS:I'IBfM4tB'D9P@Cd_'H[Z"/7&U.-J#A,q+c2uUM)!TAE&s6d\8NFVY<A.%ZrA_Z8M\LZq?\dPQJ$t<VJt3;:<l9rIY7&Ik^G;dY;tim/tjic2P%Jq,De[e?#k^.Ph.l1YqUP8h"HR>3#k6&C&DYl^]dsR@0+4diF.:I(-fN@5[=I?ZOEF\Qe-1&@L4p%'_*<g_jQ0]_DmCK:7"Ii/LLiYQjXWIfJ`YRhD=:*GNB^>L_ZnpZc<a2=RI(/@^8+L+A_^)%7;Eq4+5>--;\5K6r?,LkV5J'bU'3(8ugT5W:)DKAVAOG8AsE%A2o22Ca.lUN9h)W`QSINCI39s^dEQjNhjp/['JpYXGkA(7V5[uGqE'O='Db4J.j&JOej>E8PB3RqJM$aClBs4"=uf!gNYE"T0]TR$IW_bC%n/=TE3:R.gX%44l!RlNpCp,nDi;#i`F('#[=Eke>^jl<[a)c`:ku3)K<PogJU/H/eZ\-EhYUdn(@9#D(E>H`6Kl`QYfsR0q"nI'#Skt0OPD3VHsT%:3FJ@CmR4.q"`3\^pi^nFhR_gmQ6CdgtanMh<%FI#6<*[\oNGb!LIGM3&p*lBADG,WGkQ=N#Qs&`d&acUgj^n==1?goPBuH.@l?&K]a+H75Do9CefcLBc6ZAR7jCUo-LVWQS=?/D["^7^"J"_=hE'p_.Bt#Y.)_0^[;(;\j9D8r,8fC=?d!--Dn3\Z*kflZa`5K!=Bo%VCm(A%Z6qOi<^4Sp3d0A-X8Mmf<=]B]\]c(H['jXh`=8.]abL;*.Q58?(pcph1EmSdB7p'Ue?M4F&3eu9csdQGli"1eHj:'X:7On;co!T15.WLF)1q+<<-05XlYf_)s8an#aP)+RMHJj22pKl7T3tHMrVMYFf5[+Y*RGn.$fMG=e'tlJaB-PSo.KOV:$_6qL,>cB_WU)SrE:L2&mTj[Fo3L>>_repq,5S#L>N(rkDdc':*CA[f)53$HbF,,Y_4226t674Y4Hlr6RqpO/*ZZ77eR%_GAgiFVp/\ZA/0FL$Z]5O-b`SK?Q:!jc,@;h/jU,f+I$g0Y>cB6L;7]?[qu)BOC9)m=9056C`S9"tf2:?JaVoT+?_cMp4.D=Z,bb/:pW/A?F0])oL6:lSZ:k9+ims/IrSMDfZ\%T199YgR2E-(QK[&Lb?-5[8j63dKAd-/2JSth5D<oN%C$7=Ih@/b-BBNgVhE5`gTa^<Z4s>B0EP@/2om)OV>cg?[^T5s6^KND!mFeGePj0Fo&03f6.DU\,J-I#A7d":g8X;BsbfcM6^)gEMbanfXR+>"%o^PJ\N7).40DP[?k*E\[@c.Hb&h.j;'qAVD`>b5'5B/YLZk2*I,%SX,`V:.=pIZd]ns]S=#eWrFELXp*U&;kfI7BH=VI8s$J<=3*@49@+D&LVQ4>ZZrZ&ZMGOAQ]a3ANYe:=sMm0l#HcI=HrL`#u9eQn-l$Ar[:6EpGKfL.N#7<k<G5~>endstream
+endobj
+38 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1847
+>>
+stream
+Gb"/)gN)%,&:O:Slq;!H<.YC=i2(nd.(5YEF_jR2gW>Wa+s@7!0+(6BdGK.6MNmK&QDl7&Ypk`O^_0b>4kMoN9YnM/>.t1q^tT1f:+9!Q-8V;QZ!hYWK?:s]K5H[M41qG]=M@@p$cHYcDjWeWbm`J32:iYkmHBj3*01sqR#E^k4URAi%S'tS`>[lr-[>nf$E?X;)%5@k^.=O52Zta/:19T3'nZ4h9N;R:&oEZ9EOLtPV$Q$pf[4'(.U?[R_,@,oXDA2@*):@n$aW1YYY4=fnVI)MPKtq.U]'(kdWHQs:#EYKj<^E+TPX([NsJ4'NGT4/Qd:1b*\i&3+c+d1*t@KsJE%e(5g3GW(gu[GH`&2e7g!KE)UH>#0q@c%5SqF\T#bFP$Rlck_.(joTiA%t%T&)^!oYKbYm_c4/B&(Ume4r5M6ld`_dmZ&AX/>FgbUJT&/6/L)>I4I%rI[_NY)UP+rPrK"F1\]/\mP],/I=^<7rQs2s0B5bbU'!HQ)G8$g9!/YUEtPCsC$7Q9[/c^>\9%ghG[j`u%2'Q>8>"mV5lNToG5^Ajbap[@2?:iE0<'I&&DNQ1u)VM9d0f.1o1ZZ/H8OoT@Q;D@XuKU"dot.5lPEoU0Qh5-5%DP(qq?3-.G.a*)I=[pqd^f9"#qk&,:::RBpr,Z9bL*j1=qN0q4[.ILOJ3GQ)>=)HQq/UGI=%:rgS<CstXB,qAfOo]I(\Ip)%8Uc.CJ\(&"F_e(NPW\Tn<]rC9?d2lYpi84hcl[[fX79R#+0Pn/ame<f#nWaKFQ\B]/\0^H`5Xurh;JR=[tUSeT\ZhE2ia$Bq*I=ti[O#_+pitGEkN?4CQQQ@bV_.0'seTgP#]-kO,&h&*+Bi9GqPmVoS;T`4rt.;kO<p[)"gD>mlrr9.<L41h"]2dD9:4WRD>-m651SNE>j_5"(<)^,tsHF*b(7eUJZg"5DG/)47sUPPL7nt2_1C-hY#4arM2[Bf@(hU]sp*f6&n*g'kSS,c`O*SjUle\XgSu22cpA40o(M>OQQ](8]25!?;kp-"IngQ,26M=&5)-A8?B%g*]4<R'5b3NZrft`S6V=*[%$SVA0;P10;9b_Vs@Z^A0s)tmcG_J%AESI_Hr@(+!;6ug8,,>jGm2(!ZhIgbN(KHn+]jMf`NZDC_KaTB=cF.mEsk\iSYg%!14/nH9=ri\]qhPT,8rj::oD;C!![i=ejlWf.p]<#KZ5Acu%5[%1jZ['MF*,R9u<RoCiIBlT6-uAHa$@YA;B=+a8Ai)2oY-N"KFC8tQKr]2nn*j$uE4';(m-#kJJC$&GA(_QrH-"`O&$J2jdI=k2P<?#SF@(md_3I]madfskn4B6W6p`:Y.g7=jE#bk/1,UP6[gdP$f$*CJ0c>qAs%UGQhq#Ll5.VK;CD;;Ke?)(on`45DTjgM.sF&[0t-HU^_6D:Id?rKYoMPn@bgME#qXc'KBms*0H;(3<'84C=<m1Om+Y]=dA%6rtaN9Zf@Bl.7<'L0:Lf1^6&qn,,d#?mW,\mo;7o1h)klXiH;=$Xo&.9rL=[`+r=_[nuAJ%G[K6%:-Q`S'FiB*/f-qMc(V])q%=s[,S/%B<=./`E=_:?A1AV-dpM]WEt6-Zi5_IZDPd1a1/<KPLW06Kg);6,"StRJkjB99!EH<:X$2Y^cI<Q8t0^k.VQ"^PDo\pM[j::;ZGlVrgFE7b=Dh>q7BcaNMVrBafNQ)f(Z9^CUI9F`EFkEC9a,#`L;Fb(F@2iT.e<8i-4g[.`tLa;&tp13Qk9*7(`IX5k1OKEi#fN(/N#j\,6sJYuCTOATNma_0XBo/LieC;:/T]:!hhLWj,Ta[;)dCA$$Yrd;#b/LP('W\dZLK~>endstream
+endobj
+39 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1745
+>>
+stream
+Gb"/(gN"2m&:O:SoV4?\jO)aqrNJ_,S<.l0#OnV]j:X7X:coO<bs;4$gR9)6nV,K(G,o(k@6j+?\kaDj*sN&VrmC"\Qiapk^u6^GC;OKce0[(Ic<r?ZqmP,#G^@6q`ebFteFA(ANZAr`&BAsQ^]tbC$YZlX'bJu@$l_lq30a7R-7S;BpepSr`0+\cJh..0Aq`c9Yd0YZ;A?SC/l,5NRPPf^s1ZQc!I:!d*bf+A(Q/HXi+dM05>Ge(;I%(*k4u(s$$0?HhGtGm;W=tiS6W@Qr!&@g0R9Glhf.$8>XH]N]BeN(M`FUXj-!1D7XL,3&-Kgo^p/8r"L`q*i\\A,B]&rpLTgb5n)7]*XVX2a20!=>W+fp-pN<iU/E>*0;iuke"q4)aV96;G^p46q,0s5k_\>`ZhBFjh(,:)]a1mBm1i;6T4iC<f:!0R&nUla3m32V,ZTWr6:AV[.1W_=D+_F.TBX5^BU`QMj9K66sOOY&3]p-VXQjKABoJC"0%HpJ50J?@j2.gBW&1D-=0O,X8K*ECfb]/`W<K'C)?&)FBg8IPZG*Lj>e\isIf4r)-OM](>'%CG=J`HTEKi"Y+%@730J@)cSJG?hb]oFj=Ze:i8GIE&,ZsKgWNe?ZVc5hI@gV\R1kCsVa,EP48p$.u44o-Rka@G7e(_R8t@]m2:G_fWNWo_ca[6<EUkQBR_]_.(\<s#SZp,HJ)KhE3<kTftL.Y2p00D/ME[jiJGA#nE&Z*-*(iZ/Imp.&KJC-3?LVlRXY1;#U(,(=WdY2(etGh\uYCn,R;#Ma:P6fI;=BK*$8NR)m<7)3p?RGh9`H,^Jaj`71j(S96H82uFbc_ll0>[eW$I48\jp4qfb4rt.;kO<p[)"gD>n%W[i%(\aVDZ"9\7XW3%cU*'\.PGAS!=KiJ#8$!*RI[G0E6c@j7&])OE-toN\rQ`1hup/`5CbO-?&eAj_V*jQrsW71qNHB?rVkQ0X7HuMeam0W_=9J>g(l63cpuGDDOT/FYf+\F,r=gTXJdj8!hOEM,F5gPR?4G!eJt:%RZm4ep<]QeJ?#dGlFP]W#i.@bMBuMYaP]3W(3#kK%RV\0:nS0N7]i"R,0kFT=D%4FLj1=)X[1QZ0%CQ<0[rdg,-_e>jb\;XJqIoLAbJjeV8te<r&l$I`ZpP"s0(VWKSA.8fRD"+"`9P'+\`?!rV-rrbOnIAoBUA@ZC's_Bp+5W&ACd@_NVsj<P/1(6h^A-a&?Qc7cs$fnj:Eg?VC[ak7Mc+TQd4cL"Jai5QCL]cp$CZlQ1%n"*"D%C:(4'H?FQR^"XbaXR8":FPXsKYlr(3Og-o^g_i$<>Ar.W[NtAEfC2U4pm,Cof]CMtEidD:dqKdhck0RM9H1$SA$$!c7T$%@oVPJIeeo>HnZY(10l"a4,KD!WFYYk6]!9hbP;etn[:?TV.YsNQ3rJE`Sa\l"j-o(SUahtNQMNB:HhB8!C\6W:b-)t;m3j2V!4KO2M[]s^.u4>"j^gOZ?)$qr^qNlhWKl.<-K@48Kka:;KbaI=E/W3H/Fl3e=%O)G]"t-sj59$/MI<07&?'2b\nn:fG.MLfbBCJ`Fm(T.,#'ZElIQSXf)Hl6RbP2#N[9a/UQAa<^4(LQlm0X:>Kf)c.c%?@#Ed8OI2f,PZ_G((*AYU'c36Nl`B&=!!j1?8VPeq.J<UjJKW>#;"#2i1Grins(@d!5A1,TE_JCUDG/A&Cb^Nu/[eW"2GK7omG.O9C\^P*]>@S.irr@=kN)T~>endstream
+endobj
+40 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1070
+>>
+stream
+Gb!$F968Q9&BF88'RKt;D"X)OS9U<MJXKEQR;in:2'c4a*D4%/.m%pE6>6XE82>Im<nb<;?>DJ>(d3095$\6&R)%B8#;0C>#Hgn>j?:/IN4t@],;p!A]cEp_>['IiQ"'kl/'V<'nN'D&gXW,fPA-mZB[iPb*%"='FQn8hrYDYH?IfjU!TL\lMku2V?/L<;e/O(!=6FN;ni-aOEtr-nTj2E*-0OQj=KVK05/2N7IU:!4>PSQ*(rEqj9EQj_2pK9U*GO1A%K=Ebp_Y>b@Ib].+,I;T+;`>kMnI-74`EKMnr[=%Etgu2gXi*0L<M)@&8@NG1@>RtH@uGugu6(7V8^d+"`TZU$C5pSM9mk-ID(XeS;4W0M`csCR6[XNTZI8#@W!.>[9!@!@5_'VBoTD\.4Ao%PT5[K)S"A^R+<tZ9uL`EAAjr0>JX#dYU1/ST*[Y7OIS'Lc"nUHPRI+Mg$RXhC\(-amJm/K)psP/gnNFiVI3jP<&TfpJr2H3WD9uc#M5jBUG)Z;\5t$=:e"-Hj@:F.(*:cZq`8'uo4"0?7497T,Vk*hVrI=s.>:f\lr]KY1ab_.ZY4L^+!jeQir;*4U9&d5Kr)!<inJ\qY)7oTYD`)"EE1JqRaO]^S)th42t+8Fc2S!&=]-ZtZ,"#pCOZ<oB$ft?Sm8jGbE6LY/1;TtW[c/,R)b^Lgr"BHEL?FX:QLN8-lCKuA)0h:0`C.o+^h*6[YoNRA=Q)V.f-Ek]F:hMPhs_ap9^aB_iPj\(BY6s#K\[LN*1?U8C+24:\PZrK[e(?1KI8!4J65!LN4Ntj=gm3]b6N!_fU15kClkir6gr)!=(M?IKM>)%Vp)`<81+GCHqe'8akm9FbDe#*>I-O,1QEliaNm4^)<Vqg\o]E#tA+*:<T2F!M:8X2B6:TAp2dQi-4(AA4g\m?m`:#e.$&YOQ;XJ$,%'C".5oCBs:3JlP'V!,rtW*6`85\3sgp0<R@F<BBu(47L(g$Ob$;@l<P*0TQHn<I6(U$`9ET<I".j8ei?l),sC'["/k#,3CuSl/`k@k@qTSJqS*DpFoPs4ouH2$UL/]sDPR~>endstream
+endobj
+xref
+0 41
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000526 00000 n 
+0000000731 00000 n 
+0000000936 00000 n 
+0000001141 00000 n 
+0000001346 00000 n 
+0000001551 00000 n 
+0000001757 00000 n 
+0000001963 00000 n 
+0000002169 00000 n 
+0000002375 00000 n 
+0000002581 00000 n 
+0000002787 00000 n 
+0000002993 00000 n 
+0000003199 00000 n 
+0000003405 00000 n 
+0000003611 00000 n 
+0000003817 00000 n 
+0000003887 00000 n 
+0000004168 00000 n 
+0000004339 00000 n 
+0000005670 00000 n 
+0000007551 00000 n 
+0000009060 00000 n 
+0000010936 00000 n 
+0000012309 00000 n 
+0000014178 00000 n 
+0000015529 00000 n 
+0000017420 00000 n 
+0000018883 00000 n 
+0000020759 00000 n 
+0000022128 00000 n 
+0000024055 00000 n 
+0000025548 00000 n 
+0000027299 00000 n 
+0000029238 00000 n 
+0000031075 00000 n 
+trailer
+<<
+/ID 
+[<15b104d8e0a3cfcbe5f528ef75097232><15b104d8e0a3cfcbe5f528ef75097232>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 22 0 R
+/Root 21 0 R
+/Size 41
+>>
+startxref
+32237
+%%EOF

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54957822,
-  "maxTrackedFiles": 4767,
+  "maxTrackedBytes": 54993126,
+  "maxTrackedFiles": 4769,
   "maxCategoryBytes": {
-    "other": 18821537,
+    "other": 18854810,
     "large support/generated-ish": 16077049,
     "source/scripts": 7152638,
-    "docs/text": 6237478,
+    "docs/text": 6239509,
     "tests/e2e": 5106882,
     "config/data/messages": 1562238
   },


### PR DESCRIPTION
## Summary
- Adds a generated static PDF board for Step 3 mobile UI/UX review.
- The board contains 43 frame cards generated from the frame inventory, blank reviewer-mark fields, and a reviewer return form.
- Updates the storyboard/review docs and nine-step sequence to say PDF board ready while keeping human findings and runtime authority pending.
- Syncs repo-size budget for the new tracked PDF artifact.

## Classification
`documentation/external-tracker-only`, Tier 0. No app code, routes, auth, tenancy, billing, proxy, package install, Figma approval, or runtime exposure.

## Verification
- `git diff --check`
- `pnpm docs:verify`
- `pnpm plan:status`
- `pnpm plan:audit`
- `pnpm track:audit`
- `pnpm security:guard`
- `pnpm repo:size:check`
- `pdfinfo output/pdf/2026-07-05-mobile-uiux-static-storyboard-board/interdomestik-mobile-uiux-static-storyboard-board.pdf` -> 17 pages, unencrypted
- `pdftotext ... | rg ... | sort -u | wc -l` -> 43 unique frame IDs
- Rendered PDF preview pages with `pdftoppm`; visually checked cover, early lane pages, later lane pages, and reviewer return form
- Resolver check remains expected: `blocked_requires_current_authority`, `activeSlice=null`

## Review Fix
- Addressed Codex P1 feedback by replacing the output-folder `README.md` with `artifact-metadata.md`, preserving metadata without violating the Phase C README rule.

## Residual Risk
- Step 3 is reviewable, not complete. Dated human UI/UX findings are still required.
- This PDF grants no runtime authority and does not prove browser behavior.
- Obsidian advisory note was updated locally outside this repo and is not part of this PR.
