### PR TITLE
docs: close dependency maintenance bridge

### DIFF
--- a/docs/plans/current-program.md
+++ b/docs/plans/current-program.md
@@ -2205,6 +2205,43 @@ reconciliation, in that order and one at a time. Frozen `IDA-UI03a2`,
 UI/product and every architecture successor remain separate, blocked or
 unpromoted until a fresh current-authority decision.
 
+Rev 169 supersedes only the Rev 168 replacement-pending sentence above. The
+bounded existing-issue dependency bridge is terminal: grouped PRs `#1422` and
+`#1432` remain closed as superseded, and their current-main replacements
+`#1443` and `#1444` are merged.
+
+PR `#1443` merged approved head
+`deaa4f8600e0896d9afb75784161aa0a3547810d` as
+`acd9680463d97585e606a419df1cfeef0af3cb19` after exact 28-path development
+dependency reconciliation, including the effective PostCSS `8.5.23`
+alignment. Focused proof, current-head GitHub gates, Sonar and Codex review
+passed; CD `30188302706` was cancelled with every job at `steps: []`; and
+exact-main CI, Sonar, both CodeQL runs and Secret Scan passed.
+
+PR `#1444` merged approved head
+`59cf156ff954d7d0a115937fcdd2582cbc18bd49` as
+`2c8d4131be371174128d8635aae89331f5755bb5`, with an approved/merge tree of
+`37aaaeb3e9d9afd1516f3831b2e22357e91ad062`. Its exact nine-path production
+dependency reconciliation aligns the database Next peer floor with the sole
+`next@16.2.12` resolution and passed focused proof, 31 current-head checks,
+Sonar and Codex review; Copilot was unavailable and remains NON-PASS. CD
+`30189636128` was cancelled after checkout and a failed Docker Buildx setup,
+before registry login, image build, provider or deploy; every downstream job
+has `steps: []`. Exact-main CI `30189636118`, Sonar `30189636136`, CodeQL
+`30189635752` / `30189635819` and Secret Scan `30189636117` passed.
+
+Live GitHub REST now reports zero open Dependabot alerts and zero open
+secret-scanning alerts. CodeQL alerts `#181`, `#182` and `#183` remain open
+and are not promoted or waived by this closeout. Detached clean-tree
+repo-size synchronization/audit passes. A red local measurement caused by the
+preserved skip-worktree `.codex/config.toml` (+902 bytes) is local
+contamination and must not be converted into false canonical budget growth.
+
+No replacement implementation slice is promoted. Expected resolver state is
+`blocked_requires_current_authority`, `activeSlice=null`; the three CodeQL
+alerts, frozen `IDA-UI03a2`, UI/product and every architecture successor
+remain separate and require a fresh current-authority decision.
+
 Retained M4 product-model closeout: `T-401` completed in PR `#1010` / squash
 merge `956bf21a77d4be46d8e7c05be434577cf8d69705`, closing the
 `grace_period` membership-card lockout. The canonical tracker row remains the

--- a/docs/plans/current-tracker.md
+++ b/docs/plans/current-tracker.md
@@ -1440,3 +1440,48 @@ replacements `#1443` and `#1444` require fresh bounded current-main
 reconciliation, in that order and one at a time. Frozen `IDA-UI03a2`,
 UI/product and every architecture successor remain separate, blocked or
 unpromoted until a fresh current-authority decision.
