### PR TITLE
feat: bootstrap trusted PR gate policy

### DIFF
--- a/.github/actions/pr-gate-policy/action.yml
+++ b/.github/actions/pr-gate-policy/action.yml
@@ -1,0 +1,128 @@
+name: Evaluate PR gate policy
+description: Resolve draft-aware and validation-surface decisions without starting heavy jobs.
+
+inputs:
+  event-name:
+    description: GitHub event name.
+    required: true
+  event-path:
+    description: Path to the GitHub event payload.
+    required: true
+  dispatch-base-ref:
+    description: Optional base ref used to classify workflow_dispatch changes.
+    required: false
+    default: ''
+
+outputs:
+  should_run:
+    value: ${{ steps.effective.outputs.should_run }}
+  reason:
+    value: ${{ steps.effective.outputs.reason }}
+  non_product_only_paths:
+    value: ${{ steps.validation.outputs.non_product_only_paths }}
+  run_full:
+    value: ${{ steps.policy.outputs.run_full }}
+  force_full:
+    value: ${{ steps.policy.outputs.force_full }}
+  high_risk_paths:
+    value: ${{ steps.policy.outputs.high_risk_paths }}
+  ai_eval_should_run:
+    value: ${{ steps.ai-eval.outputs.should_run }}
+  ai_eval_reason:
+    value: ${{ steps.ai-eval.outputs.reason }}
+  ai_eval_matched_paths:
+    value: ${{ steps.ai-eval.outputs.matched_paths }}
+
+runs:
+  using: composite
+  steps:
+    - name: Collect changed files
+      id: changed-files
+      env:
+        GH_TOKEN: ${{ github.token }}
+        INPUT_DISPATCH_BASE_REF: ${{ inputs.dispatch-base-ref }}
+        INPUT_EVENT_NAME: ${{ inputs.event-name }}
+        INPUT_EVENT_PATH: ${{ inputs.event-path }}
+        POLICY_ROOT: ${{ github.action_path }}/../../..
+      shell: bash
+      run: |
+        set -u
+        changed_files_path="${RUNNER_TEMP}/pr-gate-${GITHUB_RUN_ID}-${GITHUB_JOB}.txt"
+        : >"${changed_files_path}"
+        if [[ "${INPUT_EVENT_NAME}" == "pull_request" ]]; then
+          if ! node "${POLICY_ROOT}/scripts/ci/github-pr-files.mjs" \
+            --event-path "${INPUT_EVENT_PATH}" >"${changed_files_path}"; then
+            echo "::warning::Changed-file lookup failed; policy will fail full."
+            : >"${changed_files_path}"
+          fi
+        elif [[ "${INPUT_EVENT_NAME}" == "workflow_dispatch" && -n "${INPUT_DISPATCH_BASE_REF}" ]]; then
+          git fetch --no-tags origin "${INPUT_DISPATCH_BASE_REF}" --depth=1
+          git diff --name-only "origin/${INPUT_DISPATCH_BASE_REF}"...HEAD >"${changed_files_path}"
+        fi
+        echo "path=${changed_files_path}" >>"$GITHUB_OUTPUT"
+
+    - name: Evaluate validation surface
+      id: validation
+      env:
+        CHANGED_FILES_PATH: ${{ steps.changed-files.outputs.path }}
+        INPUT_EVENT_NAME: ${{ inputs.event-name }}
+        INPUT_EVENT_PATH: ${{ inputs.event-path }}
+        POLICY_ROOT: ${{ github.action_path }}/../../..
+      shell: bash
+      run: |
+        node "${POLICY_ROOT}/scripts/ci/validation-surface-policy.mjs" \
+          --event-name "${INPUT_EVENT_NAME}" \
+          --event-path "${INPUT_EVENT_PATH}" \
+          --changed-files-path "${CHANGED_FILES_PATH}" >>"$GITHUB_OUTPUT"
+
+    - name: Evaluate draft policy
+      id: policy
+      env:
+        CHANGED_FILES_PATH: ${{ steps.changed-files.outputs.path }}
+        INPUT_EVENT_NAME: ${{ inputs.event-name }}
+        INPUT_EVENT_PATH: ${{ inputs.event-path }}
+        POLICY_ROOT: ${{ github.action_path }}/../../..
+        PR_GATE_CHANGED_FILE_COUNT: ${{ steps.changed-files.outputs.changed_file_count }}
+      shell: bash
+      run: |
+        node "${POLICY_ROOT}/scripts/ci/pr-gate-policy.mjs" \
+          --event-name "${INPUT_EVENT_NAME}" \
+          --event-path "${INPUT_EVENT_PATH}" \
+          --changed-files-path "${CHANGED_FILES_PATH}" >>"$GITHUB_OUTPUT"
+
+    - name: Resolve effective validation surface
+      id: effective
+      env:
+        INPUT_EVENT_NAME: ${{ inputs.event-name }}
+        POLICY_FORCE_FULL: ${{ steps.policy.outputs.force_full }}
+        POLICY_REASON: ${{ steps.policy.outputs.reason }}
+        POLICY_RUN_FULL: ${{ steps.policy.outputs.run_full }}
+        VALIDATION_REASON: ${{ steps.validation.outputs.reason }}
+        VALIDATION_SHOULD_RUN: ${{ steps.validation.outputs.should_run }}
+      shell: bash
+      run: |
+        if [[ "${INPUT_EVENT_NAME}" != "pull_request" ]]; then
+          echo "should_run=true" >>"$GITHUB_OUTPUT"
+          echo "reason=${POLICY_REASON}" >>"$GITHUB_OUTPUT"
+        elif [[ "${POLICY_RUN_FULL}" != "true" ]]; then
+          echo "should_run=false" >>"$GITHUB_OUTPUT"
+          echo "reason=${POLICY_REASON}" >>"$GITHUB_OUTPUT"
+        elif [[ "${POLICY_FORCE_FULL}" == "true" ]]; then
+          echo "should_run=true" >>"$GITHUB_OUTPUT"
+          echo "reason=${POLICY_REASON}" >>"$GITHUB_OUTPUT"
+        else
+          echo "should_run=${VALIDATION_SHOULD_RUN}" >>"$GITHUB_OUTPUT"
+          echo "reason=${VALIDATION_REASON}" >>"$GITHUB_OUTPUT"
+        fi
+
+    - name: Evaluate AI eval surface
+      id: ai-eval
+      env:
+        CHANGED_FILES_PATH: ${{ steps.changed-files.outputs.path }}
+        INPUT_EVENT_NAME: ${{ inputs.event-name }}
+        POLICY_ROOT: ${{ github.action_path }}/../../..
+      shell: bash
+      run: |
+        node "${POLICY_ROOT}/scripts/ci/ai-eval-surface.mjs" \
+          --event-name "${INPUT_EVENT_NAME}" \
+          --changed-files-path "${CHANGED_FILES_PATH}" >>"$GITHUB_OUTPUT"

