### PR TITLE
docs: add MOB-03a authority evidence packet

### DIFF
--- a/docs/plans/2026-07-09-mob-03a-promotion-blocker-packet.md
+++ b/docs/plans/2026-07-09-mob-03a-promotion-blocker-packet.md
@@ -1,0 +1,77 @@
+---
+plan_role: input
+status: active
+source_of_truth: false
+owner: platform
+last_reviewed: 2026-07-09
+related:
+  - docs/plans/2026-07-09-mob-dg04-next-slice-current-authority.md
+  - docs/product/2026-07-09-mob-03a-authority-evidence-request.md
+  - docs/product/2026-07-09-mob-03a-authority-evidence-request-part-a.md
+  - docs/product/2026-07-09-mob-03a-authority-evidence-request-part-b.md
+  - docs/product/2026-07-03-mobile-program-authority-packet-part-2.md
+  - docs/reviews/2026-07-05-enterprise-transformation-register.md
+---
+
+# MOB-03a Promotion Blocker Packet
+
+> Status: blocker packet after `MOB-DG04`. This document does not promote
+> runtime work.
+
+## Verdict
+
+`MOB-03a` is the nearest next candidate, but it is not ready to promote.
+
+Reason: the latest reviewer portal corrections confirm the requirements for
+the next gate, but they do not provide the repo-safe authority facts required to
+authorize implementation.
+
+Expected resolver state remains:
+
+```text
+status: blocked_requires_current_authority
+activeSlice: null
+```
+
+## Candidate
+
+`MOB-03a` - non-medical, car/property-only Vault + Consent display foundation.
+
+This is narrower than the `MOB-03` umbrella and excludes medical/injury data
+unless a signed/accepted DPIA / Art. 9 authority later exists.
+
+## Evidence Table
+
+| Requirement                  | Status  | Current evidence                                                                                                                                           | Blocker                                                                                                                      |
+| ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Exactly one candidate        | Partial | `MOB-DG04` identifies `MOB-03a` as nearest candidate.                                                                                                      | Candidate is not promotable until entry evidence is complete.                                                                |
+| Privacy/legal owner          | Missing | Reviewer item `M03-DPIA-OWNER` says not to accept without owner name, role, date, and evidence reference.                                                  | No repo-safe privacy/legal owner fact is recorded.                                                                           |
+| Medical/injury boundary      | Partial | Reviewer item `M03-NO-MEDICAL-FALLBACK` allows car/property-only planning; `M03-ART9-SCOPE` blocks medical/injury without DPIA.                            | Need explicit signed decision that `MOB-03a` excludes medical/injury, or signed/accepted DPIA / Art. 9 authority.            |
+| Consent-record fields        | Partial | Reviewer item `M03-CONSENT-RECORD` lists minimum fields.                                                                                                   | Need accepted repo-safe authority for those fields and confirmation it is not migration/runtime authority.                   |
+| Access roles                 | Partial | Reviewer item `M03-ACCESS-ROLES` limits access to member and authorized internal case-scoped roles.                                                        | Need consolidated access boundary proof for the future display surface.                                                      |
+| Document boundary            | Partial | Reviewer item `M03-DOCUMENT-BOUNDARY` forbids raw IDs, private legal docs, medical docs, payment data, and staff-private notes without separate authority. | Need exact allowed display data for `MOB-03a`.                                                                               |
+| Threat recheck               | Missing | Reviewer item `M03-THREAT-RECHECK` requires recheck.                                                                                                       | Need evidence reference for document access, revocation, sponsor/payer visibility, erased rendering, and audit trail review. |
+| Erasure/revocation rendering | Missing | Reviewer item `M03-ERASURE-AUDIT` requires skeleton-preserving, subject-hiding proof.                                                                      | Need proof rule accepted for the future display surface.                                                                     |
+| Exact scope / exclusions     | Partial | `MOB-DG04` records high-level exclusions.                                                                                                                  | Need accepted `MOB-03a` exact scope and stop conditions before promotion.                                                    |
+
+## Required Next Action
+
+Complete `docs/product/2026-07-09-mob-03a-authority-evidence-request.md`
+and both linked Part A / Part B forms.
+
+After it is complete, draft a new `MOB-DG04b` authority/design-gate PR. That PR
+may promote exactly one slice only if every blocker above is closed with
+repo-safe evidence.
+
+## Non-Goals
+
+This blocker packet does not authorize:
+
+- full `MOB-03`;
+- medical or injury data;
+- claim writers, status mutation, or outbox writes;
+- Agreement Ceremony, ProposalCard approval, POA/e-sign runtime, or billing;
+- schema/RLS/migrations;
+- auth, proxy, routing, session, or tenancy changes;
+- sponsor, payer, partner, KS, or AL exposure;
+- generated Wiki, Brain tooling, README, AGENTS, or architecture docs.

