### PR TITLE
fix(ci): pin Semgrep to verified version

### DIFF
--- a/.github/workflows/pr-deterministic-backstops.yml
+++ b/.github/workflows/pr-deterministic-backstops.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Semgrep
-        run: python -m pip install --upgrade semgrep
+        run: python -m pip install semgrep==1.171.0
       - name: Run Semgrep against new PR findings
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/scripts/ci/pr-deterministic-backstops-contracts.test.mjs
+++ b/scripts/ci/pr-deterministic-backstops-contracts.test.mjs
@@ -26,7 +26,9 @@ test('PR deterministic backstops run free scanner gates without AI review depend
     'actions/dependency-review-action@v5.0.0'
   );
   assert.equal(
-    dependencyReview.steps.find(step => step?.name === 'Dependency Review').with['fail-on-severity'],
+    dependencyReview.steps.find(step => step?.name === 'Dependency Review').with[
+      'fail-on-severity'
+    ],
     'high'
   );
 
@@ -39,8 +41,14 @@ test('PR deterministic backstops run free scanner gates without AI review depend
   assert.match(osv.with['scan-args'], /--recursive/u);
 
   const semgrep = workflow.jobs['semgrep-ce'];
-  const semgrepRun = semgrep.steps.find(step => step?.name === 'Run Semgrep against new PR findings');
+  const installSemgrep = semgrep.steps.find(step => step?.name === 'Install Semgrep');
+  const semgrepRun = semgrep.steps.find(
+    step => step?.name === 'Run Semgrep against new PR findings'
+  );
   assert.equal(semgrep.permissions['security-events'], 'write');
+  assert.equal(installSemgrep.run, 'python -m pip install semgrep==1.171.0');
+  assert.doesNotMatch(installSemgrep.run, /--upgrade\s+semgrep/u);
+  assert.doesNotMatch(installSemgrep.run, /pip install semgrep(?:\s|$)/u);
   assert.match(semgrepRun.run, /--baseline-commit "\$\{BASE_SHA\}"/u);
   assert.match(semgrepRun.run, /--config p\/ci/u);
   assert.match(semgrepRun.run, /--sarif/u);

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58873598,
+  "maxTrackedBytes": 58873924,
   "maxTrackedFiles": 5582,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16711291,
     "source/scripts": 7868217,
     "docs/text": 7766804,
-    "tests/e2e": 5861768,
-    "config/data/messages": 1809123
+    "tests/e2e": 5862095,
+    "config/data/messages": 1809122
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary

- Pin the deterministic PR backstops Semgrep installation to the exact verified version `1.171.0`.
- Add focused contract coverage that rejects floating, upgraded, or unversioned Semgrep installation commands.
- Deterministically synchronize repository-size metadata for the scoped change.

## Root cause and impact

The PR backstops workflow installed Semgrep using a floating `--upgrade` command, so identical repository revisions could execute different analyzer versions over time. The exact pin makes the security backstop reproducible without changing product runtime behavior.

## Exact authority and changed areas

- Base: `0dbe72d6bd7d78ee505d30e432773ff77307efca`
- Head: `065dddde9604d8e41f01934c641cc7a5f440a27a`
- Branch: `codex/ida-sec03-semgrep-version-pin`
- `.github/workflows/pr-deterministic-backstops.yml`
- `scripts/ci/pr-deterministic-backstops-contracts.test.mjs`
- `scripts/repo-size-budget.json`

Dependency hotfix PR #1424 merged first and established the exact prerequisite base above. The original scoped IDA-SEC03 commit was replayed onto that base; only the deterministic repository-size budget required canonical regeneration. The workflow and focused-contract blobs are unchanged from the prior PR head.

No auth, routing, proxy, tenancy, schema, billing, UI, product-runtime, or architecture surface is changed.

## Verification

- Focused deterministic-backstops contract: 1/1 green.
- `node scripts/repo-size-budget-sync.mjs --check`: green.
- `pnpm repo:size:check`: green.
- `pnpm security:guard`: green.
- `git diff --check 0dbe72d6bd7d78ee505d30e432773ff77307efca..065dddde9604d8e41f01934c641cc7a5f440a27a`: green.

## Isolated full-gate evidence

- One Z620 full `e2e-merge` attempt was classified `known_test_flake_confirmed` for the unrelated Help Now watcher.
- The focused exact Help Now test passed 1/1 in 10.1s.
- Evidence: `/home/arben/ci/interdomestik/runs/ida-sec03-ba74c892-help-now-flake-r2`
- Cleanup: task DB, port, and locks cleaned; PostgreSQL healthy/0; Forgejo HTTP 200.
- This evidence predates the prerequisite-base replay and is not claimed as a current-head full E2E pass.

## Edge cases, rollback, and residual risk

- The contract rejects restoration of `--upgrade semgrep` and unversioned `pip install semgrep` forms.
- Rollback is the single scoped commit, but should only occur through the normal reviewed PR path.
- The unrelated Help Now watcher flake is not treated as evidence that the current exact head passed the full E2E lane.

## Merge and authority boundary

Merge remains blocked until all required GitHub checks on this exact head are green, including full E2E, Sonar, and security. No deploy or release authority is granted, and this PR must not be merged by this implementation handoff.