### PR TITLE
fix(ci): roll back staging alias after failed checks

### DIFF
--- a/.github/actions/trigger-digest-verified-deploy/action.yml
+++ b/.github/actions/trigger-digest-verified-deploy/action.yml
@@ -1,30 +1,24 @@
 name: Deploy Vercel Prebuilt Artifact
 description: Pulls Vercel env, builds locally, and deploys a prebuilt artifact.
 inputs:
-  environment:
-    required: true
-  production:
-    required: true
-  commit-sha:
-    required: true
-  attested-image-digest:
-    required: true
+  environment: { required: true }
+  production: { required: true }
+  commit-sha: { required: true }
+  attested-image-digest: { required: true }
   vercel-automation-bypass-secret:
     required: false
     default: ''
 outputs:
-  deployment_url:
-    value: ${{ steps.deploy.outputs.deployment_url }}
-  base_url:
-    value: ${{ steps.deploy.outputs.base_url }}
-  hostname:
-    value: ${{ steps.deploy.outputs.hostname }}
-  gate_base_url:
-    value: ${{ steps.deploy.outputs.gate_base_url }}
-  gate_hostname:
-    value: ${{ steps.deploy.outputs.gate_hostname }}
-  vercel_output_digest:
-    value: ${{ steps.deploy.outputs.vercel_output_digest }}
+  deployment_url: { value: '${{ steps.deploy.outputs.deployment_url }}' }
+  base_url: { value: '${{ steps.deploy.outputs.base_url }}' }
+  hostname: { value: '${{ steps.deploy.outputs.hostname }}' }
+  gate_base_url: { value: '${{ steps.deploy.outputs.gate_base_url }}' }
+  gate_hostname: { value: '${{ steps.deploy.outputs.gate_hostname }}' }
+  previous_deployment_hostname:
+    value: ${{ steps.deploy.outputs.previous_deployment_hostname }}
+  previous_commit_sha: { value: '${{ steps.deploy.outputs.previous_commit_sha }}' }
+  alias_moved: { value: '${{ steps.deploy.outputs.alias_moved }}' }
+  vercel_output_digest: { value: '${{ steps.deploy.outputs.vercel_output_digest }}' }
 runs:
   using: composite
   steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,16 +2,10 @@ name: CD
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
-    tags:
-      - 'v*'
-concurrency:
-  group: cd-staging-canonical-${{ github.repository }}
-  cancel-in-progress: false
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+    branches: [main]
+    tags: ['v*']
+concurrency: { group: 'cd-staging-canonical-${{ github.repository }}', cancel-in-progress: false }
+env: { REGISTRY: ghcr.io, IMAGE_NAME: '${{ github.repository }}' }
 jobs:
   build-staging:
     runs-on: [self-hosted, interdomestik-mac]
@@ -21,12 +15,10 @@ jobs:
       image_tag: ${{ steps.meta.outputs.version }}
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          driver: docker-container
+        with: { driver: docker-container }
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -38,8 +30,7 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=staging-${{ github.sha }}
+          tags: type=raw,value=staging-${{ github.sha }}
       - name: Build, attest, and verify Docker image
         id: build
         uses: ./.github/actions/build-attested-image
@@ -57,8 +48,7 @@ jobs:
     needs: build-staging
     runs-on: [self-hosted, interdomestik-mac]
     timeout-minutes: 25
-    environment:
-      name: staging
+    environment: { name: staging }
     permissions: { contents: read, id-token: write, attestations: write }
     outputs:
       base_url: ${{ steps.vercel.outputs.base_url }}
@@ -67,9 +57,9 @@ jobs:
       gate_hostname: ${{ steps.vercel.outputs.gate_hostname }}
     env:
       EXPECTED_COMMIT_SHA: ${{ github.sha }}
+      STAGING_PREIMAGE_RECEIPT_PATH: tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage.json
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
       - name: Deploy Staging to Vercel
         id: vercel
         uses: ./.github/actions/trigger-digest-verified-deploy
