### PR TITLE
feat(database): add administrative connection config contract

### DIFF
--- a/packages/database/src/admin-connection-config.ts
+++ b/packages/database/src/admin-connection-config.ts
@@ -133,7 +133,7 @@ export function resolveAdminConnectionConfig(
   if (typeof raw !== 'string') return reject('ADMIN_DB_CONFIG_URL_INVALID', 'url');
   const values = parseUrl(raw);
   if (!values) return reject('ADMIN_DB_CONFIG_URL_INVALID', 'url');
-  const local = values.host === '127.0.0.1' || values.host === '[::1]';
+  const local = values.host === '127.0.0.1';
   if (!local && (!DIRECT_HOST.test(values.host) || values.port !== 5432))
     return reject('ADMIN_DB_CONFIG_ENDPOINT_REJECTED', 'endpoint');
   const scratch = env.ADMIN_DB_LOCAL_SCRATCH === '1';

--- a/packages/database/src/admin-connection-config.ts
+++ b/packages/database/src/admin-connection-config.ts
@@ -1,0 +1,150 @@
+import { X509Certificate } from 'node:crypto';
+import { checkServerIdentity } from 'node:tls';
+import { inspect } from 'node:util';
+import type postgres from 'postgres';
+type LockedOptions = postgres.Options<Record<never, never>> & {
+  sslnegotiation: null;
+  max_pipeline: 1;
+};
+const NOOP = (): void => {};
+const STRUCTURAL = /[\u0000-\u0020\u007f:/?#\[\]@,\\]/;
+const DIRECT_HOST = /^db\.[a-z0-9]{20}\.supabase\.co$/;
+const BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const MAX_CA_BYTES = 65_536;
+function reject<const C extends string, const F extends string>(code: C, field: F) {
+  return Object.freeze({ ok: false as const, error: Object.freeze({ code, field }) });
+}
+function parseUrl(raw: string) {
+  if (raw.length === 0 || raw.length > 8192 || /[\u0000-\u0020\u007f]/.test(raw)) return null;
+  const match = /^(postgres|postgresql):\/\/([^/?#]+)\/([^/?#]+)$/.exec(raw);
+  if (!match) return null;
+  const [, , authority, rawDatabase] = match;
+  if (authority.includes(',') || (authority.match(/@/g) ?? []).length !== 1) return null;
+  const [credentials, rawHostPort] = authority.split('@');
+  const separator = credentials.indexOf(':');
+  if (separator < 1 || separator === credentials.length - 1 || rawHostPort.includes('%'))
+    return null;
+  const hostMatch = rawHostPort.startsWith('[')
+    ? /^(\[[0-9a-f:.]+\]):([0-9]+)$/.exec(rawHostPort)
+    : /^([^:]+):([0-9]+)$/.exec(rawHostPort);
+  if (!hostMatch || !/^[\x21-\x7e]+$/.test(hostMatch[1]) || hostMatch[1].endsWith('.')) return null;
+  const port = Number(hostMatch[2]);
+  if (String(port) !== hostMatch[2] || port < 1 || port > 65_535) return null;
+  try {
+    const username = decodeURIComponent(credentials.slice(0, separator));
+    const password = decodeURIComponent(credentials.slice(separator + 1));
+    const database = decodeURIComponent(rawDatabase);
+    const url = new URL(raw);
+    if ([username, password, database].some(value => !value || STRUCTURAL.test(value))) return null;
+    if (hostMatch[1] !== hostMatch[1].toLowerCase() || url.hostname !== hostMatch[1]) return null;
+    if (url.port !== hostMatch[2] || url.pathname !== `/${rawDatabase}`) return null;
+    return { host: url.hostname, port, database, username, password };
+  } catch {
+    return null;
+  }
+}
+function parseCa(value: unknown, nowEpochMs: number): string | null {
+  if (typeof value !== 'string' || value.length > Math.ceil(MAX_CA_BYTES / 3) * 4) return null;
+  if (!BASE64.test(value)) return null;
+  const bytes = Buffer.from(value, 'base64');
+  if (!bytes.length || bytes.length > MAX_CA_BYTES || bytes.toString('base64') !== value)
+    return null;
+  const pem = bytes.toString('utf8');
+  if (!Buffer.from(pem).equals(bytes)) return null;
+  const begins = (pem.match(/-----BEGIN CERTIFICATE-----/g) ?? []).length;
+  const ends = (pem.match(/-----END CERTIFICATE-----/g) ?? []).length;
+  if (begins !== 1 || ends !== 1) return null;
+  if (!/^\s*-----BEGIN CERTIFICATE-----[\s\S]+-----END CERTIFICATE-----\s*$/.test(pem)) return null;
+  try {
+    const certificate = new X509Certificate(pem);
+    const validFrom = Date.parse(certificate.validFrom);
+    const validTo = Date.parse(certificate.validTo);
+    return certificate.ca && nowEpochMs >= validFrom && nowEpochMs <= validTo ? pem : null;
+  } catch {
+    return null;
+  }
+}
+function summaryFor(local: boolean) {
+  return Object.freeze({
+    contract_version: 'admin_connection_config_v1' as const,
+    endpoint_class: local ? ('local_scratch' as const) : ('supabase_direct' as const),
+    transport_policy: local
+      ? ('unauthenticated_loopback_test_only' as const)
+      : ('explicit_ca_hostname_verified' as const),
+    connection_count: 1 as const,
+    target_session: 'primary' as const,
+  });
+}
+type ParsedUrl = NonNullable<ReturnType<typeof parseUrl>>;
+type Values = ParsedUrl & { ca?: string; summary: ReturnType<typeof summaryFor> };
+class AdminConnectionConfig {
+  readonly #values: Readonly<Values>;
+  constructor(values: Values) {
+    this.#values = Object.freeze(values);
+    Object.freeze(this);
+  }
+  toJSON(): ReturnType<typeof summaryFor> {
+    return this.#values.summary;
+  }
+  [inspect.custom](): ReturnType<typeof summaryFor> {
+    return this.toJSON();
+  }
+  toPostgresOptions(): LockedOptions {
+    const { ca, summary: _summary, ...credentials } = this.#values;
+    const ssl = ca
+      ? Object.freeze({
+          ca,
+          rejectUnauthorized: true,
+          servername: this.#values.host,
+          checkServerIdentity,
+        })
+      : false;
+    return Object.freeze({
+      ...credentials,
+      path: undefined,
+      ssl,
+      sslnegotiation: null,
+      max: 1,
+      idle_timeout: 0,
+      connect_timeout: 5,
+      max_lifetime: null,
+      max_pipeline: 1,
+      backoff: false,
+      keep_alive: 30,
+      prepare: false,
+      debug: false,
+      fetch_types: false,
+      publications: 'none',
+      target_session_attrs: 'primary',
+      types: Object.freeze({}),
+      transform: Object.freeze({ undefined: undefined }),
+      connection: Object.freeze({ application_name: 'interdomestik_admin_config_v1' }),
+      onnotice: NOOP,
+      onparameter: NOOP,
+    });
+  }
+}
+export function resolveAdminConnectionConfig(
+  env: Readonly<Record<string, unknown>>,
+  nowEpochMs: number
+) {
+  const raw = env.DATABASE_URL;
+  if (raw === undefined) return reject('ADMIN_DB_CONFIG_MISSING', 'url');
+  if (typeof raw !== 'string') return reject('ADMIN_DB_CONFIG_URL_INVALID', 'url');
+  const values = parseUrl(raw);
+  if (!values) return reject('ADMIN_DB_CONFIG_URL_INVALID', 'url');
+  const local = values.host === '127.0.0.1' || values.host === '[::1]';
+  if (!local && (!DIRECT_HOST.test(values.host) || values.port !== 5432))
+    return reject('ADMIN_DB_CONFIG_ENDPOINT_REJECTED', 'endpoint');
+  const scratch = env.ADMIN_DB_LOCAL_SCRATCH === '1';
+  const localAuthorized =
+    env.NODE_ENV === 'test' && scratch && values.database.startsWith('interdomestik_admin_config_');
+  if (local && !localAuthorized)
+    return reject('ADMIN_DB_CONFIG_LOCAL_AUTHORITY_REQUIRED', 'local_authority');
+  if (!local && env.DATABASE_ADMIN_CA_PEM_BASE64 === undefined)
+    return reject('ADMIN_DB_CONFIG_CA_REQUIRED', 'ca');
+  const ca = local ? undefined : parseCa(env.DATABASE_ADMIN_CA_PEM_BASE64, nowEpochMs);
+  if (ca === null) return reject('ADMIN_DB_CONFIG_CA_INVALID', 'ca');
+  const config = new AdminConnectionConfig({ ...values, ca, summary: summaryFor(local) });
+  return Object.freeze({ ok: true as const, config });
+}

--- a/packages/database/src/admin-connection-config.ts
+++ b/packages/database/src/admin-connection-config.ts
@@ -7,7 +7,7 @@ type LockedOptions = postgres.Options<Record<never, never>> & {
   max_pipeline: 1;
 };
 const NOOP = (): void => {};
-const STRUCTURAL = /[\u0000-\u0020\u007f:/?#\[\]@,\\]/;
+const STRUCTURAL = /[\u0000-\u0020\u007f:/?#[\]@,\\]/;
 const DIRECT_HOST = /^db\.[a-z0-9]{20}\.supabase\.co$/;
 const BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 const MAX_CA_BYTES = 65_536;
@@ -25,8 +25,8 @@ function parseUrl(raw: string) {
   if (separator < 1 || separator === credentials.length - 1 || rawHostPort.includes('%'))
     return null;
   const hostMatch = rawHostPort.startsWith('[')
-    ? /^(\[[0-9a-f:.]+\]):([0-9]+)$/.exec(rawHostPort)
-    : /^([^:]+):([0-9]+)$/.exec(rawHostPort);
+    ? /^(\[[\da-f:.]+\]):(\d+)$/.exec(rawHostPort)
+    : /^([^:]+):(\d+)$/.exec(rawHostPort);
   if (!hostMatch || !/^[\x21-\x7e]+$/.test(hostMatch[1]) || hostMatch[1].endsWith('.')) return null;
   const port = Number(hostMatch[2]);
   if (String(port) !== hostMatch[2] || port < 1 || port > 65_535) return null;

--- a/packages/database/test/admin-connection-config.test.ts
+++ b/packages/database/test/admin-connection-config.test.ts
@@ -37,41 +37,38 @@ test('statically enforces the pure no-I/O boundary', () => {
   assert.match(SOURCE, /import type postgres from 'postgres'/);
 });
 test('locks loopback options and keeps the configuration opaque and immutable', () => {
+  const result = resolveAdminConnectionConfig(localEnv(), VALID_NOW);
+  if (!result.ok) assert.fail('expected accepted loopback configuration');
   // prettier-ignore
-  for (const url of [LOCAL_URL, 'postgresql://admin:secret@[::1]:5439/interdomestik_admin_config_test']) {
-    const result = resolveAdminConnectionConfig(localEnv(url), VALID_NOW);
-    if (!result.ok) assert.fail('expected accepted loopback configuration');
-    // prettier-ignore
-    assert.equal(JSON.stringify(result.config), '{"contract_version":"admin_connection_config_v1","endpoint_class":"local_scratch","transport_policy":"unauthenticated_loopback_test_only","connection_count":1,"target_session":"primary"}');
-    assert.deepEqual(Object.keys(result.config), []);
-    assert(Object.isFrozen(result.config));
-    const first = result.config.toPostgresOptions();
-    const second = result.config.toPostgresOptions();
-    const host = url.includes('[::1]') ? '[::1]' : '127.0.0.1';
-    assert.notEqual(first, second);
-    // prettier-ignore
-    assert.equal(Object.keys(first).sort().join(','), 'backoff,connect_timeout,connection,database,debug,fetch_types,host,idle_timeout,keep_alive,max,max_lifetime,max_pipeline,onnotice,onparameter,password,path,port,prepare,publications,ssl,sslnegotiation,target_session_attrs,transform,types,username');
-    // prettier-ignore
-    assert.equal(JSON.stringify(first), `{"host":"${host}","port":5439,"database":"interdomestik_admin_config_test","username":"admin","password":"secret","ssl":false,"sslnegotiation":null,"max":1,"idle_timeout":0,"connect_timeout":5,"max_lifetime":null,"max_pipeline":1,"backoff":false,"keep_alive":30,"prepare":false,"debug":false,"fetch_types":false,"publications":"none","target_session_attrs":"primary","types":{},"transform":{},"connection":{"application_name":"interdomestik_admin_config_v1"}}`);
-    assert.equal(first.path, undefined);
-    assert.equal(first.transform?.undefined, undefined);
-    assert.equal(typeof first.onnotice, 'function');
-    assert.equal(typeof first.onparameter, 'function');
-    for (const value of [first, first.types, first.transform, first.connection]) assert(Object.isFrozen(value));
-    assert(!JSON.stringify(result).includes('secret'));
-    assert(!inspect(result).includes('secret'));
-  }
+  assert.equal(JSON.stringify(result.config), '{"contract_version":"admin_connection_config_v1","endpoint_class":"local_scratch","transport_policy":"unauthenticated_loopback_test_only","connection_count":1,"target_session":"primary"}');
+  assert.deepEqual(Object.keys(result.config), []);
+  assert(Object.isFrozen(result.config));
+  const first = result.config.toPostgresOptions();
+  const second = result.config.toPostgresOptions();
+  assert.notEqual(first, second);
+  // prettier-ignore
+  assert.equal(Object.keys(first).sort().join(','), 'backoff,connect_timeout,connection,database,debug,fetch_types,host,idle_timeout,keep_alive,max,max_lifetime,max_pipeline,onnotice,onparameter,password,path,port,prepare,publications,ssl,sslnegotiation,target_session_attrs,transform,types,username');
+  // prettier-ignore
+  assert.equal(JSON.stringify(first), '{"host":"127.0.0.1","port":5439,"database":"interdomestik_admin_config_test","username":"admin","password":"secret","ssl":false,"sslnegotiation":null,"max":1,"idle_timeout":0,"connect_timeout":5,"max_lifetime":null,"max_pipeline":1,"backoff":false,"keep_alive":30,"prepare":false,"debug":false,"fetch_types":false,"publications":"none","target_session_attrs":"primary","types":{},"transform":{},"connection":{"application_name":"interdomestik_admin_config_v1"}}');
+  assert.equal(first.path, undefined);
+  assert.equal(first.transform?.undefined, undefined);
+  assert.equal(typeof first.onnotice, 'function');
+  assert.equal(typeof first.onparameter, 'function');
+  for (const value of [first, first.types, first.transform, first.connection])
+    assert(Object.isFrozen(value));
+  assert(!JSON.stringify(result).includes('secret'));
+  assert(!inspect(result).includes('secret'));
 });
 test('rejects ambiguous URLs, endpoints, and implicit loopback authority', () => {
   const encodedInvalidUrls =
-    'POSTGRES://a:b@127.0.0.1:5432/interdomestik_admin_config_x|postgres://a@127.0.0.1:5432/interdomestik_admin_config_x|postgres://a:b@127.0.0.1/interdomestik_admin_config_x|postgres://a:b@127.0.0.1:5432/db/extra|postgres://a:b@127.0.0.1:5432/db?sslmode=require|postgres://a:b@127.0.0.1:5432/db#fragment|postgres://a:b@127.0.0.1,127.0.0.2:5432/db|postgres://a:b@@127.0.0.1:5432/db|postgres://a:b@%31%32%37.0.0.1:5432/db|postgres://a:%40b@127.0.0.1:5432/db|postgres://a:b@127.0.0.1:5432/db%2Fother|postgres://a:b@127.0.0.1:5432/db%ZZ|postgres://a:b@db.ABC123def456ghi789jk.supabase.co:5432/db|postgres://a:b@db.abc123def456ghi789jk.supabase.co.:5432/db';
+    'POSTGRES://a:b@127.0.0.1:5432/interdomestik_admin_config_x|postgres://a:b@::1:5439/interdomestik_admin_config_x|postgres://a@127.0.0.1:5432/interdomestik_admin_config_x|postgres://a:b@127.0.0.1/interdomestik_admin_config_x|postgres://a:b@127.0.0.1:5432/db/extra|postgres://a:b@127.0.0.1:5432/db?sslmode=require|postgres://a:b@127.0.0.1:5432/db#fragment|postgres://a:b@127.0.0.1,127.0.0.2:5432/db|postgres://a:b@@127.0.0.1:5432/db|postgres://a:b@%31%32%37.0.0.1:5432/db|postgres://a:%40b@127.0.0.1:5432/db|postgres://a:b@127.0.0.1:5432/db%2Fother|postgres://a:b@127.0.0.1:5432/db%ZZ|postgres://a:b@db.ABC123def456ghi789jk.supabase.co:5432/db|postgres://a:b@db.abc123def456ghi789jk.supabase.co.:5432/db';
   const invalidUrls: unknown[] = [undefined, 123, '', ...encodedInvalidUrls.split('|'), 'bad\n'];
   for (const DATABASE_URL of invalidUrls) {
     // prettier-ignore
     fail({ ...localEnv(), DATABASE_URL }, DATABASE_URL === undefined ? 'ADMIN_DB_CONFIG_MISSING' : 'ADMIN_DB_CONFIG_URL_INVALID', 'url');
   }
   const rejectedHosts =
-    'localhost:5432|127.0.0.2:5432|aws-0-eu.pooler.supabase.com:6543|db.abc123def456ghi789jk.supabase.co:6543';
+    '[::1]:5439|localhost:5432|127.0.0.2:5432|aws-0-eu.pooler.supabase.com:6543|db.abc123def456ghi789jk.supabase.co:6543';
   for (const host of rejectedHosts.split('|')) {
     // prettier-ignore
     fail(localEnv(`postgres://a:b@${host}/interdomestik_admin_config_x`), 'ADMIN_DB_CONFIG_ENDPOINT_REJECTED', 'endpoint');

--- a/packages/database/test/admin-connection-config.test.ts
+++ b/packages/database/test/admin-connection-config.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { X509Certificate } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { checkServerIdentity } from 'node:tls';
+import { inspect } from 'node:util';
+import { resolveAdminConnectionConfig } from '../src/admin-connection-config';
+const CA_PEM_BASE64 =
+  'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFVENDQWZtZ0F3SUJBZ0lVWWpTSkJSQ1dyRGVvZ2tHNFBIVGtEbS9oVjY4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0dERVdNQlFHQTFVRUF3d05VREJoTUdFZ1ZHVnpkQ0JEUVRBZUZ3MHlOakEzTVRreE16QTFOVGhhRncwegpOakEzTVRZeE16QTFOVGhhTUJneEZqQVVCZ05WQkFNTURWQXdZVEJoSUZSbGMzUWdRMEV3Z2dFaU1BMEdDU3FHClNJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUMzL0hTUHhjZnc4NlRGM0Q5VnY1MCtXK0hZelFxWVNTTVMKWWFnSjhMNDd0RmZmMVZvMzlqWXltODB6cEtiS0ZibUV2WXM5N0VKbEVvaHM1UzlkOUxhWllVb3NSdWVEelNRdwpiYW53dGF0b1QvOENJUVdUWWlRcDZ6V1VHd0FXbUlSRXQrbEJhOFpPYzdiek90eUxJVEpoZUpUVTBwUXMxRTRnCmczUThBMXFody93TGY0QnR0RGZpeGxZdmtwY3NJMzFmdVJCazQ2MFZZbytLT3ZvTy9XQjFpL0VUWHdxSzQzT0wKTytGRnFOcWpBcytyVHV6Y3BzWjBlZDd3QW1Yb1dXdW9mamUxNmFIQ2JGWDYxOUw0TUlYTjF1MHBJajR5N3BDdwozbmxqZC9naUROaGJlQ2RKMW5aMXF4QUhzaGhiMWQwSjZEanBDN0tyd00zRnVJNUJpWXZCQWdNQkFBR2pVekJSCk1CMEdBMVVkRGdRV0JCVERmN1JTV2lzTzJPTzBHakVaVTQ2VW5IR2J2ekFmQmdOVkhTTUVHREFXZ0JURGY3UlMKV2lzTzJPTzBHakVaVTQ2VW5IR2J2ekFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBMEw3dXhMZ3Nxdm8wZlltNWlObXFGRDZVME01WS9ZZHc4UnJYc2RJeHBvcGVsWEVzWkF4SmhzV2V0CkQyQmJqZ3hIWVZGeDRZcmtlQWVVNWlQN1MwbWhGY0tvOVdWN1VZY1EvQktleTVhVENHakRaUmtNMzFoRCtsQzMKN09acHdoR1VyMCtBaHpmZG1SNTQzdkxnODNEd1VQWnlUbWUwOFlCUTQ3Rnc5cHhaL3FQZlVsRCtIM3VhbHVtdApCcWdXZXR0aEpZU3lrNUVYQmFsUXh0SGNpaWxhQVB4QWIxTUJSYTlLbmZpR3daOGUrQVdETDR5U0tlM2JpMmQyClhESUl4WW5EL1V0Tlg1ZTJNMy9IZlJGQTIyNW5tdHJuQkZDa0ovMlROU1g2UVlmMlRhY1hUMDliM1U4b0VpN0UKeDVyRG9Wd1RyUFNrRzZaNk5sT2huSWpmYXQ2SgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==';
+const LEAF_PEM_BASE64 =
+  'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDRENDQWZDZ0F3SUJBZ0lVVVZTRldVYnppYWxtcHA2UCtTaFNMYmk2aXJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZURVRNQkVHQTFVRUF3d0tVREJoTUdFZ1RHVmhaakFlRncweU5qQTNNVGt4TXpBMU5UaGFGdzB6TmpBMwpNVFl4TXpBMU5UaGFNQlV4RXpBUkJnTlZCQU1NQ2xBd1lUQmhJRXhsWVdZd2dnRWlNQTBHQ1NxR1NJYjNEUUVCCkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDN1REc2E0OGkvMCszcTJRVUVwZnU2L3IrcSt6UnQrVndaNk5tUjVxMDMKai9vOFZyMzRiMHIxWk92NEJHUStzM2FBQVc0R2xWanhhZXpXUHB1R2d6R0VkSVpDT3J5SHBUVFFsUW5kVWRmbQo4bm1Qam9GUEYxNDBDaDlZdDhDUmo3TVNPN0R0TWF1Qm1uYWFjRmJGOG90ZUdOTG5PMmc1a2RRbjgwcUppWk5ICjA0UCt2ZVZSYXJqZ2hSNWp5QmppclczMndBWlhEMU4yejRJL2ZqalgxNTYzMzFoQzl1ZTEreEJMTVMxblN4ckYKS0d2MDk3TzZKcjlScXZSNk4yeWRJTFloTUlUb0szQXJzS2gwcG9FbXE1OFNTVExPWTJsQ1U0Q0l5YlpTSGNUOQp0TmtOQzQxR2FJbmo2eDkzL3hLMklOSXBnYWVYcWE1Nys1WFRaOWdEMXF6ekFnTUJBQUdqVURCT01CMEdBMVVkCkRnUVdCQlI1bU1zZ01tZTJLRjdkdXNrV0V6Z1BsL0tXYURBZkJnTlZIU01FR0RBV2dCUjVtTXNnTW1lMktGN2QKdXNrV0V6Z1BsL0tXYURBTUJnTlZIUk1CQWY4RUFqQUFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNVUXQ5egozSkI2enhoeTBGS2FrTUY0Q0hoQ1BKN0t0aU1zUUQ2OGQ0bEwxZVppUHFwUTQyT2s1QUE3ZktSaWtBa2NtL0pIClZPTTdnKzB6Vk14blNhQW11M2V6am0vR1RvdU5Rb1RYc2x6dTZGN1hrcldrODc4Mi9VOGtnYmtwQ1dJaEZzbFgKQTl6TzZPMlBhWmEyQklhd1JqQjRtb01xMFdzKzFVNTRwZTBRNnYwZXdQSWV0YWoxeDAwWC96R2NjMm9jZHY1bgphTXFON1N5ZjNXd0xuZ2x5cHo3RHh5SUVaN3UrUVRiRGVIK2x1dDdndFlVTDZLQmt4a2xUaUJQVHdTODZudFh2CkZPbmNIQW84cE5Edk54Q1dQU2NyUGI1OW9yQ0poZTVtNGY2RmNWM2hwZDlIUHlOQW55YzVmTnBVYXpuaUVXUlMKU2lFbXhrYmFOMVFDT2lQKwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==';
+const CA_PEM = Buffer.from(CA_PEM_BASE64, 'base64').toString('utf8');
+const SOURCE = readFileSync(new URL('../src/admin-connection-config.ts', import.meta.url), 'utf8');
+const CERT = new X509Certificate(CA_PEM);
+const VALID_NOW = Math.trunc((Date.parse(CERT.validFrom) + Date.parse(CERT.validTo)) / 2);
+const CA_INVALID = 'ADMIN_DB_CONFIG_CA_INVALID';
+type Env = Readonly<Record<string, unknown>>;
+const LOCAL_URL = 'postgres://admin:secret@127.0.0.1:5439/interdomestik_admin_config_test';
+const localEnv = (DATABASE_URL = LOCAL_URL) => ({
+  DATABASE_URL,
+  NODE_ENV: 'test',
+  ADMIN_DB_LOCAL_SCRATCH: '1',
+});
+const remoteEnv = (ca = CA_PEM_BASE64) => ({
+  DATABASE_URL: 'postgresql://admin:secret@db.abc123def456ghi789jk.supabase.co:5432/app',
+  DATABASE_ADMIN_CA_PEM_BASE64: ca,
+});
+function fail(env: Env, code: string, field: string, now = VALID_NOW) {
+  const result = resolveAdminConnectionConfig(env, now);
+  assert.deepEqual(result, { ok: false, error: { code, field } });
+  return result;
+}
+test('statically enforces the pure no-I/O boundary', () => {
+  const forbidden =
+    /\bpostgres\s*\(|from ['"]node:(?:net|dns|fs|child_process|timers(?:\/promises)?)['"]|\b(?:fetch|setTimeout|setInterval|setImmediate)\s*\(|\b(?:net|tls)\s*\.\s*(?:connect|createConnection)\s*\(|from ['"][^'"]*(?:drizzle|migration|\/migrate)['"]|\bsql\s*`|\b(?:console\.(?:log|warn|error)|process\.(?:stdout|stderr)\.write)\s*\(|\bprocess\.env(?:\.[A-Za-z_]\w*|\[[^\]]+\])\s*=/;
+  assert.doesNotMatch(SOURCE, forbidden);
+  assert.match(SOURCE, /import type postgres from 'postgres'/);
+});
+test('locks loopback options and keeps the configuration opaque and immutable', () => {
+  // prettier-ignore
+  for (const url of [LOCAL_URL, 'postgresql://admin:secret@[::1]:5439/interdomestik_admin_config_test']) {
+    const result = resolveAdminConnectionConfig(localEnv(url), VALID_NOW);
+    if (!result.ok) assert.fail('expected accepted loopback configuration');
+    // prettier-ignore
+    assert.equal(JSON.stringify(result.config), '{"contract_version":"admin_connection_config_v1","endpoint_class":"local_scratch","transport_policy":"unauthenticated_loopback_test_only","connection_count":1,"target_session":"primary"}');
+    assert.deepEqual(Object.keys(result.config), []);
+    assert(Object.isFrozen(result.config));
+    const first = result.config.toPostgresOptions();
+    const second = result.config.toPostgresOptions();
+    const host = url.includes('[::1]') ? '[::1]' : '127.0.0.1';
+    assert.notEqual(first, second);
+    // prettier-ignore
+    assert.equal(Object.keys(first).sort().join(','), 'backoff,connect_timeout,connection,database,debug,fetch_types,host,idle_timeout,keep_alive,max,max_lifetime,max_pipeline,onnotice,onparameter,password,path,port,prepare,publications,ssl,sslnegotiation,target_session_attrs,transform,types,username');
+    // prettier-ignore
+    assert.equal(JSON.stringify(first), `{"host":"${host}","port":5439,"database":"interdomestik_admin_config_test","username":"admin","password":"secret","ssl":false,"sslnegotiation":null,"max":1,"idle_timeout":0,"connect_timeout":5,"max_lifetime":null,"max_pipeline":1,"backoff":false,"keep_alive":30,"prepare":false,"debug":false,"fetch_types":false,"publications":"none","target_session_attrs":"primary","types":{},"transform":{},"connection":{"application_name":"interdomestik_admin_config_v1"}}`);
+    assert.equal(first.path, undefined);
+    assert.equal(first.transform?.undefined, undefined);
+    assert.equal(typeof first.onnotice, 'function');
+    assert.equal(typeof first.onparameter, 'function');
+    for (const value of [first, first.types, first.transform, first.connection]) assert(Object.isFrozen(value));
+    assert(!JSON.stringify(result).includes('secret'));
+    assert(!inspect(result).includes('secret'));
+  }
+});
+test('rejects ambiguous URLs, endpoints, and implicit loopback authority', () => {
+  const encodedInvalidUrls =
+    'POSTGRES://a:b@127.0.0.1:5432/interdomestik_admin_config_x|postgres://a@127.0.0.1:5432/interdomestik_admin_config_x|postgres://a:b@127.0.0.1/interdomestik_admin_config_x|postgres://a:b@127.0.0.1:5432/db/extra|postgres://a:b@127.0.0.1:5432/db?sslmode=require|postgres://a:b@127.0.0.1:5432/db#fragment|postgres://a:b@127.0.0.1,127.0.0.2:5432/db|postgres://a:b@@127.0.0.1:5432/db|postgres://a:b@%31%32%37.0.0.1:5432/db|postgres://a:%40b@127.0.0.1:5432/db|postgres://a:b@127.0.0.1:5432/db%2Fother|postgres://a:b@127.0.0.1:5432/db%ZZ|postgres://a:b@db.ABC123def456ghi789jk.supabase.co:5432/db|postgres://a:b@db.abc123def456ghi789jk.supabase.co.:5432/db';
+  const invalidUrls: unknown[] = [undefined, 123, '', ...encodedInvalidUrls.split('|'), 'bad\n'];
+  for (const DATABASE_URL of invalidUrls) {
+    // prettier-ignore
+    fail({ ...localEnv(), DATABASE_URL }, DATABASE_URL === undefined ? 'ADMIN_DB_CONFIG_MISSING' : 'ADMIN_DB_CONFIG_URL_INVALID', 'url');
+  }
+  const rejectedHosts =
+    'localhost:5432|127.0.0.2:5432|aws-0-eu.pooler.supabase.com:6543|db.abc123def456ghi789jk.supabase.co:6543';
+  for (const host of rejectedHosts.split('|')) {
+    // prettier-ignore
+    fail(localEnv(`postgres://a:b@${host}/interdomestik_admin_config_x`), 'ADMIN_DB_CONFIG_ENDPOINT_REJECTED', 'endpoint');
+  }
+  // prettier-ignore
+  for (const env of [{ ...localEnv(), NODE_ENV: 'production' }, { ...localEnv(), NODE_ENV: 'CI' }, { ...localEnv(), ADMIN_DB_LOCAL_SCRATCH: 'true' }, localEnv('postgres://a:b@127.0.0.1:5432/app')]) {
+    fail(env, 'ADMIN_DB_CONFIG_LOCAL_AUTHORITY_REQUIRED', 'local_authority');
+  }
+});
+test('requires a bounded current CA and returns the exact remote TLS/options posture', () => {
+  fail({ DATABASE_URL: remoteEnv().DATABASE_URL }, 'ADMIN_DB_CONFIG_CA_REQUIRED', 'ca');
+  // prettier-ignore
+  for (const ca of [`${CA_PEM_BASE64}\n`, LEAF_PEM_BASE64, Buffer.from(`${CA_PEM}${CA_PEM}`).toString('base64'), Buffer.from(`${CA_PEM}trailing-data`).toString('base64'), Buffer.alloc(65_537).toString('base64')]) {
+    fail(remoteEnv(ca), CA_INVALID, 'ca');
+  }
+  const invalidAt = (now: number) => fail(remoteEnv(), CA_INVALID, 'ca', now);
+  invalidAt(Date.parse(CERT.validFrom) - 1);
+  invalidAt(Date.parse(CERT.validTo) + 1);
+  const ignoredNames =
+    'PGHOST PGPORT PGUSERNAME PGUSER PGPASSWORD PGDATABASE PGMAX PGSSL PGSSLMODE PGSSLNEGOTIATION PGIDLE_TIMEOUT PGCONNECT_TIMEOUT PGMAX_LIFETIME PGMAX_PIPELINE PGBACKOFF PGKEEP_ALIVE PGPREPARE PGDEBUG PGFETCH_TYPES PGPUBLICATIONS PGTARGET_SESSION_ATTRS PGTARGETSESSIONATTRS PGAPPNAME USER USERNAME LOGNAME DATABASE_URL_RLS DB_RLS_ROLE E2E_DATABASE_URL E2E_DATABASE_URL_ADMIN NODE_EXTRA_CA_CERTS SSL_CERT_FILE NODE_TLS_REJECT_UNAUTHORIZED';
+  const ignored = Object.fromEntries(ignoredNames.split(' ').map(key => [key, `SENTINEL_${key}`]));
+  const hostile = { ...remoteEnv(), ...ignored };
+  const result = resolveAdminConnectionConfig(hostile, VALID_NOW);
+  if (!result.ok) assert.fail('expected accepted remote configuration');
+  const options = result.config.toPostgresOptions();
+  const baseline = resolveAdminConnectionConfig(remoteEnv(), VALID_NOW);
+  if (!baseline.ok) assert.fail('expected baseline remote configuration');
+  assert.deepEqual(options, baseline.config.toPostgresOptions());
+  // prettier-ignore
+  assert.equal(JSON.stringify(result.config), '{"contract_version":"admin_connection_config_v1","endpoint_class":"supabase_direct","transport_policy":"explicit_ca_hostname_verified","connection_count":1,"target_session":"primary"}');
+  const ssl = options.ssl as Record<string, unknown>;
+  assert.equal(
+    Object.keys(ssl).sort().join(','),
+    'ca,checkServerIdentity,rejectUnauthorized,servername'
+  );
+  assert.equal(ssl.ca, CA_PEM);
+  assert.equal(ssl.rejectUnauthorized, true);
+  assert.equal(ssl.servername, 'db.abc123def456ghi789jk.supabase.co');
+  assert.equal(ssl.checkServerIdentity, checkServerIdentity);
+  assert(Object.isFrozen(options.ssl));
+  for (const sentinel of Object.values(hostile).filter(value => value.startsWith('SENTINEL_'))) {
+    assert(!JSON.stringify(result).includes(sentinel));
+    assert(!inspect(result).includes(sentinel));
+  }
+});
+test('returns stable redacted failures and emits no stdout or stderr', t => {
+  const sentinel = 'DO_NOT_DISCLOSE_SENTINEL';
+  const output: string[] = [];
+  const capture = (chunk: string | Uint8Array) => (output.push(String(chunk)), true);
+  t.mock.method(process.stdout, 'write', capture as typeof process.stdout.write);
+  t.mock.method(process.stderr, 'write', capture as typeof process.stderr.write);
+  const redacted = (env: Env, code: string, field: string) => {
+    const result = fail(env, code, field);
+    assert(!JSON.stringify(result).includes(sentinel));
+    assert(!inspect(result).includes(sentinel));
+    assert.deepEqual(Object.keys(result), ['ok', 'error']);
+    if (result.ok) assert.fail('expected rejected configuration');
+    assert.deepEqual(Object.keys(result.error), ['code', 'field']);
+  };
+  // prettier-ignore
+  redacted({ DATABASE_URL: `postgres://${sentinel}:secret@127.0.0.1:5432/db?${sentinel}` }, 'ADMIN_DB_CONFIG_URL_INVALID', 'url');
+  // prettier-ignore
+  redacted({ DATABASE_URL: `postgres://user:${sentinel}@127.0.0.1:5432/db` }, 'ADMIN_DB_CONFIG_LOCAL_AUTHORITY_REQUIRED', 'local_authority');
+  // prettier-ignore
+  redacted({ DATABASE_URL: `postgres://user:secret@${sentinel.toLowerCase()}:5432/db` }, 'ADMIN_DB_CONFIG_ENDPOINT_REJECTED', 'endpoint');
+  // prettier-ignore
+  redacted({ DATABASE_URL: `postgres://user:secret@127.0.0.1:5432/${sentinel}` }, 'ADMIN_DB_CONFIG_LOCAL_AUTHORITY_REQUIRED', 'local_authority');
+  redacted({ ...remoteEnv(sentinel), PGHOST: sentinel }, CA_INVALID, 'ca');
+  assert.deepEqual(output, []);
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58266224,
+  "maxTrackedBytes": 58266028,
   "maxTrackedFiles": 5483,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16646454,
-    "source/scripts": 7740748,
+    "source/scripts": 7740721,
     "docs/text": 7476929,
-    "tests/e2e": 5791562,
+    "tests/e2e": 5791393,
     "config/data/messages": 1754136
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58266232,
+  "maxTrackedBytes": 58266224,
   "maxTrackedFiles": 5483,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16646454,
-    "source/scripts": 7740756,
+    "source/scripts": 7740748,
     "docs/text": 7476929,
     "tests/e2e": 5791562,
     "config/data/messages": 1754136

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58246727,
-  "maxTrackedFiles": 5481,
+  "maxTrackedBytes": 58266232,
+  "maxTrackedFiles": 5483,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16646454,
-    "source/scripts": 7734246,
+    "source/scripts": 7740756,
     "docs/text": 7476929,
-    "tests/e2e": 5778567,
+    "tests/e2e": 5791562,
     "config/data/messages": 1754136
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Summary

- Implements promoted slice `IDA-UI03a2-P0a0a` / gate `IDA-DG19-A2a0a`.
- Adds a pure, deterministic administrative `DATABASE_URL` configuration contract.
- Produces opaque/redacted configuration and locked Postgres.js options without opening a socket or issuing SQL.

Accepted design: SHA-256 `2419d382d99c5742be5a8810a518f5ab928be99e857c06ce9fb0735f7f47fbfb`, 25,466 UTF-8 bytes.

Semantic addendum accepted by the orchestrator: `IDA-DG19-A2a0a semantic addendum: IPv4-only local_scratch; IPv6 deferred to P0a0b`.

## Changed paths

- `packages/database/src/admin-connection-config.ts`
- `packages/database/test/admin-connection-config.test.ts`
- `scripts/repo-size-budget.json` (unchanged deterministic generator metadata)

## Contract and abuse controls

- Requires explicit `DATABASE_URL`; no `PG*`, trust-store, RLS URL, or other environment fallback.
- Rejects ambiguous URL syntax, unsupported query/startup options, credentials with structural delimiters, indirect/pooler endpoints, and implicit loopback authority.
- Allows only an explicit test-only, uniquely named IPv4 `127.0.0.1` scratch database or a canonical Supabase direct endpoint on port 5432.
- Bracketed `[::1]` and unbracketed `::1` reject deterministically; IPv6 driver normalization remains owned by P0a0b.
- Requires a bounded, current, self-signed CA for nonloopback and locks hostname verification plus single-connection Postgres.js posture.
- Keeps credentials/CA opaque in JSON, inspection, and error results; emits no stdout/stderr.
- Does not export or construct a live client and never connects to a database.

## Verification

- Focused configuration tests: 5/5 PASS.
- `@interdomestik/database` type-check: PASS.
- Prettier/diff, modularity, DB-access, size sync/check, repo-size, and `security:guard`: PASS.
- Final post-addendum exact-current architecture review: PASS, no findings.
- Final post-addendum exact-current Tier-3 security review: PASS, no findings.
- Source/test line counts: 150/141.
- `pnpm pr:verify`: PASS against disposable `127.0.0.1:55532/interdomestik_p0a0a`; includes RLS 41/41, coverage 85.10%, build/bundle, PR E2E 214/214, and smoke 13 passed / 11 expected skipped.
- Separate `pnpm e2e:gate`: PASS against the same disposable target; 205 passed / 9 expected skipped.
- Sonnet: architecture/security/scope PASS with no P0/P1; route overall NON_PASS only because it declined independent inline artifact hashing.
- Gemini: BLOCKED by quota/rate limit. Fable: unverified/non-PASS.

## Local default-DB incident and adopted policy

During an earlier mandatory-gate attempt, `pnpm pr:verify` reached `check:fast -> e2e:gate:pr -> scripts/run-with-default-db-url.mjs` without an inherited `DATABASE_URL`, so the runner selected the local default `127.0.0.1:54322/postgres`. RLS tests, migrations, and the deterministic E2E reset/reseed ran before the command was stopped during build. No production/remote database, frozen worktree/container, provider, deployment, or production alias was contacted. No ad hoc rollback or inspection was attempted.

The remainder of this PR used a permanent no-default-DB verification policy: every database URL was explicitly pinned to the uniquely named disposable PostgreSQL target `ida-p0a0a-pg-20260719t1413` on port 55532. The content-free incident receipt is preserved outside the repository as SHA-256 `9e51e0c650974a22e3c82daeea338559b7cd9bab00b49b9bd5e92c28b521cc1f` (4,643 bytes).

## Classified baseline defect

`pnpm slice:verify` has one unchanged `origin/main` `gate_env_defect`: `packages/database/test/deferred-backfills.test.ts` still reads `claims.ts` after the asserted index moved to `claim-core.ts`. The failure reproduces without this diff; this slice does not modify that test or schema surface. Mandatory Phase C gates above are green on the isolated route.

## Exclusions and rollback

No socket/SQL/DDL/reserved session/migration execution, migration-folder mutation, Docker/CI role topology, privilege manifest, runtime-role provisioning, caller/export wiring, IPv6 driver arrays/client proof, provider mutation, deployment, or follow-up `P0a0b`/`P0a1`/`P0a2` work.

Binding P0a0b precondition from current-head review: `publications: 'none'` is not proof that logical replication is disabled. Before any authorized `postgres(options)` construction, P0a0b must keep the raw client private, prove that subscribe/listen/replication surfaces are neither invoked nor exposed, cover nested idle-client teardown, and separately adjudicate a supported fail-closed subscription mechanism. Postgres.js 3.4.9's internal `no_subscribe` recursion guard is not added to this exact P0a0a options contract.

Rollback is to revert this PR's three authorized paths; the module has no callers or persistent side effects in this slice.
