### PR TITLE
fix(ci): activate trusted PR gate policy pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           package-manager-cache: false
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@9a81dd9767aabeef25889eb791f20e9496a52205
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@9a81dd9767aabeef25889eb791f20e9496a52205
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}

--- a/.github/workflows/pilot-gate.yml
+++ b/.github/workflows/pilot-gate.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@9a81dd9767aabeef25889eb791f20e9496a52205
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}

--- a/.github/workflows/pr-deterministic-backstops.yml
+++ b/.github/workflows/pr-deterministic-backstops.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@9a81dd9767aabeef25889eb791f20e9496a52205
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}

--- a/.github/workflows/pr-finalizer.yml
+++ b/.github/workflows/pr-finalizer.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 1
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@9a81dd9767aabeef25889eb791f20e9496a52205
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}

--- a/scripts/ci/draft-gate-workflow-contracts.test.mjs
+++ b/scripts/ci/draft-gate-workflow-contracts.test.mjs
@@ -8,7 +8,7 @@ import yaml from 'js-yaml';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const TRUSTED_GATE_ACTION =
-  'interdomestik/interdomestik/.github/actions/pr-gate-policy@9a81dd9767aabeef25889eb791f20e9496a52205';
+  'interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19';
 const EVENT_TYPES = [
   'opened',
   'synchronize',

--- a/scripts/ci/pr-gate-pin-contracts.test.mjs
+++ b/scripts/ci/pr-gate-pin-contracts.test.mjs
@@ -8,7 +8,7 @@ import yaml from 'js-yaml';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const trustedAction =
-  'interdomestik/interdomestik/.github/actions/pr-gate-policy@9a81dd9767aabeef25889eb791f20e9496a52205';
+  'interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19';
 const targets = [
   ['ci.yml', 'validation-surface'],
   ['e2e-pr.yml', 'e2e-preflight'],

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -14,7 +14,7 @@ import {
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '../..');
 const TRUSTED_GATE_ACTION =
-  'interdomestik/interdomestik/.github/actions/pr-gate-policy@9a81dd9767aabeef25889eb791f20e9496a52205';
+  'interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19';
 function readWorkflow(relativePath) {
   const content = fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
   return yaml.load(content);

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "workflowDigests": {
-    ".github/workflows/ci.yml": "9fc4e1bed2b3826295e9bf8de005c72ff7e7bb43c5b3ac0a924e5de37325f373",
+    ".github/workflows/ci.yml": "95fb78785bf9bf997dae6bbedcfc3e401a790decfdd97eac3a26730181346c01",
     ".github/workflows/security.yml": "72e957bba4773deb3212d6db1d16f398c8fed53e538c6a060ca04f07f688195a",
-    ".github/workflows/e2e-pr.yml": "fb510f7185d24d630255a4b6830412430a910c4e858a635d89d2c7e2377580a7",
+    ".github/workflows/e2e-pr.yml": "2cb54c57c1df0237beb97252d00315f2f84a861f0fd869f72e1a0eb3d802d50a",
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",
-    ".github/workflows/pilot-gate.yml": "18a7223afc1c750ed454f29d42576676ecfe35c76f935c8646b3bb33681875d4",
+    ".github/workflows/pilot-gate.yml": "4b9ad1e56df586849ad3b02111178322297ab6d56fa730083ebc1e60e8148bc3",
     ".github/workflows/release-candidate.yml": "ec03f5eb63d19bff1e8502257e36d264fed70733ca682f5820cd74af93f99bac",
     ".github/workflows/cd.yml": "1e78d39cf3ed7c6df1c0421553d19c101f632c361da78f678bdbd774d708ed25"
   },


### PR DESCRIPTION
## Summary
- pin all five mandatory PR gate callers to canonical IDA-SEC08a merge `2a5d9fa14334766e0668c7b160ea065a0c25ec19`
- update the three exact pin contracts
- synchronize the three reviewed Z620 workflow parity digests under the user-authorized deterministic addendum

## Scope
Exact 9 paths. No workflow trigger, permission, concurrency, job, condition, input, output, provider, deployment, product, database, routing, auth, tenancy or UI change.

## Proof
- test-first semantic RED: 5 expected old-pin failures
- focused GREEN: 28/28
- CI contracts: 445/445
- `pnpm security:guard`: PASS
- `pnpm repo:size:check`: PASS; no budget edit required
- `git diff --check`: PASS
- exact-SHA Z620 FAST on `11860cc916c5db97a4a81f6228e1095d29d8604a`: validation/static/unit/security PASS in r1; audit PASS in one environment-only correction r2
- no DB, browser, build, Pilot, provider or deploy lane selected

## Exact evidence
- runtime receipt: external `Notes/decisions/2026-07-26-interdomestik-ida-sec08b-runtime-authority-receipt.md`, 6,839 bytes, SHA-256 `e9cfc9a61fed60a3a7550bd4835dc993f853f2864378bbff00f119ada9c06d43`
- r1 gate results: `22d7bf0561064c25b72756ff7254ed16bbe5b58a4fff40ba2b6b38872aba34f3`
- audit-r2 results: `3b670a71c5f91b38b793781b3c408edd6ee398673cc331caa1a462ae148435ee`
- candidate bundle: 51,929,297 bytes, SHA-256 `fd0018504b432f88e6276974fb257a7b3057d1ba0730901ac41156b8b8e41de3`
- Z620 task processes after proof: 0; candidate clean

Copilot is unavailable until 2026-08-01 and remains explicit NON-PASS. Current-head Codex review and GitHub required checks remain mandatory before merge.