@@ -86,30 +76,32 @@ jobs:
           commit-sha: ${{ github.sha }}
           attested-image-digest: ${{ needs.build-staging.outputs.image_digest }}
           vercel-automation-bypass-secret: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      - name: Upload staging alias preimage receipt
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: staging-alias-preimage-${{ github.run_id }}
+          path: ${{ env.STAGING_PREIMAGE_RECEIPT_PATH }}
+          if-no-files-found: ignore
+          retention-days: 14
       - name: Wait for Staging Health
         shell: bash
         env:
           BASE_URL: ${{ steps.vercel.outputs.base_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: |
-          set -euo pipefail
-          node scripts/ci/wait-for-vercel-health.mjs "${BASE_URL}/api/health"
+        run: node scripts/ci/wait-for-vercel-health.mjs "${BASE_URL}/api/health"
       - name: Verify Staging Build Provenance
         shell: bash
         env:
           BASE_URL: ${{ steps.vercel.outputs.base_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: |
-          set -euo pipefail
-          node scripts/ci/fetch-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
+        run: node scripts/ci/fetch-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
       - name: Verify Staging Canonical Alias Provenance
         shell: bash
         env:
           BASE_URL: ${{ steps.vercel.outputs.gate_base_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: |
-          set -euo pipefail
-          node scripts/ci/wait-for-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
+        run: node scripts/ci/wait-for-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
   e2e-staging:
     needs: deploy-staging
     runs-on: [self-hosted, interdomestik-mac]
@@ -141,22 +133,55 @@ jobs:
         shell: bash
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: |
-          set -euo pipefail
-          mkdir -p "${EVIDENCE_DIR}/logs" "${EVIDENCE_DIR}/release-gates"
-          pnpm -s release:gate:raw \
-            --envName staging \
-            --suite p0 \
-            --baseUrl "${BASE_URL}" \
-            --authBaseUrl "${AUTH_BASE_URL}" \
-            --outDir "${EVIDENCE_DIR}/release-gates" \
-            2>&1 | tee "${EVIDENCE_DIR}/logs/release-gate-staging.log"
+        run: >-
+          set -euo pipefail; mkdir -p "${EVIDENCE_DIR}/logs" "${EVIDENCE_DIR}/release-gates"; pnpm -s release:gate:raw --envName staging --suite p0 --baseUrl "${BASE_URL}" --authBaseUrl "${AUTH_BASE_URL}" --outDir "${EVIDENCE_DIR}/release-gates" 2>&1 | tee "${EVIDENCE_DIR}/logs/release-gate-staging.log"
       - name: Upload staging verification artifacts
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: staging-verification-${{ github.run_id }}
           path: ${{ env.EVIDENCE_DIR }}/**
+          if-no-files-found: error
+          retention-days: 14
+  rollback-staging-alias:
+    if: >-
+      ${{ always() && !cancelled() && (needs.deploy-staging.result == 'failure' || needs.e2e-staging.result == 'failure') }}
+    needs: [deploy-staging, e2e-staging]
+    runs-on: [self-hosted, interdomestik-mac]
+    timeout-minutes: 10
+    environment: { name: staging, deployment: false }
+    permissions: { contents: read }
+    env:
+      STAGING_PREIMAGE_RECEIPT_PATH: tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage/staging-alias-preimage.json
+      STAGING_ROLLBACK_RECEIPT_PATH: tmp/cd-evidence/${{ github.run_id }}/staging-alias-rollback.json
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+      - name: Download staging alias preimage receipt
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: staging-alias-preimage-${{ github.run_id }}
+          path: tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage
+      - name: Validate staging alias rollback authority
+        id: rollback_guard
+        if: ${{ always() }}
+        shell: bash
+        run: node scripts/ci/configure-vercel-gate-url.mjs guard >> "${GITHUB_OUTPUT}"
+      - name: Restore exact staging alias preimage
+        if: ${{ success() && steps.rollback_guard.outputs.should_restore == 'true' }}
+        shell: bash
+        env:
+          STAGING_ALIAS_DOMAIN: staging.interdomestik.com
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        run: node scripts/ci/configure-vercel-gate-url.mjs restore
+      - name: Upload staging alias rollback receipt
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: staging-alias-rollback-${{ github.run_id }}
+          path: tmp/cd-evidence/${{ github.run_id }}/staging-alias-rollback.json
           if-no-files-found: error
           retention-days: 14
   production-evidence:
@@ -171,9 +196,7 @@ jobs:
         with: { install-playwright: 'false' }
       - name: Check Production Human Evidence
         shell: bash
-        run: |
-          set -euo pipefail
-          pnpm release:evidence:check
+        run: pnpm release:evidence:check
   build-production:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     needs: production-evidence
@@ -184,12 +207,10 @@ jobs:
       image_tag: ${{ steps.meta.outputs.version }}
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          driver: docker-container
+        with: { driver: docker-container }
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -227,8 +248,7 @@ jobs:
     environment: { name: production, url: https://www.interdomestik.com }
     permissions: { contents: read, id-token: write, attestations: write }
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
       - name: Deploy Production to Vercel
         id: vercel
         uses: ./.github/actions/trigger-digest-verified-deploy
@@ -277,58 +297,37 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
       - uses: ./.github/actions/setup
         with: { install-playwright: 'true' }
-
       - name: Validate optional Sentry Seer configuration
         shell: bash
         run: |
           set -euo pipefail
-          sentry_vars=(SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT)
           sentry_missing=()
-
-          for name in "${sentry_vars[@]}"; do
-            if [[ -z "${!name:-}" ]]; then
-              sentry_missing+=("${name}")
-            fi
+          for name in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT; do
+            [[ -n "${!name:-}" ]] || sentry_missing+=("${name}")
           done
-
           if (( ${#sentry_missing[@]} == 0 )); then
             echo "SENTRY_SEER_ENABLED=true" >> "$GITHUB_ENV"
           else
             echo "::warning::Skipping Sentry Seer sweep due to missing configuration: ${sentry_missing[*]}"
             echo "SENTRY_SEER_ENABLED=false" >> "$GITHUB_ENV"
           fi
-
       - name: Open Sentry Seer sweep window
         if: env.SENTRY_SEER_ENABLED == 'true'
         shell: bash
         env:
           SENTRY_SWEEP_CONTEXT: post-deploy verification
         run: bash scripts/sentry-seer-sweep.sh pre
-
       - name: Health Check
         shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "${EVIDENCE_DIR}/logs" "${EVIDENCE_DIR}/notes" "${EVIDENCE_DIR}/release-gates"
-          node scripts/ci/wait-for-vercel-health.mjs "${BASE_URL}/api/health"
+        run: >-
+          set -euo pipefail; mkdir -p "${EVIDENCE_DIR}/logs" "${EVIDENCE_DIR}/notes" "${EVIDENCE_DIR}/release-gates"; node scripts/ci/wait-for-vercel-health.mjs "${BASE_URL}/api/health"
       - name: Verify Production Build Provenance
         shell: bash
-        run: |
-          set -euo pipefail
-          node scripts/ci/fetch-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
-
+        run: node scripts/ci/fetch-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
       - name: Run Production Release Gate
         shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "${EVIDENCE_DIR}/logs" "${EVIDENCE_DIR}/release-gates"
-          pnpm -s release:gate:raw \
-            --envName production \
-            --suite all \
-            --baseUrl "${BASE_URL}" \
-            --outDir "${EVIDENCE_DIR}/release-gates" \
-            2>&1 | tee "${EVIDENCE_DIR}/logs/release-gate-production.log"
-
+        run: >-
+          set -euo pipefail; mkdir -p "${EVIDENCE_DIR}/logs" "${EVIDENCE_DIR}/release-gates"; pnpm -s release:gate:raw --envName production --suite all --baseUrl "${BASE_URL}" --outDir "${EVIDENCE_DIR}/release-gates" 2>&1 | tee "${EVIDENCE_DIR}/logs/release-gate-production.log"
       - name: Close Sentry Seer sweep window
         if: always() && env.SENTRY_SEER_ENABLED == 'true'
         continue-on-error: true
@@ -336,7 +335,6 @@ jobs:
         env:
           SENTRY_SWEEP_CONTEXT: post-deploy verification
         run: bash scripts/sentry-seer-sweep.sh post
-
       - name: Upload production verification artifacts
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/scripts/ci/cd-deploy-env-scope.test.mjs
+++ b/scripts/ci/cd-deploy-env-scope.test.mjs
@@ -6,40 +6,139 @@ import { fileURLToPath } from 'node:url';
 
 import yaml from 'js-yaml';
 
-const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const cdWorkflow = readYaml('.github/workflows/cd.yml');
-const deployAction = readYaml('.github/actions/trigger-digest-verified-deploy/action.yml');
+import { validatePreimageReceipt } from './configure-vercel-gate-url.mjs';
 
-function readYaml(relativePath) {
-  return yaml.load(fs.readFileSync(path.join(rootDir, relativePath), 'utf8'));
-}
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = file => yaml.load(fs.readFileSync(path.join(root, file), 'utf8'));
+const cd = read('.github/workflows/cd.yml');
+const action = read('.github/actions/trigger-digest-verified-deploy/action.yml');
+const configure = fs.readFileSync(
+  path.join(root, 'scripts/ci/configure-vercel-gate-url.mjs'),
+  'utf8'
+);
+const rollback = cd.jobs['rollback-staging-alias'];
+const rollbackIf = rollback.if;
+const findStep = (steps, name) => steps.find(step => step?.name === name);
+const stepIndex = (steps, name) => steps.findIndex(step => step?.name === name);
+const scheduled = ({ cancelled = false, deploy = 'success', e2e = 'success' }) =>
+  !cancelled && (deploy === 'failure' || e2e === 'failure');
+const receipt = aliasMoved => ({
+  version: 1,
+  alias: 'staging.interdomestik.com',
+  deploymentHostname: 'interdomestik-old.vercel.app',
+  commitSha: 'a'.repeat(40),
+  aliasMoved,
+});
 
-test('CD build digest outputs remain wired into deploy jobs', () => {
-  for (const jobName of ['build-staging', 'build-production']) {
-    assert.equal(
-      cdWorkflow.jobs[jobName].outputs.image_digest,
-      '${{ steps.build.outputs.digest }}'
-    );
+test('CD build digests remain wired into staging and production deploys', () => {
+  for (const name of ['build-staging', 'build-production']) {
+    assert.equal(cd.jobs[name].outputs.image_digest, '${{ steps.build.outputs.digest }}');
   }
 });
 
-test('Vercel and database credentials stay out of workflow-level env', () => {
+test('provider and database credentials stay job/action scoped', () => {
   for (const key of [
     'DATABASE_URL',
     'DATABASE_URL_RLS',
     'VERCEL_ORG_ID',
     'VERCEL_PROJECT_ID',
     'VERCEL_TOKEN',
-  ]) {
-    assert.equal(cdWorkflow.env[key], undefined);
-  }
+  ])
+    assert.equal(cd.env[key], undefined);
 });
 
-test('Vercel deploy action still exports deployment and gate hostnames', () => {
-  const deployStep = deployAction.runs.steps.find(step => step?.name === 'Deploy Vercel artifact');
+test('deploy action exports rollback controls without expanding historical job outputs', () => {
+  const deploy = findStep(action.runs.steps, 'Deploy Vercel artifact');
+  assert.match(deploy.run, /configure-vercel-gate-url\.mjs/u);
+  for (const output of [
+    'alias_moved',
+    'gate_base_url',
+    'gate_hostname',
+    'previous_commit_sha',
+    'previous_deployment_hostname',
+  ])
+    assert.match(action.outputs[output].value, new RegExp(`steps\\.deploy\\.outputs\\.${output}`));
+  assert.deepEqual(cd.jobs['deploy-staging'].outputs, {
+    base_url: '${{ steps.vercel.outputs.base_url }}',
+    hostname: '${{ steps.vercel.outputs.hostname }}',
+    gate_base_url: '${{ steps.vercel.outputs.gate_base_url }}',
+    gate_hostname: '${{ steps.vercel.outputs.gate_hostname }}',
+  });
+});
 
-  assert.ok(deployStep);
-  assert.match(deployStep.run, /hostname=/u);
-  assert.match(deployStep.run, /configure-vercel-gate-url\.mjs/u);
-  assert.match(deployStep.run, /GITHUB_OUTPUT/u);
+test('preimage is uploaded before checks and atomically confirms alias movement', () => {
+  const steps = cd.jobs['deploy-staging'].steps;
+  const upload = findStep(steps, 'Upload staging alias preimage receipt');
+  assert.ok(
+    stepIndex(steps, 'Deploy Staging to Vercel') <
+      stepIndex(steps, upload.name) <
+      stepIndex(steps, 'Wait for Staging Health')
+  );
+  assert.match(upload.if, /always\(\)/u);
+  assert.doesNotMatch(upload.if, /alias_moved/u);
+  assert.equal(upload.with['if-no-files-found'], 'ignore');
+  const snapshot = configure.indexOf('aliasMoved: false');
+  const assignment = configure.indexOf('await aliasStagingDeployment', snapshot);
+  const moved = configure.indexOf('aliasMoved: true', assignment);
+  assert.ok(snapshot < assignment && assignment < moved);
+});
+
+test('post-alias red deploy job restores only from a confirmed receipt', () => {
+  assert.equal(scheduled({ deploy: 'failure', e2e: 'skipped' }), true);
+  assert.equal(validatePreimageReceipt(receipt(true)).aliasMoved, true);
+  assert.match(rollbackIf, /deploy-staging\.result == 'failure'/u);
+  assert.doesNotMatch(rollbackIf, /outputs\.gate_hostname/u);
+});
+
+test('pre-alias failure reaches a local guard but never the provider restore', () => {
+  assert.equal(scheduled({ deploy: 'failure', e2e: 'skipped' }), true);
+  assert.equal(validatePreimageReceipt(receipt(false)).aliasMoved, false);
+  assert.throws(
+    () =>
+      validatePreimageReceipt({
+        ...receipt(false),
+        deploymentHostname: 'https://interdomestik-old.vercel.app/path',
+      }),
+    /invalid staging alias preimage receipt/u
+  );
+  const guard = findStep(rollback.steps, 'Validate staging alias rollback authority');
+  const restore = findStep(rollback.steps, 'Restore exact staging alias preimage');
+  assert.match(guard.if, /always\(\)/u);
+  assert.match(guard.run, /configure-vercel-gate-url\.mjs guard/u);
+  assert.equal(guard.env?.VERCEL_TOKEN, undefined);
+  assert.match(restore.if, /rollback_guard\.outputs\.should_restore == 'true'/u);
+});
+
+test('failed staging E2E after confirmed movement schedules restore', () => {
+  assert.equal(scheduled({ e2e: 'failure' }), true);
+  assert.equal(validatePreimageReceipt(receipt(true)).aliasMoved, true);
+  assert.match(rollbackIf, /e2e-staging\.result == 'failure'/u);
+});
+
+test('cancellation freezes staging and successful E2E skips rollback', () => {
+  assert.equal(scheduled({ cancelled: true, deploy: 'failure' }), false);
+  assert.equal(scheduled({}), false);
+  assert.match(rollbackIf, /always\(\).*!\s*cancelled\(\)/su);
+});
+
+test('restore credentials are scoped and failure receipt always uploads hard red', () => {
+  const restore = findStep(rollback.steps, 'Restore exact staging alias preimage');
+  const upload = findStep(rollback.steps, 'Upload staging alias rollback receipt');
+  assert.match(restore.env.VERCEL_TOKEN, /secrets\.VERCEL_TOKEN/u);
+  assert.equal(restore['continue-on-error'], undefined);
+  assert.match(upload.if, /always\(\)/u);
+  assert.equal(upload['continue-on-error'], undefined);
+  assert.equal(upload.with['if-no-files-found'], 'error');
+});
+
+test('ordinary pushes still skip every production job', () => {
+  for (const name of [
+    'production-evidence',
+    'build-production',
+    'deploy-production',
+    'verify-production',
+  ]) {
+    assert.match(cd.jobs[name].if, /refs\/tags\/v|workflow_dispatch/u);
+    assert.doesNotMatch(cd.jobs[name].if, /refs\/heads\/main/u);
+  }
 });

--- a/scripts/ci/cd-deploy-env-scope.test.mjs
+++ b/scripts/ci/cd-deploy-env-scope.test.mjs
@@ -80,7 +80,9 @@ test('preimage is uploaded before checks and atomically confirms alias movement'
   const snapshot = configure.indexOf('aliasMoved: false');
   const assignment = configure.indexOf('await aliasStagingDeployment', snapshot);
   const moved = configure.indexOf('aliasMoved: true', assignment);
-  assert.ok(snapshot < assignment && assignment < moved);
+  const snapshotPrecedesAssignment = snapshot < assignment;
+  const assignmentPrecedesMovement = assignment < moved;
+  assert.ok(snapshotPrecedesAssignment && assignmentPrecedesMovement);
 });
 
 test('post-alias red deploy job restores only from a confirmed receipt', () => {

--- a/scripts/ci/cd-deploy-env-scope.test.mjs
+++ b/scripts/ci/cd-deploy-env-scope.test.mjs
@@ -69,19 +69,23 @@ test('deploy action exports rollback controls without expanding historical job o
 test('preimage is uploaded before checks and atomically confirms alias movement', () => {
   const steps = cd.jobs['deploy-staging'].steps;
   const upload = findStep(steps, 'Upload staging alias preimage receipt');
+  const download = findStep(rollback.steps, 'Download staging alias preimage receipt');
+  const deployReceipt = cd.jobs['deploy-staging'].env.STAGING_PREIMAGE_RECEIPT_PATH;
+  const downloadedReceipt = `${download.with.path}/${path.posix.basename(deployReceipt)}`;
   const deployIndex = stepIndex(steps, 'Deploy Staging to Vercel');
   const uploadIndex = stepIndex(steps, upload.name);
   const healthIndex = stepIndex(steps, 'Wait for Staging Health');
   assert.ok(deployIndex < uploadIndex && uploadIndex < healthIndex);
+  assert.equal(upload.with.name, download.with.name);
+  assert.equal(upload.with.path, '${{ env.STAGING_PREIMAGE_RECEIPT_PATH }}');
+  assert.equal(rollback.env.STAGING_PREIMAGE_RECEIPT_PATH, downloadedReceipt);
   assert.match(upload.if, /always\(\)/u);
   assert.doesNotMatch(upload.if, /alias_moved/u);
   assert.equal(upload.with['if-no-files-found'], 'ignore');
   const snapshot = configure.indexOf('aliasMoved: false');
   const assignment = configure.indexOf('await aliasStagingDeployment', snapshot);
   const moved = configure.indexOf('aliasMoved: true', assignment);
-  const snapshotPrecedesAssignment = snapshot < assignment;
-  const assignmentPrecedesMovement = assignment < moved;
-  assert.ok(snapshotPrecedesAssignment && assignmentPrecedesMovement);
+  assert.ok(snapshot < assignment && assignment < moved);
 });
 
 test('post-alias red deploy job restores only from a confirmed receipt', () => {

--- a/scripts/ci/cd-deploy-env-scope.test.mjs
+++ b/scripts/ci/cd-deploy-env-scope.test.mjs
@@ -69,11 +69,10 @@ test('deploy action exports rollback controls without expanding historical job o
 test('preimage is uploaded before checks and atomically confirms alias movement', () => {
   const steps = cd.jobs['deploy-staging'].steps;
   const upload = findStep(steps, 'Upload staging alias preimage receipt');
-  assert.ok(
-    stepIndex(steps, 'Deploy Staging to Vercel') <
-      stepIndex(steps, upload.name) <
-      stepIndex(steps, 'Wait for Staging Health')
-  );
+  const deployIndex = stepIndex(steps, 'Deploy Staging to Vercel');
+  const uploadIndex = stepIndex(steps, upload.name);
+  const healthIndex = stepIndex(steps, 'Wait for Staging Health');
+  assert.ok(deployIndex < uploadIndex && uploadIndex < healthIndex);
   assert.match(upload.if, /always\(\)/u);
   assert.doesNotMatch(upload.if, /alias_moved/u);
   assert.equal(upload.with['if-no-files-found'], 'ignore');

--- a/scripts/ci/configure-vercel-gate-url.mjs
+++ b/scripts/ci/configure-vercel-gate-url.mjs
@@ -1,130 +1,130 @@
+import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
-const VERCEL_TEAM_SLUG = 'ecohub';
-const DEFAULT_ALIAS_ATTEMPTS = 4;
-const DEFAULT_ALIAS_RETRY_MS = 5_000;
+import * as state from './vercel-staging-alias-state.mjs';
 
+export const aliasStagingDeployment = state.aliasStagingDeployment;
 export function cleanHostname(value) {
-  return String(value || '')
-    .replace(/^https?:\/\//u, '')
-    .split('/')[0]
-    .split(':')[0]
-    .toLowerCase();
+  const text = String(value || '').replace(/^https?:\/\//u, '');
+  return text.split(/[/:]/u)[0].toLowerCase();
 }
-
 export function requireHostname(label, value) {
   const hostname = cleanHostname(value);
-  const validLabels = hostname
-    .split('.')
-    .every(label => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(label));
-  if (hostname.length > 253 || !validLabels) {
-    throw new Error(`${label} must be a valid hostname`);
-  }
+  const valid =
+    hostname.length <= 253 &&
+    hostname.split('.').every(part => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(part));
+  if (!valid) throw new Error(`${label} must be a valid hostname`);
   return hostname;
-}
-
-function positiveInteger(value, fallback) {
-  const parsed = Number.parseInt(String(value || ''), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-function aliasEndpoint(deploymentHostname, env) {
-  const endpoint = new URL(
-    `https://api.vercel.com/v2/deployments/${encodeURIComponent(deploymentHostname)}/aliases`
-  );
-  endpoint.searchParams.set('slug', VERCEL_TEAM_SLUG);
-  return endpoint;
-}
-
-function compactBody(body) {
-  return body.replace(/\s+/gu, ' ').trim().slice(0, 800);
-}
-
-function isTransientAliasFailure(status, body) {
-  return (
-    status === 400 &&
-    /(cert .*not ready|deployment .*not ready|not READY|can not be aliased)/iu.test(body)
-  );
-}
-
-export async function aliasStagingDeployment(
-  deploymentHostname,
-  aliasHostname,
-  env = process.env,
-  fetchImpl = fetch,
-  waitImpl = delay
-) {
-  const token = env.VERCEL_TOKEN;
-  if (!token) throw new Error('VERCEL_TOKEN is required to assign the staging alias');
-
-  console.error('Assigning canonical staging alias to the verified Vercel deployment');
-  const endpoint = aliasEndpoint(deploymentHostname, env);
-  const attempts = positiveInteger(env.STAGING_ALIAS_ATTEMPTS, DEFAULT_ALIAS_ATTEMPTS);
-  const retryMs = positiveInteger(env.STAGING_ALIAS_RETRY_MS, DEFAULT_ALIAS_RETRY_MS);
-
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const response = await fetchImpl(endpoint, {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${token}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({ alias: aliasHostname, redirect: null }),
-    });
-    if (response.ok) return;
-
-    const body = await response.text();
-    if (response.status === 409 && /already assigned/iu.test(body)) {
-      console.error('Canonical staging alias is already assigned to the verified Vercel deployment');
-      return;
-    }
-    if (attempt < attempts && isTransientAliasFailure(response.status, body)) {
-      console.error(`Canonical staging alias not ready yet; retrying (${attempt}/${attempts})`);
-      await waitImpl(retryMs);
-      continue;
-    }
-    throw new Error(
-      `Failed to assign canonical staging alias: ${response.status} ${compactBody(body)}`
-    );
-  }
 }
 
 export async function resolveGateUrl(
   baseUrl,
-  deploymentHostname,
+  hostname,
   env = process.env,
-  aliasImpl = aliasStagingDeployment
+  assign = aliasStagingDeployment
 ) {
-  const deployEnvironment = env.DEPLOY_ENVIRONMENT || '';
-  const deployProduction = env.DEPLOY_PRODUCTION || '';
-  if (deployEnvironment !== 'staging' || deployProduction === 'true') {
-    return { gateBaseUrl: baseUrl, gateHostname: deploymentHostname };
+  if (env.DEPLOY_ENVIRONMENT !== 'staging' || env.DEPLOY_PRODUCTION === 'true') {
+    return { gateBaseUrl: baseUrl, gateHostname: hostname };
   }
-  const aliasHostname = requireHostname(
-    'STAGING_ALIAS_DOMAIN',
-    env.STAGING_ALIAS_DOMAIN || 'staging.interdomestik.com'
-  );
-  await aliasImpl(deploymentHostname, aliasHostname, env);
-  return { gateBaseUrl: `https://${aliasHostname}`, gateHostname: aliasHostname };
+  const requested = env.STAGING_ALIAS_DOMAIN || state.CANONICAL_STAGING_ALIAS;
+  const alias = requireHostname('STAGING_ALIAS_DOMAIN', requested);
+  if (alias !== state.CANONICAL_STAGING_ALIAS) {
+    throw new Error(`STAGING_ALIAS_DOMAIN must be ${state.CANONICAL_STAGING_ALIAS}`);
+  }
+  await assign(hostname, alias, env);
+  return { gateBaseUrl: `https://${alias}`, gateHostname: alias };
 }
 
-async function main() {
+function receiptPath(name) {
+  const result = process.env[name]?.trim();
+  if (!result) throw new Error(`${name} is required`);
+  return result;
+}
+
+export function validatePreimageReceipt(value) {
+  const hostname = requireHostname('preimage deployment hostname', value?.deploymentHostname);
+  const receipt = { ...value, deploymentHostname: hostname };
+  if (
+    receipt.version !== 1 ||
+    receipt.alias !== state.CANONICAL_STAGING_ALIAS ||
+    value?.deploymentHostname !== hostname ||
+    !receipt.deploymentHostname.endsWith('.vercel.app') ||
+    !/^[a-f0-9]{40}$/u.test(receipt.commitSha || '') ||
+    typeof receipt.aliasMoved !== 'boolean'
+  )
+    throw new Error('invalid staging alias preimage receipt');
+  return receipt;
+}
+
+async function readPreimage() {
+  const source = await readFile(receiptPath('STAGING_PREIMAGE_RECEIPT_PATH'), 'utf8');
+  return validatePreimageReceipt(JSON.parse(source));
+}
+async function writeRollback(receipt, outcome, error) {
+  await state.writeAliasReceipt(receiptPath('STAGING_ROLLBACK_RECEIPT_PATH'), {
+    ...receipt,
+    outcome,
+    ...(error ? { error: state.boundedProviderText(error?.message) } : {}),
+  });
+}
+
+async function guardRollback() {
+  let receipt = { alias: state.CANONICAL_STAGING_ALIAS };
+  try {
+    receipt = await readPreimage();
+    if (!receipt.aliasMoved) await writeRollback(receipt, 'not-required');
+    process.stdout.write(`should_restore=${receipt.aliasMoved}\n`);
+  } catch (error) {
+    await writeRollback(receipt, 'failed', error);
+    throw error;
+  }
+}
+
+async function restore() {
+  let receipt = { alias: state.CANONICAL_STAGING_ALIAS };
+  try {
+    receipt = await readPreimage();
+    if (!receipt.aliasMoved) throw new Error('staging alias movement was not confirmed');
+    await state.restoreStagingAlias(receipt);
+    await writeRollback(receipt, 'restored');
+  } catch (error) {
+    await writeRollback(receipt, 'failed', error);
+    throw error;
+  }
+}
+
+async function deploy() {
   const baseUrl = process.argv[2];
-  const deploymentHostname = requireHostname('deployment hostname', process.argv[3]);
+  const hostname = requireHostname('deployment hostname', process.argv[3]);
   if (!baseUrl?.startsWith('https://')) throw new Error('base URL must use https');
-  const { gateBaseUrl, gateHostname } = await resolveGateUrl(baseUrl, deploymentHostname);
-  process.stdout.write(`gate_base_url=${gateBaseUrl}\ngate_hostname=${gateHostname}\n`);
+  let receipt;
+  let aliasImpl = aliasStagingDeployment;
+  if (process.env.DEPLOY_ENVIRONMENT === 'staging' && process.env.DEPLOY_PRODUCTION !== 'true') {
+    const preimage = await state.snapshotStagingAlias();
+    const target = receiptPath('STAGING_PREIMAGE_RECEIPT_PATH');
+    receipt = { alias: state.CANONICAL_STAGING_ALIAS, ...preimage, aliasMoved: false };
+    await state.writeAliasReceipt(target, receipt);
+    console.error(`Staging alias preimage: ${preimage.deploymentHostname} ${preimage.commitSha}`);
+    aliasImpl = async (...args) => {
+      await aliasStagingDeployment(...args);
+      receipt = { ...receipt, aliasMoved: true };
+      await state.writeAliasReceipt(target, receipt);
+    };
+  }
+  const gate = await resolveGateUrl(baseUrl, hostname, process.env, aliasImpl);
+  let output = `gate_base_url=${gate.gateBaseUrl}\ngate_hostname=${gate.gateHostname}\n`;
+  if (receipt) {
+    output += `previous_deployment_hostname=${receipt.deploymentHostname}\n`;
+    output += `previous_commit_sha=${receipt.commitSha}\nalias_moved=true\n`;
+  }
+  process.stdout.write(output);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  try {
-    await main();
-  } catch (error) {
+  const command =
+    process.argv[2] === 'guard' ? guardRollback : process.argv[2] === 'restore' ? restore : deploy;
+  await command().catch(error => {
     console.error(error);
-    process.exit(1);
-  }
+    process.exitCode = 1;
+  });
 }

--- a/scripts/ci/configure-vercel-gate-url.mjs
+++ b/scripts/ci/configure-vercel-gate-url.mjs
@@ -121,8 +121,10 @@ async function deploy() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const command =
-    process.argv[2] === 'guard' ? guardRollback : process.argv[2] === 'restore' ? restore : deploy;
+  const requestedCommand = process.argv[2];
+  let command = deploy;
+  if (requestedCommand === 'guard') command = guardRollback;
+  else if (requestedCommand === 'restore') command = restore;
   await command().catch(error => {
     console.error(error);
     process.exitCode = 1;

--- a/scripts/ci/vercel-staging-alias-state.mjs
+++ b/scripts/ci/vercel-staging-alias-state.mjs
@@ -51,7 +51,8 @@ async function providerJson(response, label) {
     throw new Error(`${label} failed (${response.status}): ${boundedProviderText(body)}`);
   try {
     const parsed = JSON.parse(body);
-    if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') throw new Error();
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object')
+      throw new Error('Provider response must be a JSON object');
     return parsed;
   } catch {
     throw new Error(`${label} returned an invalid response`);

--- a/scripts/ci/vercel-staging-alias-state.mjs
+++ b/scripts/ci/vercel-staging-alias-state.mjs
@@ -105,19 +105,20 @@ export async function snapshotStagingAlias({
   );
   if (aliasState.alias !== alias) throw new Error('canonical staging alias missing');
   if (aliasState.redirect) throw new Error('canonical staging alias must not redirect');
-  const deploymentHostname = deploymentHost(aliasState.deployment?.url);
+  const deploymentId = requireValue('Vercel alias deploymentId', aliasState.deploymentId);
+  if (aliasState.projectId !== projectId)
+    throw new Error('Vercel alias project ownership mismatch');
   const deployment = await providerJson(
     await fetchImpl(
-      scopedUrl(`/v13/deployments/${encodeURIComponent(deploymentHostname)}`, teamId),
+      scopedUrl(`/v13/deployments/${encodeURIComponent(deploymentId)}`, teamId),
       init
     ),
     'Vercel deployment lookup'
   );
+  const deploymentHostname = deploymentHost(deployment.url);
   const resolvedTeam = deployment.teamId || deployment.team?.id;
   const ownershipMatches =
-    deploymentHost(deployment.url) === deploymentHostname &&
-    deployment.projectId === projectId &&
-    resolvedTeam === teamId;
+    deployment.id === deploymentId && deployment.projectId === projectId && resolvedTeam === teamId;
   if (!ownershipMatches) throw new Error('Vercel deployment project/team ownership mismatch');
   const body = await healthImpl({ healthUrl: `https://${deploymentHostname}/api/health` });
   const commitSha = JSON.parse(body)?.build?.commitSha;

--- a/scripts/ci/vercel-staging-alias-state.mjs
+++ b/scripts/ci/vercel-staging-alias-state.mjs
@@ -114,13 +114,11 @@ export async function snapshotStagingAlias({
     'Vercel deployment lookup'
   );
   const resolvedTeam = deployment.teamId || deployment.team?.id;
-  if (
-    deploymentHost(deployment.url) !== deploymentHostname ||
-    deployment.projectId !== projectId ||
-    resolvedTeam !== teamId
-  ) {
-    throw new Error('Vercel deployment project/team ownership mismatch');
-  }
+  const ownershipMatches =
+    deploymentHost(deployment.url) === deploymentHostname &&
+    deployment.projectId === projectId &&
+    resolvedTeam === teamId;
+  if (!ownershipMatches) throw new Error('Vercel deployment project/team ownership mismatch');
   const body = await healthImpl({ healthUrl: `https://${deploymentHostname}/api/health` });
   const commitSha = JSON.parse(body)?.build?.commitSha;
   if (!/^[a-f0-9]{40}$/u.test(commitSha || '')) {
@@ -138,6 +136,7 @@ export async function restoreStagingAlias({
   const hostname = deploymentHost(deploymentHostname);
   if (!/^[a-f0-9]{40}$/u.test(commitSha || '')) throw new Error('invalid preimage commit SHA');
   const alias = canonicalAlias(env.STAGING_ALIAS_DOMAIN);
+  await healthImpl({ healthUrl: `https://${hostname}/api/health`, expectedCommitSha: commitSha });
   await aliasImpl(hostname, alias, env);
   await healthImpl({ healthUrl: `https://${alias}/api/health`, expectedCommitSha: commitSha });
 }

--- a/scripts/ci/vercel-staging-alias-state.mjs
+++ b/scripts/ci/vercel-staging-alias-state.mjs
@@ -1,0 +1,149 @@
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fetchVercelHealth } from './fetch-vercel-health.mjs';
+import { waitForVercelHealth } from './wait-for-vercel-health.mjs';
+export const CANONICAL_STAGING_ALIAS = 'staging.interdomestik.com';
+const ALIAS_DEFAULTS = { teamSlug: 'ecohub', attempts: 4, retryMs: 5_000 };
+function requireValue(name, value) {
+  const result = String(value || '').trim();
+  if (!result) throw new Error(`${name} is required`);
+  return result;
+}
+function deploymentHost(value) {
+  const host = String(value || '').toLowerCase();
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.vercel\.app$/u.test(host))
+    throw new Error('preimage must be a valid Vercel deployment hostname');
+  return host;
+}
+function canonicalAlias(value = CANONICAL_STAGING_ALIAS) {
+  if (String(value).toLowerCase() !== CANONICAL_STAGING_ALIAS)
+    throw new Error(`canonical staging alias must be ${CANONICAL_STAGING_ALIAS}`);
+  return CANONICAL_STAGING_ALIAS;
+}
+function positiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+function scopedUrl(pathname, teamId) {
+  const url = new URL(`https://api.vercel.com${pathname}`);
+  url.searchParams.set('teamId', teamId);
+  return url;
+}
+function assignmentUrl(hostname) {
+  return new URL(
+    `https://api.vercel.com/v2/deployments/${encodeURIComponent(hostname)}/aliases?slug=${ALIAS_DEFAULTS.teamSlug}`
+  );
+}
+export function boundedProviderText(value) {
+  return String(value || '')
+    .replace(
+      /(token|secret|password|key)(?:["']?\s*[:=]\s*["']?|\s+)[^"',\s}]+/giu,
+      '$1=[redacted]'
+    )
+    .replace(/\s+/gu, ' ')
+    .trim()
+    .slice(0, 180);
+}
+async function providerJson(response, label) {
+  const body = await response.text();
+  if (!response.ok)
+    throw new Error(`${label} failed (${response.status}): ${boundedProviderText(body)}`);
+  try {
+    const parsed = JSON.parse(body);
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') throw new Error();
+    return parsed;
+  } catch {
+    throw new Error(`${label} returned an invalid response`);
+  }
+}
+export async function aliasStagingDeployment(
+  deploymentHostname,
+  aliasHostname,
+  env = process.env,
+  fetchImpl = fetch,
+  waitImpl = delay
+) {
+  const token = requireValue('VERCEL_TOKEN', env.VERCEL_TOKEN);
+  const attempts = positiveInt(env.STAGING_ALIAS_ATTEMPTS, ALIAS_DEFAULTS.attempts);
+  const retryMs = positiveInt(env.STAGING_ALIAS_RETRY_MS, ALIAS_DEFAULTS.retryMs);
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = await fetchImpl(assignmentUrl(deploymentHostname), {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ alias: aliasHostname, redirect: null }),
+    });
+    if (response.ok) return;
+    const body = await response.text();
+    if (response.status === 409 && /already assigned/iu.test(body)) return;
+    const transient =
+      response.status === 400 &&
+      /(cert .*not ready|deployment .*not ready|not READY|can not be aliased)/iu.test(body);
+    if (attempt < attempts && transient) {
+      await waitImpl(retryMs);
+      continue;
+    }
+    throw new Error(
+      `Failed to assign canonical staging alias: ${response.status} ${boundedProviderText(body)}`
+    );
+  }
+}
+export async function snapshotStagingAlias({
+  env = process.env,
+  fetchImpl = fetch,
+  healthImpl = fetchVercelHealth,
+} = {}) {
+  const alias = canonicalAlias(env.STAGING_ALIAS_DOMAIN);
+  const token = requireValue('VERCEL_TOKEN', env.VERCEL_TOKEN);
+  const teamId = requireValue('VERCEL_ORG_ID', env.VERCEL_ORG_ID);
+  const projectId = requireValue('VERCEL_PROJECT_ID', env.VERCEL_PROJECT_ID);
+  const init = { headers: { authorization: `Bearer ${token}` } };
+  const aliasState = await providerJson(
+    await fetchImpl(scopedUrl(`/v4/aliases/${encodeURIComponent(alias)}`, teamId), init),
+    'Vercel alias lookup'
+  );
+  if (aliasState.alias !== alias) throw new Error('canonical staging alias missing');
+  if (aliasState.redirect) throw new Error('canonical staging alias must not redirect');
+  const deploymentHostname = deploymentHost(aliasState.deployment?.url);
+  const deployment = await providerJson(
+    await fetchImpl(
+      scopedUrl(`/v13/deployments/${encodeURIComponent(deploymentHostname)}`, teamId),
+      init
+    ),
+    'Vercel deployment lookup'
+  );
+  const resolvedTeam = deployment.teamId || deployment.team?.id;
+  if (
+    deploymentHost(deployment.url) !== deploymentHostname ||
+    deployment.projectId !== projectId ||
+    resolvedTeam !== teamId
+  ) {
+    throw new Error('Vercel deployment project/team ownership mismatch');
+  }
+  const body = await healthImpl({ healthUrl: `https://${deploymentHostname}/api/health` });
+  const commitSha = JSON.parse(body)?.build?.commitSha;
+  if (!/^[a-f0-9]{40}$/u.test(commitSha || '')) {
+    throw new Error('preimage health must expose a full lowercase commit SHA');
+  }
+  return { deploymentHostname, commitSha };
+}
+export async function restoreStagingAlias({
+  deploymentHostname,
+  commitSha,
+  env = process.env,
+  aliasImpl = aliasStagingDeployment,
+  healthImpl = waitForVercelHealth,
+}) {
+  const hostname = deploymentHost(deploymentHostname);
+  if (!/^[a-f0-9]{40}$/u.test(commitSha || '')) throw new Error('invalid preimage commit SHA');
+  const alias = canonicalAlias(env.STAGING_ALIAS_DOMAIN);
+  await aliasImpl(hostname, alias, env);
+  await healthImpl({ healthUrl: `https://${alias}/api/health`, expectedCommitSha: commitSha });
+}
+export async function writeAliasReceipt(filePath, receipt) {
+  const target = requireValue('receipt path', filePath);
+  await mkdir(path.dirname(target), { recursive: true });
+  const temporary = `${target}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify({ version: 1, ...receipt })}\n`, { mode: 0o600 });
+  await rename(temporary, target);
+}

--- a/scripts/ci/vercel-staging-alias-state.test.mjs
+++ b/scripts/ci/vercel-staging-alias-state.test.mjs
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CANONICAL_STAGING_ALIAS,
+  restoreStagingAlias,
+  snapshotStagingAlias,
+} from './vercel-staging-alias-state.mjs';
+
+const COMMIT = 'a'.repeat(40);
+const HOST = 'interdomestik-web-old-ecohub.vercel.app';
+const ENV = {
+  VERCEL_AUTOMATION_BYPASS_SECRET: 'bypass-secret',
+  VERCEL_ORG_ID: 'team_expected',
+  VERCEL_PROJECT_ID: 'prj_expected',
+  VERCEL_TOKEN: 'token-secret',
+};
+
+function response(body, status = 200) {
+  return new Response(typeof body === 'string' ? body : JSON.stringify(body), { status });
+}
+
+function snapshotFetch({
+  alias = { alias: CANONICAL_STAGING_ALIAS, deployment: { url: HOST }, redirect: null },
+  deployment = { projectId: ENV.VERCEL_PROJECT_ID, teamId: ENV.VERCEL_ORG_ID, url: HOST },
+} = {}) {
+  const calls = [];
+  return {
+    calls,
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (String(url).includes('/v4/aliases/')) return response(alias);
+      if (String(url).includes('/v13/deployments/')) return response(deployment);
+      throw new Error(`Unexpected request: ${url}`);
+    },
+  };
+}
+
+test('snapshot authenticates alias/deployment ownership and captures exact commit', async () => {
+  const fixture = snapshotFetch();
+  const result = await snapshotStagingAlias({
+    env: ENV,
+    fetchImpl: fixture.fetchImpl,
+    healthImpl: async ({ healthUrl }) => {
+      assert.equal(healthUrl, `https://${HOST}/api/health`);
+      return JSON.stringify({ build: { commitSha: COMMIT } });
+    },
+  });
+  assert.deepEqual(result, { deploymentHostname: HOST, commitSha: COMMIT });
+  assert.equal(fixture.calls.length, 2);
+  for (const call of fixture.calls) {
+    assert.equal(call.init.headers.authorization, `Bearer ${ENV.VERCEL_TOKEN}`);
+    assert.match(call.url, new RegExp(`teamId=${ENV.VERCEL_ORG_ID}`));
+  }
+});
+
+test('snapshot fails closed for missing, redirected, or malformed aliases', async () => {
+  for (const alias of [
+    {},
+    { alias: CANONICAL_STAGING_ALIAS, deployment: { url: HOST }, redirect: 'other.example' },
+    {
+      alias: CANONICAL_STAGING_ALIAS,
+      deployment: { url: 'staging.interdomestik.com' },
+      redirect: null,
+    },
+  ]) {
+    const fixture = snapshotFetch({ alias });
+    await assert.rejects(
+      snapshotStagingAlias({ env: ENV, fetchImpl: fixture.fetchImpl }),
+      /canonical staging alias|redirect|Vercel deployment hostname/u
+    );
+  }
+});
+
+test('snapshot rejects foreign project or team ownership', async () => {
+  for (const deployment of [
+    { projectId: 'prj_foreign', teamId: ENV.VERCEL_ORG_ID, url: HOST },
+    { projectId: ENV.VERCEL_PROJECT_ID, teamId: 'team_foreign', url: HOST },
+  ]) {
+    const fixture = snapshotFetch({ deployment });
+    await assert.rejects(
+      snapshotStagingAlias({ env: ENV, fetchImpl: fixture.fetchImpl }),
+      /project\/team ownership mismatch/u
+    );
+  }
+});
+
+test('snapshot rejects missing or malformed build commits', async () => {
+  const fixture = snapshotFetch();
+  for (const commitSha of [undefined, 'ABC123', 'b'.repeat(39)]) {
+    await assert.rejects(
+      snapshotStagingAlias({
+        env: ENV,
+        fetchImpl: fixture.fetchImpl,
+        healthImpl: async () => JSON.stringify({ build: { commitSha } }),
+      }),
+      /full lowercase commit SHA/u
+    );
+  }
+});
+
+test('provider errors are bounded and redact secrets', async () => {
+  await assert.rejects(
+    snapshotStagingAlias({
+      env: ENV,
+      fetchImpl: async () =>
+        response(`token=${ENV.VERCEL_TOKEN} ${'provider-noise '.repeat(200)}`, 503),
+    }),
+    error => {
+      assert.doesNotMatch(error.message, new RegExp(ENV.VERCEL_TOKEN));
+      assert.ok(error.message.length < 300);
+      return true;
+    }
+  );
+});
+
+test('restore assigns only the canonical alias and verifies the exact preimage commit', async () => {
+  const calls = [];
+  await restoreStagingAlias({
+    commitSha: COMMIT,
+    deploymentHostname: HOST,
+    env: ENV,
+    aliasImpl: async (...args) => calls.push(args),
+    healthImpl: async ({ healthUrl, expectedCommitSha }) => {
+      assert.equal(healthUrl, `https://${CANONICAL_STAGING_ALIAS}/api/health`);
+      assert.equal(expectedCommitSha, COMMIT);
+    },
+  });
+  assert.deepEqual(calls, [[HOST, CANONICAL_STAGING_ALIAS, ENV]]);
+});
+
+test('restore mismatch stays hard red', async () => {
+  await assert.rejects(
+    restoreStagingAlias({
+      commitSha: COMMIT,
+      deploymentHostname: HOST,
+      env: ENV,
+      aliasImpl: async () => {},
+      healthImpl: async () => {
+        throw new Error('Deployed build provenance mismatch');
+      },
+    }),
+    /provenance mismatch/u
+  );
+});

--- a/scripts/ci/vercel-staging-alias-state.test.mjs
+++ b/scripts/ci/vercel-staging-alias-state.test.mjs
@@ -15,11 +15,12 @@ const ENV = {
   VERCEL_PROJECT_ID: 'prj_expected',
   VERCEL_TOKEN: 'token-secret',
 };
-
+const DIRECT_HEALTH = `health:https://${HOST}/api/health:${COMMIT}`;
+const ALIAS_MOVE = `alias:${HOST}:${CANONICAL_STAGING_ALIAS}:true`;
+const CANONICAL_HEALTH = `health:https://${CANONICAL_STAGING_ALIAS}/api/health:${COMMIT}`;
 function response(body, status = 200) {
   return new Response(typeof body === 'string' ? body : JSON.stringify(body), { status });
 }
-
 function snapshotFetch({
   alias = { alias: CANONICAL_STAGING_ALIAS, deployment: { url: HOST }, redirect: null },
   deployment = { projectId: ENV.VERCEL_PROJECT_ID, teamId: ENV.VERCEL_ORG_ID, url: HOST },
@@ -35,7 +36,25 @@ function snapshotFetch({
     },
   };
 }
-
+function restoreFixture(failOnHealth = 0) {
+  const calls = [];
+  let healthChecks = 0;
+  return {
+    calls,
+    options: {
+      commitSha: COMMIT,
+      deploymentHostname: HOST,
+      env: ENV,
+      aliasImpl: async (hostname, alias, env) =>
+        calls.push(`alias:${hostname}:${alias}:${env === ENV}`),
+      healthImpl: async ({ healthUrl, expectedCommitSha }) => {
+        healthChecks += 1;
+        calls.push(`health:${healthUrl}:${expectedCommitSha}`);
+        if (healthChecks === failOnHealth) throw new Error('Deployed build provenance mismatch');
+      },
+    },
+  };
+}
 test('snapshot authenticates alias/deployment ownership and captures exact commit', async () => {
   const fixture = snapshotFetch();
   const result = await snapshotStagingAlias({
@@ -53,7 +72,6 @@ test('snapshot authenticates alias/deployment ownership and captures exact commi
     assert.match(call.url, new RegExp(`teamId=${ENV.VERCEL_ORG_ID}`));
   }
 });
-
 test('snapshot fails closed for missing, redirected, or malformed aliases', async () => {
   for (const alias of [
     {},
@@ -71,7 +89,6 @@ test('snapshot fails closed for missing, redirected, or malformed aliases', asyn
     );
   }
 });
-
 test('snapshot rejects foreign project or team ownership', async () => {
   for (const deployment of [
     { projectId: 'prj_foreign', teamId: ENV.VERCEL_ORG_ID, url: HOST },
@@ -84,7 +101,6 @@ test('snapshot rejects foreign project or team ownership', async () => {
     );
   }
 });
-
 test('snapshot rejects missing or malformed build commits', async () => {
   const fixture = snapshotFetch();
   for (const commitSha of [undefined, 'ABC123', 'b'.repeat(39)]) {
@@ -98,7 +114,6 @@ test('snapshot rejects missing or malformed build commits', async () => {
     );
   }
 });
-
 test('provider errors are bounded and redact secrets', async () => {
   await assert.rejects(
     snapshotStagingAlias({
@@ -113,33 +128,22 @@ test('provider errors are bounded and redact secrets', async () => {
     }
   );
 });
-
 test('restore assigns only the canonical alias and verifies the exact preimage commit', async () => {
-  const calls = [];
-  await restoreStagingAlias({
-    commitSha: COMMIT,
-    deploymentHostname: HOST,
-    env: ENV,
-    aliasImpl: async (...args) => calls.push(args),
-    healthImpl: async ({ healthUrl, expectedCommitSha }) => {
-      assert.equal(healthUrl, `https://${CANONICAL_STAGING_ALIAS}/api/health`);
-      assert.equal(expectedCommitSha, COMMIT);
-    },
+  const fixture = restoreFixture();
+  await restoreStagingAlias(fixture.options);
+  assert.deepEqual(fixture.calls, [DIRECT_HEALTH, ALIAS_MOVE, CANONICAL_HEALTH]);
+});
+for (const [name, failOnHealth, expectedCalls] of [
+  ['never moves the alias when direct preimage health fails', 1, [DIRECT_HEALTH]],
+  [
+    'keeps a post-move canonical mismatch hard red',
+    2,
+    [DIRECT_HEALTH, ALIAS_MOVE, CANONICAL_HEALTH],
+  ],
+]) {
+  test(`restore ${name}`, async () => {
+    const fixture = restoreFixture(failOnHealth);
+    await assert.rejects(restoreStagingAlias(fixture.options), /provenance mismatch/u);
+    assert.deepEqual(fixture.calls, expectedCalls);
   });
-  assert.deepEqual(calls, [[HOST, CANONICAL_STAGING_ALIAS, ENV]]);
-});
-
-test('restore mismatch stays hard red', async () => {
-  await assert.rejects(
-    restoreStagingAlias({
-      commitSha: COMMIT,
-      deploymentHostname: HOST,
-      env: ENV,
-      aliasImpl: async () => {},
-      healthImpl: async () => {
-        throw new Error('Deployed build provenance mismatch');
-      },
-    }),
-    /provenance mismatch/u
-  );
-});
+}

--- a/scripts/ci/vercel-staging-alias-state.test.mjs
+++ b/scripts/ci/vercel-staging-alias-state.test.mjs
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-
 import {
   CANONICAL_STAGING_ALIAS,
   restoreStagingAlias,
@@ -8,23 +7,26 @@ import {
 } from './vercel-staging-alias-state.mjs';
 
 const COMMIT = 'a'.repeat(40);
+const DEPLOYMENT_ID = 'dpl_previous';
 const HOST = 'interdomestik-web-old-ecohub.vercel.app';
+const ALIAS_NAME = CANONICAL_STAGING_ALIAS;
+const PROJECT_ID = 'prj_expected';
+const TEAM_ID = 'team_expected';
 const ENV = {
   VERCEL_AUTOMATION_BYPASS_SECRET: 'bypass-secret',
-  VERCEL_ORG_ID: 'team_expected',
-  VERCEL_PROJECT_ID: 'prj_expected',
+  VERCEL_ORG_ID: TEAM_ID,
+  VERCEL_PROJECT_ID: PROJECT_ID,
   VERCEL_TOKEN: 'token-secret',
 };
+const ALIAS_STATE = { alias: ALIAS_NAME, deploymentId: DEPLOYMENT_ID, projectId: PROJECT_ID };
+const DEPLOYMENT = { id: DEPLOYMENT_ID, projectId: PROJECT_ID, teamId: TEAM_ID, url: HOST };
 const DIRECT_HEALTH = `health:https://${HOST}/api/health:${COMMIT}`;
-const ALIAS_MOVE = `alias:${HOST}:${CANONICAL_STAGING_ALIAS}:true`;
-const CANONICAL_HEALTH = `health:https://${CANONICAL_STAGING_ALIAS}/api/health:${COMMIT}`;
+const ALIAS_MOVE = `alias:${HOST}:${ALIAS_NAME}:true`;
+const CANONICAL_HEALTH = `health:https://${ALIAS_NAME}/api/health:${COMMIT}`;
 function response(body, status = 200) {
   return new Response(typeof body === 'string' ? body : JSON.stringify(body), { status });
 }
-function snapshotFetch({
-  alias = { alias: CANONICAL_STAGING_ALIAS, deployment: { url: HOST }, redirect: null },
-  deployment = { projectId: ENV.VERCEL_PROJECT_ID, teamId: ENV.VERCEL_ORG_ID, url: HOST },
-} = {}) {
+function snapshotFetch({ alias = ALIAS_STATE, deployment = DEPLOYMENT } = {}) {
   const calls = [];
   return {
     calls,
@@ -67,6 +69,7 @@ test('snapshot authenticates alias/deployment ownership and captures exact commi
   });
   assert.deepEqual(result, { deploymentHostname: HOST, commitSha: COMMIT });
   assert.equal(fixture.calls.length, 2);
+  assert.equal(new URL(fixture.calls[1].url).pathname, `/v13/deployments/${DEPLOYMENT_ID}`);
   for (const call of fixture.calls) {
     assert.equal(call.init.headers.authorization, `Bearer ${ENV.VERCEL_TOKEN}`);
     assert.match(call.url, new RegExp(`teamId=${ENV.VERCEL_ORG_ID}`));
@@ -75,29 +78,27 @@ test('snapshot authenticates alias/deployment ownership and captures exact commi
 test('snapshot fails closed for missing, redirected, or malformed aliases', async () => {
   for (const alias of [
     {},
-    { alias: CANONICAL_STAGING_ALIAS, deployment: { url: HOST }, redirect: 'other.example' },
-    {
-      alias: CANONICAL_STAGING_ALIAS,
-      deployment: { url: 'staging.interdomestik.com' },
-      redirect: null,
-    },
+    { ...ALIAS_STATE, redirect: 'other.example' },
+    { alias: ALIAS_NAME, projectId: PROJECT_ID },
   ]) {
     const fixture = snapshotFetch({ alias });
     await assert.rejects(
       snapshotStagingAlias({ env: ENV, fetchImpl: fixture.fetchImpl }),
-      /canonical staging alias|redirect|Vercel deployment hostname/u
+      /canonical staging alias|redirect|deploymentId/u
     );
   }
 });
-test('snapshot rejects foreign project or team ownership', async () => {
-  for (const deployment of [
-    { projectId: 'prj_foreign', teamId: ENV.VERCEL_ORG_ID, url: HOST },
-    { projectId: ENV.VERCEL_PROJECT_ID, teamId: 'team_foreign', url: HOST },
+test('snapshot rejects alias project and foreign deployment ownership', async () => {
+  for (const [alias, deployment] of [
+    [{ ...ALIAS_STATE, projectId: 'prj_foreign' }],
+    [undefined, { ...DEPLOYMENT, id: 'dpl_foreign' }],
+    [undefined, { ...DEPLOYMENT, projectId: 'prj_foreign' }],
+    [undefined, { ...DEPLOYMENT, teamId: 'team_foreign' }],
   ]) {
-    const fixture = snapshotFetch({ deployment });
+    const fixture = snapshotFetch({ alias, deployment });
     await assert.rejects(
       snapshotStagingAlias({ env: ENV, fetchImpl: fixture.fetchImpl }),
-      /project\/team ownership mismatch/u
+      /project ownership mismatch|deployment project\/team ownership mismatch/u
     );
   }
 });

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58675716,
+  "maxTrackedBytes": 58676132,
   "maxTrackedFiles": 5528,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16697727,
-    "source/scripts": 7799938,
+    "source/scripts": 7800086,
     "docs/text": 7704702,
-    "tests/e2e": 5816103,
+    "tests/e2e": 5816371,
     "config/data/messages": 1800851
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58674562,
+  "maxTrackedBytes": 58674812,
   "maxTrackedFiles": 5528,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16697727,
-    "source/scripts": 7799687,
+    "source/scripts": 7799807,
     "docs/text": 7704702,
-    "tests/e2e": 5815200,
+    "tests/e2e": 5815330,
     "config/data/messages": 1800851
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58674912,
+  "maxTrackedBytes": 58675716,
   "maxTrackedFiles": 5528,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16697727,
-    "source/scripts": 7799807,
+    "source/scripts": 7799938,
     "docs/text": 7704702,
-    "tests/e2e": 5815430,
+    "tests/e2e": 5816103,
     "config/data/messages": 1800851
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58657336,
-  "maxTrackedFiles": 5526,
+  "maxTrackedBytes": 58674562,
+  "maxTrackedFiles": 5528,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16697727,
-    "source/scripts": 7792944,
+    "source/scripts": 7799687,
     "docs/text": 7704702,
-    "tests/e2e": 5806008,
-    "config/data/messages": 1799560
+    "tests/e2e": 5815200,
+    "config/data/messages": 1800851
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58674812,
+  "maxTrackedBytes": 58674912,
   "maxTrackedFiles": 5528,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16697727,
     "source/scripts": 7799807,
     "docs/text": 7704702,
-    "tests/e2e": 5815330,
+    "tests/e2e": 5815430,
     "config/data/messages": 1800851
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58676132,
+  "maxTrackedBytes": 58676477,
   "maxTrackedFiles": 5528,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16697727,
     "source/scripts": 7800086,
     "docs/text": 7704702,
-    "tests/e2e": 5816371,
+    "tests/e2e": 5816716,
     "config/data/messages": 1800851
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Summary

- Snapshot the canonical staging-alias preimage before movement and persist a fail-closed receipt with `aliasMoved: false`.
- Atomically promote that receipt to `aliasMoved: true` only after Vercel confirms alias assignment.
- Restore the exact preimage after any non-cancellation failure that occurs after confirmed alias movement, including staging health, provenance, canonical-alias, or staging E2E failure.
- Keep cancellation as an incident-authority stop: cancellation never performs provider rollback.
- Preserve the historical `deploy-staging` job-output contract exactly: `base_url`, `hostname`, `gate_base_url`, and `gate_hostname`.

## Changed areas

Exactly seven governed paths from IDA-CD-DG01 R1 / IDA-CD01:

1. `.github/workflows/cd.yml`
2. `.github/actions/trigger-digest-verified-deploy/action.yml`
3. `scripts/ci/configure-vercel-gate-url.mjs`
4. `scripts/ci/vercel-staging-alias-state.mjs`
5. `scripts/ci/vercel-staging-alias-state.test.mjs`
6. `scripts/ci/cd-deploy-env-scope.test.mjs`
7. deterministic-only `scripts/repo-size-budget.json`

No package, lockfile, database, migration, schema, seed, proxy, auth, tenancy, product, or provider-state path changed.

## Failure and rollback semantics

- Before alias assignment, an authenticated exact-host/commit snapshot is written with `aliasMoved: false`.
- After confirmed assignment, the receipt is atomically replaced with `aliasMoved: true` before downstream checks.
- The preimage artifact is always attempted before downstream checks.
- The rollback job may start only for non-cancelled deploy-staging or e2e-staging failure.
- A credential-free local guard validates the exact downloaded receipt before the provider restore step receives credentials.
- Missing, malformed, ownership-mismatched, or `aliasMoved: false` receipts cannot call the provider; the original failure remains red.
- Restore verifies the exact preimage commit health before assigning the canonical alias.
- Restore failure remains red and an always-attempted rollback receipt records the failure.

## Verification

GREEN local evidence on the exact seven-file content:

- `git diff --check`
- deterministic repo-size sync/check and `pnpm repo:size:check`
- Prettier checks and governed line limits
- focused helper/workflow/frozen-attestation suite: 27/27 passing
- workflow contract and deploy-environment-scope suites: passing
- `pnpm security:guard`: passing
- `pnpm pr:verify` constituents before its final local E2E bootstrap: repository size, 367 CI contracts, 148 release-gate tests, E2E contracts, lint baseline, migration journal, 41 RLS tests with required coverage, i18n, database/architecture guards, 3032 unit tests passing with 8 skipped, 85.60% repository coverage, reset/seed, and Next build/size

### `local_blocker` disposition

The final local E2E bootstrap was attempted once through `pnpm pr:verify`, then once as the exact targeted failed constituent `pnpm e2e:gate:pr`. Both reached unchanged Supabase CLI 2.109.0 bootstrap and failed before Playwright while applying unchanged baseline migration `supabase/migrations/00000_extensions.sql`:

```text
ERROR: duplicate key value violates unique constraint "schema_migrations_pkey"
Key (version)=(00000) already exists.
```

This is classified as `local_blocker`, not `slice_defect`, by disposition `IDA-CD01-LB01`. No migration/history repair, cleanup workaround, database mutation, provider call, or additional local E2E retry was authorized or performed.

Matching exact-main evidence exists for the unchanged baseline only:

- E2E gate run `30004617438`, job `89197636211`: green on base `483dc33015515400d7e784976893407ce78c6f41`
- Supabase Preview check `89197690179`: green on the same base

That base evidence does **not** prove this PR head and is not a waiver.

## Required current-head evidence

This PR is ready for review but is **not merge-ready** unless this exact PR head receives:

- green current-head `e2e-gate`;
- green current-head Supabase Preview, or an exact non-actionable classification that requires no database/provider mutation;
- green current-head mandatory CI, security, Sonar, CodeQL, and finalizer signals;
- clean current-head feedback intake and all required Tier-3 reviewer dispositions.

If current-head E2E or Supabase Preview fails, stop. `IDA-CD01-LB01` cannot waive, bypass, or reclassify that failure.

## Authority and evidence

- exact base: `483dc33015515400d7e784976893407ce78c6f41`
- canonical gate R1: 12,974 bytes, SHA-256 `87e3683f1150cc5eb7a2fca4638cc6bb865d9cf850017594b1ca96bd5ad83357`
- runtime-authority receipt: 8,257 bytes, SHA-256 `544156dda6b15836061219e3a2a880ad135a4bc7680df8221a049b622a2dde5a`
- local-bootstrap disposition receipt: 6,680 bytes, SHA-256 `513aa5658702a5bac97fa0c2d140260640ce398099fca86455d5174d5c560087`
- durable governance comment: https://github.com/interdomestik/interdomestik/pull/1410#issuecomment-5059257197

Provider, deployment, production, database, migration-history, workflow-dispatch, and merge-bypass authority remain false.

## Reviewer and security disposition

- Gate R1 exact-hash Sonnet 4.6 review: PASS.
- Local `security:guard`: PASS.
- Implementation current-head model/GitHub reviewer, Sonar, CodeQL, security, feedback-intake, and finalizer dispositions remain pending and are owned by the root orchestrator.

## Rollback and residual risk

- Code rollback is a single-commit revert.
- Runtime rollback is fail-closed and bound to the exact authenticated preimage receipt.
- Cancellation continues to freeze provider mutation.
- The exact PR head still requires remote E2E and Supabase Preview proof because local Playwright never started.
- After any future approved merge, the root must identify and cancel only the exact automatic CD run before checkout, registry login, image build, provider mutation, or deployment.
