### PR TITLE
fix(deps): update hono node server to 2.0.10

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   rollup: 4.59.0
   express-rate-limit: 8.3.0
   hono: ^4.12.25
+  '@hono/node-server': 2.0.5
   postcss: 8.5.18
   defu: ^6.1.5
   path-to-regexp: ^8.4.0
@@ -1926,9 +1927,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.5':
+    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4.12.25
 
@@ -10577,7 +10578,7 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.13(hono@4.12.27)':
+  '@hono/node-server@2.0.5(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -10888,7 +10889,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.2.1)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.27)
+      '@hono/node-server': 2.0.5(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -10910,7 +10911,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.27)
+      '@hono/node-server': 2.0.5(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ overrides:
   rollup: 4.59.0
   express-rate-limit: 8.3.0
   hono: ^4.12.25
-  '@hono/node-server': 2.0.5
+  '@hono/node-server': 2.0.10
   postcss: 8.5.18
   defu: ^6.1.5
   path-to-regexp: ^8.4.0
@@ -1927,8 +1927,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@2.0.5':
-    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4.12.25
@@ -10578,7 +10578,7 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.2
 
-  '@hono/node-server@2.0.5(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -10889,7 +10889,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.2.1)':
     dependencies:
-      '@hono/node-server': 2.0.5(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -10911,7 +10911,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.5(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ overrides:
   rollup: 4.59.0
   express-rate-limit: 8.3.0
   hono: ^4.12.25
+  '@hono/node-server': 2.0.5
   postcss: 8.5.18
   defu: ^6.1.5
   path-to-regexp: ^8.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,7 @@ overrides:
   rollup: 4.59.0
   express-rate-limit: 8.3.0
   hono: ^4.12.25
-  '@hono/node-server': 2.0.5
+  '@hono/node-server': 2.0.10
   postcss: 8.5.18
   defu: ^6.1.5
   path-to-regexp: ^8.4.0

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58947258,
+  "maxTrackedBytes": 58947264,
   "maxTrackedFiles": 5588,
   "maxCategoryBytes": {
     "other": 18856395,
-    "large support/generated-ish": 16726210,
+    "large support/generated-ish": 16726215,
     "source/scripts": 7868217,
     "docs/text": 7825190,
     "tests/e2e": 5862095,
-    "config/data/messages": 1810024
+    "config/data/messages": 1809152
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58936534,
-  "maxTrackedFiles": 5587,
+  "maxTrackedBytes": 58947258,
+  "maxTrackedFiles": 5588,
   "maxCategoryBytes": {
     "other": 18856395,
-    "large support/generated-ish": 16726194,
+    "large support/generated-ish": 16726210,
     "source/scripts": 7868217,
-    "docs/text": 7813609,
+    "docs/text": 7825190,
     "tests/e2e": 5862095,
     "config/data/messages": 1810024
   },


### PR DESCRIPTION
## Summary

- pin transitive `@hono/node-server` to exact `2.0.10`
- remove both the original path-traversal advisory and the newly surfaced WebSocket memory-leak DoS advisory
- preserve `@upstash/context7-mcp@2.3.0`, `@modelcontextprotocol/sdk@1.29.0`, Hono, Vitest, and unrelated resolutions
- synchronize the deterministic repository-size budget

There are no application, routing, auth, tenancy, database, provider, workflow, deployment, or production changes.

## Exact scope

Only:

- `pnpm-workspace.yaml`
- `pnpm-lock.yaml`
- `scripts/repo-size-budget.json`

Current candidate: `25130343ee5365c7bf541652e0a23e388cd39d23`

## Why the head changed

The first exact head used `2.0.5`, the first fix for `GHSA-frvp-7c67-39w9`. GitHub OSV then deterministically reported reviewed advisory `GHSA-9mqv-5hh9-4cgg`, which affects `2.0.0` through `2.0.9` and is fixed in `2.0.10`.

No failing check was retried blindly and no vulnerability was suppressed. The same three-path slice was corrected to the first version that clears both advisories.

## Verification

Focused proof on the current candidate:

- frozen install, lock unchanged
- both MCP SDK dependency paths resolve only `@hono/node-server@2.0.10`
- QA build
- both target GHSAs absent
- production audit: zero high, zero critical
- security guard and canonical size check
- 434/434 CI contracts and E2E base contracts
- exact three-path diff and focused formatting

Exact-SHA Z620 FAST proof selected only validation, audit/contracts, static, unit, and security:

- audit, static, unit, and security passed in the first preserved run
- validation initially failed before diff evaluation because the invocation omitted the verified base SHA
- exactly one focused unchanged-SHA validation correction passed using base `280dab9172e0fed048ac39750214743be350f4ef`
- database, build-resource, browser E2E, Pilot, release, and deploy lanes were not selected and were not run
- no task database, listener, lock, or surviving process; PostgreSQL remained healthy with restart count 0

GitHub current-head CI/E2E/Pilot/Sonar/CodeQL/security/finalizer checks and terminal Codex review remain mandatory before merge. Copilot is unavailable until the user's quota renews and is not counted as PASS.

## Security and rollback

Both targeted Hono advisories are absent without allowlisting. Other default-branch dependency alerts are separate and remain out of scope.

Rollback is a revert of this PR's merge commit. This PR does not authorize release, deployment, provider contact, or production mutation.