--- a/docs/product/2026-07-09-mob-03a-authority-evidence-request-part-a.md
+++ b/docs/product/2026-07-09-mob-03a-authority-evidence-request-part-a.md
@@ -1,0 +1,117 @@
+---
+plan_role: input
+status: draft
+source_of_truth: false
+owner: product
+last_reviewed: 2026-07-09
+related:
+  - docs/product/2026-07-09-mob-03a-authority-evidence-request.md
+---
+
+# MOB-03a Evidence Request Part A
+
+> Status: repo-safe review form. This document does not promote runtime work.
+
+## 1. Privacy / Legal Owner
+
+Kjo duhet te plotesohet nga personi qe mban pergjegjesine privacy/legal per
+scope-in `MOB-03a`.
+
+| Field              | Answer |
+| ------------------ | ------ |
+| Owner name         |        |
+| Owner role         |        |
+| Decision date      |        |
+| Evidence reference |        |
+| Reviewer name      |        |
+| Reviewer role      |        |
+
+Decision:
+
+- [ ] Approve for `MOB-03a` non-medical planning only.
+- [ ] Request change.
+- [ ] Block.
+
+Reason / notes:
+
+```text
+
+```
+
+## 2. Medical / Injury Boundary
+
+Recommended decision: approve only the non-medical boundary now. Medical and
+injury data should stay disabled until a signed/accepted DPIA / Art. 9 authority
+exists.
+
+| Field                                         | Answer                                               |
+| --------------------------------------------- | ---------------------------------------------------- |
+| Is medical/injury data allowed in this slice? | No                                                   |
+| If yes, DPIA / Art. 9 evidence reference      |                                                      |
+| If no, disabled-scope statement               | Medical and injury data are excluded from `MOB-03a`. |
+| Decision date                                 |                                                      |
+| Reviewer                                      |                                                      |
+
+Decision:
+
+- [ ] Approve non-medical boundary.
+- [ ] Request change.
+- [ ] Block.
+
+Reason / notes:
+
+```text
+
+```
+
+## 3. Consent Record Fields
+
+Recommended decision: accept these fields as the minimum authority requirement,
+but do not treat this as migration/runtime authority.
+
+Required fields: `consentType`, `subject`, `scope`, `grantedBy`, `grantedAt`,
+`revokedAt`, `evidenceRef`, `retentionOrErasureRule`, `reviewer`.
+
+Decision:
+
+- [ ] Approve as `MOB-03a` evidence requirement only.
+- [ ] Request change.
+- [ ] Block.
+
+Additional required fields or exclusions:
+
+```text
+
+```
+
+Reason / notes:
+
+```text
+
+```
+
+## 4. Access Roles
+
+Recommended decision: allow member and authorized internal roles by case scope
+only. Sponsor, payer, partner, and external parties must have no document
+visibility without explicit consent authority.
+
+| Role                     | Allowed for `MOB-03a`? | Notes                                |
+| ------------------------ | ---------------------- | ------------------------------------ |
+| Member                   | Yes                    | Own case only.                       |
+| Authorized internal role | Yes                    | Case-scoped only.                    |
+| Sponsor                  | No by default          | Requires separate consent authority. |
+| Payer                    | No by default          | Requires separate consent authority. |
+| Partner / external party | No by default          | Requires separate consent authority. |
+
+Decision:
+
+- [ ] Approve.
+- [ ] Request change.
+- [ ] Block.
+
+Reason / notes:
+
+```text
+
+```

