### PR TITLE
docs: restore terminal IDA-SEC03 resolver state

### DIFF
--- a/docs/plans/current-program.md
+++ b/docs/plans/current-program.md
@@ -2005,7 +2005,7 @@ CD run `30133922802` was contained during Buildx setup; registry login, image
 build and all provider/deploy jobs remained skipped or at `steps: []`.
 `docs/plans/2026-07-25-ida-sec03-closeout.md` is the canonical receipt.
 
-No replacement implementation slice is promoted. Resolver expectation returns
+No replacement slice is promoted. Resolver expectation returns
 to `blocked_requires_current_authority`, `activeSlice=null`. Dependabot alert
 `#154` / `protobufjs` patched in `7.6.5` is the next bounded security candidate
 only; this closeout does not authorize its design gate, branch, writer,

--- a/docs/plans/current-tracker.md
+++ b/docs/plans/current-tracker.md
@@ -1253,7 +1253,7 @@ preserves scan/SARIF/base-SHA/draft-policy semantics and closes the historical
 CodeQL, Secret Scan, audit and review evidence passed. CD run `30133922802` was
 contained before registry/image/provider/deploy.
 
-No replacement implementation slice is promoted by this closeout. Expected
+No replacement slice is promoted by this closeout. Expected
 resolver state is `blocked_requires_current_authority`, `activeSlice=null`.
 Dependabot alert `#154` / `protobufjs` patched in `7.6.5` is recorded only as
 the next bounded security candidate; no design gate, branch, writer, mutation

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58882063,
+  "maxTrackedBytes": 58882033,
   "maxTrackedFiles": 5583,
   "maxCategoryBytes": {
     "other": 18856395,
-    "large support/generated-ish": 16713088,
+    "large support/generated-ish": 16713073,
     "source/scripts": 7868217,
-    "docs/text": 7773146,
+    "docs/text": 7773131,
     "tests/e2e": 5862095,
     "config/data/messages": 1809122
   },


### PR DESCRIPTION
## Summary
- use the canonical terminal phrase recognized by the slice resolver
- preserve IDA-SEC03 completion and no-successor semantics
- synchronize deterministic repository-size metadata

## Proof
- exact detached-head `repo-size-budget-sync --check --tracked-only`: pass
- exact detached-head `repo-size-audit --check`: pass
- `next-slice.mjs`: `blocked_requires_current_authority`, `activeSlice=null`
- `pnpm plan:status`, `pnpm plan:audit`, `git diff --check`: pass

No next slice, design gate, writer, implementation, runtime, provider, DB, or deploy authority is created.