### PR TITLE
fix(ci): prevent Vercel health diagnostic leaks

### DIFF
--- a/scripts/ci/wait-for-vercel-health.mjs
+++ b/scripts/ci/wait-for-vercel-health.mjs
@@ -3,6 +3,9 @@ import { pathToFileURL } from 'node:url';
 
 import { fetchVercelHealth } from './fetch-vercel-health.mjs';
 
+const HEALTH_CHECK_FAILED = 'Vercel health check failed';
+const LOG_PREFIX = '[vercel-health]';
+
 function positiveInt(value, fallback) {
   const parsed = Number.parseInt(value || '', 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
@@ -17,20 +20,18 @@ export async function waitForVercelHealth({
   fetchImpl = fetchVercelHealth,
   log = console.log,
 }) {
-  let lastError;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    log(`Attempt ${attempt}/${attempts}: checking ${healthUrl}`);
+    log(`${LOG_PREFIX} attempt ${attempt}/${attempts}`);
     try {
       const body = await fetchImpl({ healthUrl, expectedCommitSha });
-      log('Vercel health check succeeded.');
+      log(`${LOG_PREFIX} result=success`);
       return body;
-    } catch (error) {
-      lastError = error;
-      log(`Vercel health check failed: ${error.message}`);
+    } catch {
+      log(`${LOG_PREFIX} result=health_check_failed`);
       if (attempt < attempts) await sleep(sleepMs);
     }
   }
-  throw lastError || new Error('Vercel health check failed');
+  throw new Error(HEALTH_CHECK_FAILED);
 }
 
 async function main() {
@@ -39,15 +40,14 @@ async function main() {
   if (process.argv.length > 3 && !expectedCommitSha) {
     throw new Error('expectedCommitSha must not be empty when provided');
   }
-  const body = await waitForVercelHealth({ healthUrl, expectedCommitSha });
-  process.stdout.write(`${body}\n`);
+  await waitForVercelHealth({ healthUrl, expectedCommitSha });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
     await main();
-  } catch (error) {
-    console.error(error);
-    process.exit(1);
+  } catch {
+    process.stderr.write(`${HEALTH_CHECK_FAILED}\n`);
+    process.exitCode = 1;
   }
 }

--- a/scripts/ci/wait-for-vercel-health.test.mjs
+++ b/scripts/ci/wait-for-vercel-health.test.mjs
@@ -1,38 +1,150 @@
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { syncBuiltinESMExports } from 'node:module';
+import timersPromises from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
+import { promisify } from 'node:util';
 
 import { waitForVercelHealth } from './wait-for-vercel-health.mjs';
 
-test('waitForVercelHealth retries until the health check succeeds', async () => {
-  let calls = 0;
+const execFileAsync = promisify(execFile);
+const scriptPath = fileURLToPath(new URL('./wait-for-vercel-health.mjs', import.meta.url));
+const healthUrlCanary =
+  'https://user-CANARY:password-CANARY@staging.interdomestik.com/api/health' +
+  '?token=QUERY-CANARY#FRAGMENT-CANARY';
+const rawErrorMessage =
+  'provider=PROVIDER_CANARY token=TOKEN_CANARY password=PASSWORD_CANARY ' +
+  'databaseUrl=postgresql://POSTGRES_URL_CANARY responseBody=RESPONSE_BODY_CANARY';
+const errorCanaries = rawErrorMessage
+  .match(/[A-Z_]+CANARY/gu)
+  .concat('CAUSE_CANARY', 'PAYLOAD_CANARY');
+const cliPreload = `
+  import childProcess from 'node:child_process'; import { syncBuiltinESMExports } from 'node:module';
+  import { promisify } from 'node:util';
+  const body = '{"body":"CLI-RESPONSE-BODY-CANARY"}\\n__INTERDOMESTIK_HEALTH_STATUS__:200';
+  const error = Object.assign(new Error(${JSON.stringify(rawErrorMessage)}),
+    { cause: new Error('CAUSE_CANARY'), payload: { responseBody: 'PAYLOAD_CANARY' } });
+  const succeeds = process.env.CLI_STUB_OUTCOME === 'success';
+  const stub = (_file, _args, _options, callback) => succeeds
+    ? callback(null, body, '') : callback(error, '', '');
+  stub[promisify.custom] = async () => {
+    if (!succeeds) throw error; return { stdout: body, stderr: '' };
+  };
+  childProcess.execFile = stub; syncBuiltinESMExports();
+`;
+function assertCanaryFree(value, canaries) {
+  for (const canary of canaries) assert.doesNotMatch(value, new RegExp(canary, 'u'));
+}
+async function runCli(outcome) {
+  const args = [
+    '--import',
+    `data:text/javascript,${encodeURIComponent(cliPreload)}`,
+    scriptPath,
+    'https://staging.interdomestik.com/api/health',
+  ];
+  const env = {
+    ...process.env,
+    VERCEL_HEALTH_MAX_ATTEMPTS: '1',
+    VERCEL_HEALTH_SLEEP_SECONDS: '1',
+    CLI_STUB_OUTCOME: outcome,
+  };
+  try {
+    const result = await execFileAsync(process.execPath, args, { env });
+    return { code: 0, ...result };
+  } catch (error) {
+    return { code: error.code, stdout: error.stdout, stderr: error.stderr };
+  }
+}
+test('waitForVercelHealth preserves retry order and the successful body', async () => {
+  const events = [];
+  const bodyCanary = '{"body":"IMPORTED-BODY-CANARY"}';
   const body = await waitForVercelHealth({
-    healthUrl: 'https://staging.interdomestik.com/api/health',
+    healthUrl: healthUrlCanary,
     expectedCommitSha: 'abc123',
     attempts: 2,
     sleepMs: 0,
-    log: () => {},
+    log: message => events.push(`log:${message}`),
     fetchImpl: async params => {
-      calls += 1;
+      events.push(`fetch:${events.filter(event => event.startsWith('fetch:')).length + 1}`);
       assert.equal(params.expectedCommitSha, 'abc123');
-      if (calls === 1) throw new Error('not ready');
-      return '{"ok":true}';
+      assert.equal(params.healthUrl, healthUrlCanary);
+      if (events.includes('fetch:1') && !events.includes('fetch:2')) throw new Error('not ready');
+      return bodyCanary;
     },
   });
-  assert.equal(calls, 2);
-  assert.equal(body, '{"ok":true}');
+  assert.equal(body, bodyCanary);
+  assert.deepEqual(events, [
+    'log:[vercel-health] attempt 1/2',
+    'fetch:1',
+    'log:[vercel-health] result=health_check_failed',
+    'log:[vercel-health] attempt 2/2',
+    'fetch:2',
+    'log:[vercel-health] result=success',
+  ]);
+  assertCanaryFree(events.join('\n'), [
+    'user-CANARY',
+    'password-CANARY',
+    'QUERY-CANARY',
+    'FRAGMENT-CANARY',
+    'IMPORTED-BODY-CANARY',
+  ]);
 });
-
-test('waitForVercelHealth throws the final health error', async () => {
-  await assert.rejects(
-    waitForVercelHealth({
+test('waitForVercelHealth sleeps exactly between failed attempts and sanitizes errors', async () => {
+  const events = [];
+  const providerError = Object.assign(new Error(rawErrorMessage), {
+    cause: new Error('CAUSE_CANARY'),
+    payload: { responseBody: 'PAYLOAD_CANARY' },
+  });
+  const originalSleep = timersPromises.setTimeout;
+  timersPromises.setTimeout = async ms => events.push(`sleep:${ms}`);
+  syncBuiltinESMExports();
+  let terminalError;
+  try {
+    await waitForVercelHealth({
       healthUrl: 'https://staging.interdomestik.com/api/health',
       attempts: 2,
-      sleepMs: 0,
-      log: () => {},
+      sleepMs: 17,
+      log: message => events.push(`log:${message}`),
       fetchImpl: async () => {
-        throw new Error('still unhealthy');
+        events.push(`fetch:${events.filter(event => event.startsWith('fetch:')).length + 1}`);
+        throw providerError;
       },
-    }),
-    /still unhealthy/u
+    });
+  } catch (error) {
+    terminalError = error;
+  } finally {
+    timersPromises.setTimeout = originalSleep;
+    syncBuiltinESMExports();
+  }
+  assert.deepEqual(events, [
+    'log:[vercel-health] attempt 1/2',
+    'fetch:1',
+    'log:[vercel-health] result=health_check_failed',
+    'sleep:17',
+    'log:[vercel-health] attempt 2/2',
+    'fetch:2',
+    'log:[vercel-health] result=health_check_failed',
+  ]);
+  assert.equal(terminalError?.message, 'Vercel health check failed');
+  assert.equal(terminalError?.cause, undefined);
+  assert.equal(terminalError?.payload, undefined);
+  assert.notEqual(terminalError, providerError);
+  assertCanaryFree(
+    [terminalError?.message, terminalError?.stack, JSON.stringify(terminalError)].join('\n'),
+    errorCanaries
   );
+  assertCanaryFree(events.join('\n'), errorCanaries);
+});
+test('CLI success output never includes the successful response body', async () => {
+  const result = await runCli('success');
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  assertCanaryFree(result.stdout, ['CLI-RESPONSE-BODY-CANARY']);
+});
+test('CLI failure output is deterministic and excludes nested diagnostics', async () => {
+  const result = await runCli('failure');
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, 'Vercel health check failed\n');
+  assertCanaryFree(`${result.stdout}\n${result.stderr}`, errorCanaries);
 });

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58706506,
+  "maxTrackedBytes": 58711243,
   "maxTrackedFiles": 5530,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16704558,
-    "source/scripts": 7800086,
+    "source/scripts": 7800071,
     "docs/text": 7727900,
-    "tests/e2e": 5816716,
+    "tests/e2e": 5821468,
     "config/data/messages": 1800851
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Summary

- Harden `wait-for-vercel-health` diagnostics to emit only deterministic allowlisted status lines.
- Replace arbitrary terminal error propagation with the fixed message `Vercel health check failed`.
- Suppress health response bodies from CLI stdout while preserving the imported function's return contract and expected-commit validation.
- Add deterministic canary coverage for URL credentials/query/fragment data, token/password/PostgreSQL URL/provider diagnostics, response bodies, and nested error causes/payloads.
- Directly stub the default `node:timers/promises` boundary to prove exact retry/sleep ordering without changing the production export signature.
- Scope is exactly the two health-check files plus deterministic repo-size budget synchronization.

## Review focus

- Primary review surface: `scripts/ci/wait-for-vercel-health.mjs` and its focused test.
- Primary contracts or risks to verify: no secret-bearing URL, response payload, or arbitrary error reaches stdout/stderr; retries and `expectedCommitSha` behavior remain intact; the default sleep happens exactly once between two failed attempts and never before the first or after the final failure; imported callers still receive the response body.
- Ignore unless behavior changed: routing, auth, tenancy, application runtime, deployment workflows, and provider configuration.

## Acceptance

- [x] Slice criteria are explicit and complete.
- [x] No behavior changed outside slice scope.

## Evidence (mandatory before merge)

- PR status: `PARTIAL` — implementation proof is green; current-head GitHub CI must supply the infrastructure-backed remainder.
- Summary JSON: not generated by this focused slice run.
- Closure note: this PR body is the implementation handoff; governance closure remains with the root/reviewer lane.
- Gates:
  - RED: `node --test scripts/ci/wait-for-vercel-health.test.mjs` (exit: `1`, `0/4`; all four confidentiality canaries exposed before the production change)
  - GREEN: `node --test scripts/ci/wait-for-vercel-health.test.mjs` (exit: `0`, `4/4`); the built-in timer stub observes exact `attempt 1 → failure → sleep(17) → attempt 2 → final failure` ordering and would fail if the production sleep boundary were removed or misplaced.
  - `pnpm test:ci:contracts` (exit: `0`, `370/370`)
  - `pnpm security:guard` (exit: `0`; rerun for current head)
  - `node scripts/repo-size-budget-sync.mjs --check` (exit: `0`; current head)
  - `pnpm repo:size:check` (exit: `0`; current head)
  - `pnpm check:modularity-guard` (exit: `0`; production 53 lines, test 150 lines; current head)
  - focused Prettier check and `git diff --check` (exit: `0`; current head)
  - `pnpm pr:verify` (exit: `1` on predecessor with the same production implementation): passed repo-size, 370 CI contracts, 148 release-gate tests, E2E contracts, migrations, RLS integration `41/41` with 100% RLS coverage, i18n, DB access, architecture, 3,032 web tests, domain coverage, and the 85.60% coverage gate; then the canonical `check:fast` / `e2e:gate:pr` path required retired local Docker/Supabase. It was not rerun after this test-only proof strengthening.
  - `pnpm e2e:gate` (not run locally): same accepted retired-local-Docker blocker. Mac mini Docker stays stopped; Z620 local infrastructure was not touched. Current-head GitHub CI is the required remaining proof.
- Logs/screenshots/runbooks: no durable pilot-evidence bundle was generated by this focused script-only slice.

No direct Vercel/provider request, workflow dispatch, deployment command, production mutation, local Docker startup, or Z620 action was performed by this slice. Normal repository automation may run in response to the PR update.

## Product-readiness sequence

- [ ] Root/reviewer lane to run `pnpm pr:request-reviewers -- <PR_NUMBER>` for the current head.
- [ ] Root/reviewer lane to request and disposition current-head Copilot and Codex review.
- [ ] Root/reviewer lane to disposition Copilot, Codex, CodeQL, Sonar, and bot-review findings.
- [ ] Root/reviewer lane to run `pnpm pr:review-ready -- <PR_NUMBER>` after any final push.

## Pilot guardrails

- [x] No changes to auth, routing, proxy, or API contract files were made.
- [x] No allowed exception was needed.

## Reproducibility and rollback

- Base: `d2ea5cd7e7f04dac7938b69077fcfc9e1af9b3e3`
- Head: `56187af355d3bf8d217e8778700c58a1a1078cc7`
- Tree: `7705243cb7409370b3a87987e0fd3f39e7c68961`
- Diff SHA-256: `f922e2fbb0496c1523851827be6e9fef57866727913c4d74289ec62dd7969bd6`
- Stable patch ID: `dd06e952797c27fd4e88553c83aaaf590b60d5ad`
- Rollback: revert commit `56187af355d3bf8d217e8778700c58a1a1078cc7`; no migration or external-state rollback is required.

## Merge readiness

- [ ] All GitHub review threads resolved.
- [ ] Bot or reviewer findings fixed or technically closed.
- [ ] Required current-head checks green.
- [ ] Governance report recorded.
- [ ] Root/reviewer lane authorizes merge. This writer will not merge.
