### PR TITLE
fix(auth): enforce server-owned Better Auth authority assignment

### DIFF
--- a/apps/web/e2e/gate/auth-authority-fields.spec.ts
+++ b/apps/web/e2e/gate/auth-authority-fields.spec.ts
@@ -1,0 +1,87 @@
+import { account, db, eq, session as authSession, user } from '@interdomestik/database';
+import { expect, test } from '@playwright/test';
+
+test.describe('SEC-AUTH01 Better Auth authority gate', () => {
+  test('signup is canonical and generic update is atomic', async ({ browser }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL?.toString();
+    if (!baseURL) throw new Error('Project baseURL is required');
+    const origin = new URL(baseURL).origin;
+    const isMk = testInfo.project.name.includes('mk');
+    const tenant = isMk ? 'tenant_mk' : 'tenant_ks';
+    const hostileTenant = isMk ? 'tenant_ks' : 'tenant_mk';
+    const hostileBranch = isMk ? 'ks_branch_a' : 'mk_branch_a';
+    const email = `sec-auth01-${testInfo.project.name}-${Date.now()}@example.com`;
+    const context = await browser.newContext({
+      baseURL: origin,
+      extraHTTPHeaders: testInfo.project.use.extraHTTPHeaders,
+      storageState: { cookies: [], origins: [] },
+    });
+
+    try {
+      const created = await context.request.post('/api/auth/sign-up/email', {
+        data: {
+          email,
+          password: 'Password123!',
+          name: 'Authority Original',
+          onboarding: { tenant, mode: 'resolved' },
+          role: 'super_admin',
+          tenantId: hostileTenant,
+          branchId: hostileBranch,
+          memberNumber: 'ATTACKER',
+          tenantClassificationPending: true,
+          agentId: 'agent-attacker',
+          referralCode: 'OWNED',
+        },
+        headers: { Origin: origin, Referer: `${baseURL}/register` },
+      });
+      expect(created.status(), await created.text()).toBe(200);
+      const createdBody = await created.json();
+      expect(createdBody.user).toMatchObject({
+        role: 'member',
+        tenantId: tenant,
+        branchId: null,
+        tenantClassificationPending: false,
+        agentId: null,
+        referralCode: null,
+      });
+      expect(createdBody.user.memberNumber).not.toBe('ATTACKER');
+
+      const before = await db.query.user.findFirst({ where: eq(user.email, email) });
+      expect(before).toBeDefined();
+      const denied = await context.request.post('/api/auth/update-user', {
+        data: { name: 'Poisoned', role: 'super_admin' },
+        headers: { Origin: origin, Referer: `${baseURL}/member/profile` },
+      });
+      expect(denied.status()).toBe(400);
+      expect(await denied.json()).toMatchObject({ code: 'AUTHORITY_FIELD_NOT_WRITABLE' });
+      expect(denied.headers()['set-cookie']).toBeUndefined();
+      const afterDenied = await db.query.user.findFirst({ where: eq(user.email, email) });
+      expect(afterDenied).toEqual(before);
+
+      const safe = await context.request.post('/api/auth/update-user', {
+        data: { name: 'Authority Changed', image: 'https://example.test/a.png' },
+        headers: { Origin: origin, Referer: `${baseURL}/member/profile` },
+      });
+      expect(safe.status(), await safe.text()).toBe(200);
+      const afterSafe = await db.query.user.findFirst({ where: eq(user.email, email) });
+      expect(afterSafe).toMatchObject({
+        name: 'Authority Changed',
+        role: before?.role,
+        tenantId: before?.tenantId,
+        branchId: before?.branchId,
+        agentId: before?.agentId,
+      });
+    } finally {
+      const created = await db.query.user.findFirst({
+        where: eq(user.email, email),
+        columns: { id: true },
+      });
+      if (created) {
+        await db.delete(account).where(eq(account.userId, created.id));
+        await db.delete(authSession).where(eq(authSession.userId, created.id));
+        await db.delete(user).where(eq(user.id, created.id));
+      }
+      await context.close();
+    }
+  });
+});

--- a/apps/web/src/app/api/auth/[...all]/neutral-otp-boundary.ts
+++ b/apps/web/src/app/api/auth/[...all]/neutral-otp-boundary.ts
@@ -1,3 +1,5 @@
+import { parseOnboardingSelector } from '@/lib/auth/onboarding-authority';
+
 export type NeutralOtpKind = 'send' | 'verify';
 
 const SEND_PATH = '/api/auth/email-otp/send-verification-otp';
