### PR TITLE
fix(deps): pin DOMPurify 3.4.12

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
   yaml@>=2.0.0 <2.8.3: 2.8.3
   ip-address: 10.1.1
   shell-quote: 1.8.4
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   '@babel/core': 7.29.7
   '@opentelemetry/core': 2.8.0
   '@opentelemetry/auto-instrumentations-node': 0.75.0
@@ -6093,8 +6093,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -14924,7 +14924,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -17402,7 +17402,7 @@ snapshots:
       '@posthog/core': 1.38.1
       '@posthog/types': 1.392.0
       core-js: 3.49.0
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       fflate: 0.4.8
       preact: 10.29.3
       query-selector-shadow-dom: 1.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,7 @@ overrides:
   yaml@>=2.0.0 <2.8.3: 2.8.3
   ip-address: 10.1.1
   shell-quote: 1.8.4
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   '@babel/core': 7.29.7
   '@opentelemetry/core': 2.8.0
   '@opentelemetry/auto-instrumentations-node': 0.75.0


### PR DESCRIPTION
## Summary

- pin the existing DOMPurify workspace override from 3.4.11 to the first compatible patched release, 3.4.12
- regenerate only the matching lockfile resolution and integrity
- close Dependabot alert #159 / GHSA-c2j3-45gr-mqc4 without allowlisting or suppression

## Scope

Changed exactly:
- pnpm-workspace.yaml
- pnpm-lock.yaml

No runtime code, UI, routing, auth, tenancy, schema, database, workflow, provider, deployment, or production behavior changed. Alerts #157 and #158 remain separate.

## Verification

Z620 exact-SHA proof for 097794397921a26a4eb8f631ebff39f6faca8743:
- frozen install: PASS
- validation, audit, static, unit, AI eval, security, database, build: PASS
- E2E PR: 206 passed / 9 skipped
- E2E merge: 208 passed / 9 skipped
- pilot: PASS, all canonical roles HTTP 200
- cleanup: zero task DBs, ports, locks, listeners, or processes

One isolated unit correction was required because the resource wrapper injected PLAYWRIGHT=1 into unit tests. The preserved initial evidence shows that environment-only failure; the single clean unit rerun with PLAYWRIGHT unset passed 612 files with 2 skips and OTP 4/4. No other lane was rerun.

## Review and risk

- classified Tier 1 dependency-security
- senior external model review skipped because this is a two-file exact-version lock correction with full exact-SHA proof; GitHub Copilot and required PR checks remain mandatory
- rollback: restore the prior override and regenerate the lockfile
- residual risk: unrelated Dependabot alerts #157 and #158 are outside this slice

## Deployment

No deploy or release authority is included. Automatic post-merge CD must be contained before checkout, registry, image, provider, or deployment activity.