### PR TITLE
fix(docker): fix MinIO bucket provisioning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,7 +240,7 @@ services:
       SLEEP_INTERVAL=2;
       ATTEMPT=1;
       while [ \"$$ATTEMPT\" -le \"$$MAX_ATTEMPTS\" ]; do
-        if /usr/bin/mc config host add myminio http://minio:9000 minioadmin minioadmin >/dev/null 2>&1; then
+        if /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin >/dev/null 2>&1; then
           break;
         fi;
         echo \"Waiting for MinIO to accept connections... (attempt $$ATTEMPT/$$MAX_ATTEMPTS)\";

--- a/scripts/docker-workflow.test.mjs
+++ b/scripts/docker-workflow.test.mjs
@@ -273,10 +273,7 @@ test('createbuckets waits for MinIO readiness before creating the claim-evidence
       'ERROR: Timed out waiting for MinIO to accept connections after $$MAX_ATTEMPTS attempts (about $$((MAX_ATTEMPTS * SLEEP_INTERVAL)) seconds).'
     )
   );
-  assert.match(
-    compose,
-    /\/usr\/bin\/mc mb -p myminio\/claim-evidence >\/dev\/null 2>&1 \|\| true;/
-  );
+  assert.match(compose, /\/usr\/bin\/mc mb -p myminio\/claim-evidence >\/dev\/null 2>&1 \|\| true;/);
   assert.match(compose, /\/usr\/bin\/mc anonymous set public myminio\/claim-evidence >/);
 });
 

--- a/scripts/docker-workflow.test.mjs
+++ b/scripts/docker-workflow.test.mjs
@@ -258,6 +258,8 @@ test('createbuckets waits for MinIO readiness before creating the claim-evidence
   const compose = readRepoFile('docker-compose.yml');
 
   assert.match(compose, /createbuckets:[\s\S]*profiles: \['infra', 'gate'\]/);
+  assert.match(compose, /\/usr\/bin\/mc alias set myminio http:\/\/minio:9000 minioadmin minioadmin/);
+  assert.doesNotMatch(compose, /\/usr\/bin\/mc config host add/);
   assert.ok(compose.includes('MAX_ATTEMPTS=30;'));
   assert.ok(compose.includes('ATTEMPT=1;'));
   assert.ok(compose.includes(String.raw`while [ \"$$ATTEMPT\" -le \"$$MAX_ATTEMPTS\" ]; do`));


### PR DESCRIPTION
## Summary
- Replace removed `mc config host add` usage with current `mc alias set` in the MinIO bucket provisioning command.
- Add regression assertions so the Docker workflow test requires `mc alias set` and rejects the removed command.

## Scope
- Docker/MinIO local infra only.
- No runtime app behavior, auth, routing, proxy, schema, RLS, billing, CRM, Help Now, Brain, generated Wiki, or product tracker changes.
- Excludes local untracked `docs/product/2026-07-08-memo1-finance-cap-evidence-addendum.md`.

## Verification
- `docker compose --profile infra config --quiet`
- `docker compose --profile gate config --quiet`
- `docker compose --profile ci-local config --quiet`
- `docker compose --profile sonar config --quiet`
- `node --test scripts/docker-workflow.test.mjs scripts/ci/docker-lowdisk-workflow.test.mjs`
- `pnpm docker:infra:up`
- `pnpm docker:infra:down`

## Reviewer / Risk Disposition
- Classified as verification-infrastructure scope only because this touches compose provisioning and Docker workflow tests.
- Senior reviewer: skipped; small infra compatibility fix with focused evidence and no product runtime surface.
- Codex Security scan: not applicable; no app runtime, auth, tenancy, schema, secret, or dependency change.

## Residual Risk
- Current evidence covers local Docker compose syntax, Docker workflow regression tests, and local MinIO bucket provisioning.
- Full CI remains authoritative for branch acceptance.
