### PR TITLE
fix(deps): patch brace-expansion advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   seroval: '>=1.4.1'
   tar: 7.5.11
   '@isaacs/brace-expansion': ^5.0.1
-  brace-expansion: 5.0.7
+  brace-expansion: 5.0.8
   cross-spawn: ^7.0.6
   fast-uri: 3.1.4
   sharp: 0.35.3
@@ -5554,9 +5554,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -14419,7 +14419,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -16822,11 +16822,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ overrides:
   seroval: '>=1.4.1'
   tar: 7.5.11
   '@isaacs/brace-expansion': ^5.0.1
-  brace-expansion: 5.0.7
+  brace-expansion: 5.0.8
   cross-spawn: ^7.0.6
   fast-uri: 3.1.4
   sharp: 0.35.3

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58873604,
+  "maxTrackedBytes": 58873598,
   "maxTrackedFiles": 5582,
   "maxCategoryBytes": {
     "other": 18856395,
-    "large support/generated-ish": 16711297,
+    "large support/generated-ish": 16711291,
     "source/scripts": 7868217,
     "docs/text": 7766804,
     "tests/e2e": 5861768,


### PR DESCRIPTION
## Summary

- Fix npm advisory 1124334 / GHSA-mh99-v99m-4gvg by pinning the existing global `brace-expansion` override from 5.0.7 to patched 5.0.8.
- Regenerate only the affected lockfile resolution edges and synchronize the deterministic repository-size budget.
- Keep the change bounded to exactly three paths; no dependency broadening, audit allowlist, workflow change, runtime change, or product behavior change.

## Exact scope

- `pnpm-workspace.yaml`
- `pnpm-lock.yaml`
- `scripts/repo-size-budget.json`

Exact head: `cd7245f19a0efbaa9564c944db85c5842da172a1`
Exact base: `cc0d4f7bca2467824d4a54a524d16d3711d7566e`
Diff: 3 files, 10 insertions, 10 deletions.

## RED / GREEN evidence

RED on the exact base:
- `pnpm audit --prod --audit-level=high --json` exposed advisory 1124334 at `brace-expansion@5.0.7` through the production Sentry -> glob -> minimatch path and exited non-zero.

GREEN on the exact candidate:
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @interdomestik/web why brace-expansion --prod` resolves both Sentry production paths to 5.0.8
- no 5.0.7 resolution remains in workspace or lockfile
- `pnpm audit --prod --audit-level=high` exits 0
- `pnpm security:guard`
- focused lockfile/PR policy contracts: 22/22
- `pnpm repo:size:check`
- repository-size synchronization check
- `git diff --check`

The audit still reports two pre-existing moderate and two pre-existing low advisories. They remain explicitly out of scope for this high-severity hotfix.

## Commit-hook disposition

The normal commit hook ran, but its Prettier step reformatted the entire generated pnpm lockfile and produced thousands of non-semantic out-of-scope lines. That tooling-only rewrite was discarded. The exact minimal tree was reconstructed and every frozen-install, dependency-resolution, audit, security, contract, size, and diff proof above was rerun GREEN. Root independently reviewed the reconstructed 3-path 10+/10- diff and authorized the final no-verify amend solely to avoid reproducing the proven formatter defect.

## Explicit exclusions

- No audit allowlist or severity weakening
- No Z620 local full gate
- No release permit or release evidence
- No provider call, deployment, production mutation, database work, or Mac Docker
- No merge authority implied