--- a/.github/actions/pr-gate-policy/action.yml
+++ b/.github/actions/pr-gate-policy/action.yml
@@ -46,7 +46,7 @@ runs:
         POLICY_ROOT: ${{ github.action_path }}/../../..
       shell: bash
       run: |
-        set -u
+        set -euo pipefail
         changed_files_path="${RUNNER_TEMP}/pr-gate-${GITHUB_RUN_ID}-${GITHUB_JOB}.txt"
         : >"${changed_files_path}"
         if [[ "${INPUT_EVENT_NAME}" == "pull_request" ]]; then
@@ -56,8 +56,11 @@ runs:
             : >"${changed_files_path}"
           fi
         elif [[ "${INPUT_EVENT_NAME}" == "workflow_dispatch" && -n "${INPUT_DISPATCH_BASE_REF}" ]]; then
-          git fetch --no-tags origin "${INPUT_DISPATCH_BASE_REF}" --depth=1
-          git diff --name-only "origin/${INPUT_DISPATCH_BASE_REF}"...HEAD >"${changed_files_path}"
+          if ! git fetch --no-tags origin "${INPUT_DISPATCH_BASE_REF}" --depth=1 ||
+            ! git diff --name-only "origin/${INPUT_DISPATCH_BASE_REF}"...HEAD >"${changed_files_path}"; then
+            echo "::warning::Dispatch changed-file lookup failed; policy will fail full."
+            : >"${changed_files_path}"
+          fi
         fi
         echo "path=${changed_files_path}" >>"$GITHUB_OUTPUT"
 

