### PR TITLE
fix: remove Albanian intake jargon

### DIFF
--- a/apps/web/src/app/[locale]/components/home/injury-journey-test-messages.ts
+++ b/apps/web/src/app/[locale]/components/home/injury-journey-test-messages.ts
@@ -52,7 +52,8 @@ export const injuryJourneyTestMessages = {
       },
       diasporaTitle: 'Incidenti ndodhi jashtë vendit ku banoni?',
       diasporaBody: 'I mbajmë dy vendet të ndara pa dhënë përfundim ligjor.',
-      handoff: 'Tani fillon intake-i. Ju zgjidhni çfarë të dërgoni.',
+      handoff:
+        'Tani vazhdoni me organizimin e të dhënave të rastit në Free Start. Ju vendosni çfarë të dërgoni.',
       continue: 'Organizo të dhënat e rastit tim',
     },
   },

--- a/apps/web/src/app/[locale]/components/home/injury-safety-journey.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/injury-safety-journey.test.tsx
@@ -59,7 +59,7 @@ describe('InjurySafetyJourney', () => {
     expect(screen.getByLabelText('Shteti i vendbanimit të zakonshëm')).toHaveValue('');
   });
 
-  it('shows a useful free result before the explicit intake handoff', () => {
+  it('shows a useful free result before the explicit organizer handoff', () => {
     const onContinue = vi.fn();
     render(<InjurySafetyJourney onContinue={onContinue} />);
     reachEvidence();
@@ -67,7 +67,9 @@ describe('InjurySafetyJourney', () => {
     expect(
       screen.getByRole('heading', { name: 'Ruani faktet që mund t’ju duhen.' })
     ).toBeInTheDocument();
-    expect(screen.getByText(/Tani fillon intake-i/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Tani vazhdoni me organizimin e të dhënave të rastit/i)
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Organizo të dhënat e rastit tim' }));
     expect(onContinue).toHaveBeenCalledOnce();
   });

--- a/apps/web/src/app/[locale]/components/home/property-journey-test-messages.ts
+++ b/apps/web/src/app/[locale]/components/home/property-journey-test-messages.ts
@@ -80,7 +80,8 @@ export const propertyJourneyTestMessages = {
       diasporaTitle: 'Prona ndodhet jashtë vendit ku banoni?',
       diasporaBody:
         'Rregullat e vendit, policës dhe kontratës kërkojnë shqyrtim të veçantë; nuk supozojmë pse vendet ndryshojnë.',
-      handoff: 'Tani fillon intake-i i ri Free Start. Asnjë përgjigje nga ky orientim nuk bartet.',
+      handoff:
+        'Tani vazhdoni me organizimin e të dhënave të dëmit në Free Start. Asnjë përgjigje nuk kalon automatikisht.',
       continue: 'Organizo të dhënat e dëmit tim',
     },
   },

--- a/apps/web/src/app/[locale]/components/home/property-safety-journey.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/property-safety-journey.test.tsx
@@ -54,6 +54,9 @@ describe('PropertySafetyJourney', () => {
       screen.getByRole('heading', { name: 'Mbroni njerëzit dhe ruani faktet e dëmit.' })
     ).toBeInTheDocument();
     expect(screen.getByText(/Rregullat e vendit, policës dhe kontratës/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Tani vazhdoni me organizimin e të dhënave të dëmit/i)
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Organizo të dhënat e dëmit tim' }));
     expect(onContinue).toHaveBeenCalledOnce();
   });

--- a/apps/web/src/messages/free-start-premium-contract.test.ts
+++ b/apps/web/src/messages/free-start-premium-contract.test.ts
@@ -52,7 +52,7 @@ describe('premium Free Start copy contract', () => {
     const publicCopy = [
       ...collectCopyValues(sq.freeStart),
       ...collectCopyValues(sqInjuryJourney.injuryJourney.evidence),
-      ...collectCopyValues(sqPropertyJourney.propertyJourney.result),
+      ...collectCopyValues(sqPropertyJourney.propertyJourney.evidence),
     ].join(' ');
 
     expect(publicCopy).not.toMatch(/intake/i);

--- a/apps/web/src/messages/free-start-premium-contract.test.ts
+++ b/apps/web/src/messages/free-start-premium-contract.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import en from './en/freeStart.json';
 import mk from './mk/freeStart.json';
 import sq from './sq/freeStart.json';
+import sqInjuryJourney from './sq/injuryJourney.json';
+import sqPropertyJourney from './sq/propertyJourney.json';
 import sr from './sr/freeStart.json';
 
 const localeMessages = { en, mk, sq, sr } as const;
@@ -46,8 +48,12 @@ describe('premium Free Start copy contract', () => {
     }
   );
 
-  it('keeps internal intake jargon out of the Albanian public journey', () => {
-    const publicCopy = collectCopyValues(sq.freeStart).join(' ');
+  it('keeps internal intake jargon out of Albanian public organizer handoffs', () => {
+    const publicCopy = [
+      ...collectCopyValues(sq.freeStart),
+      ...collectCopyValues(sqInjuryJourney.injuryJourney.evidence),
+      ...collectCopyValues(sqPropertyJourney.propertyJourney.result),
+    ].join(' ');
 
     expect(publicCopy).not.toMatch(/intake/i);
   });

--- a/apps/web/src/messages/sq/injuryJourney.json
+++ b/apps/web/src/messages/sq/injuryJourney.json
@@ -70,7 +70,7 @@
       },
       "diasporaTitle": "Incidenti ndodhi jashtë vendit ku banoni?",
       "diasporaBody": "Vendi i incidentit dhe vendbanimi mbeten të ndara që konteksti ndërkufitar të jetë i qartë, pa dhënë përfundim ligjor.",
-      "handoff": "Tani fillon intake-i ekzistues Free Start. Asnjë përgjigje nga ky orientim nuk bartet; ju zgjidhni çfarë të dërgoni.",
+      "handoff": "Tani vazhdoni me organizimin e të dhënave të rastit në Free Start. Asnjë përgjigje nga ky orientim nuk kalon automatikisht; ju vendosni çfarë të dërgoni.",
       "continue": "Organizo të dhënat e rastit tim"
     }
   }

--- a/apps/web/src/messages/sq/propertyJourney.json
+++ b/apps/web/src/messages/sq/propertyJourney.json
@@ -89,7 +89,7 @@
       },
       "diasporaTitle": "Prona ndodhet jashtë vendit ku banoni?",
       "diasporaBody": "Rregullat e vendit, policës dhe kontratës kërkojnë shqyrtim të veçantë. Nuk supozojmë pse vendet ndryshojnë dhe nuk nxjerrim përfundim ligjor.",
-      "handoff": "Tani fillon një intake i ri Free Start. Asnjë përgjigje nga ky orientim nuk bartet; ju zgjidhni çfarë të dërgoni.",
+      "handoff": "Tani vazhdoni me organizimin e të dhënave të dëmit në Free Start. Asnjë përgjigje nga ky orientim nuk kalon automatikisht; ju vendosni çfarë të dërgoni.",
       "continue": "Organizo të dhënat e dëmit tim"
     }
   }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 57132073,
+  "maxTrackedBytes": 57132699,
   "maxTrackedFiles": 5369,
   "maxCategoryBytes": {
     "other": 18855992,
     "large support/generated-ish": 16143420,
-    "source/scripts": 7611598,
+    "source/scripts": 7611693,
     "docs/text": 7215578,
-    "tests/e2e": 5617806,
-    "config/data/messages": 1687679
+    "tests/e2e": 5618253,
+    "config/data/messages": 1687763
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 57132699,
+  "maxTrackedBytes": 57132701,
   "maxTrackedFiles": 5369,
   "maxCategoryBytes": {
     "other": 18855992,
     "large support/generated-ish": 16143420,
     "source/scripts": 7611693,
     "docs/text": 7215578,
-    "tests/e2e": 5618253,
+    "tests/e2e": 5618255,
     "config/data/messages": 1687763
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Outcome
- replaces user-facing Albanian intake terminology in the injury and property handoffs with plain-language case/damage organization
- clarifies that orientation answers do not transfer automatically
- adds regression coverage across the public organizer handoffs

## Authority
This is a bounded wording correction within the sole active IDA-UI02a journey-to-organizer handoff. It changes no workflow, field, route, data contract, persistence, auth, tenancy, billing, deployment, or protected surface.

## Verification
- focused unit/translation proof: 20/20
- final current-head pnpm pr:verify passed: 593 files; 2,951 passed / 1 skipped; 84.84% repository line coverage; PR E2E 200 passed / 8 skipped; smoke 13 passed / 9 skipped
- final current-head pnpm security:guard passed
- independent pnpm e2e:gate passed on the correction tree: 200 passed / 8 skipped
- required current-head CI and review signals must be green before merge

No Vercel deployment or production alias change is authorized.