@@ -72,8 +74,12 @@ export function extractNeutralOtpEmail(body: unknown): string | null {
 }
 
 export function hasValidNeutralVerifyHints(body: unknown, defaultTenantId: string): boolean {
-  const value = record(body);
-  return value?.tenantId === defaultTenantId && value.tenantClassificationPending === true;
+  const parsed = parseOnboardingSelector(body);
+  return (
+    parsed.kind === 'valid' &&
+    parsed.selector.tenant === defaultTenantId &&
+    parsed.selector.mode === 'deferred'
+  );
 }
 
 export function otpUnavailable(status = 400): Response {

--- a/apps/web/src/app/api/auth/[...all]/neutral-otp-route.ts
+++ b/apps/web/src/app/api/auth/[...all]/neutral-otp-route.ts
@@ -28,8 +28,7 @@ function sanitizedRequest(args: {
       : {
           email: args.email,
           otp: typeof value.otp === 'string' ? value.otp : undefined,
-          tenantId: args.tenantId,
-          tenantClassificationPending: true,
+          onboarding: { tenant: args.tenantId, mode: 'deferred' },
         };
   const headers = new Headers(args.request.headers);
   headers.set('content-type', 'application/json');

--- a/apps/web/src/app/api/auth/[...all]/route.otp-verify.test.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.otp-verify.test.ts
@@ -60,8 +60,7 @@ describe('IDA-UI03a0b2 neutral OTP verify route', () => {
   it('C07 accepts only matching creation hints without a pre-verification tenant lookup', async () => {
     const response = await POST(
       verifyRequest({
-        tenantId: 'tenant_ks',
-        tenantClassificationPending: true,
+        onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
         role: 'admin',
         branchId: 'attacker-branch',
         memberNumber: 'attacker-member',
@@ -89,26 +88,23 @@ describe('IDA-UI03a0b2 neutral OTP verify route', () => {
     expect(await forwarded.json()).toEqual({
       email: 'member@example.com',
       otp: '123456',
-      tenantId: 'tenant_ks',
-      tenantClassificationPending: true,
+      onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
     });
   });
 
   it('C08 rejects conflicting or malformed neutral hints generically before Better Auth', async () => {
     const responses = await Promise.all([
-      POST(verifyRequest({ tenantId: 'tenant_mk', tenantClassificationPending: false })),
+      POST(verifyRequest({ onboarding: { tenant: 'tenant_mk', mode: 'resolved' } })),
       POST(
         verifyRequest({
           otp: undefined,
-          tenantId: 'tenant_ks',
-          tenantClassificationPending: true,
+          onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
         })
       ),
       POST(
         verifyRequest({
           otp: '   ',
-          tenantId: 'tenant_ks',
-          tenantClassificationPending: true,
+          onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
         })
       ),
     ]);

--- a/apps/web/src/app/api/auth/[...all]/sign-up-tenant-guard.test.ts
+++ b/apps/web/src/app/api/auth/[...all]/sign-up-tenant-guard.test.ts
@@ -25,12 +25,15 @@ describe('isEmailSignUpUrl', () => {
 
 describe('evaluateEmailSignUpTenantGuard', () => {
   const url = 'https://ida.localhost:3000/api/auth/sign-up/email';
+  const onboarding = (tenant: string, mode: 'resolved' | 'deferred' = 'resolved') => ({
+    onboarding: { tenant, mode },
+  });
 
   it('allows signup when country host and payload tenant match', () => {
     const result = evaluateEmailSignUpTenantGuard({
       url,
       headers: new Headers({ host: 'ks.localhost:3000' }),
-      body: { tenantId: 'tenant_ks' },
+      body: onboarding('tenant_ks'),
     });
 
     expect(result).toEqual({ decision: 'allow' });
@@ -40,7 +43,7 @@ describe('evaluateEmailSignUpTenantGuard', () => {
     const result = evaluateEmailSignUpTenantGuard({
       url,
       headers: new Headers({ host: 'ks.localhost:3000' }),
-      body: { tenantId: 'tenant_mk' },
+      body: onboarding('tenant_mk'),
     });
 
     expect(result).toEqual({
@@ -58,7 +61,7 @@ describe('evaluateEmailSignUpTenantGuard', () => {
     const result = evaluateEmailSignUpTenantGuard({
       url,
       headers: new Headers({ host: 'ida.localhost:3000' }),
-      body: { tenantId: 'tenant_mk' },
+      body: onboarding('tenant_mk', 'deferred'),
     });
 
     expect(result).toEqual({ decision: 'allow' });
@@ -73,7 +76,7 @@ describe('evaluateEmailSignUpTenantGuard', () => {
         host: 'ida.localhost:3000',
         'x-forwarded-host': 'ks.localhost:3000',
       }),
-      body: { tenantId: 'tenant_mk' },
+      body: onboarding('tenant_mk', 'deferred'),
     });
 
     expect(result).toEqual({
@@ -94,10 +97,34 @@ describe('evaluateEmailSignUpTenantGuard', () => {
     const malformed = evaluateEmailSignUpTenantGuard({
       url,
       headers: new Headers({ host: 'ks.localhost:3000' }),
-      body: { tenantId: 'not-a-tenant' },
+      body: onboarding('not-a-tenant'),
     });
 
     expect(missing?.decision).toBe('deny');
     expect(malformed?.decision).toBe('deny');
+  });
+
+  it('enforces host-owned mode and accepts the deferred social selector shape', () => {
+    expect(
+      evaluateEmailSignUpTenantGuard({
+        url,
+        headers: new Headers({ host: 'ks.localhost:3000' }),
+        body: onboarding('tenant_ks', 'deferred'),
+      })?.decision
+    ).toBe('deny');
+    expect(
+      evaluateEmailSignUpTenantGuard({
+        url,
+        headers: new Headers({ host: 'ida.localhost:3000' }),
+        body: onboarding('tenant_ks', 'resolved'),
+      })?.decision
+    ).toBe('deny');
+    expect(
+      evaluateEmailSignUpTenantGuard({
+        url,
+        headers: new Headers({ host: 'ida.localhost:3000' }),
+        body: { additionalData: onboarding('tenant_ks', 'deferred') },
+      })
+    ).toEqual({ decision: 'allow' });
   });
 });

--- a/apps/web/src/app/api/auth/[...all]/sign-up-tenant-guard.ts
+++ b/apps/web/src/app/api/auth/[...all]/sign-up-tenant-guard.ts
@@ -1,15 +1,5 @@
-import { isKnownIdaFrontDoorHost, normalizeTenantHost } from '@/lib/tenant/tenant-front-door';
-import {
-  coerceTenantId,
-  resolveTenantIdFromSources,
-  TENANT_HEADER_NAME,
-  type TenantId,
-} from '@/lib/tenant/tenant-hosts';
-
-type TenantHintResult =
-  | { kind: 'absent' }
-  | { kind: 'valid'; tenantId: TenantId }
-  | { kind: 'invalid' };
+import { resolveOnboardingAuthority } from '@/lib/auth/onboarding-authority';
+import type { TenantId } from '@/lib/tenant/tenant-hosts';
 
 export type SignUpTenantGuardResult =
   | { decision: 'allow' }
@@ -25,61 +15,6 @@ function getAuthPathname(url: string): string | null {
   return URL.canParse(url) ? new URL(url).pathname : null;
 }
 
-function getRequestHost(headers: Headers): string {
-  return headers.get('x-forwarded-host') ?? headers.get('host') ?? '';
-}
-
-function getDirectRequestHost(headers: Headers): string {
-  return headers.get('host') ?? '';
-}
-
-function hasUnambiguousFrontDoorHost(headers: Headers): boolean {
-  const host = normalizeTenantHost(getDirectRequestHost(headers));
-  if (!isKnownIdaFrontDoorHost(host)) return false;
-
-  const forwardedHost = headers.get('x-forwarded-host');
-  if (!forwardedHost) return true;
-
-  return normalizeTenantHost(forwardedHost) === host;
-}
-
-function readAdditionalData(body: unknown): Record<string, unknown> | null {
-  if (!body || typeof body !== 'object') return null;
-  const additionalData = (body as { additionalData?: unknown }).additionalData;
-  return additionalData && typeof additionalData === 'object'
-    ? (additionalData as Record<string, unknown>)
-    : null;
-}
-
-function resolveSignUpTenantHint(body: unknown): TenantHintResult {
-  if (!body || typeof body !== 'object') return { kind: 'absent' };
-
-  const directTenantId = (body as { tenantId?: unknown }).tenantId;
-  const additionalTenantId = readAdditionalData(body)?.tenantId;
-  const rawTenantId = directTenantId ?? additionalTenantId;
-  if (rawTenantId === undefined) return { kind: 'absent' };
-  if (typeof rawTenantId !== 'string') return { kind: 'invalid' };
-
-  const tenantId = coerceTenantId(rawTenantId.trim());
-  return tenantId ? { kind: 'valid', tenantId } : { kind: 'invalid' };
-}
-
-function resolveRequestTenant(headers: Headers, body: unknown): TenantId | null {
-  const bodyTenant = resolveSignUpTenantHint(body);
-  if (isKnownIdaFrontDoorHost(getDirectRequestHost(headers))) {
-    if (!hasUnambiguousFrontDoorHost(headers)) return null;
-    return (
-      coerceTenantId(headers.get(TENANT_HEADER_NAME)) ??
-      (bodyTenant.kind === 'valid' ? bodyTenant.tenantId : null)
-    );
-  }
-
-  return resolveTenantIdFromSources(
-    { host: getRequestHost(headers) },
-    { productionSensitive: true, allowLoopbackFallback: true }
-  );
-}
-
 export function isEmailSignUpUrl(url: string): boolean {
   return getAuthPathname(url)?.endsWith('/api/auth/sign-up/email') ?? false;
 }
@@ -91,27 +26,14 @@ export function evaluateEmailSignUpTenantGuard(args: {
 }): SignUpTenantGuardResult | null {
   if (!isEmailSignUpUrl(args.url)) return null;
 
-  const bodyTenant = resolveSignUpTenantHint(args.body);
-  if (bodyTenant.kind !== 'valid') {
-    return {
-      decision: 'deny',
-      code: 'WRONG_TENANT_CONTEXT',
-      message: 'Wrong tenant context',
-      reason: 'missing_tenant_context',
-      resolvedTenantId: null,
-    };
-  }
-
-  const resolvedTenantId = resolveRequestTenant(args.headers, args.body);
-  if (!resolvedTenantId || resolvedTenantId !== bodyTenant.tenantId) {
-    return {
-      decision: 'deny',
-      code: 'WRONG_TENANT_CONTEXT',
-      message: 'Wrong tenant context',
-      reason: resolvedTenantId ? 'tenant_mismatch' : 'missing_tenant_context',
-      resolvedTenantId,
-    };
-  }
-
-  return { decision: 'allow' };
+  const result = resolveOnboardingAuthority({ headers: args.headers, body: args.body });
+  if (result.ok) return { decision: 'allow' };
+  const mismatch = result.reason === 'tenant_mismatch' || result.reason === 'forbidden_mode';
+  return {
+    decision: 'deny',
+    code: 'WRONG_TENANT_CONTEXT',
+    message: 'Wrong tenant context',
+    reason: mismatch ? 'tenant_mismatch' : 'missing_tenant_context',
+    resolvedTenantId: result.resolvedTenantId,
+  };
 }

--- a/apps/web/src/components/auth/login-form.test.tsx
+++ b/apps/web/src/components/auth/login-form.test.tsx
@@ -292,15 +292,14 @@ describe('LoginForm', () => {
     });
   });
 
-  it('handles GitHub OAuth sign in', async () => {
+  it('uses resolved onboarding for GitHub OAuth with server tenant context', async () => {
     const originalLocation = globalThis.location;
     Object.defineProperty(globalThis, 'location', {
       value: { origin: 'http://localhost:3000' },
       writable: true,
     });
 
-    render(<LoginForm githubOAuthEnabled />);
-
+    render(<LoginForm githubOAuthEnabled tenantId="tenant_ks" />);
     const githubButton = screen.getByText('GitHub');
     fireEvent.click(githubButton);
 
@@ -308,13 +307,14 @@ describe('LoginForm', () => {
       expect(mockSignInSocial).toHaveBeenCalledWith({
         provider: 'github',
         callbackURL: 'http://localhost:3000/en/login',
+        additionalData: { onboarding: { tenant: 'tenant_ks', mode: 'resolved' } },
       });
     });
 
     Object.defineProperty(globalThis, 'location', { value: originalLocation });
   });
 
-  it('preserves the current login URL as the GitHub callback', async () => {
+  it('preserves the GitHub callback and defers a neutral tenant hint', async () => {
     const originalLocation = globalThis.location;
     mockSearchParams = new URLSearchParams('tenantId=tenant_ks&next=%2Fen%2Fmember%2Fclaims');
     Object.defineProperty(globalThis, 'location', {
@@ -334,7 +334,7 @@ describe('LoginForm', () => {
         provider: 'github',
         callbackURL:
           'http://localhost:3000/en/login?tenantId=tenant_ks&next=%2Fen%2Fmember%2Fclaims',
-        additionalData: { tenantId: 'tenant_ks' },
+        additionalData: { onboarding: { tenant: 'tenant_ks', mode: 'deferred' } },
       });
     });
 

--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -26,14 +26,11 @@ import { Code, Eye, EyeOff, Shield } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { usePathname, useSearchParams } from 'next/navigation';
 import * as React from 'react';
+import { buildSocialOnboardingPayload } from './register-onboarding-payload';
 
 const SESSION_SYNC_RETRY_COUNT = 2;
 const SESSION_SYNC_RETRY_DELAY_MS = 250;
-
-type ResolvedAuthenticatedRole = {
-  role?: string;
-  timedOut: boolean;
-};
+type ResolvedAuthenticatedRole = { role?: string; timedOut: boolean };
 
 function getAllowedSurfacePrefix(role: string, locale: string): string | null {
   if (role === 'agent') {
@@ -332,7 +329,9 @@ export function LoginForm({
                     provider: 'github',
                     callbackURL:
                       globalThis.location.href || `${globalThis.location.origin}/${locale}/login`,
-                    ...(resolvedTenantId ? { additionalData: { tenantId: resolvedTenantId } } : {}),
+                    ...(resolvedTenantId
+                      ? buildSocialOnboardingPayload(resolvedTenantId, tenantId === undefined)
+                      : {}),
                   });
                 }}
               >

--- a/apps/web/src/components/auth/register-form.test.tsx
+++ b/apps/web/src/components/auth/register-form.test.tsx
@@ -5,7 +5,6 @@ import { authClient } from '@/lib/auth-client';
 
 let mockSearchParams = new URLSearchParams('');
 
-// Mock authClient
 vi.mock('@/lib/auth-client', () => ({
   authClient: {
     signUp: {
@@ -17,7 +16,6 @@ vi.mock('@/lib/auth-client', () => ({
   },
 }));
 
-// Mock next-intl
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => {
     const translations: Record<string, string> = {
@@ -44,7 +42,6 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/en/register',
 }));
 
-// Mock routing
 vi.mock('@/i18n/routing', () => ({
   Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
     <a href={href}>{children}</a>
@@ -58,59 +55,26 @@ describe('RegisterForm', () => {
     mockSearchParams = new URLSearchParams('');
   });
 
-  it('renders the title and subtitle', () => {
+  it('renders the complete default registration surface', () => {
     render(<RegisterForm />);
-
     expect(screen.getByText('Create Account')).toBeInTheDocument();
     expect(screen.getByText('Get started with your account')).toBeInTheDocument();
-  });
-
-  it('renders all form fields', () => {
-    render(<RegisterForm />);
-
     expect(screen.getByLabelText('Full Name')).toBeInTheDocument();
     expect(screen.getByLabelText('Email')).toBeInTheDocument();
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
-  });
-
-  it('renders terms checkbox', () => {
-    render(<RegisterForm />);
-
     expect(screen.getByText('I agree to the Terms of Service')).toBeInTheDocument();
-  });
-
-  it('does not render GitHub OAuth button by default', () => {
-    render(<RegisterForm />);
-
     expect(screen.queryByText('GitHub')).not.toBeInTheDocument();
-  });
-
-  it('renders GitHub OAuth button when enabled', () => {
-    render(<RegisterForm githubOAuthEnabled />);
-
-    expect(screen.getByText('GitHub')).toBeInTheDocument();
-  });
-
-  it('has login link for existing users', () => {
-    render(<RegisterForm />);
-
     expect(screen.getByText('Already have an account?')).toBeInTheDocument();
-    const loginLink = screen.getByText('Sign in');
-    expect(loginLink.closest('a')).toHaveAttribute('href', '/login');
-  });
-
-  it('renders submit button', () => {
-    render(<RegisterForm />);
-
+    expect(screen.getByText('Sign in').closest('a')).toHaveAttribute('href', '/login');
     expect(screen.getByText('Sign Up')).toBeInTheDocument();
     expect(
       screen.getByText('Your account keeps cases, documents, and history safe. No spam.')
     ).toBeInTheDocument();
   });
 
-  it('shows "or" divider for social login when GitHub OAuth is enabled', () => {
+  it('renders optional GitHub affordances', () => {
     render(<RegisterForm githubOAuthEnabled />);
-
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
     expect(screen.getByText('or')).toBeInTheDocument();
   });
 
@@ -122,8 +86,17 @@ describe('RegisterForm', () => {
     expect(loginLink).toHaveAttribute('href', '/login?plan=family');
   });
 
-  it('persists deferred tenant-classification flag during signup', async () => {
-    render(<RegisterForm tenantId="tenant_ks" tenantClassificationPending />);
+  it('sends only a distinct onboarding selector for email and social registration', async () => {
+    render(<RegisterForm tenantId="tenant_ks" tenantClassificationPending githubOAuthEnabled />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
+    await vi.waitFor(() =>
+      expect(authClient.signIn.social).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalData: { onboarding: { tenant: 'tenant_ks', mode: 'deferred' } },
+        })
+      )
+    );
 
     fireEvent.change(screen.getByLabelText('Full Name'), { target: { value: 'John Doe' } });
     fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'john@example.com' } });
@@ -136,10 +109,14 @@ describe('RegisterForm', () => {
         expect.objectContaining({
           email: 'john@example.com',
           name: 'John Doe',
-          tenantId: 'tenant_ks',
-          tenantClassificationPending: true,
+          onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
         })
       )
+    );
+    expect(authClient.signUp.email).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: expect.anything(),
+      })
     );
   });
 });

--- a/apps/web/src/components/auth/register-form.tsx
+++ b/apps/web/src/components/auth/register-form.tsx
@@ -17,6 +17,10 @@ import { Code, Eye, EyeOff, Shield } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import * as React from 'react';
+import {
+  buildEmailOnboardingPayload,
+  buildSocialOnboardingPayload,
+} from './register-onboarding-payload';
 
 export function RegisterForm({
   githubOAuthEnabled = false,
@@ -65,8 +69,7 @@ export function RegisterForm({
         password,
         name,
         callbackURL: loginHref,
-        tenantId: resolvedTenantId,
-        tenantClassificationPending,
+        ...buildEmailOnboardingPayload(resolvedTenantId, tenantClassificationPending),
       };
 
       const { error: signUpError } = await authClient.signUp.email(signUpPayload);
@@ -95,12 +98,7 @@ export function RegisterForm({
       provider,
       callbackURL: `${window.location.origin}${loginHref}`,
       ...(resolvedTenantId
-        ? {
-            additionalData: {
-              tenantId: resolvedTenantId,
-              tenantClassificationPending,
-            },
-          }
+        ? buildSocialOnboardingPayload(resolvedTenantId, tenantClassificationPending)
         : {}),
     });
   };

--- a/apps/web/src/components/auth/register-onboarding-payload.test.ts
+++ b/apps/web/src/components/auth/register-onboarding-payload.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildEmailOnboardingPayload,
+  buildSocialOnboardingPayload,
+} from './register-onboarding-payload';
+
+const authorityNames = [
+  'role',
+  'tenantId',
+  'branchId',
+  'memberNumber',
+  'tenantClassificationPending',
+  'agentId',
+  'referralCode',
+];
+
+describe('registration onboarding payload', () => {
+  it.each([false, true])('emits a selector, never persisted authority names (%s)', deferred => {
+    const email = buildEmailOnboardingPayload('tenant_ks', deferred);
+    const social = buildSocialOnboardingPayload('tenant_ks', deferred);
+    const serialized = JSON.stringify({ email, social });
+
+    expect(email).toEqual({
+      onboarding: { tenant: 'tenant_ks', mode: deferred ? 'deferred' : 'resolved' },
+    });
+    expect(social).toEqual({ additionalData: email });
+    for (const name of authorityNames) expect(serialized).not.toContain(`"${name}"`);
+  });
+});

--- a/apps/web/src/components/auth/register-onboarding-payload.ts
+++ b/apps/web/src/components/auth/register-onboarding-payload.ts
@@ -1,0 +1,11 @@
+type OnboardingPayload = {
+  onboarding: { tenant: string; mode: 'resolved' | 'deferred' };
+};
+
+export function buildEmailOnboardingPayload(tenant: string, deferred: boolean): OnboardingPayload {
+  return { onboarding: { tenant, mode: deferred ? 'deferred' : 'resolved' } };
+}
+
+export function buildSocialOnboardingPayload(tenant: string, deferred: boolean) {
+  return { additionalData: buildEmailOnboardingPayload(tenant, deferred) };
+}

--- a/apps/web/src/components/auth/use-neutral-email-otp.ts
+++ b/apps/web/src/components/auth/use-neutral-email-otp.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
 import { authClient } from '@/lib/auth-client';
+import { buildEmailOnboardingPayload } from './register-onboarding-payload';
 export type NeutralEmailOtpError = 'missingEmail' | 'sendFailed' | 'verify' | 'accountStop';
 type VerifiedIdentity = { email: string; userId: string };
 // prettier-ignore
@@ -107,7 +108,7 @@ export function useNeutralEmailOtp(args: NeutralEmailOtpArgs) {
       const result = await authClient.signIn.emailOtp({
         email: lockedEmail,
         otp: code.trim(),
-        ...(args.tenantId ? { tenantClassificationPending: true, tenantId: args.tenantId } : {}),
+        ...(args.tenantId ? buildEmailOnboardingPayload(args.tenantId, true) : {}),
       });
       if (result.error) {
         const providerCode = (result.error as { code?: string }).code;

--- a/apps/web/src/components/pricing/pricing-table.test.tsx
+++ b/apps/web/src/components/pricing/pricing-table.test.tsx
@@ -334,7 +334,7 @@ describe('PricingTable', () => {
     expect(await screen.findByText('otpStep.sent')).toBeInTheDocument();
   });
 
-  it('verifies the OTP with default acquisition tenant fields and continues into checkout for the selected plan', async () => {
+  it('verifies the OTP with the deferred onboarding selector and continues into checkout for the selected plan', async () => {
     render(
       <PricingTable billingTestMode={false} checkoutConfig={checkoutConfig} tenantId="tenant_ks" />
     );
@@ -356,8 +356,7 @@ describe('PricingTable', () => {
       expect(authClient.signIn.emailOtp).toHaveBeenCalledWith({
         email: 'member@example.com',
         otp: '123456',
-        tenantClassificationPending: true,
-        tenantId: 'tenant_ks',
+        onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
       });
     });
 

--- a/apps/web/src/components/pricing/pricing-table/use-pricing-email-otp.test.ts
+++ b/apps/web/src/components/pricing/pricing-table/use-pricing-email-otp.test.ts
@@ -116,7 +116,7 @@ describe('usePricingEmailOtp recovery boundary', () => {
     expect(auth.send).toHaveBeenCalledTimes(2);
   });
 
-  it('continues once with existing tenant fields and stops generically when checkout cannot open', async () => {
+  it('continues once with the deferred onboarding selector and stops generically on failure', async () => {
     const onVerified = vi.fn().mockRejectedValue(new Error('PRIVATE_CHECKOUT_DETAIL'));
     const { result } = setup({ onVerified });
     await act(async () => result.current.send());
@@ -128,8 +128,7 @@ describe('usePricingEmailOtp recovery boundary', () => {
     expect(auth.verify).toHaveBeenCalledWith({
       email: 'member@example.com',
       otp: '123456',
-      tenantClassificationPending: true,
-      tenantId: 'tenant_ks',
+      onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
     });
     expect(onVerified).toHaveBeenCalledOnce();
     expect(result.current.error).toBe('accountStop');

--- a/apps/web/src/lib/auth/auth-request-authority.test.ts
+++ b/apps/web/src/lib/auth/auth-request-authority.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AUTHORITY_FIELDS, AUTHORITY_INTENT_KEY } from './authority-fields';
+import { applyAuthRequestAuthority } from './auth-request-authority';
+
+const headers = new Headers({ host: 'ida.localhost:3000' });
+const onboarding = { tenant: 'tenant_ks', mode: 'deferred' };
+
+async function rejection(body: object) {
+  try {
+    await applyAuthRequestAuthority({ path: '/update-user', body, headers });
+  } catch (error) {
+    return error as { body?: { code?: string } };
+  }
+  throw new Error('Expected authority rejection');
+}
+
+describe('Better Auth request authority boundary', () => {
+  it('C04 rejects every own, falsy, undefined and inherited authority field', async () => {
+    for (const field of AUTHORITY_FIELDS) {
+      for (const value of ['super_admin', null, false, '', 0, undefined]) {
+        expect((await rejection({ [field]: value })).body?.code).toBe(
+          'AUTHORITY_FIELD_NOT_WRITABLE'
+        );
+      }
+      const inherited = Object.create({ [field]: 'super_admin' }) as object;
+      expect((await rejection(inherited)).body?.code).toBe('AUTHORITY_FIELD_NOT_WRITABLE');
+      const nullPrototype = Object.assign(Object.create(null), { [field]: undefined });
+      expect((await rejection(nullPrototype)).body?.code).toBe('AUTHORITY_FIELD_NOT_WRITABLE');
+    }
+  });
+
+  it('C02 strips hostile create fields and installs only a server-issued intent', async () => {
+    const body: Record<string, unknown> = {
+      email: 'new@example.com',
+      onboarding,
+      role: 'super_admin',
+      tenantId: 'tenant_mk',
+      referralCode: 'owned',
+    };
+    await applyAuthRequestAuthority({ path: '/sign-up/email', body, headers, now: 1000 });
+
+    expect(body).toMatchObject({ email: 'new@example.com' });
+    for (const field of AUTHORITY_FIELDS) expect(field in body).toBe(false);
+    expect('onboarding' in body).toBe(false);
+    expect(body[AUTHORITY_INTENT_KEY]).toMatchObject({
+      version: 1,
+      tenant: 'tenant_ks',
+      mode: 'deferred',
+    });
+  });
+
+  it('C07 rejects new OTP users without intent but permits existing sign-in', async () => {
+    const findUserByEmail = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({ user: {} });
+    await expect(
+      applyAuthRequestAuthority({
+        path: '/sign-in/email-otp',
+        body: { email: 'new@example.com', otp: '123456' },
+        headers,
+        findUserByEmail,
+      })
+    ).rejects.toMatchObject({ body: { code: 'INVALID_ONBOARDING_CONTEXT' } });
+    await expect(
+      applyAuthRequestAuthority({
+        path: '/sign-in/email-otp',
+        body: { email: 'old@example.com', otp: '123456' },
+        headers,
+        findUserByEmail,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('C08 replaces all caller OAuth additionalData with one issued envelope', async () => {
+    const body: Record<string, unknown> = {
+      provider: 'github',
+      additionalData: { onboarding, role: 'super_admin', expiresAt: 0 },
+    };
+    await applyAuthRequestAuthority({ path: '/sign-in/social', body, headers, now: 1000 });
+    expect(body.additionalData).toEqual({
+      [AUTHORITY_INTENT_KEY]: expect.objectContaining({ tenant: 'tenant_ks', mode: 'deferred' }),
+    });
+  });
+});

--- a/apps/web/src/lib/auth/auth-request-authority.ts
+++ b/apps/web/src/lib/auth/auth-request-authority.ts
@@ -1,0 +1,79 @@
+import { createAuthMiddleware } from 'better-auth/api';
+
+import {
+  assertNoAuthorityFields,
+  AUTHORITY_INTENT_KEY,
+  CREATION_AUTHORITY_KEYS,
+  invalidOnboardingError,
+  recordValue,
+  replaceRecordContents,
+} from './authority-fields';
+import { parseOnboardingSelector, resolveOnboardingAuthority } from './onboarding-authority';
+
+type FindUserByEmail = (email: string) => Promise<unknown>;
+type RequestAuthorityArgs = {
+  path: string;
+  body: unknown;
+  headers: Headers;
+  now?: number;
+  findUserByEmail?: FindUserByEmail;
+};
+
+function issuedIntent(args: RequestAuthorityArgs) {
+  const resolved = resolveOnboardingAuthority({
+    headers: args.headers,
+    body: args.body,
+    now: args.now,
+  });
+  if (!resolved.ok) throw invalidOnboardingError();
+  return resolved.intent;
+}
+
+function sanitizeWithIntent(body: unknown, intent: unknown): void {
+  replaceRecordContents(body, CREATION_AUTHORITY_KEYS, { [AUTHORITY_INTENT_KEY]: intent });
+}
+
+function sanitizeSocial(body: unknown, intent?: unknown): void {
+  const additions = intent ? { additionalData: { [AUTHORITY_INTENT_KEY]: intent } } : {};
+  replaceRecordContents(body, CREATION_AUTHORITY_KEYS, additions);
+}
+
+export async function applyAuthRequestAuthority(args: RequestAuthorityArgs): Promise<void> {
+  if (args.path === '/update-user') {
+    assertNoAuthorityFields(args.body);
+    return;
+  }
+  if (args.path === '/sign-up/email') {
+    sanitizeWithIntent(args.body, issuedIntent(args));
+    return;
+  }
+  if (args.path === '/sign-in/social') {
+    const selector = parseOnboardingSelector(args.body);
+    if (selector.kind === 'invalid') throw invalidOnboardingError();
+    sanitizeSocial(args.body, selector.kind === 'valid' ? issuedIntent(args) : undefined);
+    return;
+  }
+  if (args.path !== '/sign-in/email-otp') return;
+  const selector = parseOnboardingSelector(args.body);
+  if (selector.kind === 'invalid') throw invalidOnboardingError();
+  if (selector.kind === 'valid') {
+    sanitizeWithIntent(args.body, issuedIntent(args));
+    return;
+  }
+  const body = recordValue(args.body);
+  const email = typeof body?.email === 'string' ? body.email.trim().toLowerCase() : '';
+  if (!email || !args.findUserByEmail || !(await args.findUserByEmail(email))) {
+    throw invalidOnboardingError();
+  }
+  replaceRecordContents(args.body, CREATION_AUTHORITY_KEYS);
+}
+
+export const authRequestAuthority = createAuthMiddleware(async context => {
+  const headers = context.headers ?? context.request?.headers ?? new Headers();
+  await applyAuthRequestAuthority({
+    path: context.path,
+    body: context.body,
+    headers,
+    findUserByEmail: email => context.context.internalAdapter.findUserByEmail(email),
+  });
+});

--- a/apps/web/src/lib/auth/authority-fields.ts
+++ b/apps/web/src/lib/auth/authority-fields.ts
@@ -1,0 +1,78 @@
+import { APIError } from 'better-auth/api';
+
+export const AUTHORITY_FIELDS = [
+  'role',
+  'tenantId',
+  'branchId',
+  'memberNumber',
+  'tenantClassificationPending',
+  'agentId',
+  'referralCode',
+] as const;
+
+export const AUTHORITY_INTENT_KEY = '__interdomestikAuthorityIntent';
+export type AuthorityField = (typeof AUTHORITY_FIELDS)[number];
+
+export function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function authorityFieldsPresent(value: unknown): AuthorityField[] {
+  const record = recordValue(value);
+  return record ? AUTHORITY_FIELDS.filter(field => field in record) : [];
+}
+
+export function authorityFieldError(): APIError {
+  return new APIError('BAD_REQUEST', {
+    code: 'AUTHORITY_FIELD_NOT_WRITABLE',
+    message: 'Authority fields are server managed',
+  });
+}
+
+export function invalidOnboardingError(): APIError {
+  return new APIError('BAD_REQUEST', {
+    code: 'INVALID_ONBOARDING_CONTEXT',
+    message: 'Invalid onboarding context',
+  });
+}
+
+export function assertNoAuthorityFields(value: unknown): void {
+  if (authorityFieldsPresent(value).length > 0) throw authorityFieldError();
+}
+
+export function replaceRecordContents(
+  value: unknown,
+  omitted: ReadonlySet<string>,
+  additions: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const record = recordValue(value);
+  if (!record) throw invalidOnboardingError();
+  const next = Object.create(null) as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (omitted.has(key)) continue;
+    const descriptor = Object.getOwnPropertyDescriptor(record, key);
+    if (!descriptor || !('value' in descriptor)) throw invalidOnboardingError();
+    next[key] = descriptor.value;
+  }
+  Object.assign(next, additions);
+  try {
+    for (const key of Reflect.ownKeys(record)) {
+      if (!delete record[key as keyof typeof record]) throw invalidOnboardingError();
+    }
+    Object.setPrototypeOf(record, null);
+    Object.assign(record, next);
+  } catch (error) {
+    if (error instanceof APIError) throw error;
+    throw invalidOnboardingError();
+  }
+  return record;
+}
+
+export const CREATION_AUTHORITY_KEYS = new Set<string>([
+  ...AUTHORITY_FIELDS,
+  AUTHORITY_INTENT_KEY,
+  'onboarding',
+  'additionalData',
+]);

--- a/apps/web/src/lib/auth/better-auth-authority.contract.test.ts
+++ b/apps/web/src/lib/auth/better-auth-authority.contract.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+
+import {
+  cleanupContractRows,
+  contractAuth,
+  cookieHeaderFrom,
+  insertRegisteredUser,
+  send,
+  signUp,
+  sqlClient,
+  uniqueEmail,
+  updateUser,
+  verify,
+} from './better-auth-email-otp.contract-test-support';
+
+interface AuthorityRow {
+  id: string;
+  name: string;
+  role: string;
+  tenantId: string;
+  branchId: string | null;
+  memberNumber: string | null;
+  pending: boolean;
+  agentId: string | null;
+  referralCode: string | null;
+}
+
+function authorityRows(email: string) {
+  return sqlClient<AuthorityRow[]>`
+    select "id", "name", "role", "tenant_id" as "tenantId", "branch_id" as "branchId",
+      "member_number" as "memberNumber", "tenant_classification_pending" as "pending",
+      "agentId", "referral_code" as "referralCode"
+    from "user" where "email" = ${email}
+  `;
+}
+
+afterEach(cleanupContractRows);
+afterAll(async () => sqlClient.end());
+
+describe.runIf(process.env.REQUIRE_BETTER_AUTH_AUTHORITY_CONTRACT === '1')(
+  'Better Auth authority contract on isolated local Postgres',
+  () => {
+    it('C02/C04/C12 persists only canonical create authority and denies atomic update', async () => {
+      const auth = contractAuth();
+      const email = uniqueEmail('authority');
+      const created = await signUp(auth, {
+        email,
+        password: 'Password123!',
+        name: 'Canonical',
+        onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
+        role: 'super_admin',
+        tenantId: 'tenant_mk',
+        branchId: 'mk_branch_a',
+        memberNumber: 'ATTACKER',
+        tenantClassificationPending: false,
+        agentId: 'agent-attacker',
+        referralCode: 'OWNED',
+      });
+      expect(created.status, await created.clone().text()).toBe(200);
+      const cookie = cookieHeaderFrom(created);
+      const rows = await authorityRows(email);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        name: 'Canonical',
+        role: 'member',
+        tenantId: 'tenant_ks',
+        branchId: null,
+        pending: true,
+        agentId: null,
+        referralCode: null,
+      });
+      expect(rows[0]?.memberNumber).not.toBe('ATTACKER');
+      const before = { ...rows[0] };
+
+      const denied = await updateUser(auth, { name: 'Poisoned', role: 'super_admin' }, cookie);
+      expect(denied.status).toBe(400);
+      expect(await denied.json()).toMatchObject({ code: 'AUTHORITY_FIELD_NOT_WRITABLE' });
+      expect(denied.headers.getSetCookie().some(value => value.includes('session_token'))).toBe(
+        false
+      );
+      const after = await authorityRows(email);
+      expect(after[0]).toEqual(before);
+      const fresh = await auth.api.getSession({
+        headers: new Headers({ cookie }),
+        query: { disableCookieCache: true, disableRefresh: true },
+      });
+      expect(fresh?.user).toMatchObject({ role: 'member', tenantId: 'tenant_ks' });
+    });
+
+    it('C07 creates an OTP user canonically and preserves existing-user sign-in', async () => {
+      const auth = contractAuth();
+      const newEmail = uniqueEmail('otp-new');
+      await send(auth, newEmail);
+      const created = await verify(auth, newEmail, '123456');
+      expect(created.status).toBe(200);
+      const newRows = await sqlClient<
+        { role: string; tenantId: string; branchId: string | null; pending: boolean }[]
+      >`
+        select "role", "tenant_id" as "tenantId", "branch_id" as "branchId",
+          "tenant_classification_pending" as "pending"
+        from "user" where "email" = ${newEmail}
+      `;
+      expect(newRows).toEqual([
+        { role: 'member', tenantId: 'tenant_ks', branchId: null, pending: true },
+      ]);
+
+      const existingEmail = uniqueEmail('otp-existing');
+      await insertRegisteredUser(existingEmail);
+      await send(auth, existingEmail);
+      const signedIn = await verify(auth, existingEmail, '123456', false);
+      expect(signedIn.status).toBe(200);
+      const existingRows = await sqlClient<{ role: string; tenantId: string }[]>`
+        select "role", "tenant_id" as "tenantId" from "user" where "email" = ${existingEmail}
+      `;
+      expect(existingRows).toEqual([{ role: 'member', tenantId: 'tenant_ks' }]);
+    });
+  }
+);

--- a/apps/web/src/lib/auth/better-auth-email-otp.contract-test-support.ts
+++ b/apps/web/src/lib/auth/better-auth-email-otp.contract-test-support.ts
@@ -6,6 +6,8 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import { randomUUID } from 'node:crypto';
 import postgres from 'postgres';
 
+import { authRequestAuthority } from './auth-request-authority';
+import { databaseHooks } from './hooks';
 import { userSchemaConfig } from './schema';
 
 export const sqlClient = postgres(
@@ -41,6 +43,9 @@ export function contractAuth(delivery: () => Promise<void> = async () => {}) {
       },
     }),
     user: userSchemaConfig,
+    hooks: { before: authRequestAuthority },
+    databaseHooks,
+    emailAndPassword: { enabled: true },
     rateLimit: { enabled: false },
     session: { cookieCache: { enabled: true, maxAge: 300 } },
     plugins: [
@@ -57,10 +62,15 @@ export function contractAuth(delivery: () => Promise<void> = async () => {}) {
   });
 }
 
-function request(path: string, body: Record<string, unknown>) {
+function request(path: string, body: Record<string, unknown>, cookie?: string) {
   return new Request(`http://localhost:3000/api/auth/${path}`, {
     method: 'POST',
-    headers: { host: 'localhost:3000', 'content-type': 'application/json' },
+    headers: {
+      host: 'ida.localhost:3000',
+      origin: 'http://localhost:3000',
+      'content-type': 'application/json',
+      ...(cookie ? { cookie } : {}),
+    },
     body: JSON.stringify(body),
   });
 }
@@ -69,15 +79,31 @@ export function send(auth: ReturnType<typeof contractAuth>, email: string) {
   return auth.handler(request('email-otp/send-verification-otp', { email, type: 'sign-in' }));
 }
 
-export function verify(auth: ReturnType<typeof contractAuth>, email: string, otp: string) {
+export function verify(
+  auth: ReturnType<typeof contractAuth>,
+  email: string,
+  otp: string,
+  withOnboarding = true
+) {
   return auth.handler(
     request('sign-in/email-otp', {
       email,
       otp,
-      tenantId: 'tenant_ks',
-      tenantClassificationPending: true,
+      ...(withOnboarding ? { onboarding: { tenant: 'tenant_ks', mode: 'deferred' } } : {}),
     })
   );
+}
+
+export function signUp(auth: ReturnType<typeof contractAuth>, body: Record<string, unknown>) {
+  return auth.handler(request('sign-up/email', body));
+}
+
+export function updateUser(
+  auth: ReturnType<typeof contractAuth>,
+  body: Record<string, unknown>,
+  cookie: string
+) {
+  return auth.handler(request('update-user', body, cookie));
 }
 
 export function cookieHeaderFrom(response: Response) {
@@ -93,7 +119,7 @@ export async function insertRegisteredUser(email: string) {
     insert into "user"
       ("id", "tenant_id", "name", "email", "emailVerified", "role", "tenant_classification_pending", "createdAt", "updatedAt")
     values
-      (${randomUUID()}, 'tenant_ks', 'Registered', ${email}, true, 'user', false, now(), now())
+      (${randomUUID()}, 'tenant_ks', 'Registered', ${email}, true, 'member', false, now(), now())
   `;
 }
 

--- a/apps/web/src/lib/auth/better-auth-oauth-authority.test.ts
+++ b/apps/web/src/lib/auth/better-auth-oauth-authority.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getTestInstance } from 'better-auth/test';
+
+vi.mock('./member-number-session-hook', () => ({ runMemberNumberSessionHook: vi.fn() }));
+vi.mock('./member-number-user-create-hook', () => ({ runMemberNumberUserCreateHook: vi.fn() }));
+
+import { authRequestAuthority } from './auth-request-authority';
+import { databaseHooks } from './hooks';
+import { userSchemaConfig } from './schema';
+
+const profile = { id: 'gh', name: 'GitHub', email: 'gh@example.com', emailVerified: true };
+const memoryUserSchema = {
+  ...userSchemaConfig,
+  additionalFields: {
+    ...userSchemaConfig.additionalFields,
+    branchId: { ...userSchemaConfig.additionalFields.branchId, required: false as const },
+    memberNumber: { ...userSchemaConfig.additionalFields.memberNumber, required: false as const },
+    agentId: { ...userSchemaConfig.additionalFields.agentId, required: false as const },
+    referralCode: { ...userSchemaConfig.additionalFields.referralCode, required: false as const },
+  },
+};
+
+async function harness() {
+  const instance = await getTestInstance(
+    {
+      baseURL: 'http://ida.localhost:3000',
+      hooks: { before: authRequestAuthority },
+      databaseHooks,
+      user: memoryUserSchema,
+      socialProviders: {
+        github: {
+          clientId: 'test',
+          clientSecret: 'test',
+          getUserInfo: async () => ({ user: profile, data: profile }),
+        },
+      },
+    },
+    { disableTestUser: true }
+  );
+  return instance.auth;
+}
+
+type Auth = Awaited<ReturnType<typeof harness>>;
+
+function cookie(response: Response) {
+  return response.headers
+    .getSetCookie()
+    .map(value => value.split(';', 1)[0])
+    .join('; ');
+}
+
+function hasSessionCookie(response: Response) {
+  return response.headers.getSetCookie().some(value => value.includes('session_token'));
+}
+
+async function initiate(auth: Auth, additionalData?: object) {
+  const response = await auth.handler(
+    new Request('http://ida.localhost:3000/api/auth/sign-in/social', {
+      method: 'POST',
+      headers: {
+        host: 'ida.localhost:3000',
+        origin: 'http://ida.localhost:3000',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        provider: 'github',
+        callbackURL: '/done',
+        disableRedirect: true,
+        additionalData,
+      }),
+    })
+  );
+  const data = (await response.json()) as { url: string };
+  return { state: new URL(data.url).searchParams.get('state')!, cookie: cookie(response) };
+}
+
+async function callback(auth: Auth, state: string, stateCookie: string) {
+  return auth.handler(
+    new Request(`http://ida.localhost:3000/api/auth/callback/github?code=ok&state=${state}`, {
+      headers: { host: 'ida.localhost:3000', cookie: stateCookie },
+      redirect: 'manual',
+    })
+  );
+}
+
+function fresh(auth: Auth, response: Response) {
+  return auth.api.getSession({
+    headers: new Headers({ cookie: cookie(response) }),
+    query: { disableCookieCache: true, disableRefresh: true },
+  });
+}
+
+describe('deterministic database-state GitHub authority', () => {
+  beforeEach(() =>
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({ access_token: 'token' }))
+    )
+  );
+
+  it('C08/C09 creates canonically, rejects tamper and replay, without provider network', async () => {
+    const auth = await harness();
+    const start = await initiate(auth, {
+      onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
+      role: 'super_admin',
+      expiresAt: 0,
+    });
+    const missingCookie = await callback(auth, start.state, '');
+    expect(missingCookie.status).toBe(302);
+    expect(hasSessionCookie(missingCookie)).toBe(false);
+    const tampered = await callback(auth, `${start.state}x`, start.cookie);
+    expect(tampered.status).toBe(302);
+    expect(hasSessionCookie(tampered)).toBe(false);
+
+    const success = await callback(auth, start.state, start.cookie);
+    expect(
+      success.status,
+      `${success.headers.get('location')} ${await success.clone().text()}`
+    ).toBe(302);
+    expect(success.headers.get('location')).toBe('/done');
+    expect((await fresh(auth, success))?.user).toMatchObject({
+      role: 'member',
+      tenantId: 'tenant_ks',
+      branchId: null,
+    });
+
+    const replay = await callback(auth, start.state, start.cookie);
+    expect(replay.status).toBe(302);
+    expect(hasSessionCookie(replay)).toBe(false);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it('C10 signs in an existing social user without rewriting authority', async () => {
+    const auth = await harness();
+    const first = await initiate(auth, { onboarding: { tenant: 'tenant_ks', mode: 'deferred' } });
+    await callback(auth, first.state, first.cookie);
+    const second = await initiate(auth, { onboarding: { tenant: 'tenant_mk', mode: 'deferred' } });
+    const signedIn = await callback(auth, second.state, second.cookie);
+    expect((await fresh(auth, signedIn))?.user).toMatchObject({
+      role: 'member',
+      tenantId: 'tenant_ks',
+      branchId: null,
+    });
+  });
+});

--- a/apps/web/src/lib/auth/better-auth-user-authority.test.ts
+++ b/apps/web/src/lib/auth/better-auth-user-authority.test.ts
@@ -1,0 +1,131 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { getTestInstance } from 'better-auth/test';
+
+vi.mock('./member-number-session-hook', () => ({ runMemberNumberSessionHook: vi.fn() }));
+vi.mock('./member-number-user-create-hook', () => ({ runMemberNumberUserCreateHook: vi.fn() }));
+
+import { authRequestAuthority } from './auth-request-authority';
+import { databaseHooks } from './hooks';
+import { userSchemaConfig } from './schema';
+
+const memoryUserSchema = {
+  ...userSchemaConfig,
+  additionalFields: {
+    ...userSchemaConfig.additionalFields,
+    branchId: { ...userSchemaConfig.additionalFields.branchId, required: false as const },
+    memberNumber: { ...userSchemaConfig.additionalFields.memberNumber, required: false as const },
+    agentId: { ...userSchemaConfig.additionalFields.agentId, required: false as const },
+    referralCode: { ...userSchemaConfig.additionalFields.referralCode, required: false as const },
+  },
+};
+
+async function createHarness() {
+  return getTestInstance(
+    {
+      baseURL: 'http://ida.localhost:3000',
+      hooks: { before: authRequestAuthority },
+      databaseHooks,
+      user: memoryUserSchema,
+    },
+    { disableTestUser: true }
+  );
+}
+
+let auth: Awaited<ReturnType<typeof createHarness>>['auth'];
+
+function call(path: string, body: object, cookie?: string) {
+  return auth.handler(
+    new Request(`http://ida.localhost:3000/api/auth/${path}`, {
+      method: 'POST',
+      headers: {
+        host: 'ida.localhost:3000',
+        origin: 'http://ida.localhost:3000',
+        'content-type': 'application/json',
+        ...(cookie ? { cookie } : {}),
+      },
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+function cookies(response: Response) {
+  return response.headers
+    .getSetCookie()
+    .map(value => value.split(';', 1)[0])
+    .join('; ');
+}
+
+function fresh(cookie: string) {
+  return auth.api.getSession({
+    headers: new Headers({ cookie }),
+    query: { disableCookieCache: true, disableRefresh: true },
+  });
+}
+
+describe('real Better Auth authority boundary', () => {
+  beforeAll(async () => {
+    ({ auth } = await createHarness());
+  });
+
+  it('C02/C04/C06 canonicalizes create, rejects update atomically, and permits profile data', async () => {
+    const signUp = await call('sign-up/email', {
+      email: 'authority@example.com',
+      password: 'password123',
+      name: 'Original',
+      onboarding: { tenant: 'tenant_ks', mode: 'deferred' },
+      role: 'super_admin',
+      tenantId: 'tenant_mk',
+      branchId: 'mk_branch',
+      memberNumber: 'ATTACKER',
+      tenantClassificationPending: false,
+      agentId: 'agent-attacker',
+      referralCode: 'OWNED',
+    });
+    expect(signUp.status, await signUp.clone().text()).toBe(200);
+    const created = (await signUp.json()) as { user: Record<string, unknown> };
+    expect(created.user).toMatchObject({
+      role: 'member',
+      tenantId: 'tenant_ks',
+      branchId: null,
+      memberNumber: null,
+      tenantClassificationPending: true,
+      agentId: null,
+      referralCode: null,
+    });
+    const cookie = cookies(signUp);
+    const before = await fresh(cookie);
+
+    const denied = await call('update-user', { name: 'Poisoned', role: 'super_admin' }, cookie);
+    expect(denied.status).toBe(400);
+    expect(await denied.json()).toMatchObject({ code: 'AUTHORITY_FIELD_NOT_WRITABLE' });
+    expect(denied.headers.getSetCookie().some(value => value.includes('session_token'))).toBe(
+      false
+    );
+    const afterDenied = await fresh(cookie);
+    expect(afterDenied?.user).toEqual(before?.user);
+
+    expect(
+      (await call('update-user', { name: 'Changed', image: 'https://example.test/a.png' }, cookie))
+        .status
+    ).toBe(200);
+    const afterSafe = await fresh(cookie);
+    expect(afterSafe?.user).toMatchObject({
+      name: 'Changed',
+      role: 'member',
+      tenantId: 'tenant_ks',
+    });
+  });
+
+  it('C03 denies signup without server-resolvable onboarding context and emits no cookie', async () => {
+    const response = await call('sign-up/email', {
+      email: 'missing@example.com',
+      password: 'password123',
+      name: 'Missing',
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ code: 'INVALID_ONBOARDING_CONTEXT' });
+    expect(response.headers.getSetCookie().some(value => value.includes('session_token'))).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/src/lib/auth/hooks.ts
+++ b/apps/web/src/lib/auth/hooks.ts
@@ -2,17 +2,18 @@ import type { BetterAuthOptions } from 'better-auth';
 
 import { runMemberNumberSessionHook } from './member-number-session-hook';
 import { runMemberNumberUserCreateHook } from './member-number-user-create-hook';
+import {
+  assertUserAuthorityUpdateBefore,
+  assignUserAuthorityBeforeCreate,
+} from './user-authority-assignment';
 
 export const databaseHooks: BetterAuthOptions['databaseHooks'] = {
   user: {
     create: {
-      before: async user => {
-        if (user.role === 'user') {
-          return { data: { ...user, role: 'member' } };
-        }
-      },
+      before: (user, context) => assignUserAuthorityBeforeCreate(user, context),
       after: async user => runMemberNumberUserCreateHook(user),
     },
+    update: { before: async data => assertUserAuthorityUpdateBefore(data) },
   },
   session: {
     create: {

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from 'better-auth';
 import { authConfig } from './config';
+import { authRequestAuthority } from './auth-request-authority';
 import { databaseHooks } from './hooks';
 import { authProviders } from './providers';
 import { databaseAdapter, userSchemaConfig } from './schema';
@@ -8,6 +9,7 @@ export const auth = betterAuth({
   ...authConfig,
   database: databaseAdapter,
   databaseHooks,
+  hooks: { before: authRequestAuthority },
   user: userSchemaConfig,
   ...authProviders,
 });

--- a/apps/web/src/lib/auth/onboarding-authority.test.ts
+++ b/apps/web/src/lib/auth/onboarding-authority.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { revalidateOnboardingIntent, resolveOnboardingAuthority } from './onboarding-authority';
+
+const at = 1_800_000_000_000;
+const ida = () => new Headers({ host: 'ida.localhost:3000' });
+const selector = (tenant = 'tenant_ks', mode: 'resolved' | 'deferred' = 'resolved') => ({
+  onboarding: { tenant, mode },
+});
+
+describe('server onboarding authority', () => {
+  it('resolves tenant hosts and IDA deferred mode without a fallback tenant', () => {
+    expect(
+      resolveOnboardingAuthority({
+        headers: new Headers({ host: 'ks.localhost:3000' }),
+        body: selector(),
+        now: at,
+      })
+    ).toMatchObject({ ok: true, intent: { tenant: 'tenant_ks', mode: 'resolved' } });
+    expect(
+      resolveOnboardingAuthority({
+        headers: ida(),
+        body: selector('tenant_mk', 'deferred'),
+        now: at,
+      })
+    ).toMatchObject({ ok: true, intent: { tenant: 'tenant_mk', mode: 'deferred' } });
+    expect(
+      resolveOnboardingAuthority({ headers: ida(), body: selector('tenant_ks'), now: at })
+    ).toMatchObject({ ok: false, reason: 'forbidden_mode' });
+    expect(
+      resolveOnboardingAuthority({
+        headers: new Headers({ host: 'unknown.example' }),
+        body: selector(),
+        now: at,
+      })
+    ).toMatchObject({ ok: false, reason: 'unknown_host' });
+  });
+
+  it.each([
+    [{}, 'missing_selector'],
+    [{ onboarding: { tenant: 'invalid', mode: 'resolved' } }, 'malformed_selector'],
+    [selector('tenant_mk'), 'tenant_mismatch'],
+    [selector('tenant_ks', 'deferred'), 'forbidden_mode'],
+  ] as const)('rejects invalid context: %s', (body, reason) => {
+    const headers =
+      reason === 'missing_selector' || reason === 'malformed_selector'
+        ? ida()
+        : new Headers({ host: 'ks.localhost:3000' });
+    expect(resolveOnboardingAuthority({ headers, body, now: at })).toMatchObject({
+      ok: false,
+      reason,
+    });
+  });
+
+  it('rejects forwarded-host conflict and stale or rebound intents', () => {
+    const conflict = new Headers({
+      host: 'ida.localhost:3000',
+      'x-forwarded-host': 'ks.localhost:3000',
+    });
+    expect(
+      resolveOnboardingAuthority({ headers: conflict, body: selector(), now: at })
+    ).toMatchObject({
+      ok: false,
+      reason: 'host_conflict',
+    });
+    const issued = resolveOnboardingAuthority({
+      headers: ida(),
+      body: selector('tenant_ks', 'deferred'),
+      now: at,
+    });
+    expect(issued.ok).toBe(true);
+    if (!issued.ok) return;
+    expect(revalidateOnboardingIntent(issued.intent, ida(), at + 60_000)).toEqual(issued.intent);
+    expect(revalidateOnboardingIntent(issued.intent, ida(), at + 601_000)).toBeNull();
+    expect(
+      revalidateOnboardingIntent(issued.intent, new Headers({ host: 'ks.localhost:3000' }), at)
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/auth/onboarding-authority.ts
+++ b/apps/web/src/lib/auth/onboarding-authority.ts
@@ -1,0 +1,143 @@
+import {
+  isKnownIdaFrontDoorHost,
+  normalizeTenantHost,
+  resolveTenantHostContext,
+} from '@/lib/tenant/tenant-front-door';
+import { coerceTenantId, TENANT_HEADER_NAME, type TenantId } from '@/lib/tenant/tenant-hosts';
+
+import { recordValue } from './authority-fields';
+
+export type OnboardingMode = 'resolved' | 'deferred';
+export type OnboardingSelector = { tenant: TenantId; mode: OnboardingMode };
+export type OnboardingIntent = OnboardingSelector & {
+  version: 1;
+  host: string;
+  issuedAt: number;
+};
+export type OnboardingFailure =
+  | 'missing_selector'
+  | 'malformed_selector'
+  | 'host_conflict'
+  | 'tenant_mismatch'
+  | 'forbidden_mode'
+  | 'unknown_host';
+export type OnboardingResolution =
+  | { ok: true; intent: OnboardingIntent }
+  | { ok: false; reason: OnboardingFailure; resolvedTenantId: TenantId | null };
+
+const MAX_INTENT_AGE_MS = 10 * 60 * 1000;
+const FUTURE_SKEW_MS = 30 * 1000;
+
+function selectorCandidate(body: unknown): {
+  present: boolean;
+  value?: unknown;
+  conflict?: boolean;
+} {
+  const root = recordValue(body);
+  if (!root) return { present: false };
+  const direct = Object.prototype.hasOwnProperty.call(root, 'onboarding');
+  const additional = recordValue(root.additionalData);
+  const nested = Boolean(
+    additional && Object.prototype.hasOwnProperty.call(additional, 'onboarding')
+  );
+  if (direct && nested) return { present: true, conflict: true };
+  if (direct) return { present: true, value: root.onboarding };
+  return nested ? { present: true, value: additional?.onboarding } : { present: false };
+}
+
+export function parseOnboardingSelector(
+  body: unknown
+): { kind: 'absent' } | { kind: 'invalid' } | { kind: 'valid'; selector: OnboardingSelector } {
+  const candidate = selectorCandidate(body);
+  if (!candidate.present) return { kind: 'absent' };
+  const value = recordValue(candidate.value);
+  if (candidate.conflict || !value) return { kind: 'invalid' };
+  if (Object.keys(value).sort().join(',') !== 'mode,tenant') return { kind: 'invalid' };
+  const tenant = typeof value.tenant === 'string' ? coerceTenantId(value.tenant.trim()) : null;
+  const mode = value.mode;
+  if (!tenant || (mode !== 'resolved' && mode !== 'deferred')) return { kind: 'invalid' };
+  return { kind: 'valid', selector: { tenant, mode } };
+}
+
+function observedHost(headers: Headers): {
+  host: string;
+  tenant: TenantId | null;
+  conflict: boolean;
+} {
+  const direct = normalizeTenantHost(headers.get('host'));
+  const forwarded = normalizeTenantHost(headers.get('x-forwarded-host'));
+  const directContext = resolveTenantHostContext(direct);
+  const directTenant = directContext.kind === 'compatibility_alias' ? directContext.tenantId : null;
+  const directKnown = directContext.kind !== 'unknown';
+  if (directKnown && forwarded && forwarded !== direct)
+    return { host: direct, tenant: directTenant, conflict: true };
+  const host = directKnown || !forwarded ? direct : forwarded;
+  const context = resolveTenantHostContext(host);
+  const tenant = context.kind === 'compatibility_alias' ? context.tenantId : null;
+  return { host, tenant, conflict: !host };
+}
+
+export function resolveOnboardingAuthority(args: {
+  headers: Headers;
+  body: unknown;
+  now?: number;
+}): OnboardingResolution {
+  const parsed = parseOnboardingSelector(args.body);
+  if (parsed.kind !== 'valid') {
+    return {
+      ok: false,
+      reason: parsed.kind === 'absent' ? 'missing_selector' : 'malformed_selector',
+      resolvedTenantId: null,
+    };
+  }
+  const observed = observedHost(args.headers);
+  if (observed.conflict)
+    return { ok: false, reason: 'host_conflict', resolvedTenantId: observed.tenant };
+  if (observed.tenant) {
+    if (parsed.selector.tenant !== observed.tenant)
+      return { ok: false, reason: 'tenant_mismatch', resolvedTenantId: observed.tenant };
+    if (parsed.selector.mode !== 'resolved')
+      return { ok: false, reason: 'forbidden_mode', resolvedTenantId: observed.tenant };
+  } else if (isKnownIdaFrontDoorHost(observed.host)) {
+    if (parsed.selector.mode !== 'deferred')
+      return { ok: false, reason: 'forbidden_mode', resolvedTenantId: null };
+    const headerTenant = coerceTenantId(args.headers.get(TENANT_HEADER_NAME));
+    if (headerTenant && headerTenant !== parsed.selector.tenant) {
+      return { ok: false, reason: 'tenant_mismatch', resolvedTenantId: headerTenant };
+    }
+  } else return { ok: false, reason: 'unknown_host', resolvedTenantId: null };
+  return {
+    ok: true,
+    intent: {
+      version: 1,
+      ...parsed.selector,
+      host: observed.host,
+      issuedAt: args.now ?? Date.now(),
+    },
+  };
+}
+
+export function revalidateOnboardingIntent(
+  value: unknown,
+  headers: Headers,
+  now = Date.now()
+): OnboardingIntent | null {
+  const intent = recordValue(value);
+  if (!intent || Object.keys(intent).sort().join(',') !== 'host,issuedAt,mode,tenant,version')
+    return null;
+  if (
+    intent.version !== 1 ||
+    typeof intent.host !== 'string' ||
+    typeof intent.issuedAt !== 'number'
+  )
+    return null;
+  if (intent.issuedAt > now + FUTURE_SKEW_MS || now - intent.issuedAt > MAX_INTENT_AGE_MS)
+    return null;
+  const resolved = resolveOnboardingAuthority({
+    headers,
+    body: { onboarding: { tenant: intent.tenant, mode: intent.mode } },
+    now: intent.issuedAt,
+  });
+  if (!resolved.ok || resolved.intent.host !== intent.host) return null;
+  return resolved.intent;
+}

--- a/apps/web/src/lib/auth/onboarding-authority.ts
+++ b/apps/web/src/lib/auth/onboarding-authority.ts
@@ -24,22 +24,23 @@ export type OnboardingFailure =
 export type OnboardingResolution =
   | { ok: true; intent: OnboardingIntent }
   | { ok: false; reason: OnboardingFailure; resolvedTenantId: TenantId | null };
+type SelectorCandidate = { present: boolean; value?: unknown; conflict?: boolean };
 
 const MAX_INTENT_AGE_MS = 10 * 60 * 1000;
 const FUTURE_SKEW_MS = 30 * 1000;
 
-function selectorCandidate(body: unknown): {
-  present: boolean;
-  value?: unknown;
-  conflict?: boolean;
-} {
+function sortedKeys(value: Record<string, unknown>): string {
+  return Object.keys(value)
+    .sort((a, b) => a.localeCompare(b))
+    .join(',');
+}
+
+function selectorCandidate(body: unknown): SelectorCandidate {
   const root = recordValue(body);
   if (!root) return { present: false };
-  const direct = Object.prototype.hasOwnProperty.call(root, 'onboarding');
+  const direct = Object.hasOwn(root, 'onboarding');
   const additional = recordValue(root.additionalData);
-  const nested = Boolean(
-    additional && Object.prototype.hasOwnProperty.call(additional, 'onboarding')
-  );
+  const nested = Boolean(additional && Object.hasOwn(additional, 'onboarding'));
   if (direct && nested) return { present: true, conflict: true };
   if (direct) return { present: true, value: root.onboarding };
   return nested ? { present: true, value: additional?.onboarding } : { present: false };
@@ -52,7 +53,7 @@ export function parseOnboardingSelector(
   if (!candidate.present) return { kind: 'absent' };
   const value = recordValue(candidate.value);
   if (candidate.conflict || !value) return { kind: 'invalid' };
-  if (Object.keys(value).sort().join(',') !== 'mode,tenant') return { kind: 'invalid' };
+  if (sortedKeys(value) !== 'mode,tenant') return { kind: 'invalid' };
   const tenant = typeof value.tenant === 'string' ? coerceTenantId(value.tenant.trim()) : null;
   const mode = value.mode;
   if (!tenant || (mode !== 'resolved' && mode !== 'deferred')) return { kind: 'invalid' };
@@ -77,6 +78,12 @@ function observedHost(headers: Headers): {
   return { host, tenant, conflict: !host };
 }
 
+function countryHostFailure(s: OnboardingSelector, host: TenantId): OnboardingResolution | null {
+  if (s.tenant === host && s.mode === 'resolved') return null;
+  const reason = s.tenant === host ? 'forbidden_mode' : 'tenant_mismatch';
+  return { ok: false, reason, resolvedTenantId: host };
+}
+
 export function resolveOnboardingAuthority(args: {
   headers: Headers;
   body: unknown;
@@ -94,10 +101,8 @@ export function resolveOnboardingAuthority(args: {
   if (observed.conflict)
     return { ok: false, reason: 'host_conflict', resolvedTenantId: observed.tenant };
   if (observed.tenant) {
-    if (parsed.selector.tenant !== observed.tenant)
-      return { ok: false, reason: 'tenant_mismatch', resolvedTenantId: observed.tenant };
-    if (parsed.selector.mode !== 'resolved')
-      return { ok: false, reason: 'forbidden_mode', resolvedTenantId: observed.tenant };
+    const failure = countryHostFailure(parsed.selector, observed.tenant);
+    if (failure) return failure;
   } else if (isKnownIdaFrontDoorHost(observed.host)) {
     if (parsed.selector.mode !== 'deferred')
       return { ok: false, reason: 'forbidden_mode', resolvedTenantId: null };
@@ -123,8 +128,7 @@ export function revalidateOnboardingIntent(
   now = Date.now()
 ): OnboardingIntent | null {
   const intent = recordValue(value);
-  if (!intent || Object.keys(intent).sort().join(',') !== 'host,issuedAt,mode,tenant,version')
-    return null;
+  if (!intent || sortedKeys(intent) !== 'host,issuedAt,mode,tenant,version') return null;
   if (
     intent.version !== 1 ||
     typeof intent.host !== 'string' ||

--- a/apps/web/src/lib/auth/schema.test.ts
+++ b/apps/web/src/lib/auth/schema.test.ts
@@ -31,4 +31,27 @@ describe('auth database adapter', () => {
       expect.objectContaining({ provider: 'pg' })
     );
   });
+
+  it('C01 keeps every authority field server-owned with non-privileged defaults', async () => {
+    const { userSchemaConfig } = await import('./schema');
+    const fields = userSchemaConfig.additionalFields;
+    const authorityKeys = [
+      'role',
+      'tenantId',
+      'branchId',
+      'memberNumber',
+      'tenantClassificationPending',
+      'agentId',
+      'referralCode',
+    ] as const;
+
+    expect(Object.keys(fields).sort()).toEqual([...authorityKeys].sort());
+    for (const key of authorityKeys) {
+      expect(fields[key].input).toBe(false);
+      expect(fields[key]).not.toHaveProperty('validator.input');
+      expect(fields[key]).not.toHaveProperty('transform.input');
+    }
+    expect(fields.role.defaultValue).toBe('member');
+    expect(fields.tenantClassificationPending.defaultValue).toBe(false);
+  });
 });

--- a/apps/web/src/lib/auth/schema.ts
+++ b/apps/web/src/lib/auth/schema.ts
@@ -18,33 +18,40 @@ export const userSchemaConfig = {
     tenantId: {
       type: 'string',
       fieldName: 'tenantId',
+      input: false,
     },
     branchId: {
       type: 'string',
       fieldName: 'branchId', // Maps to Drizzle schema key 'branchId'
+      input: false,
       // CRITICAL FOR RLS: This field scopes Branch Managers to their specific branch.
       // It MUST be checked in all protected actions to prevent cross-branch data leakage.
     },
     role: {
       type: 'string',
-      defaultValue: 'user',
+      defaultValue: 'member',
+      input: false,
     },
     memberNumber: {
       type: 'string',
       fieldName: 'memberNumber',
+      input: false,
     },
     tenantClassificationPending: {
       type: 'boolean',
       fieldName: 'tenantClassificationPending',
       defaultValue: false,
+      input: false,
     },
     agentId: {
       type: 'string',
       fieldName: 'agentId',
+      input: false,
     },
     referralCode: {
       type: 'string',
       fieldName: 'referralCode',
+      input: false,
     },
   },
 } satisfies BetterAuthOptions['user'];

--- a/apps/web/src/lib/auth/user-authority-assignment.ts
+++ b/apps/web/src/lib/auth/user-authority-assignment.ts
@@ -1,0 +1,60 @@
+import { getOAuthState } from 'better-auth/api';
+
+import {
+  assertNoAuthorityFields,
+  AUTHORITY_INTENT_KEY,
+  invalidOnboardingError,
+  recordValue,
+} from './authority-fields';
+import { revalidateOnboardingIntent, type OnboardingIntent } from './onboarding-authority';
+
+function contextPath(context: unknown): string {
+  const record = recordValue(context);
+  return typeof record?.path === 'string' ? record.path : '';
+}
+
+function contextHeaders(context: unknown): Headers {
+  const record = recordValue(context);
+  if (record?.headers instanceof Headers) return record.headers;
+  const request = record?.request;
+  return request instanceof Request ? request.headers : new Headers();
+}
+
+async function requestIntent(context: unknown): Promise<unknown> {
+  const record = recordValue(context);
+  const body = recordValue(record?.body);
+  if (contextPath(context).startsWith('/callback/')) {
+    return recordValue(await getOAuthState())?.[AUTHORITY_INTENT_KEY];
+  }
+  if (body && AUTHORITY_INTENT_KEY in body) return body[AUTHORITY_INTENT_KEY];
+  return recordValue(body?.additionalData)?.[AUTHORITY_INTENT_KEY];
+}
+
+async function canonicalIntent(context: unknown): Promise<OnboardingIntent> {
+  const intent = revalidateOnboardingIntent(await requestIntent(context), contextHeaders(context));
+  if (!intent) throw invalidOnboardingError();
+  return intent;
+}
+
+export async function assignUserAuthorityBeforeCreate(
+  user: Record<string, unknown>,
+  context: unknown
+): Promise<{ data: Record<string, unknown> }> {
+  const intent = await canonicalIntent(context);
+  return {
+    data: {
+      ...user,
+      role: 'member',
+      tenantId: intent.tenant,
+      branchId: null,
+      memberNumber: null,
+      tenantClassificationPending: intent.mode === 'deferred',
+      agentId: null,
+      referralCode: null,
+    },
+  };
+}
+
+export function assertUserAuthorityUpdateBefore(data: unknown): void {
+  assertNoAuthorityFields(data);
+}

--- a/packages/domain-referrals/src/authority-writers.test.ts
+++ b/packages/domain-referrals/src/authority-writers.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  update: vi.fn(),
+  set: vi.fn(),
+  where: vi.fn(),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+  and: vi.fn((...values: unknown[]) => values),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  db: { query: { user: { findFirst: mocks.findFirst } }, update: mocks.update },
+}));
+vi.mock('@interdomestik/database/schema', () => ({
+  user: { id: 'user.id', tenantId: 'user.tenantId' },
+}));
+vi.mock('drizzle-orm', () => ({ eq: mocks.eq, and: mocks.and }));
+vi.mock('nanoid', () => ({
+  customAlphabet: () => () => 'ABC123',
+  nanoid: () => 'ABC123',
+}));
+
+import { getMemberReferralLinkCore } from './member-referrals/link';
+import { getAgentReferralLinkCore } from './referrals/get-agent-link';
+
+describe('authorized referral-code writers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findFirst.mockResolvedValue({ referralCode: null });
+    mocks.update.mockReturnValue({ set: mocks.set });
+    mocks.set.mockReturnValue({ where: mocks.where });
+  });
+
+  it.each([
+    [getMemberReferralLinkCore, 'member', 'Mira', 'tenant_ks'],
+    [getAgentReferralLinkCore, 'agent', 'Arta', 'tenant_mk'],
+  ])(
+    'generates %s code only for the session user and tenant',
+    async (writer, role, name, tenantId) => {
+      const id = `${role}-1`;
+      const code = `${name.toUpperCase()}-ABC123`;
+      const result = await writer({
+        session: { user: { id, name, role, tenantId } },
+        referralCode: 'ATTACKER',
+      } as never);
+      expect(result).toMatchObject({ success: true, data: { code } });
+      expect(mocks.set).toHaveBeenCalledWith({ referralCode: code });
+      expect(mocks.eq).toHaveBeenCalledWith('user.id', id);
+      expect(mocks.eq).toHaveBeenCalledWith('user.tenantId', tenantId);
+    }
+  );
+});

--- a/packages/domain-users/src/admin/roles.test.ts
+++ b/packages/domain-users/src/admin/roles.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  withTenantContext: vi.fn(),
+  withTenant: vi.fn((tenantId: string, _column: unknown, condition?: unknown) => ({
+    tenantId,
+    condition,
+  })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+  audit: vi.fn(),
+}));
+
+vi.mock('@interdomestik/database', () => ({
+  withTenantContext: mocks.withTenantContext,
+  withTenant: mocks.withTenant,
+  eq: mocks.eq,
+  and: vi.fn((...values: unknown[]) => values),
+  branches: { id: 'branches.id', tenantId: 'branches.tenantId' },
+  user: { id: 'user.id', tenantId: 'user.tenantId' },
+  userRoles: {
+    id: 'roles.id',
+    tenantId: 'roles.tenantId',
+    userId: 'roles.userId',
+    role: 'roles.role',
+  },
+}));
+vi.mock('@interdomestik/database/tenant-security', () => ({ withTenant: mocks.withTenant }));
+vi.mock('@interdomestik/shared-auth', () => ({
+  ensureAccessTenantId: (session: { user: { tenantId?: string } }) => session.user.tenantId,
+  hasPermission: vi.fn(() => true),
+  requirePermission: vi.fn(),
+  PERMISSIONS: { 'roles.manage': 'roles.manage' },
+}));
+vi.mock('drizzle-orm', () => ({ isNull: vi.fn() }));
+
+import { grantUserRoleCore } from './roles';
+
+const session = { user: { id: 'admin-1', role: 'admin', tenantId: 'tenant_ks' } };
+
+describe('authorized role writer', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('grants an active same-tenant branch role and emits its audit record', async () => {
+    mocks.withTenantContext
+      .mockImplementationOnce(async (_scope, run) =>
+        run({
+          query: {
+            branches: {
+              findFirst: vi.fn().mockResolvedValue({ id: 'ks_branch_a', isActive: true }),
+            },
+          },
+        })
+      )
+      .mockImplementationOnce(async (_scope, run) =>
+        run({
+          update: vi.fn(() => ({
+            set: vi.fn(() => ({
+              where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'user-1' }]) })),
+            })),
+          })),
+          delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+          insert: vi.fn(() => ({
+            values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'role-1' }]) })),
+          })),
+        })
+      );
+
+    await expect(
+      grantUserRoleCore(
+        {
+          session,
+          tenantId: 'tenant_ks',
+          userId: 'user-1',
+          role: 'agent',
+          branchId: 'ks_branch_a',
+        },
+        { logAuditEvent: mocks.audit }
+      )
+    ).resolves.toEqual({ success: true });
+    expect(mocks.withTenant).toHaveBeenCalledWith(
+      'tenant_ks',
+      'branches.tenantId',
+      expect.anything()
+    );
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'user.role_granted',
+        tenantId: 'tenant_ks',
+        metadata: { role: 'agent', branchId: 'ks_branch_a' },
+      })
+    );
+  });
+
+  it('denies foreign tenant and invalid branch before any role mutation', async () => {
+    await expect(
+      grantUserRoleCore({
+        session,
+        tenantId: 'tenant_mk',
+        userId: 'user-1',
+        role: 'agent',
+        branchId: 'mk_branch_a',
+      })
+    ).rejects.toThrow('Unauthorized');
+    mocks.withTenantContext.mockImplementationOnce(async (_scope, run) =>
+      run({
+        query: { branches: { findFirst: vi.fn().mockResolvedValue(null) } },
+      })
+    );
+    await expect(
+      grantUserRoleCore({
+        session,
+        tenantId: 'tenant_ks',
+        userId: 'user-1',
+        role: 'agent',
+        branchId: 'ks_missing',
+      })
+    ).resolves.toEqual({ error: 'Invalid branch' });
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58754998,
+  "maxTrackedBytes": 58755317,
   "maxTrackedFiles": 5548,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16686978,
-    "source/scripts": 7859052,
+    "source/scripts": 7859188,
     "docs/text": 7655928,
-    "tests/e2e": 5897908,
+    "tests/e2e": 5898091,
     "config/data/messages": 1798737
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58754780,
+  "maxTrackedBytes": 58754998,
   "maxTrackedFiles": 5548,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16686978,
-    "source/scripts": 7858834,
+    "source/scripts": 7859052,
     "docs/text": 7655928,
     "tests/e2e": 5897908,
     "config/data/messages": 1798737

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58711583,
-  "maxTrackedFiles": 5534,
+  "maxTrackedBytes": 58754780,
+  "maxTrackedFiles": 5548,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16686978,
-    "source/scripts": 7847144,
+    "source/scripts": 7858834,
     "docs/text": 7655928,
-    "tests/e2e": 5866401,
+    "tests/e2e": 5897908,
     "config/data/messages": 1798737
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Summary

- Remediates two confirmed pre-existing Critical Better Auth findings from sealed scan `248fb4d6-52e3-436e-a925-1a9ba76ab602`:
  - anonymous signup could mass-assign privileged authority attributes;
  - authenticated generic update-user could mass-assign privileged authority attributes.
- Moves authority assignment behind a server-owned, host-bound onboarding intent. Client signup and OTP flows send only the selector payload `{ tenant, mode }`; privileged attributes are rejected or canonically derived on the server.
- Protects `role`, `tenantId`, `branchId`, `memberNumber`, `tenantClassificationPending`, `agentId`, and `referralCode` at schema, request-hook, create-hook, and update-backstop layers while preserving existing email-OTP, OAuth, and tenant contracts C01-C12.
- Scope is exactly 30 authorized paths: 13 production files, 16 tests/evals, and canonical `scripts/repo-size-budget.json` synchronization. No schema, migration, RLS, shared-auth, package, lockfile, proxy, canonical-route, tenancy-architecture, or documentation changes.

## Review focus

- Primary review surface: `apps/web/src/lib/auth/*authority*`, Better Auth hooks/schema, signup tenant guard, neutral OTP boundary, and the signup/update E2E contract.
- Primary contracts or risks to verify: property-presence rejection (including falsy/inherited values), server-issued intent freshness and host rebound protection, canonical country-host vs deferred neutral-host assignment, OAuth state binding, and atomic update rejection.
- Ignore unless behavior changed: routing/proxy, canonical routes, tenant helpers, database schema/RLS, provider configuration, and shared-auth are intentionally untouched.

## Acceptance

- [x] Slice criteria are explicit and complete.
- [x] No behavior changed outside the authorized security slice.

## Security and independent review

- Final Claude Opus 4.8 senior/security route: **PASS**; Atlas **PASS**; Sentinel **PASS**; no Critical/High/Medium findings. Receipt: `tmp/reviewer-routes/20260722T165020-opus.json` (166,221 ms; exit 0; valid output; neither output nor total timeout fired).
- Gemini independent review: **PASS**; no Critical/High/Medium findings.
- Sonnet secondary route was tooling-blocked by the documented buffered-output wrapper timeout and was not treated as an auth/network/quota failure or repeated.
- Codex Security diff scan `68c1087f-a127-4995-a2d6-43b3b93fd1c1`: zero findings across 27/27 scoped rows; snapshot `codex-security-snapshot/v1:sha256:4c77d77b43086412e968654470b5bf09cf6811c1ffea3d89227f7b3c3b694e4c`.
- The Codex Security diff scan preceded the small gate-driven canonical-resolver/E2E/pricing-test corrections. Final frozen-diff Opus review plus `pnpm security:guard` cover the committed 30-path tree.

## Evidence (mandatory before merge)

- PR status: `PASS`
- Executed RED captured before implementation; focused GREEN passed.
- Isolated local PostgreSQL contract: 2 new authority tests + 5 existing OTP tests passed; task database was removed after final gates.
- Deterministic no-provider OAuth authority coverage passed.
- Playwright MCP: foreign-tenant malicious signup returned `WRONG_TENANT_CONTEXT` with no `Set-Cookie`.
- Focused KS/MK production-server browser proof passed.
- Production build and bundle-size checks passed.
- Final focused auth suite: 23/23 passed; pricing/rate-limit suite: 32/32 passed without automation-bypass environment variables.
- Gates:
  - `pnpm pr:verify` (exit: `0`; no automation-bypass environment variables; 353 CI contracts, 148 release-gate tests, RLS 41/41, web 618 passed / 2 skipped, 3,068 tests passed / 8 skipped, repository line coverage 85.26%, integrated E2E/smoke green)
  - `pnpm security:guard` (exit: `0`; all enforced checks clean)
  - `pnpm e2e:gate` (exit: `0`; 209 passed / 9 skipped)
- Canonical size budget, formatting, lint, typecheck, architecture guards, memory precheck, and `git diff --check` passed.
- `pnpm-lock.yaml` SHA-256 remains `6da85311d306a5de5b9588a924fbe84d74ed866bdc23ddcdae76aa100225d04a`.
- Base is clean `origin/main` `39c59b2996d09531875246c6844b73214ae24c1f`; implementation commit is `bb4cfca6c191f4dfab7f7bbd53aed395189e13d4`.
- Summary/closure/log/screenshot paths: evidence is retained in the SEC-AUTH01 Codex task and reviewer receipts; no canonical repository documentation or broad pilot-evidence artifact was authorized.

## Product-readiness sequence

- [ ] Ran `pnpm pr:request-reviewers -- <PR_NUMBER>` after opening the PR and after substantive pushes; this posts `@copilot review` and `@codex review` for the current head.
- [ ] Requested current-head Copilot review and current-head Codex review.
- [ ] Addressed or technically closed Copilot, Codex, CodeQL, Sonar, and bot-review findings.
- [ ] Ran `pnpm pr:review-ready -- <PR_NUMBER>` after final push.

## Pilot guardrails

- [ ] No changes to auth, routing, proxy, or API contract files were made. **Explicit SEC-AUTH01 exception:** auth/API boundary changes are the authorized remediation; routing and proxy remain untouched.
- [x] Explicitly allowed exceptions documented:
  - `apps/web/src/proxy.ts` — unchanged and protected.
  - `apps/web/src/app/api/auth/[...all]/**` — narrow signup/neutral-OTP authorization boundary and tests.
  - `packages/**/src/api/**` — unchanged.
  - `packages/**/src/**/auth*` — test-only authority-writer inventories; shared-auth unchanged.

## Rollback and residual risk

- No database/provider/deploy action and no migration are required. Rollback is app-only.
- Prefer patch-forward or temporarily disable affected signup/update endpoints if a regression appears. A blind revert reopens both Critical privilege-escalation paths.
- Informational residual: forwarded-host fallback on an unknown direct host relies on the canonical proxy preserving a known `Host`; protected proxy behavior is unchanged.
- Informational residual: all new-user creation now requires a valid server-issued intent. This is intentional fail-closed behavior.

## Merge readiness

- [ ] All GitHub review threads resolved.
- [ ] Bot or reviewer findings were either fixed or explicitly closed with technical reasoning.
- [ ] Required checks green (`validation-surface`, `audit`, `e2e`, `pnpm-audit`, `gitleaks`, `pilot-gate`, `pr-finalizer`, `commitlint`).
- [ ] `pnpm pr:governance:report -- <PR_NUMBER>` recorded Sonar, CodeQL, Copilot, Codex, and required-check state; absent Copilot/Codex feedback is documented rather than waited on indefinitely.
- [x] Evidence and reviewer receipts are identified above.

Merge and deploy remain explicitly unauthorized.