+
+Rev 169 supersedes only the Rev 168 replacement-pending sentence. The bounded
+existing-issue dependency bridge is terminal: stale grouped PRs `#1422` and
+`#1432` remain closed as superseded, while their current-main replacements
+`#1443` and `#1444` are merged.
+
+Development bundle PR `#1443` merged approved head
+`deaa4f8600e0896d9afb75784161aa0a3547810d` as
+`acd9680463d97585e606a419df1cfeef0af3cb19`. Its 28-path reconciliation
+preserved current-main intent, aligned the effective PostCSS override at
+`8.5.23`, and passed frozen install, focused security/contracts/size proof,
+current-head GitHub gates, Sonar and Codex review. Automatic CD run
+`30188302706` was cancelled with every job at `steps: []`; exact-main CI
+`30188302711`, Sonar `30188302713`, CodeQL `30188302469` /
+`30188302473` and Secret Scan `30188302716` passed.
+
+Production bundle PR `#1444` merged approved head
+`59cf156ff954d7d0a115937fcdd2582cbc18bd49` as
+`2c8d4131be371174128d8635aae89331f5755bb5`; merge and approved-head trees are
+identical at `37aaaeb3e9d9afd1516f3831b2e22357e91ad062`. The exact nine-path
+reconciliation aligns the database Next peer floor with the sole
+`next@16.2.12` resolution and passed focused proof, 31 current-head checks,
+Sonar and Codex review. Copilot was unavailable and remains NON-PASS.
+Automatic CD run `30189636128` lost the pre-checkout cancellation race:
+checkout completed and Docker Buildx failed, while registry login, metadata,
+image build and every staging/rollback/production/deploy step remained
+skipped; all seven downstream jobs have `steps: []`. It is classified
+failed-contained before registry/image/provider/deploy. Exact-main CI
+`30189636118`, Sonar `30189636136`, CodeQL `30189635752` /
+`30189635819` and Secret Scan `30189636117` passed.
+
+Live GitHub REST reports zero open Dependabot alerts and zero open
+secret-scanning alerts. CodeQL alerts `#181`, `#182` and `#183` remain open
+and require a separate fresh current-authority decision; this closeout neither
+waives nor promotes them. Detached clean-tree proof reports
+`scripts/repo-size-budget.json` synchronized and the repo-size audit passing.
+The preserved skip-worktree `.codex/config.toml` can make a local
+worktree-scoped measurement red by 902 bytes; that is local measurement
+contamination, not authority to inflate canonical budget metadata.
+
+No replacement implementation slice is promoted by this closeout. Expected
+resolver state remains `blocked_requires_current_authority`,
+`activeSlice=null`. The three CodeQL alerts, frozen `IDA-UI03a2`, UI/product
+and every architecture successor remain separate, blocked or unpromoted until
+a fresh current-authority decision.

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 58990741,
+  "maxTrackedBytes": 58995573,
   "maxTrackedFiles": 5591,
   "maxCategoryBytes": {
     "other": 18856395,
-    "large support/generated-ish": 16735464,
+    "large support/generated-ish": 16738124,
     "source/scripts": 7868217,
-    "docs/text": 7859358,
+    "docs/text": 7861530,
     "tests/e2e": 5862095,
     "config/data/messages": 1809212
   },


### PR DESCRIPTION
## Summary
- record terminal #1443 and #1444 replacement evidence after stale #1422/#1432 retirement
- record exact CD containment and exact-main health
- reconcile live alert state: Dependabot 0, secret scan 0, CodeQL #181/#182/#183 still open and unpromoted
- classify the local repo-size false red from preserved skip-worktree `.codex/config.toml` without inflating canonical budget metadata

## Scope
Exactly three docs/metadata paths: `docs/plans/current-program.md`, `docs/plans/current-tracker.md`, and deterministic `scripts/repo-size-budget.json`. No product/runtime/workflow/provider/database/deploy change and no successor promotion.

## Focused proof
- `pnpm docs:verify`
- `pnpm plan:status`
- `pnpm plan:audit`
- `pnpm track:audit`
- `node scripts/repo-size-budget-sync.mjs --check --tracked-only`
- `node scripts/repo-size-audit.mjs --check`
- `git diff --check`
- Prettier check on all three paths
- slice-runner convergence check: pass
- resolver: expected `blocked_requires_current_authority`, `activeSlice=null`

Tier 0 closeout uses focused proof only; no local Docker/DB/browser/full runtime gate was started. Required current-head GitHub checks and Codex review remain merge authority.