### PR TITLE
feat: expose signed MK Help Now pack

### DIFF
--- a/apps/web/e2e/gate/help-now-public.spec.ts
+++ b/apps/web/e2e/gate/help-now-public.spec.ts
@@ -73,4 +73,27 @@ test.describe('MOB-01 public Help Now route', () => {
     await expectOnlyPublicHelpNowSurface(page);
     expect(protectedRequests).toEqual([]);
   });
+
+  test('MK Help Now exposes the accepted public pack only', async ({ browser }, testInfo) => {
+    const context = await browser.newContext(publicContextOptions(testInfo));
+    const page = await context.newPage();
+    const protectedRequests = watchProtectedSurfaceRequests(page);
+
+    try {
+      const response = await gotoApp(page, routes.helpNow('mk'), testInfo, {
+        marker: 'help-now-page-ready',
+      });
+
+      expect(response?.status(), 'MK Help Now should load as a public route').toBe(200);
+      await expect(page).toHaveURL(/\/mk\/help-now/);
+      await expectOnlyPublicHelpNowSurface(page);
+      await expect(page.getByLabel('Trip country')).toHaveValue('MK');
+      await expect(page.getByText('Signed packs: 1')).toBeVisible();
+      await expect(page.getByTestId('help-now-generate-pack')).toBeVisible();
+      await expect(page.getByText(/112|192/)).toHaveCount(0);
+      expect(protectedRequests).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/apps/web/public/help-now-packs/content-packs.v1.json
+++ b/apps/web/public/help-now-packs/content-packs.v1.json
@@ -1,6 +1,6 @@
 {
-  "version": "mob-01-help-now-dark-packs-2026-07-04-v1",
-  "generatedAt": "2026-07-04T00:00:00.000Z",
+  "version": "mob-01b-mk-help-now-public-2026-07-08-v1",
+  "generatedAt": "2026-07-08T00:00:00.000Z",
   "publicOnly": true,
   "containsPersonalData": false,
   "countries": [
@@ -14,9 +14,13 @@
     {
       "country": "MK",
       "marketLabel": "North Macedonia",
-      "exposure": "dark",
-      "l2SignOff": null,
-      "reviewStatus": "not_started"
+      "exposure": "public",
+      "l2SignOff": {
+        "reviewer": "appointed-mk-l2-reviewer",
+        "date": "2026-07-07",
+        "packHash": "evidence-center:2026-07-07:gazmend:mk-country-content"
+      },
+      "reviewStatus": "accepted"
     },
     {
       "country": "AL",

--- a/apps/web/src/features/help-now/claim-pack-preview.tsx
+++ b/apps/web/src/features/help-now/claim-pack-preview.tsx
@@ -38,7 +38,7 @@ export function ClaimPackPreview({
   }
 
   const metrics = [
-    { label: 'Zone', value: pack?.zone },
+    { label: 'Access zone', value: pack?.zone },
     { label: 'Checklist', value: completedCount },
     { label: 'Local evidence', value: evidenceCount },
   ];

--- a/apps/web/src/features/help-now/content-packs.test.ts
+++ b/apps/web/src/features/help-now/content-packs.test.ts
@@ -11,10 +11,22 @@ import {
 } from './content-packs';
 
 describe('MOB-01 content-pack gating', () => {
-  it('keeps unsigned country packs dark until L2 sign-off exists', () => {
-    expect(getSignedOffHelpNowPacks()).toHaveLength(0);
-    expect(HELP_NOW_COUNTRY_PACKS.every(pack => pack.exposure === 'dark')).toBe(true);
-    expect(HELP_NOW_COUNTRY_PACKS.every(pack => !canExposeCountryPack(pack))).toBe(true);
+  it('exposes only the accepted MK country pack', () => {
+    const signedPacks = getSignedOffHelpNowPacks();
+    const mkPack = HELP_NOW_COUNTRY_PACKS.find(pack => pack.country === 'MK');
+    const unsignedPacks = HELP_NOW_COUNTRY_PACKS.filter(pack => pack.country !== 'MK');
+
+    expect(signedPacks).toHaveLength(1);
+    expect(signedPacks[0]?.country).toBe('MK');
+    expect(mkPack).toBeDefined();
+    expect(mkPack?.exposure).toBe('public');
+    expect(mkPack?.reviewStatus).toBe('accepted');
+    expect(mkPack?.l2SignOff?.packHash).toBe(
+      'evidence-center:2026-07-07:gazmend:mk-country-content'
+    );
+    expect(mkPack ? canExposeCountryPack(mkPack) : false).toBe(true);
+    expect(unsignedPacks.every(pack => pack.exposure === 'dark')).toBe(true);
+    expect(unsignedPacks.every(pack => !canExposeCountryPack(pack))).toBe(true);
   });
 
   it('keeps unsupported route locales on English copy while preserving Germany as a trip country', () => {

--- a/apps/web/src/features/help-now/content-packs.ts
+++ b/apps/web/src/features/help-now/content-packs.ts
@@ -23,7 +23,7 @@ export type HelpNowCountryPack = {
   marketLabel: string;
   exposure: 'dark' | 'public';
   l2SignOff: { reviewer: string; date: string; packHash: string } | null;
-  reviewStatus: 'not_started';
+  reviewStatus: 'not_started' | 'accepted';
 };
 
 export const HELP_NOW_SCENARIOS: readonly HelpNowScenario[] = [
@@ -45,7 +45,21 @@ function createDarkCountryPack(country: HelpNowCountry): HelpNowCountryPack {
 
 export const HELP_NOW_COUNTRY_PACKS: readonly HelpNowCountryPack[] = (
   Object.keys(HELP_NOW_COUNTRY_LABELS) as HelpNowCountry[]
-).map(createDarkCountryPack);
+).map(country => {
+  if (country !== 'MK') return createDarkCountryPack(country);
+
+  return {
+    country,
+    marketLabel: HELP_NOW_COUNTRY_LABELS[country],
+    exposure: 'public',
+    l2SignOff: {
+      reviewer: 'appointed-mk-l2-reviewer',
+      date: '2026-07-07',
+      packHash: 'evidence-center:2026-07-07:gazmend:mk-country-content',
+    },
+    reviewStatus: 'accepted',
+  };
+});
 
 export function hasHelpNowContentLocale(locale: string): locale is HelpNowContentLocale {
   return HELP_NOW_CONTENT_LOCALES.includes(locale as HelpNowContentLocale);
@@ -65,11 +79,11 @@ export function getHelpNowCountryPack(country: HelpNowCountry): HelpNowCountryPa
 }
 
 export function getSignedOffHelpNowPacks() {
-  return HELP_NOW_COUNTRY_PACKS.filter(pack => pack.l2SignOff !== null);
+  return HELP_NOW_COUNTRY_PACKS.filter(canExposeCountryPack);
 }
 
 export function canExposeCountryPack(pack: HelpNowCountryPack): boolean {
-  return pack.exposure !== 'dark' && pack.l2SignOff !== null;
+  return pack.exposure !== 'dark' && pack.l2SignOff !== null && pack.reviewStatus === 'accepted';
 }
 
 export function getTripModeDownloadAssets(): readonly string[] {

--- a/apps/web/src/features/help-now/copy-types.ts
+++ b/apps/web/src/features/help-now/copy-types.ts
@@ -6,6 +6,8 @@ export type HelpNowCopy = {
   continueSafe: string;
   darkTitle: string;
   darkBody: string;
+  signedTitle: string;
+  signedBody: string;
   privacy: string;
   clear: string;
   download: string;

--- a/apps/web/src/features/help-now/copy.ts
+++ b/apps/web/src/features/help-now/copy.ts
@@ -12,6 +12,8 @@ const en: HelpNowCopy = {
   darkTitle: 'Country pack awaiting L2 sign-off',
   darkBody:
     'Country-specific numbers and police thresholds stay dark until a named reviewer signs the pack version.',
+  signedTitle: 'Country pack signed off',
+  signedBody: 'Public preview is available for this country. It still creates no case or account.',
   privacy:
     'Photo selections are recorded only as local metadata; originals stay under your control.',
   clear: 'Clear local bundle',
@@ -48,6 +50,8 @@ const sq: HelpNowCopy = {
   continueSafe: 'Nëse nuk ka të lënduar, vazhdoni listën e vendit të ngjarjes.',
   privacy:
     'Zgjedhjet e fotove ruhen vetëm si metadata lokale; origjinalet mbeten nën kontrollin tuaj.',
+  signedTitle: 'Paketa e vendit është nënshkruar',
+  signedBody: 'Parapamja publike është e hapur për këtë vend. Ende nuk hap rast ose llogari.',
   clear: 'Fshi paketën lokale',
   download: 'Shkarko paketën publike Trip Mode',
   downloadDone: 'Paketa publike u ruajt për përdorim offline.',
@@ -71,6 +75,8 @@ const mk: HelpNowCopy = {
   continueSafe: 'Ако нема повредени, продолжете со списокот за местото.',
   privacy:
     'Изборите на фотографии се бележат само како локални metadata; оригиналите остануваат под ваша контрола.',
+  signedTitle: 'Пакетот за земјата е одобрен',
+  signedBody: 'Јавниот преглед е достапен за оваа земја. Сè уште не отвора случај или сметка.',
   clear: 'Исчисти локален пакет',
   download: 'Преземи јавен Trip Mode пакет',
   downloadDone: 'Јавниот пакет е зачуван за offline употреба.',
@@ -94,6 +100,8 @@ const sr: HelpNowCopy = {
   continueSafe: 'Ako nema povređenih, nastavite listu na mestu događaja.',
   privacy:
     'Izbori fotografija se beleže samo kao lokalni metadata; originali ostaju pod vašom kontrolom.',
+  signedTitle: 'Paket za zemlju je odobren',
+  signedBody: 'Javni pregled je dostupan za ovu zemlju. I dalje ne otvara slučaj ili nalog.',
   clear: 'Obriši lokalni paket',
   download: 'Preuzmi javni Trip Mode paket',
   downloadDone: 'Javni paket je sačuvan za offline upotrebu.',

--- a/apps/web/src/features/help-now/help-now-experience.test.tsx
+++ b/apps/web/src/features/help-now/help-now-experience.test.tsx
@@ -27,7 +27,7 @@ describe('HelpNowExperience', () => {
       'public-no-account'
     );
     expect(screen.getAllByText('Country pack awaiting L2 sign-off')).toHaveLength(2);
-    expect(screen.getByText('Signed packs: 0')).toBeInTheDocument();
+    expect(screen.getByText('Signed packs: 1')).toBeInTheDocument();
     expect(screen.queryByText(/112|192/)).not.toBeInTheDocument();
     expect(screen.queryByTestId('help-now-generate-pack')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Flight: coming soon' })).toBeDisabled();
@@ -45,8 +45,14 @@ describe('HelpNowExperience', () => {
       'true'
     );
 
-    expect(screen.queryByText('Zone')).not.toBeInTheDocument();
-    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.getByText('Пакетот за земјата е одобрен')).toBeInTheDocument();
+    expect(screen.getByText('Signed packs: 1')).toBeInTheDocument();
+    expect(screen.getByTestId('help-now-generate-pack')).toBeInTheDocument();
+    expect(screen.queryByText(/112|192/)).not.toBeInTheDocument();
+    expect(screen.getByText('Access zone')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('help-now-generate-pack'));
+    expect(screen.getByText(/Local preview ready for MK/)).toBeInTheDocument();
   });
 
   it('tracks page open once when the trip country changes', async () => {

--- a/apps/web/src/features/help-now/trip-mode.test.tsx
+++ b/apps/web/src/features/help-now/trip-mode.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { HELP_NOW_COUNTRY_PACKS, getTripModeDownloadAssets } from './content-packs';
+import { getSignedOffHelpNowPacks, getTripModeDownloadAssets } from './content-packs';
 import { getHelpNowCopy } from './copy';
 import { TripMode } from './trip-mode';
 
@@ -14,8 +14,12 @@ vi.mock('@/lib/analytics', () => ({ trackEvent: hoisted.trackEventMock }));
 vi.mock('./offline', () => ({ saveTripModePackForOffline: hoisted.offlineSaveMock }));
 
 function renderTripMode() {
-  render(<TripMode copy={getHelpNowCopy('en')} country="XK" packs={HELP_NOW_COUNTRY_PACKS} />);
+  render(<TripMode copy={getHelpNowCopy('en')} country="XK" packs={getSignedOffHelpNowPacks()} />);
   return screen.getByTestId('help-now-trip-download');
+}
+
+function renderSignedTripMode() {
+  render(<TripMode copy={getHelpNowCopy('en')} country="MK" packs={getSignedOffHelpNowPacks()} />);
 }
 
 describe('TripMode', () => {
@@ -69,5 +73,13 @@ describe('TripMode', () => {
       pack_count: getTripModeDownloadAssets().length,
       total_mb_bucket: 'under_1',
     });
+  });
+
+  it('shows signed status for the accepted MK pack only', () => {
+    renderSignedTripMode();
+
+    expect(screen.getByText('Country pack signed off')).toBeInTheDocument();
+    expect(screen.getByText('Signed packs: 1')).toBeInTheDocument();
+    expect(screen.queryByText('Country pack awaiting L2 sign-off')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/help-now/trip-mode.tsx
+++ b/apps/web/src/features/help-now/trip-mode.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from 'react';
 import {
+  canExposeCountryPack,
   getTripModeDownloadAssets,
   type HelpNowCountry,
   type HelpNowCountryPack,
@@ -29,6 +30,7 @@ function getStatusMessage(copy: HelpNowCopy, status: TripModeStatus): string {
 export function TripMode({ copy, country, packs }: TripModeProps) {
   const [status, setStatus] = useState<TripModeStatus | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const currentPack = packs.find(pack => pack.country === country && canExposeCountryPack(pack));
   // Keep a synchronous lock for same-tick clicks while state drives disabled UI feedback.
   const isSavingRef = useRef(false);
 
@@ -82,9 +84,15 @@ export function TripMode({ copy, country, packs }: TripModeProps) {
           {getStatusMessage(copy, status)}
         </p>
       ) : null}
-      <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
-        <p className="font-semibold">{copy.darkTitle}</p>
-        <p className="mt-1">{copy.darkBody}</p>
+      <div
+        className={`mt-4 rounded-md border p-3 text-sm ${
+          currentPack
+            ? 'border-emerald-200 bg-emerald-50 text-emerald-950'
+            : 'border-amber-200 bg-amber-50 text-amber-950'
+        }`}
+      >
+        <p className="font-semibold">{currentPack ? copy.signedTitle : copy.darkTitle}</p>
+        <p className="mt-1">{currentPack ? copy.signedBody : copy.darkBody}</p>
         <p className="mt-2 text-xs font-semibold">Signed packs: {packs.length}</p>
       </div>
     </HelpNowPanel>

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 54993126,
-  "maxTrackedFiles": 4769,
+  "maxTrackedBytes": 55329809,
+  "maxTrackedFiles": 4824,
   "maxCategoryBytes": {
     "other": 18854810,
-    "large support/generated-ish": 16077049,
-    "source/scripts": 7152638,
-    "docs/text": 6239509,
-    "tests/e2e": 5106882,
-    "config/data/messages": 1562238
+    "large support/generated-ish": 16081043,
+    "source/scripts": 7154088,
+    "docs/text": 6568158,
+    "tests/e2e": 5109299,
+    "config/data/messages": 1562411
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary

Implements the MOB-01b runtime slice promoted by MOB-DG01B: exposes only the accepted MK Help Now country pack through the existing MOB-01 dark-pack mechanism.

## Scope

- MK (`North Macedonia`) Help Now pack marked `public` with accepted L2 evidence reference.
- All other country packs remain dark.
- Trip Mode signed-state UI now uses `canExposeCountryPack` defensively.
- Public manifest stays aligned with TS metadata.
- Public Help Now E2E proves MK exposure without auth redirects, protected route/API requests, or emergency-number display.

Out of scope and untouched: proxy, routing, auth/session, tenancy, schema/RLS, billing, member account creation, member surfaces, KS/AL exposure, claim writers, docs tracker/current-program, README, AGENTS.

## Evidence

Passed:

- `node tools/brain-task.mjs "Interdomestik MOB-01b MK Help Now non-dark current tracker evidence gates" --project interdomestik --require-current`
- `pnpm --filter @interdomestik/web test:unit --run src/features/help-now/content-packs.test.ts src/features/help-now/help-now-experience.test.tsx src/features/help-now/trip-mode.test.tsx src/features/help-now/offline.test.ts src/features/help-now/sw-cache-guard.test.ts`
- `pnpm --dir apps/web exec playwright test e2e/gate/help-now-public.spec.ts --project=gate-mk-mk`
- `pnpm slice:static`
- `git diff --check`
- `pnpm repo:size:check`
- `pnpm check:modularity-guard`
- `interdomestik_qa.scope_audit` passed with no forbidden paths changed
- Senior review pass: Sonnet post-remediation reported no blocker findings

Partial / known unrelated blocker:

- `pnpm slice:verify` passed static/security/web unit, then failed in `@interdomestik/database test:unit` on `packages/database/test/deferred-backfills.test.ts` expecting `uniqueIndex('idx_claims_tenant_number')` in a re-export file. This branch does not touch `packages/**`; classified as outside-scope gate drift.

## Safety notes

- No emergency numbers (`112`/`192`) are displayed by this slice.
- No new upload endpoint, API route, auth surface, billing behavior, or claim/case mutation is introduced.
- `packHash` currently stores the accepted evidence-center reference used by current authority.
