### PR TITLE
fix(deps): patch protobufjs parser DoS

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ overrides:
   path-to-regexp: ^8.4.0
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  protobufjs: 7.6.3
+  protobufjs: 7.6.5
   ws: 8.21.0
   smol-toml: 1.6.1
   yaml@>=2.0.0 <2.8.3: 2.8.3
@@ -3274,9 +3274,6 @@ packages:
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -8299,8 +8296,8 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  protobufjs@7.6.3:
-    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   protocols@2.0.2:
@@ -10577,7 +10574,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@hono/node-server@1.19.13(hono@4.12.27)':
@@ -11705,7 +11702,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
 
   '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -11716,7 +11713,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
 
   '@opentelemetry/propagator-b3@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -12048,8 +12045,6 @@ snapshots:
       '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -17435,7 +17430,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  protobufjs@7.6.3:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -17443,7 +17438,6 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ overrides:
   path-to-regexp: ^8.4.0
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  protobufjs: 7.6.3
+  protobufjs: 7.6.5
   ws: 8.21.0
   smol-toml: 1.6.1
   yaml@>=2.0.0 <2.8.3: 2.8.3


### PR DESCRIPTION
## Summary
- pin the existing workspace override from `protobufjs@7.6.3` to exact `7.6.5`
- regenerate the pnpm lockfile without unrelated dependency movement
- remove the no-longer-used `@protobufjs/inquire` snapshot selected by protobufjs 7.6.5

## Security evidence
- fixes Dependabot alert #154 / GHSA-j3f2-48v5-ccww / CVE-2026-59877
- `pnpm why protobufjs --recursive` resolves all affected runtime paths only to 7.6.5
- target advisory absent from production audit; high=0, critical=0
- no audit allowlist, suppression, application, workflow, provider, database, deployment, routing, auth, tenancy, schema/RLS or UI change

## Verification
- frozen install: pass
- `pnpm security:guard`: pass
- `pnpm repo:size:check`: pass; no budget change needed
- web unit: 612 files passed / 3032 tests passed
- exact-SHA Z620 code lanes: audit/static/unit/security pass; validation environment defect corrected by an exact-base-only rerun, pass
- exact-SHA Z620 database/RLS, build and E2E-PR: pass
- the combined resource run exposed cross-lane DB residue (`free_start_drafts` FK) after E2E-PR; no code change was made
- exact-SHA Z620 E2E-merge in a fresh task-owned DB/port: pass
- exact-SHA Z620 pilot in a fresh task-owned DB/port: pass
- post-run cleanup: 0 task DBs, 0 task listeners/locks/processes, Forgejo HTTP 200, Supabase DB healthy/restarts 0

## Scope
Exactly two changed paths within the approved three-path writer map:
- `pnpm-workspace.yaml`
- `pnpm-lock.yaml`

Gate: IDA-SEC-DG04 R0. Runtime authority is exact-base bound to `8f45744b1353874d05e46239894ebc713b4c13c7`.