### PR TITLE
fix(ci): contain runner-controlled file paths

### DIFF
--- a/scripts/ci-local-parity.sh
+++ b/scripts/ci-local-parity.sh
@@ -275,13 +275,10 @@ run_ci_audit() {
 }
 
 run_validation_surface_check() {
-  local changed_files_path
-  local output
-  changed_files_path="$(mktemp)"
+  local changed_files_path validation_surface_root output; validation_surface_root="$(mktemp -d)"; changed_files_path="${validation_surface_root}/changed-files.txt"
   changed_files_for_validation_surface >"${changed_files_path}"
-  output="$(node scripts/ci/validation-surface-policy.mjs --event-name pull_request --changed-files-path "${changed_files_path}")"
-  rm -f "${changed_files_path}"
-
+  output="$(RUNNER_TEMP="${validation_surface_root}" node scripts/ci/validation-surface-policy.mjs --event-name pull_request --changed-files-path "${changed_files_path}")" || { rm -rf -- "${validation_surface_root}"; return 1; }
+  rm -rf -- "${validation_surface_root}"
   printf '%s\n' "${output}"
   CI_LOCAL_VALIDATION_SHOULD_RUN="$(printf '%s\n' "${output}" | awk -F= '$1 == "should_run" {print $2}' | tail -n 1)"
   CI_LOCAL_VALIDATION_REASON="$(printf '%s\n' "${output}" | awk -F= '$1 == "reason" {print $2}' | tail -n 1)"

--- a/scripts/ci/ai-eval-surface.mjs
+++ b/scripts/ci/ai-eval-surface.mjs
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
-import fs from 'node:fs';
-
 import { evaluateAiEvalSurface } from './ai-eval-surface-lib.mjs';
-import { trustedRunnerFile } from './trusted-runner-file.mjs';
+import { readTrustedRunnerFile } from './trusted-runner-file.mjs';
 
 function fail(message) {
   process.stderr.write(`ai-eval-surface failed: ${message}\n`);
@@ -41,11 +39,14 @@ if (!eventName) {
   fail('--event-name is required');
 }
 
-const trustedChangedFilesPath = changedFilesPath ? trustedRunnerFile(changedFilesPath) : '';
-const changedFiles =
-  trustedChangedFilesPath && fs.existsSync(trustedChangedFilesPath)
-    ? fs.readFileSync(trustedChangedFilesPath, 'utf8').split(/\r?\n/)
-    : [];
+let changedFiles = [];
+if (changedFilesPath) {
+  try {
+    changedFiles = readTrustedRunnerFile(changedFilesPath).split(/\r?\n/);
+  } catch (error) {
+    if (!(error && typeof error === 'object' && error.code === 'ENOENT')) throw error;
+  }
+}
 
 const result = evaluateAiEvalSurface({ eventName, changedFiles });
 

--- a/scripts/ci/ai-eval-surface.mjs
+++ b/scripts/ci/ai-eval-surface.mjs
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 
 import { evaluateAiEvalSurface } from './ai-eval-surface-lib.mjs';
+import { trustedRunnerFile } from './trusted-runner-file.mjs';
 
 function fail(message) {
   process.stderr.write(`ai-eval-surface failed: ${message}\n`);
@@ -40,9 +41,10 @@ if (!eventName) {
   fail('--event-name is required');
 }
 
+const trustedChangedFilesPath = changedFilesPath ? trustedRunnerFile(changedFilesPath) : '';
 const changedFiles =
-  changedFilesPath && fs.existsSync(changedFilesPath)
-    ? fs.readFileSync(changedFilesPath, 'utf8').split(/\r?\n/)
+  trustedChangedFilesPath && fs.existsSync(trustedChangedFilesPath)
+    ? fs.readFileSync(trustedChangedFilesPath, 'utf8').split(/\r?\n/)
     : [];
 
 const result = evaluateAiEvalSurface({ eventName, changedFiles });

--- a/scripts/ci/ai-eval-surface.test.mjs
+++ b/scripts/ci/ai-eval-surface.test.mjs
@@ -116,12 +116,12 @@ test('AI eval surface CLI prints GitHub output fields', () => {
 
   writeFile(root, 'changed-files.txt', 'packages/domain-ai/src/telemetry.ts\nREADME.md\n');
 
-  const result = runScript('scripts/ci/ai-eval-surface.mjs', root, [
-    '--event-name',
-    'pull_request',
-    '--changed-files-path',
-    changedFilesPath,
-  ]);
+  const result = runScript(
+    'scripts/ci/ai-eval-surface.mjs',
+    root,
+    ['--event-name', 'pull_request', '--changed-files-path', changedFilesPath],
+    { env: { RUNNER_TEMP: root } }
+  );
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /^should_run=true$/m);

--- a/scripts/ci/github-pr-files.mjs
+++ b/scripts/ci/github-pr-files.mjs
@@ -3,6 +3,7 @@
 import { appendFileSync } from 'node:fs';
 
 import { fetchPullRequestFiles, readPullRequestContext } from './github-pr-files-lib.mjs';
+import { trustedRunnerFile } from './trusted-runner-file.mjs';
 
 function fail(message) {
   process.stderr.write(`github-pr-files failed: ${message}\n`);
@@ -40,7 +41,9 @@ function parseArgs(argv) {
   return parsed;
 }
 
-const { eventPath, repositoryFullName } = parseArgs(process.argv.slice(2));
+const parsed = parseArgs(process.argv.slice(2));
+const eventPath = trustedRunnerFile(parsed.eventPath);
+const { repositoryFullName } = parsed;
 const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
 
 let pullRequestContext;
@@ -64,7 +67,10 @@ try {
   const { files, fileCount } = evidence;
 
   if (process.env.GITHUB_OUTPUT) {
-    appendFileSync(process.env.GITHUB_OUTPUT, `changed_file_count=${fileCount}\n`);
+    appendFileSync(
+      trustedRunnerFile(process.env.GITHUB_OUTPUT),
+      `changed_file_count=${fileCount}\n`
+    );
   }
 
   if (files.length > 0) {

--- a/scripts/ci/github-pr-files.mjs
+++ b/scripts/ci/github-pr-files.mjs
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
-import { appendFileSync } from 'node:fs';
-
-import { fetchPullRequestFiles, readPullRequestContext } from './github-pr-files-lib.mjs';
-import { trustedRunnerFile } from './trusted-runner-file.mjs';
+import { fetchPullRequestFiles } from './github-pr-files-lib.mjs';
+import { appendTrustedRunnerFile, readTrustedRunnerFile } from './trusted-runner-file.mjs';
 
 function fail(message) {
   process.stderr.write(`github-pr-files failed: ${message}\n`);
@@ -42,14 +40,23 @@ function parseArgs(argv) {
 }
 
 const parsed = parseArgs(process.argv.slice(2));
-const eventPath = trustedRunnerFile(parsed.eventPath);
 const { repositoryFullName } = parsed;
 const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
 
 let pullRequestContext;
 
 try {
-  pullRequestContext = readPullRequestContext(eventPath, repositoryFullName);
+  const event = JSON.parse(readTrustedRunnerFile(parsed.eventPath));
+  const pullRequestNumber = event.pull_request?.number;
+  const resolvedRepository =
+    repositoryFullName.trim() || String(event.repository?.full_name || '').trim();
+
+  pullRequestContext = Number.isInteger(pullRequestNumber)
+    ? { repositoryFullName: resolvedRepository, pullRequestNumber }
+    : null;
+  if (pullRequestContext && !pullRequestContext.repositoryFullName.includes('/')) {
+    throw new TypeError('repository full name is required for pull request file discovery');
+  }
 } catch (error) {
   fail(error instanceof Error ? error.message : String(error));
 }
@@ -67,10 +74,7 @@ try {
   const { files, fileCount } = evidence;
 
   if (process.env.GITHUB_OUTPUT) {
-    appendFileSync(
-      trustedRunnerFile(process.env.GITHUB_OUTPUT),
-      `changed_file_count=${fileCount}\n`
-    );
+    appendTrustedRunnerFile(process.env.GITHUB_OUTPUT, `changed_file_count=${fileCount}\n`);
   }
 
   if (files.length > 0) {

--- a/scripts/ci/github-pr-files.test.mjs
+++ b/scripts/ci/github-pr-files.test.mjs
@@ -124,7 +124,9 @@ test('CLI exits cleanly for non pull request events', () => {
     })
   );
 
-  const result = runScript('scripts/ci/github-pr-files.mjs', root, ['--event-path', eventPath]);
+  const result = runScript('scripts/ci/github-pr-files.mjs', root, ['--event-path', eventPath], {
+    env: { RUNNER_TEMP: root },
+  });
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, '');

--- a/scripts/ci/multi-agent-policy.test.mjs
+++ b/scripts/ci/multi-agent-policy.test.mjs
@@ -1,11 +1,9 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
 import path from 'node:path';
-
+import test from 'node:test';
 import { evaluateMultiAgentPolicy, evaluatePackageJsonRisk } from './multi-agent-policy-lib.mjs';
 import { runScriptAsync } from './run-script-async-test-helper.mjs';
 import { createTempRoot, runScript, writeFile } from '../plan-test-helpers.mjs';
-
 test('manual dispatch defaults to full multi-agent hardening when changed files are unavailable', () => {
   assert.deepEqual(
     evaluateMultiAgentPolicy({
@@ -20,7 +18,6 @@ test('manual dispatch defaults to full multi-agent hardening when changed files 
     }
   );
 });
-
 test('manual dispatch skips full multi-agent hardening for docs-only branches when changed files are available', () => {
   assert.deepEqual(
     evaluateMultiAgentPolicy({
@@ -35,7 +32,6 @@ test('manual dispatch skips full multi-agent hardening for docs-only branches wh
     }
   );
 });
-
 test('manual dispatch still runs full multi-agent hardening for high-risk branches when changed files are available', () => {
   assert.deepEqual(
     evaluateMultiAgentPolicy({
@@ -50,7 +46,6 @@ test('manual dispatch still runs full multi-agent hardening for high-risk branch
     }
   );
 });
-
 test('explicit CI label forces full multi-agent hardening', () => {
   assert.deepEqual(
     evaluateMultiAgentPolicy({
@@ -65,7 +60,6 @@ test('explicit CI label forces full multi-agent hardening', () => {
     }
   );
 });
-
 test('high-risk multi-agent infrastructure changes trigger full multi-agent hardening', () => {
   assert.deepEqual(
     evaluateMultiAgentPolicy({
@@ -83,7 +77,6 @@ test('high-risk multi-agent infrastructure changes trigger full multi-agent hard
     }
   );
 });
-
 test('validation-orchestration scripts require an explicit label before full multi-agent hardening', () => {
   assert.deepEqual(
     evaluateMultiAgentPolicy({
@@ -345,6 +338,7 @@ test('CLI resolves safe package.json changes from GitHub file contents and skips
       env: {
         GH_TOKEN: 'test-token',
         GITHUB_PACKAGE_JSON_FIXTURE_DIR: fixturesPath,
+        RUNNER_TEMP: root,
       },
     }
   );
@@ -371,14 +365,19 @@ test('CLI prints GitHub output fields for risky PR changes', () => {
   );
   writeFile(root, 'changed-files.txt', 'scripts/multi-agent/orchestrator.sh\n');
 
-  const result = runScript('scripts/ci/multi-agent-policy.mjs', root, [
-    '--event-name',
-    'pull_request',
-    '--event-path',
-    eventPath,
-    '--changed-files-path',
-    changedFilesPath,
-  ]);
+  const result = runScript(
+    'scripts/ci/multi-agent-policy.mjs',
+    root,
+    [
+      '--event-name',
+      'pull_request',
+      '--event-path',
+      eventPath,
+      '--changed-files-path',
+      changedFilesPath,
+    ],
+    { env: { RUNNER_TEMP: root } }
+  );
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /^should_run=false$/m);

--- a/scripts/ci/policy-cli-common-lib.mjs
+++ b/scripts/ci/policy-cli-common-lib.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 
 import { fetchRepositoryFileContent } from './github-pr-files-lib.mjs';
 import { readPackageJsonFixture } from './package-json-fixture-lib.mjs';
+import { trustedRunnerFile } from './trusted-runner-file.mjs';
 
 export function fail(commandName, message) {
   process.stderr.write(`${commandName} failed: ${message}\n`);
@@ -41,20 +42,24 @@ export function parsePolicyArgs(argv, commandName) {
 }
 
 export function readEvent(eventPath) {
-  if (!eventPath || !fs.existsSync(eventPath)) {
+  if (!eventPath) {
     return null;
   }
 
-  return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+  const trustedPath = trustedRunnerFile(eventPath);
+  if (!fs.existsSync(trustedPath)) return null;
+  return JSON.parse(fs.readFileSync(trustedPath, 'utf8'));
 }
 
 export function readChangedFiles(changedFilesPath) {
-  if (!changedFilesPath || !fs.existsSync(changedFilesPath)) {
+  if (!changedFilesPath) {
     return [];
   }
 
+  const trustedPath = trustedRunnerFile(changedFilesPath);
+  if (!fs.existsSync(trustedPath)) return [];
   return fs
-    .readFileSync(changedFilesPath, 'utf8')
+    .readFileSync(trustedPath, 'utf8')
     .split('\n')
     .map(line => line.trim())
     .filter(Boolean);

--- a/scripts/ci/policy-cli-common-lib.mjs
+++ b/scripts/ci/policy-cli-common-lib.mjs
@@ -1,8 +1,6 @@
-import fs from 'node:fs';
-
 import { fetchRepositoryFileContent } from './github-pr-files-lib.mjs';
 import { readPackageJsonFixture } from './package-json-fixture-lib.mjs';
-import { trustedRunnerFile } from './trusted-runner-file.mjs';
+import { readTrustedRunnerFile } from './trusted-runner-file.mjs';
 
 export function fail(commandName, message) {
   process.stderr.write(`${commandName} failed: ${message}\n`);
@@ -46,9 +44,12 @@ export function readEvent(eventPath) {
     return null;
   }
 
-  const trustedPath = trustedRunnerFile(eventPath);
-  if (!fs.existsSync(trustedPath)) return null;
-  return JSON.parse(fs.readFileSync(trustedPath, 'utf8'));
+  try {
+    return JSON.parse(readTrustedRunnerFile(eventPath));
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') return null;
+    throw error;
+  }
 }
 
 export function readChangedFiles(changedFilesPath) {
@@ -56,10 +57,14 @@ export function readChangedFiles(changedFilesPath) {
     return [];
   }
 
-  const trustedPath = trustedRunnerFile(changedFilesPath);
-  if (!fs.existsSync(trustedPath)) return [];
-  return fs
-    .readFileSync(trustedPath, 'utf8')
+  let changedFiles;
+  try {
+    changedFiles = readTrustedRunnerFile(changedFilesPath);
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') return [];
+    throw error;
+  }
+  return changedFiles
     .split('\n')
     .map(line => line.trim())
     .filter(Boolean);

--- a/scripts/ci/pr-gate-policy-cli.test.mjs
+++ b/scripts/ci/pr-gate-policy-cli.test.mjs
@@ -34,7 +34,11 @@ function runCli({
     ],
     {
       encoding: 'utf8',
-      env: { ...process.env, PR_GATE_CHANGED_FILE_COUNT: String(actualCount) },
+      env: {
+        ...process.env,
+        PR_GATE_CHANGED_FILE_COUNT: String(actualCount),
+        RUNNER_TEMP: directory,
+      },
     }
   );
   rmSync(directory, { recursive: true, force: true });

--- a/scripts/ci/pr-gate-policy.mjs
+++ b/scripts/ci/pr-gate-policy.mjs
@@ -3,20 +3,25 @@
 import { existsSync, readFileSync } from 'node:fs';
 
 import { evaluatePrGatePolicy } from './pr-gate-policy-lib.mjs';
+import { trustedRunnerFile } from './trusted-runner-file.mjs';
 
 function valueFor(flag) {
   const index = process.argv.indexOf(flag);
   return index === -1 ? undefined : process.argv[index + 1];
 }
 
-function readJson(path) {
-  if (!path || !existsSync(path)) return {};
-  return JSON.parse(readFileSync(path, 'utf8'));
+function readJson(filePath) {
+  if (!filePath) return {};
+  const trustedPath = trustedRunnerFile(filePath);
+  if (!existsSync(trustedPath)) return {};
+  return JSON.parse(readFileSync(trustedPath, 'utf8'));
 }
 
-function readChangedFiles(path) {
-  if (!path || !existsSync(path)) return { files: [], exists: false };
-  const files = readFileSync(path, 'utf8')
+function readChangedFiles(filePath) {
+  if (!filePath) return { files: [], exists: false };
+  const trustedPath = trustedRunnerFile(filePath);
+  if (!existsSync(trustedPath)) return { files: [], exists: false };
+  const files = readFileSync(trustedPath, 'utf8')
     .split('\n')
     .map(value => value.trim())
     .filter(Boolean);

--- a/scripts/ci/pr-gate-policy.mjs
+++ b/scripts/ci/pr-gate-policy.mjs
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync } from 'node:fs';
-
 import { evaluatePrGatePolicy } from './pr-gate-policy-lib.mjs';
-import { trustedRunnerFile } from './trusted-runner-file.mjs';
+import { readTrustedRunnerFile } from './trusted-runner-file.mjs';
 
 function valueFor(flag) {
   const index = process.argv.indexOf(flag);
@@ -12,16 +10,26 @@ function valueFor(flag) {
 
 function readJson(filePath) {
   if (!filePath) return {};
-  const trustedPath = trustedRunnerFile(filePath);
-  if (!existsSync(trustedPath)) return {};
-  return JSON.parse(readFileSync(trustedPath, 'utf8'));
+  try {
+    return JSON.parse(readTrustedRunnerFile(filePath));
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') return {};
+    throw error;
+  }
 }
 
 function readChangedFiles(filePath) {
   if (!filePath) return { files: [], exists: false };
-  const trustedPath = trustedRunnerFile(filePath);
-  if (!existsSync(trustedPath)) return { files: [], exists: false };
-  const files = readFileSync(trustedPath, 'utf8')
+  let changedFiles;
+  try {
+    changedFiles = readTrustedRunnerFile(filePath);
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') {
+      return { files: [], exists: false };
+    }
+    throw error;
+  }
+  const files = changedFiles
     .split('\n')
     .map(value => value.trim())
     .filter(Boolean);

--- a/scripts/ci/trusted-root-callers.test.mjs
+++ b/scripts/ci/trusted-root-callers.test.mjs
@@ -16,7 +16,7 @@ test('all untrusted-path policy CLIs use the shared trusted-file boundary', () =
 
   for (const cli of clis) {
     const script = source(cli);
-    assert.match(script, /trustedRunnerFile/);
+    assert.match(script, /(read|append)TrustedRunnerFile/);
     assert.match(script, /from '\.\/trusted-runner-file\.mjs'/);
   }
 });

--- a/scripts/ci/trusted-root-callers.test.mjs
+++ b/scripts/ci/trusted-root-callers.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+function source(file) {
+  return fs.readFileSync(file, 'utf8');
+}
+
+test('all untrusted-path policy CLIs use the shared trusted-file boundary', () => {
+  const clis = [
+    'scripts/ci/github-pr-files.mjs',
+    'scripts/ci/pr-gate-policy.mjs',
+    'scripts/ci/policy-cli-common-lib.mjs',
+    'scripts/ci/ai-eval-surface.mjs',
+  ];
+
+  for (const cli of clis) {
+    const script = source(cli);
+    assert.match(script, /trustedRunnerFile/);
+    assert.match(script, /from '\.\/trusted-runner-file\.mjs'/);
+  }
+});
+
+test('Z620 validation passes its task-owned temp directory as RUNNER_TEMP', () => {
+  const script = source('scripts/ci/z620-validation-surface.mjs');
+
+  assert.match(script, /env:\s*\{\s*\.\.\.process\.env,\s*RUNNER_TEMP:\s*tempDir\s*\}/s);
+});
+
+test('PR finalizer creates a private root and passes it to policy CLIs', () => {
+  const script = source('scripts/pr-finalizer-lib.sh');
+
+  assert.match(script, /changed_files_root="\$\(mktemp -d .*pr-finalizer\.XXXXXX"\)"/);
+  assert.match(
+    script,
+    /RUNNER_TEMP="\$\{RUNNER_TEMP:-\$\{changed_files_root\}\}".*github-pr-files\.mjs/s
+  );
+  assert.match(
+    script,
+    /RUNNER_TEMP="\$\{RUNNER_TEMP:-\$\{changed_files_root\}\}".*validation-surface-policy\.mjs/s
+  );
+  assert.match(script, /rm -rf -- "\$\{changed_files_root\}"/);
+});
+
+test('local parity creates and removes a private validation root', () => {
+  const script = source('scripts/ci-local-parity.sh');
+
+  assert.match(script, /validation_surface_root="\$\(mktemp -d\)"/);
+  assert.match(
+    script,
+    /RUNNER_TEMP="\$\{validation_surface_root\}".*validation-surface-policy\.mjs/s
+  );
+  assert.match(script, /rm -rf -- "\$\{validation_surface_root\}"/);
+});

--- a/scripts/ci/trusted-runner-file.mjs
+++ b/scripts/ci/trusted-runner-file.mjs
@@ -5,10 +5,6 @@ function fail(message) {
   throw new Error(message);
 }
 
-function isContained(root, candidate) {
-  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
-}
-
 function nearestExistingPath(candidate) {
   let current = candidate;
 
@@ -24,19 +20,24 @@ function nearestExistingPath(candidate) {
 }
 
 function rejectSymlinkComponents(root, candidate) {
-  const relativePath = path.relative(root, candidate);
-  let current = root;
+  let current = candidate;
 
-  for (const segment of relativePath.split(path.sep).filter(Boolean)) {
-    current = path.join(current, segment);
+  while (current !== root) {
     try {
       if (fs.lstatSync(current).isSymbolicLink()) {
         fail('runner file symlinks are not allowed');
       }
     } catch (error) {
-      if (error && typeof error === 'object' && error.code === 'ENOENT') return;
-      throw error;
+      if (!(error && typeof error === 'object' && error.code === 'ENOENT')) {
+        throw error;
+      }
     }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      fail('runner file is outside the trusted root');
+    }
+    current = parent;
   }
 }
 
@@ -49,12 +50,13 @@ export function trustedRunnerFile(
   }
 
   const resolvedRoot = path.resolve(runnerTemp);
+  if (resolvedRoot === path.parse(resolvedRoot).root) {
+    fail('trusted runner root is invalid');
+  }
+
   let canonicalRoot;
   try {
-    canonicalRoot = fs.realpathSync(resolvedRoot);
-    if (!fs.statSync(canonicalRoot).isDirectory()) {
-      fail('trusted runner root is invalid');
-    }
+    canonicalRoot = fs.realpathSync(`${resolvedRoot}${path.sep}.`);
   } catch {
     fail('trusted runner root is invalid');
   }
@@ -66,10 +68,10 @@ export function trustedRunnerFile(
   const resolvedCandidate = path.isAbsolute(candidatePath)
     ? path.resolve(candidatePath)
     : path.resolve(resolvedRoot, candidatePath);
-  if (!isContained(resolvedRoot, resolvedCandidate)) {
+  if (!resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`)) {
     fail('runner file is outside the trusted root');
   }
-  rejectSymlinkComponents(resolvedRoot, resolvedCandidate);
+
   const existingPath = nearestExistingPath(resolvedCandidate);
   const existingMetadata = fs.lstatSync(existingPath);
 
@@ -81,9 +83,11 @@ export function trustedRunnerFile(
   const unresolvedSuffix = path.relative(existingPath, resolvedCandidate);
   const canonicalCandidate = path.resolve(canonicalExisting, unresolvedSuffix);
 
-  if (!isContained(canonicalRoot, canonicalCandidate)) {
+  if (!canonicalCandidate.startsWith(`${canonicalRoot}${path.sep}`)) {
     fail('runner file is outside the trusted root');
   }
+
+  rejectSymlinkComponents(resolvedRoot, resolvedCandidate);
 
   if (existingPath === resolvedCandidate) {
     if (!existingMetadata.isFile()) {

--- a/scripts/ci/trusted-runner-file.mjs
+++ b/scripts/ci/trusted-runner-file.mjs
@@ -69,7 +69,7 @@ export function trustedRunnerFile(
     ? path.resolve(candidatePath)
     : path.resolve(resolvedRoot, candidatePath);
   if (!resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`)) {
-    fail('runner file is outside the trusted root');
+    throw new Error('runner file is outside the trusted root');
   }
 
   const existingPath = nearestExistingPath(resolvedCandidate);
@@ -84,7 +84,7 @@ export function trustedRunnerFile(
   const canonicalCandidate = path.resolve(canonicalExisting, unresolvedSuffix);
 
   if (!canonicalCandidate.startsWith(`${canonicalRoot}${path.sep}`)) {
-    fail('runner file is outside the trusted root');
+    throw new Error('runner file is outside the trusted root');
   }
 
   rejectSymlinkComponents(resolvedRoot, resolvedCandidate);

--- a/scripts/ci/trusted-runner-file.mjs
+++ b/scripts/ci/trusted-runner-file.mjs
@@ -1,0 +1,100 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function isContained(root, candidate) {
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+function nearestExistingPath(candidate) {
+  let current = candidate;
+
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      fail('runner file has no existing parent');
+    }
+    current = parent;
+  }
+
+  return current;
+}
+
+function rejectSymlinkComponents(root, candidate) {
+  const relativePath = path.relative(root, candidate);
+  let current = root;
+
+  for (const segment of relativePath.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    try {
+      if (fs.lstatSync(current).isSymbolicLink()) {
+        fail('runner file symlinks are not allowed');
+      }
+    } catch (error) {
+      if (error && typeof error === 'object' && error.code === 'ENOENT') return;
+      throw error;
+    }
+  }
+}
+
+export function trustedRunnerFile(
+  candidatePath,
+  { runnerTemp = process.env.RUNNER_TEMP || '' } = {}
+) {
+  if (typeof runnerTemp !== 'string' || !runnerTemp.trim()) {
+    fail('trusted runner root is required');
+  }
+
+  const resolvedRoot = path.resolve(runnerTemp);
+  let canonicalRoot;
+  try {
+    canonicalRoot = fs.realpathSync(resolvedRoot);
+    if (!fs.statSync(canonicalRoot).isDirectory()) {
+      fail('trusted runner root is invalid');
+    }
+  } catch {
+    fail('trusted runner root is invalid');
+  }
+
+  if (typeof candidatePath !== 'string' || !candidatePath.trim()) {
+    fail('runner file path is required');
+  }
+
+  const resolvedCandidate = path.isAbsolute(candidatePath)
+    ? path.resolve(candidatePath)
+    : path.resolve(resolvedRoot, candidatePath);
+  if (!isContained(resolvedRoot, resolvedCandidate)) {
+    fail('runner file is outside the trusted root');
+  }
+  rejectSymlinkComponents(resolvedRoot, resolvedCandidate);
+  const existingPath = nearestExistingPath(resolvedCandidate);
+  const existingMetadata = fs.lstatSync(existingPath);
+
+  if (existingMetadata.isSymbolicLink()) {
+    fail('runner file symlinks are not allowed');
+  }
+
+  const canonicalExisting = fs.realpathSync(existingPath);
+  const unresolvedSuffix = path.relative(existingPath, resolvedCandidate);
+  const canonicalCandidate = path.resolve(canonicalExisting, unresolvedSuffix);
+
+  if (!isContained(canonicalRoot, canonicalCandidate)) {
+    fail('runner file is outside the trusted root');
+  }
+
+  if (existingPath === resolvedCandidate) {
+    if (!existingMetadata.isFile()) {
+      fail('runner file must be regular');
+    }
+    if (existingMetadata.nlink !== 1) {
+      fail('runner file must have exactly one hard link');
+    }
+  } else if (!existingMetadata.isDirectory()) {
+    fail('runner file parent must be a directory');
+  }
+
+  return canonicalCandidate;
+}

--- a/scripts/ci/trusted-runner-file.mjs
+++ b/scripts/ci/trusted-runner-file.mjs
@@ -1,13 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-
 function fail(message) {
   throw new Error(message);
 }
-
 function nearestExistingPath(candidate) {
   let current = candidate;
-
   while (!fs.existsSync(current)) {
     const parent = path.dirname(current);
     if (parent === current) {
@@ -15,13 +12,11 @@ function nearestExistingPath(candidate) {
     }
     current = parent;
   }
-
   return current;
 }
 
 function rejectSymlinkComponents(root, candidate) {
   let current = candidate;
-
   while (current !== root) {
     try {
       if (fs.lstatSync(current).isSymbolicLink()) {
@@ -32,7 +27,6 @@ function rejectSymlinkComponents(root, candidate) {
         throw error;
       }
     }
-
     const parent = path.dirname(current);
     if (parent === current) {
       fail('runner file is outside the trusted root');
@@ -48,19 +42,16 @@ export function trustedRunnerFile(
   if (typeof runnerTemp !== 'string' || !runnerTemp.trim()) {
     fail('trusted runner root is required');
   }
-
   const resolvedRoot = path.resolve(runnerTemp);
   if (resolvedRoot === path.parse(resolvedRoot).root) {
     fail('trusted runner root is invalid');
   }
-
   let canonicalRoot;
   try {
     canonicalRoot = fs.realpathSync(`${resolvedRoot}${path.sep}.`);
   } catch {
     fail('trusted runner root is invalid');
   }
-
   if (typeof candidatePath !== 'string' || !candidatePath.trim()) {
     fail('runner file path is required');
   }
@@ -74,15 +65,12 @@ export function trustedRunnerFile(
 
   const existingPath = nearestExistingPath(resolvedCandidate);
   const existingMetadata = fs.lstatSync(existingPath);
-
   if (existingMetadata.isSymbolicLink()) {
     fail('runner file symlinks are not allowed');
   }
-
   const canonicalExisting = fs.realpathSync(existingPath);
   const unresolvedSuffix = path.relative(existingPath, resolvedCandidate);
   const canonicalCandidate = path.resolve(canonicalExisting, unresolvedSuffix);
-
   if (!canonicalCandidate.startsWith(`${canonicalRoot}${path.sep}`)) {
     throw new Error('runner file is outside the trusted root');
   }
@@ -101,4 +89,61 @@ export function trustedRunnerFile(
   }
 
   return canonicalCandidate;
+}
+
+function openTrustedRunnerFile(candidatePath, flags, options) {
+  const trustedPath = trustedRunnerFile(candidatePath, options);
+  const resolvedRoot = path.resolve(options?.runnerTemp ?? process.env.RUNNER_TEMP ?? '');
+  const canonicalRoot = fs.realpathSync(`${resolvedRoot}${path.sep}.`);
+  if (!trustedPath.startsWith(`${canonicalRoot}${path.sep}`)) {
+    throw new Error('runner file is outside the trusted root');
+  }
+  const descriptor = fs.openSync(trustedPath, flags | fs.constants.O_NOFOLLOW);
+  try {
+    const descriptorMetadata = fs.fstatSync(descriptor);
+    const pathMetadata = fs.statSync(trustedPath);
+    if (!descriptorMetadata.isFile()) {
+      fail('runner file must be regular');
+    }
+    if (descriptorMetadata.nlink !== 1) {
+      fail('runner file must have exactly one hard link');
+    }
+    if (
+      descriptorMetadata.dev !== pathMetadata.dev ||
+      descriptorMetadata.ino !== pathMetadata.ino
+    ) {
+      fail('runner file changed during validation');
+    }
+    if (trustedRunnerFile(candidatePath, options) !== trustedPath) {
+      fail('runner file changed during validation');
+    }
+
+    return descriptor;
+  } catch (error) {
+    fs.closeSync(descriptor);
+    throw error;
+  }
+}
+export function readTrustedRunnerFile(candidatePath, options) {
+  const descriptor = openTrustedRunnerFile(candidatePath, fs.constants.O_RDONLY, options);
+
+  try {
+    return fs.readFileSync(descriptor, 'utf8');
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+export function appendTrustedRunnerFile(candidatePath, content, options) {
+  const descriptor = openTrustedRunnerFile(
+    candidatePath,
+    fs.constants.O_WRONLY | fs.constants.O_APPEND,
+    options
+  );
+
+  try {
+    fs.appendFileSync(descriptor, content);
+  } finally {
+    fs.closeSync(descriptor);
+  }
 }

--- a/scripts/ci/trusted-runner-file.test.mjs
+++ b/scripts/ci/trusted-runner-file.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { trustedRunnerFile } from './trusted-runner-file.mjs';
+
+function tempRoot(prefix = 'trusted-runner-file-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test('returns canonical existing and not-yet-created files inside RUNNER_TEMP', () => {
+  const root = tempRoot();
+  const existing = path.join(root, 'event.json');
+  fs.writeFileSync(existing, '{}');
+
+  assert.equal(trustedRunnerFile(existing, { runnerTemp: root }), fs.realpathSync(existing));
+  assert.equal(
+    trustedRunnerFile(path.join(root, 'nested', 'output.txt'), { runnerTemp: root }),
+    path.join(fs.realpathSync(root), 'nested', 'output.txt')
+  );
+});
+
+test('requires a non-empty existing RUNNER_TEMP directory', () => {
+  const root = tempRoot();
+
+  assert.throws(() => trustedRunnerFile(path.join(root, 'event.json'), { runnerTemp: '' }), {
+    message: 'trusted runner root is required',
+  });
+  assert.throws(
+    () =>
+      trustedRunnerFile(path.join(root, 'event.json'), {
+        runnerTemp: path.join(root, 'missing'),
+      }),
+    { message: 'trusted runner root is invalid' }
+  );
+});
+
+test('rejects separator-prefix siblings outside the trusted root', () => {
+  const parent = tempRoot();
+  const root = path.join(parent, 'runner');
+  const sibling = path.join(parent, 'runner-escape');
+  fs.mkdirSync(root);
+  fs.mkdirSync(sibling);
+  const candidate = path.join(sibling, 'event.json');
+  fs.writeFileSync(candidate, '{}');
+
+  assert.throws(() => trustedRunnerFile(candidate, { runnerTemp: root }), {
+    message: 'runner file is outside the trusted root',
+  });
+});
+
+test('rejects symlinks and paths beneath a symlink', () => {
+  const root = tempRoot();
+  const outside = tempRoot('trusted-runner-outside-');
+  const inside = path.join(root, 'inside');
+  const target = path.join(outside, 'event.json');
+  const directLink = path.join(root, 'event-link.json');
+  const directoryLink = path.join(root, 'linked-directory');
+  const insideLink = path.join(root, 'inside-link');
+  fs.mkdirSync(inside);
+  fs.writeFileSync(target, '{}');
+  fs.symlinkSync(target, directLink);
+  fs.symlinkSync(outside, directoryLink);
+  fs.symlinkSync(inside, insideLink);
+
+  assert.throws(() => trustedRunnerFile(directLink, { runnerTemp: root }), {
+    message: 'runner file symlinks are not allowed',
+  });
+  assert.throws(
+    () => trustedRunnerFile(path.join(directoryLink, 'missing.json'), { runnerTemp: root }),
+    { message: 'runner file symlinks are not allowed' }
+  );
+  assert.throws(
+    () => trustedRunnerFile(path.join(insideLink, 'missing.json'), { runnerTemp: root }),
+    { message: 'runner file symlinks are not allowed' }
+  );
+});
+
+test('rejects existing hard-linked and non-regular files', () => {
+  const root = tempRoot();
+  const source = path.join(root, 'source.json');
+  const hardLink = path.join(root, 'event.json');
+  const directory = path.join(root, 'directory');
+  fs.writeFileSync(source, '{}');
+  fs.linkSync(source, hardLink);
+  fs.mkdirSync(directory);
+
+  assert.throws(() => trustedRunnerFile(hardLink, { runnerTemp: root }), {
+    message: 'runner file must have exactly one hard link',
+  });
+  assert.throws(() => trustedRunnerFile(directory, { runnerTemp: root }), {
+    message: 'runner file must be regular',
+  });
+});

--- a/scripts/ci/trusted-runner-file.test.mjs
+++ b/scripts/ci/trusted-runner-file.test.mjs
@@ -4,7 +4,11 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { trustedRunnerFile } from './trusted-runner-file.mjs';
+import {
+  appendTrustedRunnerFile,
+  readTrustedRunnerFile,
+  trustedRunnerFile,
+} from './trusted-runner-file.mjs';
 
 function tempRoot(prefix = 'trusted-runner-file-') {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -93,4 +97,41 @@ test('rejects existing hard-linked and non-regular files', () => {
   assert.throws(() => trustedRunnerFile(directory, { runnerTemp: root }), {
     message: 'runner file must be regular',
   });
+});
+
+test('reads and appends through the validated descriptor', () => {
+  const root = tempRoot();
+  const file = path.join(root, 'runner.txt');
+  fs.writeFileSync(file, 'first');
+
+  assert.equal(readTrustedRunnerFile(file, { runnerTemp: root }), 'first');
+  appendTrustedRunnerFile(file, '-second', { runnerTemp: root });
+  assert.equal(fs.readFileSync(file, 'utf8'), 'first-second');
+});
+
+test('rejects an ancestor replaced after path validation', () => {
+  const root = tempRoot();
+  const outside = tempRoot('trusted-runner-outside-');
+  const directory = path.join(root, 'nested');
+  const movedDirectory = path.join(root, 'nested-safe');
+  const file = path.join(directory, 'event.json');
+  fs.mkdirSync(directory);
+  fs.writeFileSync(file, '{}');
+  fs.writeFileSync(path.join(outside, 'event.json'), '{"outside":true}');
+
+  const originalOpenSync = fs.openSync;
+  fs.openSync = function swapBeforeOpen(filePath, flags, mode) {
+    fs.renameSync(directory, movedDirectory);
+    fs.symlinkSync(outside, directory);
+    fs.openSync = originalOpenSync;
+    return originalOpenSync(filePath, flags, mode);
+  };
+
+  try {
+    assert.throws(() => readTrustedRunnerFile(file, { runnerTemp: root }), {
+      message: /runner file (?:symlinks are not allowed|is outside the trusted root)/,
+    });
+  } finally {
+    fs.openSync = originalOpenSync;
+  }
 });

--- a/scripts/ci/validation-surface-package-cli.test.mjs
+++ b/scripts/ci/validation-surface-package-cli.test.mjs
@@ -38,7 +38,13 @@ test('CLI resolves safe package.json changes from GitHub contents', async () => 
       '--changed-files-path',
       changedFilesPath,
     ],
-    { env: { GH_TOKEN: 'test-token', GITHUB_PACKAGE_JSON_FIXTURE_DIR: fixturesPath } }
+    {
+      env: {
+        GH_TOKEN: 'test-token',
+        GITHUB_PACKAGE_JSON_FIXTURE_DIR: fixturesPath,
+        RUNNER_TEMP: root,
+      },
+    }
   );
 
   assert.equal(result.status, 0, result.stderr);

--- a/scripts/ci/validation-surface-policy.test.mjs
+++ b/scripts/ci/validation-surface-policy.test.mjs
@@ -119,12 +119,12 @@ test('CLI prints GitHub output fields for docs-only PRs', () => {
 
   writeFile(root, 'changed-files.txt', 'docs/plans/current-program.md\nREADME.md\n');
 
-  const result = runScript('scripts/ci/validation-surface-policy.mjs', root, [
-    '--event-name',
-    'pull_request',
-    '--changed-files-path',
-    changedFilesPath,
-  ]);
+  const result = runScript(
+    'scripts/ci/validation-surface-policy.mjs',
+    root,
+    ['--event-name', 'pull_request', '--changed-files-path', changedFilesPath],
+    { env: { RUNNER_TEMP: root } }
+  );
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /^should_run=false$/m);

--- a/scripts/ci/z620-validation-surface.mjs
+++ b/scripts/ci/z620-validation-surface.mjs
@@ -34,7 +34,10 @@ try {
       '--changed-files-path',
       changedPath,
     ],
-    { encoding: 'utf8' }
+    {
+      encoding: 'utf8',
+      env: { ...process.env, RUNNER_TEMP: tempDir },
+    }
   );
   process.stdout.write(output);
 } finally {

--- a/scripts/pr-finalizer-lib.sh
+++ b/scripts/pr-finalizer-lib.sh
@@ -5,11 +5,14 @@ PR_TYPE_RUNTIME="runtime"
 pr_type="${PR_TYPE_RUNTIME}"
 pr_type_reason="unclassified"
 changed_files_path=""
+changed_files_root=""
 
 collect_changed_files() {
-  changed_files_path="$(mktemp)"
+  changed_files_root="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/pr-finalizer.XXXXXX")"
+  changed_files_path="${changed_files_root}/changed-files.txt"
   if [[ -n "${GITHUB_EVENT_PATH:-}" && -f "${GITHUB_EVENT_PATH}" ]]; then
-    node scripts/ci/github-pr-files.mjs --event-path "${GITHUB_EVENT_PATH}" >"${changed_files_path}"
+    RUNNER_TEMP="${RUNNER_TEMP:-${changed_files_root}}" \
+      node scripts/ci/github-pr-files.mjs --event-path "${GITHUB_EVENT_PATH}" >"${changed_files_path}"
     return 0
   fi
   if command -v gh >/dev/null 2>&1; then
@@ -31,12 +34,17 @@ collect_changed_files() {
 classify_pr() {
   collect_changed_files
   local output should_run reason
-  output="$(
-    node scripts/ci/validation-surface-policy.mjs \
+  if ! output="$(
+    RUNNER_TEMP="${RUNNER_TEMP:-${changed_files_root}}" \
+      node scripts/ci/validation-surface-policy.mjs \
       --event-name pull_request \
       --event-path "${GITHUB_EVENT_PATH:-}" \
       --changed-files-path "${changed_files_path}"
-  )"
+  )"; then
+    rm -rf -- "${changed_files_root}"
+    return 1
+  fi
+  rm -rf -- "${changed_files_root}"
   should_run="$(echo "${output}" | awk -F= '$1 == "should_run" { print $2 }')"
   reason="$(echo "${output}" | awk -F= '$1 == "reason" { print $2 }')"
   if [[ "${should_run}" == "false" ]]; then

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59030555,
+  "maxTrackedBytes": 59034244,
   "maxTrackedFiles": 5595,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16743686,
     "docs/text": 7881157,
-    "source/scripts": 7872511,
-    "tests/e2e": 5867594,
+    "source/scripts": 7874784,
+    "tests/e2e": 5869010,
     "config/data/messages": 1809212
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59030577,
+  "maxTrackedBytes": 59030533,
   "maxTrackedFiles": 5595,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16743686,
     "docs/text": 7881157,
-    "source/scripts": 7872533,
+    "source/scripts": 7872489,
     "tests/e2e": 5867594,
     "config/data/messages": 1809212
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59030533,
+  "maxTrackedBytes": 59030555,
   "maxTrackedFiles": 5595,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16743686,
     "docs/text": 7881157,
-    "source/scripts": 7872489,
+    "source/scripts": 7872511,
     "tests/e2e": 5867594,
     "config/data/messages": 1809212
   },

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59020762,
-  "maxTrackedFiles": 5592,
+  "maxTrackedBytes": 59030577,
+  "maxTrackedFiles": 5595,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16743686,
     "docs/text": 7881157,
-    "source/scripts": 7868217,
-    "tests/e2e": 5862095,
+    "source/scripts": 7872533,
+    "tests/e2e": 5867594,
     "config/data/messages": 1809212
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Summary

- add a shared canonical RUNNER_TEMP file boundary
- reject traversal, prefix collisions, symlinks, hardlinks, and non-regular files
- route policy CLI inputs and outputs through task-owned roots without changing gate decisions

## Scope

Exactly 17 IDA-SEC08a-authorized paths. No workflow, product, database, provider, or deployment changes.

## Proof

- focused path and caller tests: 57/57
- CI contracts: 443/443
- repo size, modularity, security guard, and diff checks: pass
- Z620 exact-SHA FAST proof: validation, audit, static, unit, security pass
- Codex Security diff scan: complete, 17/17 paths, no findings

Copilot is unavailable and is not counted as approval. Current-head Codex review is required before merge.