### PR TITLE
feat: add reserved admin DB preflight

### DIFF
--- a/packages/database/src/admin-connection-config.ts
+++ b/packages/database/src/admin-connection-config.ts
@@ -113,7 +113,7 @@ class AdminConnectionConfig {
       keep_alive: 30,
       prepare: false,
       debug: false,
-      fetch_types: false,
+      fetch_types: true,
       publications: 'none',
       target_session_attrs: 'primary',
       types: Object.freeze({}),

--- a/packages/database/src/admin-connection-preflight.ts
+++ b/packages/database/src/admin-connection-preflight.ts
@@ -26,10 +26,17 @@ function digestMatches(value: string, expected: string): boolean {
 function authorityMatches(options: Options, kind: string, authority: AdminConnectionAuthority) {
   const keys = Object.keys(authority).sort().join(',');
   const ssl = options.ssl && typeof options.ssl === 'object' ? options.ssl : undefined;
+  const receipt = JSON.stringify({
+    environmentClass: authority.environmentClass,
+    endpointSha256: authority.endpointSha256,
+    caSha256: authority.caSha256,
+    expectedRolsuper: authority.expectedRolsuper,
+    expectedRolbypassrls: authority.expectedRolbypassrls,
+  });
   return (
     keys ===
       'caSha256,endpointSha256,environmentClass,expectedRolbypassrls,expectedRolsuper,receiptSha256' &&
-    HEX.test(authority.receiptSha256) &&
+    digestMatches(receipt, authority.receiptSha256) &&
     authority.environmentClass === kind &&
     digestMatches(`${String(options.host)}:${String(options.port)}`, authority.endpointSha256) &&
     digestMatches(ssl && 'ca' in ssl ? String(ssl.ca) : '', authority.caSha256)

--- a/packages/database/src/admin-connection-preflight.ts
+++ b/packages/database/src/admin-connection-preflight.ts
@@ -26,17 +26,16 @@ function digestMatches(value: string, expected: string): boolean {
 function authorityMatches(options: Options, kind: string, authority: AdminConnectionAuthority) {
   const keys = Object.keys(authority).sort().join(',');
   const ssl = options.ssl && typeof options.ssl === 'object' ? options.ssl : undefined;
-  const receipt = JSON.stringify({
+  const receipt = {
     environmentClass: authority.environmentClass,
     endpointSha256: authority.endpointSha256,
     caSha256: authority.caSha256,
     expectedRolsuper: authority.expectedRolsuper,
     expectedRolbypassrls: authority.expectedRolbypassrls,
-  });
+  };
   return (
-    keys ===
-      'caSha256,endpointSha256,environmentClass,expectedRolbypassrls,expectedRolsuper,receiptSha256' &&
-    digestMatches(receipt, authority.receiptSha256) &&
+    keys === `${Object.keys(receipt).sort().join(',')},receiptSha256` &&
+    digestMatches(JSON.stringify(receipt), authority.receiptSha256) &&
     authority.environmentClass === kind &&
     digestMatches(`${String(options.host)}:${String(options.port)}`, authority.endpointSha256) &&
     digestMatches(ssl && 'ca' in ssl ? String(ssl.ca) : '', authority.caSha256)

--- a/packages/database/src/admin-connection-preflight.ts
+++ b/packages/database/src/admin-connection-preflight.ts
@@ -1,0 +1,142 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import postgres from 'postgres';
+import { resolveAdminConnectionConfig } from './admin-connection-config';
+
+// prettier-ignore
+export type AdminConnectionAuthority = Readonly<{ environmentClass: 'local_scratch' | 'supabase_direct'; receiptSha256: string; endpointSha256: string; caSha256: string; expectedRolsuper: boolean; expectedRolbypassrls: boolean }>;
+type Reserved = postgres.ReservedSql<Record<never, never>>;
+type Options = postgres.Options<Record<never, never>>;
+// prettier-ignore
+type Probe = Record<'identity_ok' | 'owner_ok' | 'role_ok' | 'state_ok' | 'tls', boolean> & { pid: number; server_major: number };
+const ABORT = Symbol('abort');
+const HEX = /^[a-f0-9]{64}$/;
+const APPLICATION = 'interdomestik_admin_config_v1';
+
+function fail(code: string, cleanup = false) {
+  const cleanupCode = cleanup && code !== 'ADMIN_DB_PREFLIGHT_CLEANUP_FAILED';
+  const error = cleanupCode
+    ? { code, cleanup_code: 'ADMIN_DB_PREFLIGHT_CLEANUP_FAILED' }
+    : { code };
+  return Object.freeze({ ok: false as const, error: Object.freeze(error) });
+}
+function digestMatches(value: string, expected: string): boolean {
+  if (!HEX.test(expected)) return false;
+  return timingSafeEqual(createHash('sha256').update(value).digest(), Buffer.from(expected, 'hex'));
+}
+function authorityMatches(options: Options, kind: string, authority: AdminConnectionAuthority) {
+  const keys = Object.keys(authority).sort().join(',');
+  const ssl = options.ssl && typeof options.ssl === 'object' ? options.ssl : undefined;
+  return (
+    keys ===
+      'caSha256,endpointSha256,environmentClass,expectedRolbypassrls,expectedRolsuper,receiptSha256' &&
+    HEX.test(authority.receiptSha256) &&
+    authority.environmentClass === kind &&
+    digestMatches(`${String(options.host)}:${String(options.port)}`, authority.endpointSha256) &&
+    digestMatches(ssl && 'ca' in ssl ? String(ssl.ca) : '', authority.caSha256)
+  );
+}
+async function probe(sql: Reserved, options: Options, authority: AdminConnectionAuthority) {
+  const rows = await sql<Probe[]>`
+    SELECT pg_backend_pid()::int AS pid,
+      session_user = current_user AND current_user = ${String(options.username)}
+        AND current_database() = ${String(options.database)}
+        AND current_setting('application_name') = ${APPLICATION} AS identity_ok,
+      (SELECT d.datdba = r.oid FROM pg_database d JOIN pg_roles r
+        ON r.rolname = current_user WHERE d.datname = current_database()) AS owner_ok,
+      (SELECT r.rolcanlogin AND NOT r.rolreplication
+        AND r.rolsuper = ${authority.expectedRolsuper}
+        AND r.rolbypassrls = ${authority.expectedRolbypassrls}
+        FROM pg_roles r WHERE r.rolname = current_user)
+        AND current_user <> ALL(ARRAY['anon','authenticated','service_role',
+          'interdomestik_runtime_rls','interdomestik_rls_test']::name[])
+        AND has_database_privilege(current_user, current_database(), 'CONNECT')
+        AND has_database_privilege(current_user, current_database(), 'CREATE')
+        AND has_database_privilege(current_user, current_database(), 'TEMP') AS role_ok,
+      NOT pg_is_in_recovery() AND current_setting('transaction_read_only') = 'off'
+        AND current_setting('default_transaction_read_only') = 'off' AS state_ok,
+      COALESCE((SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()), false) AS tls,
+      current_setting('server_version_num')::int / 10000 AS server_major
+  `;
+  if (!rows[0]) throw new Error('PROBE_EMPTY');
+  return rows[0];
+}
+function classify(row: Probe, kind: string): string | null {
+  if (!row.identity_ok) return 'ADMIN_DB_PREFLIGHT_IDENTITY_REJECTED';
+  if (!row.owner_ok || !row.role_ok) return 'ADMIN_DB_PREFLIGHT_ROLE_REJECTED';
+  if (!row.state_ok) return 'ADMIN_DB_PREFLIGHT_STATE_REJECTED';
+  if (row.tls !== (kind === 'supabase_direct')) return 'ADMIN_DB_PREFLIGHT_TRANSPORT_REJECTED';
+  if (row.server_major !== 15 && row.server_major !== 16)
+    return 'ADMIN_DB_PREFLIGHT_VERSION_REJECTED';
+  return null;
+}
+
+export async function withPreflightedAdminConnection(
+  env: Readonly<Record<string, unknown>>,
+  nowEpochMs: number,
+  signal: AbortSignal,
+  authority: AdminConnectionAuthority,
+  operation: (sql: Reserved, signal: AbortSignal) => Promise<void>
+) {
+  const resolved = resolveAdminConnectionConfig(env, nowEpochMs);
+  if (!resolved.ok) return fail('ADMIN_DB_PREFLIGHT_CONFIG_REJECTED');
+  const kind = resolved.config.toJSON().endpoint_class;
+  const options = resolved.config.toPostgresOptions();
+  if (!authorityMatches(options, kind, authority))
+    return fail('ADMIN_DB_PREFLIGHT_AUTHORITY_REJECTED');
+  let sql: ReturnType<typeof postgres> | undefined;
+  let reserved: Reserved | undefined;
+  let closePromise: Promise<void> | undefined;
+  let cleanupFailed = false;
+  let aborted = false;
+  let closed = false;
+  let phase = 0;
+  // prettier-ignore
+  const closeOnce = () => (closePromise ??= (async () => { try { reserved?.release(); } catch { cleanupFailed = true; } try { await sql?.end({ timeout: 1 }); } catch { cleanupFailed = true; } })());
+  let resolveAbort!: (value: typeof ABORT) => void;
+  // prettier-ignore
+  const abort = new Promise<typeof ABORT>(resolve => { resolveAbort = resolve; });
+  const onAbort = () => {
+    if (closed) return;
+    aborted = true;
+    resolveAbort(ABORT);
+    void closeOnce();
+  };
+  const race = async <T>(promise: Promise<T>): Promise<T> => {
+    // prettier-ignore
+    const outcome = await Promise.race([promise.then(value => ({ value }), error => ({ error })), abort]);
+    if (outcome === ABORT) throw ABORT;
+    if ('error' in outcome) throw outcome.error;
+    return outcome.value;
+  };
+  signal.addEventListener('abort', onAbort, { once: true });
+  let code: string | null = null;
+  let preflight: Probe | undefined;
+  try {
+    if (signal.aborted) throw ABORT;
+    sql = postgres(options);
+    reserved = await race(sql.reserve());
+    phase = 1;
+    preflight = await race(probe(reserved, options, authority));
+    code = classify(preflight, kind);
+    if (!code && !signal.aborted) {
+      phase = 2;
+      await race(operation(reserved, signal));
+      phase = 3;
+      const postflight = await race(probe(reserved, options, authority));
+      code = classify(postflight, kind);
+      if (!code && postflight.pid !== preflight.pid) code = 'ADMIN_DB_PREFLIGHT_SESSION_CHANGED';
+    } else if (signal.aborted) throw ABORT;
+  } catch (error) {
+    // prettier-ignore
+    code = error === ABORT ? 'ADMIN_DB_PREFLIGHT_ABORTED' : phase === 2 ? 'ADMIN_DB_PREFLIGHT_OPERATION_FAILED' : 'ADMIN_DB_PREFLIGHT_CONNECT_FAILED';
+  } finally {
+    await closeOnce();
+    closed = true;
+    signal.removeEventListener('abort', onAbort);
+  }
+  if (aborted) code = 'ADMIN_DB_PREFLIGHT_ABORTED';
+  if (code) return fail(code, cleanupFailed);
+  if (cleanupFailed) return fail('ADMIN_DB_PREFLIGHT_CLEANUP_FAILED');
+  // prettier-ignore
+  return Object.freeze({ ok: true as const, summary: Object.freeze({ contract_version: 'admin_connection_preflight_v1' as const, endpoint_class: kind, session_reserved: true as const, identity_verified: true as const, database_owner_verified: true as const, writable_primary_verified: true as const, transport_verified: kind === 'local_scratch' ? ('loopback_plaintext' as const) : ('explicit_ca_hostname_verified' as const), server_major: preflight!.server_major as 15 | 16, operation_completed: true as const }) });
+}

--- a/packages/database/src/admin-connection-preflight.ts
+++ b/packages/database/src/admin-connection-preflight.ts
@@ -24,7 +24,9 @@ function digestMatches(value: string, expected: string): boolean {
   return timingSafeEqual(createHash('sha256').update(value).digest(), Buffer.from(expected, 'hex'));
 }
 function authorityMatches(options: Options, kind: string, authority: AdminConnectionAuthority) {
-  const keys = Object.keys(authority).sort().join(',');
+  const keys = Object.keys(authority)
+    .sort((left, right) => left.localeCompare(right))
+    .join(',');
   const ssl = options.ssl && typeof options.ssl === 'object' ? options.ssl : undefined;
   const receipt = {
     environmentClass: authority.environmentClass,
@@ -66,14 +68,19 @@ async function probe(sql: Reserved, options: Options, authority: AdminConnection
   if (!rows[0]) throw new Error('PROBE_EMPTY');
   return rows[0];
 }
-function classify(row: Probe, kind: string): string | null {
+function classify(row: Probe, kind: string, expectedPid?: number): string | null {
   if (!row.identity_ok) return 'ADMIN_DB_PREFLIGHT_IDENTITY_REJECTED';
   if (!row.owner_ok || !row.role_ok) return 'ADMIN_DB_PREFLIGHT_ROLE_REJECTED';
   if (!row.state_ok) return 'ADMIN_DB_PREFLIGHT_STATE_REJECTED';
   if (row.tls !== (kind === 'supabase_direct')) return 'ADMIN_DB_PREFLIGHT_TRANSPORT_REJECTED';
   if (row.server_major !== 15 && row.server_major !== 16)
     return 'ADMIN_DB_PREFLIGHT_VERSION_REJECTED';
+  if (expectedPid && row.pid !== expectedPid) return 'ADMIN_DB_PREFLIGHT_SESSION_CHANGED';
   return null;
+}
+function caughtCode(error: unknown, phase: number): string {
+  if (error === ABORT) return 'ADMIN_DB_PREFLIGHT_ABORTED';
+  return phase === 2 ? 'ADMIN_DB_PREFLIGHT_OPERATION_FAILED' : 'ADMIN_DB_PREFLIGHT_CONNECT_FAILED';
 }
 
 export async function withPreflightedAdminConnection(
@@ -129,12 +136,11 @@ export async function withPreflightedAdminConnection(
       await race(operation(reserved, signal));
       phase = 3;
       const postflight = await race(probe(reserved, options, authority));
-      code = classify(postflight, kind);
-      if (!code && postflight.pid !== preflight.pid) code = 'ADMIN_DB_PREFLIGHT_SESSION_CHANGED';
-    } else if (signal.aborted) throw ABORT;
+      code = classify(postflight, kind, preflight.pid);
+    }
+    if (signal.aborted) throw ABORT;
   } catch (error) {
-    // prettier-ignore
-    code = error === ABORT ? 'ADMIN_DB_PREFLIGHT_ABORTED' : phase === 2 ? 'ADMIN_DB_PREFLIGHT_OPERATION_FAILED' : 'ADMIN_DB_PREFLIGHT_CONNECT_FAILED';
+    code = caughtCode(error, phase);
   } finally {
     await closeOnce();
     closed = true;

--- a/packages/database/src/admin-connection-preflight.ts
+++ b/packages/database/src/admin-connection-preflight.ts
@@ -11,6 +11,7 @@ type Probe = Record<'identity_ok' | 'owner_ok' | 'role_ok' | 'state_ok' | 'tls',
 const ABORT = Symbol('abort');
 const HEX = /^[a-f0-9]{64}$/;
 const APPLICATION = 'interdomestik_admin_config_v1';
+const alphabetic = (left: string, right: string) => left.localeCompare(right);
 
 function fail(code: string, cleanup = false) {
   const cleanupCode = cleanup && code !== 'ADMIN_DB_PREFLIGHT_CLEANUP_FAILED';
@@ -24,19 +25,12 @@ function digestMatches(value: string, expected: string): boolean {
   return timingSafeEqual(createHash('sha256').update(value).digest(), Buffer.from(expected, 'hex'));
 }
 function authorityMatches(options: Options, kind: string, authority: AdminConnectionAuthority) {
-  const keys = Object.keys(authority)
-    .sort((left, right) => left.localeCompare(right))
-    .join(',');
+  const keys = Object.keys(authority).sort(alphabetic).join(',');
   const ssl = options.ssl && typeof options.ssl === 'object' ? options.ssl : undefined;
-  const receipt = {
-    environmentClass: authority.environmentClass,
-    endpointSha256: authority.endpointSha256,
-    caSha256: authority.caSha256,
-    expectedRolsuper: authority.expectedRolsuper,
-    expectedRolbypassrls: authority.expectedRolbypassrls,
-  };
+  // prettier-ignore
+  const receipt = { environmentClass: authority.environmentClass, endpointSha256: authority.endpointSha256, caSha256: authority.caSha256, expectedRolsuper: authority.expectedRolsuper, expectedRolbypassrls: authority.expectedRolbypassrls };
   return (
-    keys === `${Object.keys(receipt).sort().join(',')},receiptSha256` &&
+    keys === `${Object.keys(receipt).sort(alphabetic).join(',')},receiptSha256` &&
     digestMatches(JSON.stringify(receipt), authority.receiptSha256) &&
     authority.environmentClass === kind &&
     digestMatches(`${String(options.host)}:${String(options.port)}`, authority.endpointSha256) &&

--- a/packages/database/test/admin-connection-config.test.ts
+++ b/packages/database/test/admin-connection-config.test.ts
@@ -49,7 +49,7 @@ test('locks loopback options and keeps the configuration opaque and immutable', 
   // prettier-ignore
   assert.equal(Object.keys(first).sort().join(','), 'backoff,connect_timeout,connection,database,debug,fetch_types,host,idle_timeout,keep_alive,max,max_lifetime,max_pipeline,onnotice,onparameter,password,path,port,prepare,publications,ssl,sslnegotiation,target_session_attrs,transform,types,username');
   // prettier-ignore
-  assert.equal(JSON.stringify(first), '{"host":"127.0.0.1","port":5439,"database":"interdomestik_admin_config_test","username":"admin","password":"secret","ssl":false,"sslnegotiation":null,"max":1,"idle_timeout":0,"connect_timeout":5,"max_lifetime":null,"max_pipeline":1,"backoff":false,"keep_alive":30,"prepare":false,"debug":false,"fetch_types":false,"publications":"none","target_session_attrs":"primary","types":{},"transform":{},"connection":{"application_name":"interdomestik_admin_config_v1"}}');
+  assert.equal(JSON.stringify(first), '{"host":"127.0.0.1","port":5439,"database":"interdomestik_admin_config_test","username":"admin","password":"secret","ssl":false,"sslnegotiation":null,"max":1,"idle_timeout":0,"connect_timeout":5,"max_lifetime":null,"max_pipeline":1,"backoff":false,"keep_alive":30,"prepare":false,"debug":false,"fetch_types":true,"publications":"none","target_session_attrs":"primary","types":{},"transform":{},"connection":{"application_name":"interdomestik_admin_config_v1"}}');
   assert.equal(first.path, undefined);
   assert.equal(first.transform?.undefined, undefined);
   assert.equal(typeof first.onnotice, 'function');

--- a/packages/database/test/admin-connection-preflight.support.ts
+++ b/packages/database/test/admin-connection-preflight.support.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { execFile } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 import postgres from 'postgres';
 import type { AdminConnectionAuthority } from '../src/admin-connection-preflight';
@@ -7,6 +8,7 @@ import type { AdminConnectionAuthority } from '../src/admin-connection-preflight
 const exec = promisify(execFile);
 const sha256 = (value: string) => createHash('sha256').update(value).digest('hex');
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+const IMPORT = /from ['"][^'"]*admin-connection-preflight['"]/;
 
 export type FixtureReceipt = Readonly<{
   imageId: string;
@@ -20,6 +22,21 @@ export type FixtureReceipt = Readonly<{
 }>;
 
 export type AdminFixture = Awaited<ReturnType<typeof startAdminFixture>>;
+
+export function findAdminPreflightImports() {
+  const files: string[] = [];
+  const scan = (dir: URL, prefix: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const relative = `${prefix}/${entry.name}`;
+      const next = new URL(entry.isDirectory() ? `${entry.name}/` : entry.name, dir);
+      if (entry.isDirectory()) scan(next, relative);
+      else if (relative.endsWith('.ts') && IMPORT.test(readFileSync(next, 'utf8')))
+        files.push(relative);
+    }
+  };
+  scan(new URL('../../', import.meta.url), 'packages');
+  return files.sort();
+}
 
 async function docker(...args: string[]): Promise<string> {
   return (await exec('docker', args, { timeout: 60_000 })).stdout.trim();

--- a/packages/database/test/admin-connection-preflight.support.ts
+++ b/packages/database/test/admin-connection-preflight.support.ts
@@ -1,0 +1,130 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import postgres from 'postgres';
+import type { AdminConnectionAuthority } from '../src/admin-connection-preflight';
+
+const exec = promisify(execFile);
+const sha256 = (value: string) => createHash('sha256').update(value).digest('hex');
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export type FixtureReceipt = Readonly<{
+  imageId: string;
+  containerName: string;
+  port: number;
+  databasePrefix: 'interdomestik_admin_config_p0a0b_';
+  expectedRolsuper: false;
+  expectedRolbypassrls: false;
+  startedAt: string;
+  removedAt?: string;
+}>;
+
+export type AdminFixture = Awaited<ReturnType<typeof startAdminFixture>>;
+
+async function docker(...args: string[]): Promise<string> {
+  return (await exec('docker', args, { timeout: 60_000 })).stdout.trim();
+}
+
+async function connectEventually(port: number) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const sql = postgres({ host: '127.0.0.1', port, database: 'postgres', username: 'postgres' });
+    try {
+      await sql`SELECT 1`;
+      return sql;
+    } catch {
+      await sql.end({ timeout: 0 });
+      await delay(100);
+    }
+  }
+  throw new Error('DISPOSABLE_POSTGRES_NOT_READY');
+}
+
+export async function startAdminFixture() {
+  const suffix = randomBytes(6).toString('hex');
+  const containerName = `ida-p0a0b-ecea-${suffix}`;
+  const database = `interdomestik_admin_config_p0a0b_${suffix}`;
+  const owner = `p0a0b_owner_${suffix}`;
+  const nonowner = `p0a0b_nonowner_${suffix}`;
+  const password = randomBytes(18).toString('hex');
+  const startedAt = new Date().toISOString();
+  await docker(
+    'run',
+    '--detach',
+    '--rm',
+    '--name',
+    containerName,
+    '--env',
+    'POSTGRES_HOST_AUTH_METHOD=trust',
+    '--publish',
+    '127.0.0.1::5432',
+    'postgres:16'
+  );
+  const port = Number(
+    await docker('port', containerName, '5432/tcp').then(v => v.split(':').at(-1))
+  );
+  const bootstrap = await connectEventually(port);
+  try {
+    await bootstrap.unsafe(`CREATE ROLE ${owner} LOGIN NOSUPERUSER NOBYPASSRLS NOREPLICATION`);
+    await bootstrap.unsafe(`CREATE ROLE ${nonowner} LOGIN NOSUPERUSER NOBYPASSRLS NOREPLICATION`);
+    await bootstrap.unsafe(`CREATE DATABASE ${database} OWNER ${owner}`);
+  } finally {
+    await bootstrap.end({ timeout: 1 });
+  }
+  const observer = postgres({
+    host: '127.0.0.1',
+    port,
+    database,
+    username: 'postgres',
+    max: 1,
+    connection: { application_name: `p0a0b_observer_${suffix}` },
+  });
+  const endpointSha256 = sha256(`127.0.0.1:${port}`);
+  const authorityBase = {
+    environmentClass: 'local_scratch' as const,
+    endpointSha256,
+    caSha256: sha256(''),
+    expectedRolsuper: false as const,
+    expectedRolbypassrls: false as const,
+  };
+  const authority: AdminConnectionAuthority = Object.freeze({
+    ...authorityBase,
+    receiptSha256: sha256(JSON.stringify(authorityBase)),
+  });
+  const envFor = (username: string) =>
+    Object.freeze({
+      DATABASE_URL: `postgres://${username}:${password}@127.0.0.1:${port}/${database}`,
+      NODE_ENV: 'test',
+      ADMIN_DB_LOCAL_SCRATCH: '1',
+    });
+  const receipt: FixtureReceipt = Object.freeze({
+    imageId: await docker('image', 'inspect', 'postgres:16', '--format', '{{.Id}}'),
+    containerName,
+    port,
+    databasePrefix: 'interdomestik_admin_config_p0a0b_',
+    expectedRolsuper: false,
+    expectedRolbypassrls: false,
+    startedAt,
+  });
+  const waitForNoSession = async (pid?: number) => {
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const rows = pid
+        ? await observer`SELECT count(*)::int AS count FROM pg_stat_activity WHERE pid = ${pid}`
+        : await observer`SELECT count(*)::int AS count FROM pg_stat_activity WHERE application_name = 'interdomestik_admin_config_v1'`;
+      if (rows[0]?.count === 0) return;
+      await delay(50);
+    }
+    throw new Error('ADMIN_DB_FIXTURE_SESSION_RETAINED');
+  };
+  const stop = async (): Promise<FixtureReceipt> => {
+    await observer.end({ timeout: 1 });
+    await docker('rm', '--force', containerName);
+    return Object.freeze({ ...receipt, removedAt: new Date().toISOString() });
+  };
+  return Object.freeze({
+    authority,
+    ownerEnv: envFor(owner),
+    nonownerEnv: envFor(nonowner),
+    waitForNoSession,
+    stop,
+  });
+}

--- a/packages/database/test/admin-connection-preflight.support.ts
+++ b/packages/database/test/admin-connection-preflight.support.ts
@@ -30,7 +30,7 @@ export function findAdminPreflightImports() {
       const relative = `${prefix}/${entry.name}`;
       const next = new URL(entry.isDirectory() ? `${entry.name}/` : entry.name, dir);
       if (entry.isDirectory()) scan(next, relative);
-      else if (relative.endsWith('.ts') && IMPORT.test(readFileSync(next, 'utf8')))
+      else if (/\.tsx?$/.test(relative) && IMPORT.test(readFileSync(next, 'utf8')))
         files.push(relative);
     }
   };

--- a/packages/database/test/admin-connection-preflight.support.ts
+++ b/packages/database/test/admin-connection-preflight.support.ts
@@ -35,7 +35,7 @@ export function findAdminPreflightImports() {
     }
   };
   scan(new URL('../../', import.meta.url), 'packages');
-  return files.sort();
+  return files.sort((left, right) => left.localeCompare(right));
 }
 
 async function docker(...args: string[]): Promise<string> {

--- a/packages/database/test/admin-connection-preflight.test.ts
+++ b/packages/database/test/admin-connection-preflight.test.ts
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { after, before, test } from 'node:test';
 import { inspect } from 'node:util';
 import { withPreflightedAdminConnection } from '../src/admin-connection-preflight';
-import { type AdminFixture, startAdminFixture } from './admin-connection-preflight.support';
+import {
+  findAdminPreflightImports,
+  type AdminFixture,
+  startAdminFixture,
+} from './admin-connection-preflight.support';
 const SOURCE = readFileSync(
   new URL('../src/admin-connection-preflight.ts', import.meta.url),
   'utf8'
@@ -38,14 +41,7 @@ test('keeps the wrapper internal, fixed-query-only, and free of forbidden capabi
     SOURCE,
     /\.unsafe\(|\b(?:drizzle|migration)\b|node:(?:fs|path)|console\.|process\.(?:stdout|stderr)/i
   );
-  const imports = execFileSync(
-    'rg',
-    ['-l', 'from [\'"][^\'"]*admin-connection-preflight[\'"]', 'packages'],
-    { encoding: 'utf8', cwd: '../..' }
-  )
-    .trim()
-    .split('\n');
-  assert.deepEqual(imports.sort(), [
+  assert.deepEqual(findAdminPreflightImports(), [
     'packages/database/test/admin-connection-preflight.support.ts',
     'packages/database/test/admin-connection-preflight.test.ts',
   ]);
@@ -80,19 +76,23 @@ test('accepts the disposable owner once on one reserved plaintext PostgreSQL 16 
   });
   await fixture.waitForNoSession(pid);
 });
-test('rejects an unbound endpoint before connect and a connected nonowner before operation', async () => {
+test('rejects unbound or unsealed authority before connect and a connected nonowner before operation', async () => {
   let calls = 0;
-  const wrongAuthority = { ...fixture.authority, endpointSha256: '0'.repeat(64) };
-  const authorityResult = await run(
-    fixture.ownerEnv,
-    new AbortController().signal,
-    wrongAuthority,
-    async () => {
-      calls += 1;
-    }
-  );
-  assert.equal(failureCode(authorityResult), 'ADMIN_DB_PREFLIGHT_AUTHORITY_REJECTED');
-  await fixture.waitForNoSession();
+  for (const authority of [
+    { ...fixture.authority, endpointSha256: '0'.repeat(64) },
+    { ...fixture.authority, receiptSha256: 'f'.repeat(64) },
+  ]) {
+    const authorityResult = await run(
+      fixture.ownerEnv,
+      new AbortController().signal,
+      authority,
+      async () => {
+        calls += 1;
+      }
+    );
+    assert.equal(failureCode(authorityResult), 'ADMIN_DB_PREFLIGHT_AUTHORITY_REJECTED');
+    await fixture.waitForNoSession();
+  }
   const ownerResult = await run(
     fixture.nonownerEnv,
     new AbortController().signal,

--- a/packages/database/test/admin-connection-preflight.test.ts
+++ b/packages/database/test/admin-connection-preflight.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { after, before, test } from 'node:test';
+import { inspect } from 'node:util';
+import { withPreflightedAdminConnection } from '../src/admin-connection-preflight';
+import { type AdminFixture, startAdminFixture } from './admin-connection-preflight.support';
+const SOURCE = readFileSync(
+  new URL('../src/admin-connection-preflight.ts', import.meta.url),
+  'utf8'
+);
+let fixture: AdminFixture;
+before(async () => {
+  fixture = await startAdminFixture();
+});
+after(async () => {
+  const receipt = await fixture.stop();
+  assert(receipt.removedAt);
+  assert(!JSON.stringify(receipt).includes('password'));
+});
+function failureCode(result: Awaited<ReturnType<typeof withPreflightedAdminConnection>>) {
+  if (result.ok) assert.fail('expected preflight rejection');
+  return result.error.code;
+}
+const run = (
+  env: Readonly<Record<string, unknown>>,
+  signal: AbortSignal,
+  authority: AdminFixture['authority'],
+  operation: Parameters<typeof withPreflightedAdminConnection>[4]
+) => withPreflightedAdminConnection(env, Date.now(), signal, authority, operation);
+test('keeps the wrapper internal, fixed-query-only, and free of forbidden capabilities', () => {
+  assert.equal((SOURCE.match(/postgres\(options\)/g) ?? []).length, 1);
+  assert.equal((SOURCE.match(/probe\(reserved, options, authority\)/g) ?? []).length, 2);
+  assert.match(SOURCE, /sql\.reserve\(\)/);
+  assert.match(SOURCE, /reserved\?\.release\(\)/);
+  assert.match(SOURCE, /sql\?\.end\(\{ timeout: 1 \}\)/);
+  assert.doesNotMatch(
+    SOURCE,
+    /\.unsafe\(|\b(?:drizzle|migration)\b|node:(?:fs|path)|console\.|process\.(?:stdout|stderr)/i
+  );
+  const imports = execFileSync(
+    'rg',
+    ['-l', 'from [\'"][^\'"]*admin-connection-preflight[\'"]', 'packages'],
+    { encoding: 'utf8', cwd: '../..' }
+  )
+    .trim()
+    .split('\n');
+  assert.deepEqual(imports.sort(), [
+    'packages/database/test/admin-connection-preflight.support.ts',
+    'packages/database/test/admin-connection-preflight.test.ts',
+  ]);
+});
+test('accepts the disposable owner once on one reserved plaintext PostgreSQL 16 session', async () => {
+  let pid = 0;
+  let calls = 0;
+  const result = await run(
+    fixture.ownerEnv,
+    new AbortController().signal,
+    fixture.authority,
+    async sql => {
+      calls += 1;
+      const rows = await sql`SELECT pg_backend_pid()::int AS pid`;
+      pid = rows[0]?.pid ?? 0;
+    }
+  );
+  assert.equal(calls, 1);
+  assert.deepEqual(result, {
+    ok: true,
+    summary: {
+      contract_version: 'admin_connection_preflight_v1',
+      endpoint_class: 'local_scratch',
+      session_reserved: true,
+      identity_verified: true,
+      database_owner_verified: true,
+      writable_primary_verified: true,
+      transport_verified: 'loopback_plaintext',
+      server_major: 16,
+      operation_completed: true,
+    },
+  });
+  await fixture.waitForNoSession(pid);
+});
+test('rejects an unbound endpoint before connect and a connected nonowner before operation', async () => {
+  let calls = 0;
+  const wrongAuthority = { ...fixture.authority, endpointSha256: '0'.repeat(64) };
+  const authorityResult = await run(
+    fixture.ownerEnv,
+    new AbortController().signal,
+    wrongAuthority,
+    async () => {
+      calls += 1;
+    }
+  );
+  assert.equal(failureCode(authorityResult), 'ADMIN_DB_PREFLIGHT_AUTHORITY_REJECTED');
+  await fixture.waitForNoSession();
+  const ownerResult = await run(
+    fixture.nonownerEnv,
+    new AbortController().signal,
+    fixture.authority,
+    async () => {
+      calls += 1;
+    }
+  );
+  assert.equal(failureCode(ownerResult), 'ADMIN_DB_PREFLIGHT_ROLE_REJECTED');
+  assert.equal(calls, 0);
+  await fixture.waitForNoSession();
+});
+test('linearizes pre-abort and abort during a signal-aware read-only operation', async () => {
+  const preAborted = new AbortController();
+  preAborted.abort();
+  let calls = 0;
+  const early = await run(fixture.ownerEnv, preAborted.signal, fixture.authority, async () => {
+    calls += 1;
+  });
+  assert.equal(failureCode(early), 'ADMIN_DB_PREFLIGHT_ABORTED');
+  const controller = new AbortController();
+  let pid = 0;
+  const during = await run(
+    fixture.ownerEnv,
+    controller.signal,
+    fixture.authority,
+    async (sql, signal) => {
+      calls += 1;
+      if (signal.aborted) return;
+      pid = (await sql`SELECT pg_backend_pid()::int AS pid`)[0]?.pid ?? 0;
+      // prettier-ignore
+      { const pending = sql`SELECT pg_sleep(5)`; const cancel = () => { void pending.cancel(); }; signal.addEventListener('abort', cancel, { once: true }); setTimeout(() => controller.abort(), 25); try { await pending; } finally { signal.removeEventListener('abort', cancel); } }
+    }
+  );
+  assert.equal(calls, 1);
+  assert.equal(failureCode(during), 'ADMIN_DB_PREFLIGHT_ABORTED');
+  await fixture.waitForNoSession(pid);
+});
+test('redacts operation failures and tears the reserved session down', async () => {
+  const sentinel = 'UNIQUE_OPERATION_FAILURE_DO_NOT_DISCLOSE';
+  let pid = 0;
+  const result = await run(
+    fixture.ownerEnv,
+    new AbortController().signal,
+    fixture.authority,
+    async sql => {
+      pid = (await sql`SELECT pg_backend_pid()::int AS pid`)[0]?.pid ?? 0;
+      throw new Error(sentinel);
+    }
+  );
+  assert.equal(failureCode(result), 'ADMIN_DB_PREFLIGHT_OPERATION_FAILED');
+  assert(!JSON.stringify(result).includes(sentinel));
+  assert(!inspect(result).includes(sentinel));
+  await fixture.waitForNoSession(pid);
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58329289,
+  "maxTrackedBytes": 58329331,
   "maxTrackedFiles": 5487,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16650829,
-    "source/scripts": 7753720,
+    "source/scripts": 7753762,
     "docs/text": 7517374,
     "tests/e2e": 5796835,
     "config/data/messages": 1754136

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58310848,
-  "maxTrackedFiles": 5484,
+  "maxTrackedBytes": 58328214,
+  "maxTrackedFiles": 5487,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16650829,
-    "source/scripts": 7740721,
+    "source/scripts": 7752554,
     "docs/text": 7517374,
-    "tests/e2e": 5791393,
+    "tests/e2e": 5796926,
     "config/data/messages": 1754136
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58328381,
+  "maxTrackedBytes": 58329289,
   "maxTrackedFiles": 5487,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16650829,
-    "source/scripts": 7752721,
+    "source/scripts": 7753720,
     "docs/text": 7517374,
-    "tests/e2e": 5796926,
+    "tests/e2e": 5796835,
     "config/data/messages": 1754136
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58328214,
+  "maxTrackedBytes": 58328381,
   "maxTrackedFiles": 5487,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16650829,
-    "source/scripts": 7752554,
+    "source/scripts": 7752721,
     "docs/text": 7517374,
     "tests/e2e": 5796926,
     "config/data/messages": 1754136


### PR DESCRIPTION
## Scope

Implements IDA-UI03a2-P0a0b only: a reserved-session administrative DB connection preflight with stable redacted outcomes and isolated PostgreSQL 16 live proof.

P0a0b config-compatibility amendment: fetch_types true to preserve Postgres.js 3.4.9 reserve semantics; no priming query.

- Resolves the accepted P0a0a configuration before creating a pool.
- Creates one max=1 Postgres.js pool and reserves exactly one session.
- Runs fixed parameterized preflight and postflight probes on that reservation.
- Invokes the trusted operation exactly once only after endpoint, identity, owner, posture, writable-primary, recovery, TLS, and version checks pass.
- Returns stable redacted codes and performs bounded cancellation and teardown.
- Adds no export, caller, workflow, migration, schema, provider, or deployment surface.

## RED and compatibility receipt

The required RED first failed with MODULE_NOT_FOUND before the production module existed. The first live reserve proof then exposed the accepted driver-boundary contradiction: P0a0a had fetch_types=false and Postgres.js 3.4.9 reserve could hang. The approved same-slice amendment changes only fetch_types to true and rejects an unreserved priming SELECT.

## Local proof

- focused config plus live preflight: 10/10 PASS
- database typecheck: PASS
- modularity guard: PASS
- DB-access guard: PASS
- deterministic repo-size sync/check: PASS
- security guard: PASS
- pr:verify non-browser stages: PASS, including 348 CI contracts, release-gate contracts, migration journal, RLS 41/41 with 80/80 enabled, i18n, architecture, 85.10 percent coverage, production build, and bundle size

## Local browser-gate exception

The PR browser lane stops after 51 PASS at the unrelated existing Free Start focus assertion in apps/web/e2e/gate/premium-free-start-result.spec.ts:124: free-start-save-code expected focused but was inactive after 5 seconds.

Classification evidence:

- isolated exact test on this head: PASS
- isolated exact test on clean origin/main c29913994: PASS
- full e2e:gate:pr on this head: identical failure twice after the same sequence point
- full e2e:gate:pr on clean origin/main c29913994 with a fresh baseline-only disposable PostgreSQL 16 DB: identical failure after 51 PASS

Classification: unrelated_origin_main_sequence_dependent_gate_defect. No UI or test remediation is included. Remote current-head CI remains required merge evidence.

## Review coverage

- Claude Opus 4.8 exact-current architecture and Tier-3 security review: PASS after one LOW remediation mapping postflight query errors to CONNECT_FAILED
- Claude Sonnet 4.6: NON_PASS, wrapper returned no output after 300,645 ms
- Fable: NON_PASS, callable access not verified
- Codex 5.6 ultra fallback: not required because Opus completed conclusively

## Safety and exclusions

All live proof used unique disposable no-volume or tmpfs PostgreSQL 16 containers on random loopback ports. All were removed after proof. No default, frozen, remote, Supabase, provider, or production DB was contacted. Remote readiness remains NON_PASS pending separate provider-contact authority. No deployment or alias is authorized.