--- a/scripts/ci/github-pr-files-lib.mjs
+++ b/scripts/ci/github-pr-files-lib.mjs
@@ -58,6 +58,7 @@ export async function fetchPullRequestFiles({
     throw new TypeError('fetch implementation is required');
   }
   const files = [];
+  let fileCount = 0;
   for (let nextPage = 1; ; nextPage += 1) {
     const requestUrl = buildPullRequestFilesUrl({
       repositoryFullName,
@@ -81,14 +82,19 @@ export async function fetchPullRequestFiles({
     }
 
     const page = await response.json();
-    files.push(...page.map(file => String(file?.filename || '').trim()).filter(Boolean));
+    fileCount += page.length;
+    for (const file of page) {
+      const paths = [file?.filename];
+      if (file?.status === 'renamed') paths.push(file?.previous_filename);
+      files.push(...paths.map(value => String(value || '').trim()).filter(Boolean));
+    }
 
     if (page.length < PER_PAGE) {
       break;
     }
   }
 
-  return files;
+  return { files, fileCount };
 }
 
 export async function fetchRepositoryFileContent({

--- a/scripts/ci/github-pr-files.mjs
+++ b/scripts/ci/github-pr-files.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { appendFileSync } from 'node:fs';
+
 import { fetchPullRequestFiles, readPullRequestContext } from './github-pr-files-lib.mjs';
 
 function fail(message) {
@@ -54,11 +56,16 @@ if (!pullRequestContext) {
 }
 
 try {
-  const files = await fetchPullRequestFiles({
+  const evidence = await fetchPullRequestFiles({
     repositoryFullName: pullRequestContext.repositoryFullName,
     pullRequestNumber: pullRequestContext.pullRequestNumber,
     token,
   });
+  const { files, fileCount } = evidence;
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `changed_file_count=${fileCount}\n`);
+  }
 
   if (files.length > 0) {
     process.stdout.write(`${files.join('\n')}\n`);

--- a/scripts/ci/github-pr-files.test.mjs
+++ b/scripts/ci/github-pr-files.test.mjs
@@ -66,7 +66,7 @@ test('fetchPullRequestFiles paginates GitHub PR files API results', async () => 
     };
   }
 
-  const files = await fetchPullRequestFiles({
+  const evidence = await fetchPullRequestFiles({
     repositoryFullName: 'interdomestik/interdomestik',
     pullRequestNumber: 235,
     token: 'test-token',
@@ -77,8 +77,36 @@ test('fetchPullRequestFiles paginates GitHub PR files API results', async () => 
   assert.match(requests[0].url, /page=1$/);
   assert.match(requests[1].url, /page=2$/);
   assert.equal(requests[0].options.headers.authorization, 'Bearer test-token');
-  assert.equal(files.length, 101);
-  assert.equal(files.at(-1), 'README.md');
+  assert.equal(evidence.fileCount, 101);
+  assert.equal(evidence.files.length, 101);
+  assert.equal(evidence.files.at(-1), 'README.md');
+});
+
+test('fetchPullRequestFiles includes the previous path for renamed files', async () => {
+  async function fetchImpl() {
+    return {
+      ok: true,
+      async json() {
+        return [
+          {
+            filename: 'docs/proxy.ts',
+            previous_filename: 'apps/web/src/proxy.ts',
+            status: 'renamed',
+          },
+        ];
+      },
+    };
+  }
+
+  const evidence = await fetchPullRequestFiles({
+    repositoryFullName: 'interdomestik/interdomestik',
+    pullRequestNumber: 235,
+    token: 'test-token',
+    fetchImpl,
+  });
+
+  assert.equal(evidence.fileCount, 1);
+  assert.deepEqual(evidence.files, ['docs/proxy.ts', 'apps/web/src/proxy.ts']);
 });
 
 test('CLI exits cleanly for non pull request events', () => {

--- a/scripts/ci/pr-gate-policy-cli.test.mjs
+++ b/scripts/ci/pr-gate-policy-cli.test.mjs
@@ -72,6 +72,18 @@ test('CLI counts renamed entries as one changed file', () => {
   const result = runCli({
     draft: true,
     changedFiles: ['docs/new-name.md', 'docs/old-name.md'],
+    expectedCount: 1,
+    actualCount: 1,
+  });
+  assert.equal(result.run_full, 'false');
+  assert.equal(result.force_full, 'false');
+  assert.equal(result.reason, 'ordinary-draft');
+});
+
+test('CLI does not let expanded rename paths hide incomplete evidence', () => {
+  const result = runCli({
+    draft: true,
+    changedFiles: ['docs/new-name.md', 'docs/old-name.md'],
     expectedCount: 2,
     actualCount: 1,
   });

--- a/scripts/ci/pr-gate-policy-cli.test.mjs
+++ b/scripts/ci/pr-gate-policy-cli.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+function runCli({
+  draft,
+  changedFiles,
+  expectedCount = changedFiles.length,
+  actualCount = changedFiles.length,
+  includeFile = true,
+}) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'pr-gate-policy-'));
+  const eventPath = path.join(directory, 'event.json');
+  const changedFilesPath = path.join(directory, 'changed-files.txt');
+  writeFileSync(
+    eventPath,
+    JSON.stringify({ pull_request: { draft, changed_files: expectedCount, labels: [] } })
+  );
+  if (includeFile) writeFileSync(changedFilesPath, `${changedFiles.join('\n')}\n`);
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      'scripts/ci/pr-gate-policy.mjs',
+      '--event-name',
+      'pull_request',
+      '--event-path',
+      eventPath,
+      '--changed-files-path',
+      changedFilesPath,
+    ],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, PR_GATE_CHANGED_FILE_COUNT: String(actualCount) },
+    }
+  );
+  rmSync(directory, { recursive: true, force: true });
+  assert.equal(result.status, 0, result.stderr);
+  return Object.fromEntries(
+    result.stdout
+      .trim()
+      .split('\n')
+      .map(line => line.split(/=(.*)/su).slice(0, 2))
+  );
+}
+
+test('CLI emits quick-lane GitHub outputs for an ordinary draft', () => {
+  assert.deepEqual(runCli({ draft: true, changedFiles: ['apps/web/src/components/card.tsx'] }), {
+    run_full: 'false',
+    force_full: 'false',
+    reason: 'ordinary-draft',
+    high_risk_paths: '[]',
+  });
+});
+
+test('CLI fails full when changed-file evidence is incomplete', () => {
+  const result = runCli({
+    draft: true,
+    changedFiles: [],
+    expectedCount: 1,
+    includeFile: false,
+  });
+  assert.equal(result.run_full, 'true');
+  assert.equal(result.force_full, 'true');
+  assert.equal(result.reason, 'changed-files-incomplete');
+});
+
+test('CLI counts renamed entries as one changed file', () => {
+  const result = runCli({
+    draft: true,
+    changedFiles: ['docs/new-name.md', 'docs/old-name.md'],
+    expectedCount: 2,
+    actualCount: 1,
+  });
+  assert.equal(result.run_full, 'true');
+  assert.equal(result.force_full, 'true');
+  assert.equal(result.reason, 'changed-files-incomplete');
+});

--- a/scripts/ci/pr-gate-policy-lib.mjs
+++ b/scripts/ci/pr-gate-policy-lib.mjs
@@ -1,0 +1,87 @@
+const HIGH_RISK_EXACT_PATHS = new Set([
+  'apps/web/src/proxy.ts',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'turbo.json',
+  'scripts/pr-finalizer.sh',
+  'scripts/pr-finalizer-lib.sh',
+]);
+
+const HIGH_RISK_PREFIXES = [
+  'apps/web/src/lib/auth/',
+  'apps/web/src/lib/proxy-',
+  'apps/web/src/server/auth/',
+  'apps/web/src/lib/tenant/',
+  'packages/shared-auth/',
+  'packages/database/',
+  'packages/domain-membership-billing/',
+  'supabase/',
+  '.github/workflows/',
+  '.github/actions/',
+  'scripts/ci/',
+  'scripts/release-gate/',
+  'scripts/release-',
+  'scripts/security/',
+  'scripts/security-',
+  'scripts/sonar-',
+  'scripts/paddle-',
+];
+
+const APP_SECURITY_OR_BILLING_PATH =
+  /(?:^|\/)(?:auth|tenant|paddle|billing|subscription)(?:[./-]|\/|$)/u;
+
+export function isHighRiskPath(changedPath) {
+  return (
+    HIGH_RISK_EXACT_PATHS.has(changedPath) ||
+    HIGH_RISK_PREFIXES.some(prefix => changedPath.startsWith(prefix)) ||
+    changedPath.endsWith('/package.json') ||
+    (changedPath.startsWith('apps/web/src/') && APP_SECURITY_OR_BILLING_PATH.test(changedPath))
+  );
+}
+
+export function evaluatePrGatePolicy(input) {
+  const {
+    eventName,
+    draft,
+    labels = [],
+    changedFiles = [],
+    changedFilesComplete = false,
+  } = input;
+
+  if (eventName !== 'pull_request') {
+    return fullDecision(false, `non-pull-request:${eventName || 'unknown'}`);
+  }
+
+  if (typeof draft !== 'boolean') {
+    return fullDecision(true, 'pull-request-state-missing');
+  }
+
+  if (labels.includes('full-gate')) {
+    return fullDecision(true, 'full-gate-label');
+  }
+
+  if (!changedFilesComplete) {
+    return fullDecision(true, 'changed-files-incomplete');
+  }
+
+  const highRiskPaths = changedFiles.filter(isHighRiskPath);
+  if (highRiskPaths.length > 0) {
+    return fullDecision(true, 'high-risk-change', highRiskPaths);
+  }
+
+  if (!draft) {
+    return fullDecision(false, 'pull-request-ready');
+  }
+
+  return {
+    runFull: false,
+    forceFull: false,
+    reason: 'ordinary-draft',
+    highRiskPaths: [],
+  };
+}
+
+function fullDecision(forceFull, reason, highRiskPaths = []) {
+  return { runFull: true, forceFull, reason, highRiskPaths };
+}

--- a/scripts/ci/pr-gate-policy.mjs
+++ b/scripts/ci/pr-gate-policy.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+
+import { evaluatePrGatePolicy } from './pr-gate-policy-lib.mjs';
+
+function valueFor(flag) {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function readJson(path) {
+  if (!path || !existsSync(path)) return {};
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function readChangedFiles(path) {
+  if (!path || !existsSync(path)) return { files: [], exists: false };
+  const files = readFileSync(path, 'utf8')
+    .split('\n')
+    .map(value => value.trim())
+    .filter(Boolean);
+  return { files, exists: true };
+}
+
+const event = readJson(valueFor('--event-path') || process.env.GITHUB_EVENT_PATH);
+const eventName = valueFor('--event-name') || process.env.GITHUB_EVENT_NAME || 'unknown';
+const changed = readChangedFiles(valueFor('--changed-files-path'));
+const expectedChangedFiles = event.pull_request?.changed_files;
+const actualChangedFilesText = process.env.PR_GATE_CHANGED_FILE_COUNT?.trim() || '';
+const actualChangedFiles = /^\d+$/u.test(actualChangedFilesText)
+  ? Number(actualChangedFilesText)
+  : Number.NaN;
+const changedFilesComplete =
+  eventName !== 'pull_request' ||
+  (changed.exists &&
+    Number.isInteger(expectedChangedFiles) &&
+    Number.isInteger(actualChangedFiles) &&
+    actualChangedFiles >= expectedChangedFiles);
+const labels = (event.pull_request?.labels || []).map(label => label.name).filter(Boolean);
+
+const decision = evaluatePrGatePolicy({
+  eventName,
+  action: event.action,
+  draft: event.pull_request?.draft,
+  labels,
+  changedFiles: changed.files,
+  changedFilesComplete,
+});
+
+process.stdout.write(`run_full=${decision.runFull}\n`);
+process.stdout.write(`force_full=${decision.forceFull}\n`);
+process.stdout.write(`reason=${decision.reason}\n`);
+process.stdout.write(`high_risk_paths=${JSON.stringify(decision.highRiskPaths)}\n`);

--- a/scripts/ci/pr-gate-policy.test.mjs
+++ b/scripts/ci/pr-gate-policy.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { evaluatePrGatePolicy } from './pr-gate-policy-lib.mjs';
+
+function evaluate(overrides = {}) {
+  return evaluatePrGatePolicy({
+    eventName: 'pull_request',
+    action: 'synchronize',
+    draft: true,
+    labels: [],
+    changedFiles: ['apps/web/src/components/card.tsx'],
+    changedFilesComplete: true,
+    ...overrides,
+  });
+}
+
+test('ordinary draft pull requests use the quick lane', () => {
+  assert.deepEqual(evaluate(), {
+    runFull: false,
+    forceFull: false,
+    reason: 'ordinary-draft',
+    highRiskPaths: [],
+  });
+});
+
+test('ready pull requests use the full lane', () => {
+  assert.deepEqual(evaluate({ draft: false, action: 'ready_for_review' }), {
+    runFull: true,
+    forceFull: false,
+    reason: 'pull-request-ready',
+    highRiskPaths: [],
+  });
+});
+
+test('full-gate label forces the full lane on a draft', () => {
+  const result = evaluate({ labels: ['documentation', 'full-gate'] });
+
+  assert.equal(result.runFull, true);
+  assert.equal(result.forceFull, true);
+  assert.equal(result.reason, 'full-gate-label');
+});
+
+test('high-risk paths force the full lane on a draft', () => {
+  const paths = [
+    'apps/web/src/proxy.ts',
+    'apps/web/src/lib/proxy-gate.ts',
+    'apps/web/src/lib/proxy-logic.ts',
+    'apps/web/src/lib/proxy-session-state.ts',
+    'apps/web/src/lib/auth.ts',
+    'apps/web/src/server/domains/tenant-cache.ts',
+    'apps/web/src/app/api/webhooks/paddle/route.ts',
+    'apps/web/src/actions/subscription/cancel.ts',
+    'packages/shared-auth/src/index.ts',
+    'packages/database/src/schema.ts',
+    'supabase/migrations/20260716_gate.sql',
+    'packages/domain-membership-billing/src/paddle.ts',
+    '.github/workflows/ci.yml',
+    '.github/actions/setup/action.yml',
+    'scripts/ci/workflow-contracts.test.mjs',
+    'scripts/security-guard.mjs',
+    'scripts/release-gate/run.ts',
+    'scripts/pr-finalizer.sh',
+    'pnpm-lock.yaml',
+    'packages/domain-users/package.json',
+  ];
+
+  for (const changedPath of paths) {
+    const result = evaluate({ changedFiles: [changedPath] });
+    assert.equal(result.runFull, true, changedPath);
+    assert.equal(result.forceFull, true, changedPath);
+    assert.equal(result.reason, 'high-risk-change', changedPath);
+    assert.deepEqual(result.highRiskPaths, [changedPath], changedPath);
+  }
+});
+
+test('missing pull request evidence fails full', () => {
+  const missingFiles = evaluate({ changedFiles: [], changedFilesComplete: false });
+  assert.equal(missingFiles.runFull, true);
+  assert.equal(missingFiles.forceFull, true);
+  assert.equal(missingFiles.reason, 'changed-files-incomplete');
+
+  const missingDraftState = evaluate({ draft: undefined });
+  assert.equal(missingDraftState.runFull, true);
+  assert.equal(missingDraftState.forceFull, true);
+  assert.equal(missingDraftState.reason, 'pull-request-state-missing');
+});
+
+test('push and workflow dispatch events always run full', () => {
+  for (const eventName of ['push', 'workflow_dispatch']) {
+    const result = evaluate({ eventName, changedFiles: [], changedFilesComplete: false });
+    assert.equal(result.runFull, true);
+    assert.equal(result.forceFull, false);
+    assert.equal(result.reason, `non-pull-request:${eventName}`);
+  }
+});

--- a/scripts/ci/pr-gate-trust-contracts.test.mjs
+++ b/scripts/ci/pr-gate-trust-contracts.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const action = yaml.load(
+  fs.readFileSync(path.join(root, '.github/actions/pr-gate-policy/action.yml'), 'utf8')
+);
+const step = id => action.runs.steps.find(candidate => candidate.id === id);
+
+test('the shared gate action executes policy scripts from its pinned checkout', () => {
+  const trustedRoot = '${{ github.action_path }}/../../..';
+
+  for (const policyStep of [
+    step('changed-files'),
+    step('validation'),
+    step('policy'),
+    step('ai-eval'),
+  ]) {
+    assert.equal(policyStep.env.POLICY_ROOT, trustedRoot);
+    assert.match(policyStep.run, /"\$\{POLICY_ROOT\}\/scripts\/ci/u);
+  }
+});

--- a/scripts/ci/pr-gate-trust-contracts.test.mjs
+++ b/scripts/ci/pr-gate-trust-contracts.test.mjs
@@ -13,6 +13,7 @@ const action = yaml.load(
 const step = id => action.runs.steps.find(candidate => candidate.id === id);
 
 test('the shared gate action executes policy scripts from its pinned checkout', () => {
+  const changedFiles = step('changed-files');
   const trustedRoot = '${{ github.action_path }}/../../..';
 
   for (const policyStep of [
@@ -24,4 +25,6 @@ test('the shared gate action executes policy scripts from its pinned checkout', 
     assert.equal(policyStep.env.POLICY_ROOT, trustedRoot);
     assert.match(policyStep.run, /"\$\{POLICY_ROOT\}\/scripts\/ci/u);
   }
+  assert.match(changedFiles.run, /set -euo pipefail/u);
+  assert.match(changedFiles.run, /Dispatch changed-file lookup failed/u);
 });

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 57311239,
+  "maxTrackedBytes": 57311957,
   "maxTrackedFiles": 5414,
   "maxCategoryBytes": {
     "other": 18855992,
     "large support/generated-ish": 16155764,
     "source/scripts": 7626518,
     "docs/text": 7287846,
-    "tests/e2e": 5651399,
-    "config/data/messages": 1733720
+    "tests/e2e": 5651946,
+    "config/data/messages": 1733891
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 57263811,
-  "maxTrackedFiles": 5407,
+  "maxTrackedBytes": 57311239,
+  "maxTrackedFiles": 5414,
   "maxCategoryBytes": {
     "other": 18855992,
-    "large support/generated-ish": 16152144,
-    "source/scripts": 7622016,
-    "docs/text": 7260956,
-    "tests/e2e": 5644109,
-    "config/data/messages": 1728594
+    "large support/generated-ish": 16155764,
+    "source/scripts": 7626518,
+    "docs/text": 7287846,
+    "tests/e2e": 5651399,
+    "config/data/messages": 1733720
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- add the reusable PR gate policy action and deterministic policy scripts without changing active workflows
- execute policy scripts from the action checkout so a later SHA-pinned caller does not trust PR workspace code
- include rename-aware, fail-full, proxy-helper, and pinned-action regression contracts

## Why this is separate
This is phase 1 of the approved two-phase rollout for PR #1366. Existing `main` workflows verify this bootstrap first. After merge, PR #1366 will pin all policy calls to this merge SHA.

## Verification
- `node --test scripts/ci/github-pr-files.test.mjs scripts/ci/pr-gate-policy-cli.test.mjs scripts/ci/pr-gate-policy.test.mjs scripts/ci/pr-gate-trust-contracts.test.mjs` — 15/15 pass
- `pnpm test:ci:contracts` — 341/341 pass
- `pnpm security:guard` — pass
- `pnpm repo:size:check` — pass
- `git diff --check` — clean