--- a/docs/product/2026-07-09-mob-03a-authority-evidence-request-part-b.md
+++ b/docs/product/2026-07-09-mob-03a-authority-evidence-request-part-b.md
@@ -1,0 +1,128 @@
+---
+plan_role: input
+status: draft
+source_of_truth: false
+owner: product
+last_reviewed: 2026-07-09
+related:
+  - docs/product/2026-07-09-mob-03a-authority-evidence-request.md
+---
+
+# MOB-03a Evidence Request Part B
+
+> Status: repo-safe review form. This document does not promote runtime work.
+
+## 5. Document Boundary
+
+Recommended decision: `MOB-03a` may display only safe document-state metadata
+needed for a non-medical vault/consent foundation. It must not display raw IDs,
+private legal documents, medical documents, payment data, staff-private notes,
+or document links without separate authority.
+
+Decision:
+
+- [ ] Approve the boundary.
+- [ ] Request change.
+- [ ] Block.
+
+Explicitly allowed display data:
+
+```text
+
+```
+
+Explicitly forbidden display data:
+
+```text
+Raw IDs; private legal docs; medical docs; payment data; staff-private notes;
+document links without separate authority.
+```
+
+Reason / notes:
+
+```text
+
+```
+
+## 6. Threat Recheck
+
+Recommended decision: require a targeted threat recheck before promotion, even
+for non-medical scope, because this is member-facing document/consent behavior.
+
+Threat areas: document access; consent revocation; sponsor/payer visibility;
+erased-subject rendering; audit trail.
+
+Decision:
+
+- [ ] Approve with threat recheck required before runtime PR.
+- [ ] Request change.
+- [ ] Block.
+
+Threat recheck evidence reference:
+
+```text
+
+```
+
+Reason / notes:
+
+```text
+
+```
+
+## 7. Erasure / Revocation Rendering
+
+Recommended decision: preserve useful skeleton/context, but hide subject data
+and document links when consent is revoked or the subject is erased.
+
+Decision:
+
+- [ ] Approve.
+- [ ] Request change.
+- [ ] Block.
+
+Required rendering rule:
+
+```text
+Keep non-sensitive skeleton context. Hide subject data and document links for
+revoked/erased subjects.
+```
+
+Reason / notes:
+
+```text
+
+```
+
+## 8. Exact Runtime Scope And Stop Conditions
+
+Recommended decision: if promoted later, `MOB-03a` should be display foundation
+only. Stop if implementation needs any excluded protected surface.
+
+Allowed scope:
+
+```text
+Non-medical, car/property-only Vault + Consent display foundation.
+```
+
+Forbidden scope:
+
+```text
+Full MOB-03; medical/injury data; claim writers; status mutation; outbox writes;
+Agreement Ceremony; ProposalCard approval; POA/e-sign runtime; schema/RLS/
+migrations; auth/proxy/routing/session/tenancy; billing/payment/Paddle; sponsor/
+payer/partner document sharing; KS/AL exposure; generated Wiki; Brain tooling;
+README; AGENTS; architecture docs.
+```
+
+Decision:
+
+- [ ] Approve exact scope and stop conditions.
+- [ ] Request change.
+- [ ] Block.
+
+Reason / notes:
+
+```text
+
+```

--- a/docs/product/2026-07-09-mob-03a-authority-evidence-request.md
+++ b/docs/product/2026-07-09-mob-03a-authority-evidence-request.md
@@ -1,0 +1,41 @@
+---
+plan_role: input
+status: draft
+source_of_truth: false
+owner: product
+last_reviewed: 2026-07-09
+related:
+  - docs/plans/2026-07-09-mob-dg04-next-slice-current-authority.md
+  - docs/product/2026-07-03-mobile-program-authority-packet-part-2.md
+  - docs/product/2026-07-03-mobile-legal-compliance-input-templates.md
+---
+
+# MOB-03a Authority Evidence Request
+
+> Status: repo-safe evidence request for a possible future `MOB-DG04b`
+> promotion. This document does not promote runtime work.
+
+## Candidate
+
+`MOB-03a` - non-medical, car/property-only Vault + Consent display foundation.
+
+This candidate is intentionally narrower than the `MOB-03` umbrella. It must
+not include medical/injury data, claim writers, Agreement Ceremony, POA/e-sign
+runtime, billing, schema/RLS/migrations, auth/proxy/routing/session/tenancy, or
+sponsor/payer/partner document sharing.
+
+## Review Packet
+
+Complete both repo-safe forms before drafting any `MOB-DG04b`
+current-authority/design-gate PR:
+
+- [Part A - owner, medical boundary, consent, access](2026-07-09-mob-03a-authority-evidence-request-part-a.md)
+- [Part B - document boundary, threat recheck, erasure, scope](2026-07-09-mob-03a-authority-evidence-request-part-b.md)
+
+## Completion Rule
+
+This request is complete only when every section in Part A and Part B has a
+reviewer decision, date, named owner/reviewer where applicable, and evidence
+reference. After completion, a separate `MOB-DG04b`
+current-authority/design-gate PR may decide whether exactly one implementation
+slice is promoted.


### PR DESCRIPTION
## Summary
- add a repo-safe MOB-03a authority evidence request for Arben/Gazmend/legal/privacy completion
- add a blocker packet explaining why MOB-03a is not promotable yet
- keep runtime unauthorized and avoid current-program/current-tracker promotion changes

## Verdict
MOB-03a is the nearest next candidate, but it is not ready to promote. The missing evidence is factual authority, not reviewer correction status.

## Verification
- git diff --check
- pnpm docs:verify
- pnpm plan:audit
- pnpm track:audit

## Scope
Docs/evidence only. No app source, runtime code, current-program/current-tracker promotion, schema/RLS/migrations, auth/proxy/routing/session/tenancy, billing/payment, claim writers, Agreement Ceremony writers, Brain tooling, generated Wiki, README, AGENTS, or architecture docs touched.