### PR TITLE
feat: add repository traffic email alerts

### DIFF
--- a/.github/workflows/repository-traffic-alerts.yml
+++ b/.github/workflows/repository-traffic-alerts.yml
@@ -1,0 +1,135 @@
+name: Repository Traffic Alerts
+
+on:
+  fork:
+  schedule:
+    - cron: '15 7 * * *'
+  workflow_dispatch:
+    inputs:
+      report:
+        description: Report to send
+        required: true
+        default: traffic
+        type: choice
+        options:
+          - traffic
+          - email-test
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-traffic-alerts-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      REPORT_MODE: ${{ inputs.report || 'traffic' }}
+      REPOSITORY: ${{ github.repository }}
+      FORK_OWNER: ${{ github.event.forkee.owner.login }}
+      FORK_REPOSITORY: ${{ github.event.forkee.full_name }}
+      FORK_URL: ${{ github.event.forkee.html_url }}
+      FORK_CREATED_AT: ${{ github.event.forkee.created_at }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      TRAFFIC_READ_TOKEN: ${{ secrets.TRAFFIC_READ_TOKEN }}
+      ALERT_TO: ${{ vars.REPOSITORY_ALERT_EMAIL }}
+      ALERT_FROM: ${{ vars.RESEND_FROM_EMAIL }}
+    steps:
+      - name: Build and send repository report
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const required = name => {
+            const value = process.env[name]?.trim();
+            if (!value) throw new Error(`Missing required configuration: ${name}`);
+            return value;
+          };
+
+          const githubHeaders = token => ({
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'X-GitHub-Api-Version': '2026-03-10',
+          });
+
+          async function githubTraffic(kind) {
+            const repository = required('REPOSITORY');
+            const token = required('TRAFFIC_READ_TOKEN');
+            const response = await fetch(`https://api.github.com/repos/${repository}/traffic/${kind}`, {
+              headers: githubHeaders(token),
+            });
+            if (!response.ok) throw new Error(`GitHub ${kind} request failed: ${response.status}`);
+            return response.json();
+          }
+
+          function forkReport() {
+            const owner = required('FORK_OWNER');
+            return {
+              subject: `[Interdomestik] New GitHub fork by ${owner}`,
+              text: [
+                `A new fork of ${required('REPOSITORY')} was created.`,
+                `Account: ${owner}`,
+                `Fork: ${required('FORK_REPOSITORY')}`,
+                `URL: ${required('FORK_URL')}`,
+                `Created: ${required('FORK_CREATED_AT')}`,
+                '',
+                'GitHub identifies fork owners, but not accounts or IP addresses behind clones or ZIP downloads.',
+              ].join('\n'),
+            };
+          }
+
+          async function trafficReport() {
+            const [clones, views] = await Promise.all([
+              githubTraffic('clones'),
+              githubTraffic('views'),
+            ]);
+            const latest = clones.clones?.at(-1) ?? { timestamp: 'No clone data', count: 0, uniques: 0 };
+            return {
+              subject: `[Interdomestik] Daily repository traffic — ${latest.timestamp.slice(0, 10)}`,
+              text: [
+                `Repository: ${required('REPOSITORY')}`,
+                `Latest clone day: ${latest.timestamp}`,
+                `Latest clones: ${latest.count} (${latest.uniques} unique)`,
+                `Last 14 days — clones: ${clones.count} (${clones.uniques} unique)`,
+                `Last 14 days — views: ${views.count} (${views.uniques} unique)`,
+                '',
+                'Counts are GitHub aggregates. GitHub does not expose clone/download identities.',
+              ].join('\n'),
+            };
+          }
+
+          async function sendEmail(message) {
+            const response = await fetch('https://api.resend.com/emails', {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${required('RESEND_API_KEY')}`,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                from: required('ALERT_FROM'),
+                to: [required('ALERT_TO')],
+                ...message,
+              }),
+            });
+            if (!response.ok) throw new Error(`Resend request failed: ${response.status}`);
+            const result = await response.json();
+            console.log(`Repository alert sent successfully (${result.id ?? 'no message id'}).`);
+          }
+
+          const eventName = required('EVENT_NAME');
+          const mode = process.env.REPORT_MODE;
+          let message;
+          if (eventName === 'fork') message = forkReport();
+          else if (mode === 'email-test') {
+            message = {
+              subject: '[Interdomestik] Repository alert test',
+              text: `Repository email alerts are configured for ${required('REPOSITORY')}.`,
+            };
+          } else message = await trafficReport();
+
+          await sendEmail(message);
+          NODE

--- a/.github/workflows/repository-traffic-alerts.yml
+++ b/.github/workflows/repository-traffic-alerts.yml
@@ -122,6 +122,10 @@ jobs:
 
           const eventName = required('EVENT_NAME');
           const mode = process.env.REPORT_MODE;
+          if (eventName !== 'fork' && mode === 'traffic' && !process.env.TRAFFIC_READ_TOKEN?.trim()) {
+            console.log('Traffic report skipped: TRAFFIC_READ_TOKEN is not configured.');
+            process.exit(0);
+          }
           let message;
           if (eventName === 'fork') message = forkReport();
           else if (mode === 'email-test') {

--- a/scripts/ci/repository-traffic-alerts.test.mjs
+++ b/scripts/ci/repository-traffic-alerts.test.mjs
@@ -43,6 +43,11 @@ test('repository alerts report aggregate traffic and identifiable forks by email
   assert.doesNotThrow(() => new Function(`return (async () => {\n${script}\n});`));
 });
 
+test('traffic reports exit cleanly until the scoped traffic token is configured', () => {
+  assert.match(script, /Traffic report skipped: TRAFFIC_READ_TOKEN is not configured/u);
+  assert.match(script, /eventName !== 'fork'.+mode === 'traffic'.+TRAFFIC_READ_TOKEN/u);
+});
+
 test('repository alert files remain concise', () => {
   const lineCount = value => value.trimEnd().split('\n').length;
   assert.ok(lineCount(source) < 150, 'workflow must stay below 150 lines');

--- a/scripts/ci/repository-traffic-alerts.test.mjs
+++ b/scripts/ci/repository-traffic-alerts.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const workflowPath = path.join(rootDir, '.github/workflows/repository-traffic-alerts.yml');
+const source = fs.readFileSync(workflowPath, 'utf8');
+const workflow = yaml.load(source);
+const triggers = workflow.on ?? workflow.true;
+const job = workflow.jobs.notify;
+const script = job.steps[0].run.match(/node <<'NODE'\n([\s\S]+)\n[ \t]*NODE/u)?.[1] ?? '';
+
+test('repository alerts run only on fork, daily schedule, or manual dispatch', () => {
+  assert.deepEqual(Object.keys(triggers).sort(), ['fork', 'schedule', 'workflow_dispatch']);
+  assert.equal(triggers.schedule.length, 1);
+  assert.equal(triggers.workflow_dispatch.inputs.report.default, 'traffic');
+  assert.deepEqual(workflow.permissions, { contents: 'read' });
+  assert.equal(job['runs-on'], 'ubuntu-latest');
+  assert.ok(job['timeout-minutes'] <= 5);
+});
+
+test('repository alerts use scoped secrets and never check out repository code', () => {
+  assert.equal(job.env.RESEND_API_KEY, '${{ secrets.RESEND_API_KEY }}');
+  assert.equal(job.env.TRAFFIC_READ_TOKEN, '${{ secrets.TRAFFIC_READ_TOKEN }}');
+  assert.equal(job.env.ALERT_TO, '${{ vars.REPOSITORY_ALERT_EMAIL }}');
+  assert.equal(job.env.ALERT_FROM, '${{ vars.RESEND_FROM_EMAIL }}');
+  assert.ok(job.steps.every(step => !step.uses));
+  assert.doesNotMatch(source, /actions\/checkout/u);
+  assert.doesNotMatch(script, /\$\{\{\s*github\.event/u);
+});
+
+test('repository alerts report aggregate traffic and identifiable forks by email', () => {
+  assert.match(script, /traffic\/\$\{kind\}/u);
+  assert.match(script, /githubTraffic\('clones'\)/u);
+  assert.match(script, /githubTraffic\('views'\)/u);
+  assert.match(source, /github\.event\.forkee/u);
+  assert.match(script, /https:\/\/api\.resend\.com\/emails/u);
+  assert.match(script, /GitHub does not expose clone\/download identities/u);
+  assert.doesNotThrow(() => new Function(`return (async () => {\n${script}\n});`));
+});
+
+test('repository alert files remain concise', () => {
+  const lineCount = value => value.trimEnd().split('\n').length;
+  assert.ok(lineCount(source) < 150, 'workflow must stay below 150 lines');
+  assert.ok(lineCount(fs.readFileSync(fileURLToPath(import.meta.url), 'utf8')) < 150);
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58548558,
-  "maxTrackedFiles": 5516,
+  "maxTrackedBytes": 58556070,
+  "maxTrackedFiles": 5518,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16667739,
     "source/scripts": 7811685,
     "docs/text": 7617958,
-    "tests/e2e": 5840645,
-    "config/data/messages": 1754136
+    "tests/e2e": 5843108,
+    "config/data/messages": 1759185
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- send an immediate email when GitHub records a new fork, including the fork owner account
- send a daily aggregate report for clone and view traffic over GitHub’s 14-day window
- keep the workflow read-only, dependency-free, and free of repository checkout or untrusted code execution
- add focused CI contracts for triggers, permissions, secret boundaries, endpoints, and modularity

## Verification
- `pnpm pr:verify`
- `pnpm security:guard`
- `pnpm e2e:gate` (205 passed, 9 skipped)
- focused transient retry: premium Free Start result (1 passed)

## Repository configuration
- `RESEND_API_KEY` secret configured
- `REPOSITORY_ALERT_EMAIL=arben.lila@gmail.com` configured
- `RESEND_FROM_EMAIL=arben.lila@interdomestik.com` configured
- `TRAFFIC_READ_TOKEN` remains intentionally unset until a one-repository fine-grained PAT with only Administration: read is created; the broader local GitHub CLI token was not reused