### PR TITLE
feat(cd): move staging execution to Z620

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,24 +1,22 @@
 name: CD
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    tags: ['v*']
+  push: { branches: [main], tags: ['v*'] }
 concurrency: { group: 'cd-staging-canonical-${{ github.repository }}', cancel-in-progress: false }
 env: { REGISTRY: ghcr.io, IMAGE_NAME: '${{ github.repository }}' }
+# prettier-ignore
 jobs:
   build-staging:
-    runs-on: [self-hosted, interdomestik-mac]
+    runs-on: [self-hosted, interdomestik-z620-staging]
+    timeout-minutes: 45
     environment: { name: staging }
     permissions: { contents: read, packages: write, id-token: write, attestations: write }
-    outputs:
-      image_tag: ${{ steps.meta.outputs.version }}
-      image_digest: ${{ steps.build.outputs.digest }}
+    outputs: { image_tag: '${{ steps.meta.outputs.version }}', image_digest: '${{ steps.build.outputs.digest }}' }
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with: { driver: docker-container }
+      - run: node scripts/ci/cd-runner-preflight.mjs
+      - { name: Set up Docker Buildx, uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f, with: { driver: docker-container, name: interdomestik-cd-staging, keep-state: true, cleanup: false } } # v3
+      - { name: Verify dedicated Docker builder, run: 'node scripts/ci/cd-runner-preflight.mjs verify-builder' }
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -44,22 +42,23 @@ jobs:
           supabase-url: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           supabase-anon-key: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           supabase-production-project-ref: ${{ vars.SUPABASE_PRODUCTION_PROJECT_REF || secrets.SUPABASE_PRODUCTION_PROJECT_REF }}
+      - { name: Prune stale dedicated build cache, if: '${{ always() && !cancelled() }}', run: 'node scripts/ci/cd-runner-preflight.mjs prune' }
   deploy-staging:
     needs: build-staging
-    runs-on: [self-hosted, interdomestik-mac]
+    runs-on: [self-hosted, interdomestik-z620-staging]
     timeout-minutes: 25
     environment: { name: staging }
     permissions: { contents: read, id-token: write, attestations: write }
     outputs:
+      alias_moved: ${{ steps.vercel.outputs.alias_moved }}
       base_url: ${{ steps.vercel.outputs.base_url }}
       hostname: ${{ steps.vercel.outputs.hostname }}
       gate_base_url: ${{ steps.vercel.outputs.gate_base_url }}
       gate_hostname: ${{ steps.vercel.outputs.gate_hostname }}
-    env:
-      EXPECTED_COMMIT_SHA: ${{ github.sha }}
-      STAGING_PREIMAGE_RECEIPT_PATH: tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage.json
+    env: { EXPECTED_COMMIT_SHA: '${{ github.sha }}', STAGING_PREIMAGE_RECEIPT_PATH: 'tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage.json' }
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+      - run: node scripts/ci/cd-runner-preflight.mjs
       - name: Deploy Staging to Vercel
         id: vercel
         uses: ./.github/actions/trigger-digest-verified-deploy
@@ -104,7 +103,8 @@ jobs:
         run: node scripts/ci/wait-for-vercel-health.mjs "${BASE_URL}/api/health" "${EXPECTED_COMMIT_SHA}"
   e2e-staging:
     needs: deploy-staging
-    runs-on: [self-hosted, interdomestik-mac]
+    runs-on: [self-hosted, interdomestik-z620-staging]
+    timeout-minutes: 30
     environment: { name: staging, deployment: false }
     permissions: { contents: read }
     env:
@@ -127,6 +127,7 @@ jobs:
       RELEASE_GATE_ADMIN_MK_PASSWORD: ${{ secrets.RELEASE_GATE_ADMIN_MK_PASSWORD }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+      - run: node scripts/ci/cd-runner-preflight.mjs
       - uses: ./.github/actions/setup
         with: { install-playwright: 'true' }
       - name: Run Staging Release Gate
@@ -144,19 +145,18 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   rollback-staging-alias:
-    if: >-
-      ${{ always() && !cancelled() && (needs.deploy-staging.result == 'failure' || needs.e2e-staging.result == 'failure') }}
+    if: ${{ always() && !cancelled() && (needs.deploy-staging.result == 'failure' || needs.e2e-staging.result == 'failure') }}
     needs: [deploy-staging, e2e-staging]
-    runs-on: [self-hosted, interdomestik-mac]
+    runs-on: [self-hosted, interdomestik-z620-staging]
     timeout-minutes: 10
     environment: { name: staging, deployment: false }
     permissions: { contents: read }
-    env:
-      STAGING_PREIMAGE_RECEIPT_PATH: tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage/staging-alias-preimage.json
-      STAGING_ROLLBACK_RECEIPT_PATH: tmp/cd-evidence/${{ github.run_id }}/staging-alias-rollback.json
+    env: { STAGING_PREIMAGE_RECEIPT_PATH: 'tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage/staging-alias-preimage.json', STAGING_ROLLBACK_RECEIPT_PATH: 'tmp/cd-evidence/${{ github.run_id }}/staging-alias-rollback.json' }
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
+      - run: node scripts/ci/cd-runner-preflight.mjs
       - name: Download staging alias preimage receipt
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: staging-alias-preimage-${{ github.run_id }}
@@ -165,6 +165,7 @@ jobs:
         id: rollback_guard
         if: ${{ always() }}
         shell: bash
+        env: { STAGING_ALIAS_MOVED_SIGNAL: '${{ needs.deploy-staging.outputs.alias_moved }}' }
         run: node scripts/ci/configure-vercel-gate-url.mjs guard >> "${GITHUB_OUTPUT}"
       - name: Restore exact staging alias preimage
         if: ${{ success() && steps.rollback_guard.outputs.should_restore == 'true' }}
@@ -203,9 +204,7 @@ jobs:
     runs-on: [self-hosted, interdomestik-mac]
     environment: { name: production }
     permissions: { contents: read, packages: write, id-token: write, attestations: write }
-    outputs:
-      image_tag: ${{ steps.meta.outputs.version }}
-      image_digest: ${{ steps.build.outputs.digest }}
+    outputs: { image_tag: '${{ steps.meta.outputs.version }}', image_digest: '${{ steps.build.outputs.digest }}' }
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
       - name: Set up Docker Buildx

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
       - run: node scripts/ci/cd-runner-preflight.mjs
-      - { name: Set up Docker Buildx, uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f, with: { driver: docker-container, name: interdomestik-cd-staging, keep-state: true, cleanup: false } } # v3
+      - { name: Set up Docker Buildx, uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f, with: { driver: docker-container, name: interdomestik-cd-staging, keep-state: true, cleanup: true } } # v3
       - { name: Verify dedicated Docker builder, run: 'node scripts/ci/cd-runner-preflight.mjs verify-builder' }
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -42,7 +42,6 @@ jobs:
           supabase-url: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           supabase-anon-key: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           supabase-production-project-ref: ${{ vars.SUPABASE_PRODUCTION_PROJECT_REF || secrets.SUPABASE_PRODUCTION_PROJECT_REF }}
-      - { name: Prune stale dedicated build cache, if: '${{ always() && !cancelled() }}', run: 'node scripts/ci/cd-runner-preflight.mjs prune' }
   deploy-staging:
     needs: build-staging
     runs-on: [self-hosted, interdomestik-z620-staging]

--- a/scripts/ci/cd-deploy-env-scope.test.mjs
+++ b/scripts/ci/cd-deploy-env-scope.test.mjs
@@ -59,6 +59,7 @@ test('deploy action exports rollback controls without expanding historical job o
   ])
     assert.match(action.outputs[output].value, new RegExp(`steps\\.deploy\\.outputs\\.${output}`));
   assert.deepEqual(cd.jobs['deploy-staging'].outputs, {
+    alias_moved: '${{ steps.vercel.outputs.alias_moved }}',
     base_url: '${{ steps.vercel.outputs.base_url }}',
     hostname: '${{ steps.vercel.outputs.hostname }}',
     gate_base_url: '${{ steps.vercel.outputs.gate_base_url }}',

--- a/scripts/ci/cd-runner-contract.test.mjs
+++ b/scripts/ci/cd-runner-contract.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+import { guardRollback } from './configure-vercel-gate-url.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const readText = file => fs.readFileSync(path.join(root, file), 'utf8');
+const cd = yaml.load(readText('.github/workflows/cd.yml'));
+const staging = ['build-staging', 'deploy-staging', 'e2e-staging', 'rollback-staging-alias'];
+const production = ['build-production', 'deploy-production', 'verify-production'];
+const stepIndex = (job, matcher) =>
+  job.steps.findIndex(step => matcher.test(step.name || step.uses || step.run || ''));
+const step = (job, name) => job.steps.find(candidate => candidate.name === name);
+
+test('allocates only staging execution to the exclusive Z620 runner', () => {
+  for (const name of staging)
+    assert.deepEqual(cd.jobs[name]['runs-on'], ['self-hosted', 'interdomestik-z620-staging']);
+  assert.equal(cd.jobs['production-evidence']['runs-on'], 'ubuntu-latest');
+  for (const name of production)
+    assert.deepEqual(cd.jobs[name]['runs-on'], ['self-hosted', 'interdomestik-mac']);
+  assert.equal(cd.jobs['production-evidence'].needs, 'e2e-staging');
+});
+
+test('preflights every staging job directly after checkout and bounds heavy jobs', () => {
+  for (const name of staging) {
+    const job = cd.jobs[name];
+    const checkout = stepIndex(job, /actions\/checkout/u);
+    const preflight = stepIndex(job, /cd-runner-preflight\.mjs/u);
+    assert.equal(preflight, checkout + 1, `${name} must preflight directly after checkout`);
+  }
+  assert.equal(cd.jobs['build-staging']['timeout-minutes'], 45);
+  assert.equal(cd.jobs['e2e-staging']['timeout-minutes'], 30);
+  const buildx = step(cd.jobs['build-staging'], 'Set up Docker Buildx');
+  assert.equal(buildx.with.name, 'interdomestik-cd-staging');
+  assert.equal(buildx.with['keep-state'], true);
+  assert.equal(buildx.with.cleanup, false);
+  const verifyBuilder = step(cd.jobs['build-staging'], 'Verify dedicated Docker builder');
+  assert.match(verifyBuilder.run, /cd-runner-preflight\.mjs verify-builder/u);
+  assert.equal(stepIndex(cd.jobs['build-staging'], /Verify dedicated Docker builder/u), 3);
+  const pruneBuilder = step(cd.jobs['build-staging'], 'Prune stale dedicated build cache');
+  assert.match(pruneBuilder.if, /always\(\).*!\s*cancelled\(\)/u);
+  assert.match(pruneBuilder.run, /cd-runner-preflight\.mjs prune/u);
+  assert.equal(
+    stepIndex(cd.jobs['build-staging'], /Prune stale dedicated build cache/u),
+    cd.jobs['build-staging'].steps.length - 1
+  );
+});
+
+test('propagates alias movement independently and always reaches the local guard', () => {
+  const deploy = cd.jobs['deploy-staging'];
+  const rollback = cd.jobs['rollback-staging-alias'];
+  assert.equal(deploy.outputs.alias_moved, '${{ steps.vercel.outputs.alias_moved }}');
+  const download = step(rollback, 'Download staging alias preimage receipt');
+  assert.equal(download['continue-on-error'], true);
+  const guard = step(rollback, 'Validate staging alias rollback authority');
+  assert.equal(
+    guard.env.STAGING_ALIAS_MOVED_SIGNAL,
+    '${{ needs.deploy-staging.outputs.alias_moved }}'
+  );
+  assert.match(guard.if, /always\(\)/u);
+});
+
+async function withRollbackEnv(aliasMoved, contents, callback) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'cd-rollback-'));
+  const before = { ...process.env };
+  process.env.STAGING_PREIMAGE_RECEIPT_PATH = path.join(directory, 'preimage.json');
+  process.env.STAGING_ROLLBACK_RECEIPT_PATH = path.join(directory, 'rollback.json');
+  process.env.STAGING_ALIAS_MOVED_SIGNAL = aliasMoved;
+  if (contents !== undefined)
+    fs.writeFileSync(process.env.STAGING_PREIMAGE_RECEIPT_PATH, contents, { mode: 0o600 });
+  try {
+    await callback(process.env.STAGING_ROLLBACK_RECEIPT_PATH);
+  } finally {
+    process.env = before;
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test('missing preimage is not-required only when movement is unconfirmed', async () => {
+  await withRollbackEnv('false', undefined, async rollbackPath => {
+    assert.equal(await guardRollback(), false);
+    assert.equal(JSON.parse(fs.readFileSync(rollbackPath, 'utf8')).outcome, 'not-required');
+  });
+});
+
+test('missing preimage after confirmed movement remains hard red', async () => {
+  await withRollbackEnv('true', undefined, async rollbackPath => {
+    await assert.rejects(() => guardRollback(), /confirmed alias movement.*preimage/u);
+    assert.equal(JSON.parse(fs.readFileSync(rollbackPath, 'utf8')).outcome, 'failed');
+  });
+});
+
+test('malformed preimage remains hard red regardless of movement signal', async () => {
+  await withRollbackEnv('false', '{', async rollbackPath => {
+    await assert.rejects(() => guardRollback(), /JSON|position|unexpected/iu);
+    assert.equal(JSON.parse(fs.readFileSync(rollbackPath, 'utf8')).outcome, 'failed');
+  });
+});
+
+test('exclusive label does not activate pre-claimed Linux workflows', () => {
+  for (const file of [
+    '.github/workflows/release-candidate.yml',
+    '.github/workflows/multi-agent-benchmark-weekly.yml',
+  ]) {
+    const source = readText(file);
+    assert.match(source, /interdomestik-linux/u);
+    assert.doesNotMatch(source, /interdomestik-z620-staging/u);
+  }
+  const preflight = readText('scripts/ci/cd-runner-preflight.mjs');
+  assert.doesNotMatch(
+    preflight,
+    /docker\s+system\s+prune|docker\s+(image|volume|container)\s+prune/u
+  );
+});

--- a/scripts/ci/cd-runner-contract.test.mjs
+++ b/scripts/ci/cd-runner-contract.test.mjs
@@ -39,17 +39,11 @@ test('preflights every staging job directly after checkout and bounds heavy jobs
   const buildx = step(cd.jobs['build-staging'], 'Set up Docker Buildx');
   assert.equal(buildx.with.name, 'interdomestik-cd-staging');
   assert.equal(buildx.with['keep-state'], true);
-  assert.equal(buildx.with.cleanup, false);
+  assert.equal(buildx.with.cleanup, true);
   const verifyBuilder = step(cd.jobs['build-staging'], 'Verify dedicated Docker builder');
   assert.match(verifyBuilder.run, /cd-runner-preflight\.mjs verify-builder/u);
   assert.equal(stepIndex(cd.jobs['build-staging'], /Verify dedicated Docker builder/u), 3);
-  const pruneBuilder = step(cd.jobs['build-staging'], 'Prune stale dedicated build cache');
-  assert.match(pruneBuilder.if, /always\(\).*!\s*cancelled\(\)/u);
-  assert.match(pruneBuilder.run, /cd-runner-preflight\.mjs prune/u);
-  assert.equal(
-    stepIndex(cd.jobs['build-staging'], /Prune stale dedicated build cache/u),
-    cd.jobs['build-staging'].steps.length - 1
-  );
+  assert.equal(step(cd.jobs['build-staging'], 'Prune stale dedicated build cache'), undefined);
 });
 
 test('propagates alias movement independently and always reaches the local guard', () => {

--- a/scripts/ci/cd-runner-preflight.mjs
+++ b/scripts/ci/cd-runner-preflight.mjs
@@ -1,0 +1,131 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, statfsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+export const GIB = 1024 ** 3;
+const DISK_FLOOR = 30 * GIB;
+const MEMORY_FLOOR = 8 * GIB;
+const EXPECTED_RUNNER = 'interdomestik-z620-staging';
+export const DEDICATED_PRUNE_ARGS = Object.freeze([
+  'buildx',
+  '--builder',
+  'interdomestik-cd-staging',
+  'prune',
+  '--filter',
+  'until=168h',
+  '--force',
+]);
+const DEDICATED_BUILDER = 'interdomestik-cd-staging';
+
+function freeBytes(target) {
+  if (!target) return 0;
+  const stats = statfsSync(target, { bigint: true });
+  return Number(stats.bavail * stats.bsize);
+}
+
+function availableMemoryBytes() {
+  const match = readFileSync('/proc/meminfo', 'utf8').match(/^MemAvailable:\s+(\d+)\s+kB$/mu);
+  return match ? Number(match[1]) * 1024 : 0;
+}
+
+function dockerState() {
+  try {
+    const output = execFileSync('docker', ['info', '--format', '{{json .DockerRootDir}}'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    });
+    return { dockerAvailable: true, dockerRoot: JSON.parse(output.trim()) };
+  } catch {
+    return { dockerAvailable: false, dockerRoot: '' };
+  }
+}
+
+export function collectRunnerSnapshot(env = process.env) {
+  const docker = dockerState();
+  return {
+    runnerName: env.RUNNER_NAME,
+    runnerOs: env.RUNNER_OS,
+    runnerArch: env.RUNNER_ARCH,
+    runnerTempFreeBytes: freeBytes(env.RUNNER_TEMP),
+    dockerRootFreeBytes: freeBytes(docker.dockerRoot),
+    availableMemoryBytes: availableMemoryBytes(),
+    ...docker,
+  };
+}
+
+export function evaluateRunnerPreflight(snapshot) {
+  const failures = [];
+  if (snapshot.runnerName !== EXPECTED_RUNNER)
+    failures.push(`exclusive runner must be ${EXPECTED_RUNNER}`);
+  if (snapshot.runnerOs !== 'Linux') failures.push('runner OS must be Linux');
+  if (snapshot.runnerArch !== 'X64') failures.push('runner architecture must be X64');
+  if (!snapshot.dockerAvailable) failures.push('Docker must be available');
+  if (snapshot.runnerTempFreeBytes < DISK_FLOOR)
+    failures.push('RUNNER_TEMP must have at least 30 GiB free');
+  if (snapshot.dockerRootFreeBytes < DISK_FLOOR)
+    failures.push('Docker data root must have at least 30 GiB free');
+  if (snapshot.availableMemoryBytes < MEMORY_FLOOR)
+    failures.push('host available memory must be at least 8 GiB');
+  if (failures.length)
+    throw new Error(`Z620 staging runner preflight failed: ${failures.join('; ')}`);
+  const gib = value => Number((value / GIB).toFixed(1));
+  return {
+    status: 'ready',
+    runner: snapshot.runnerName,
+    runnerTempFreeGiB: gib(snapshot.runnerTempFreeBytes),
+    dockerRoot: snapshot.dockerRoot,
+    dockerRootFreeGiB: gib(snapshot.dockerRootFreeBytes),
+    availableMemoryGiB: gib(snapshot.availableMemoryBytes),
+  };
+}
+
+export function evaluateDedicatedBuilderInspection(output) {
+  const hasName = /^Name:\s+interdomestik-cd-staging\s*$/mu.test(output);
+  const hasDriver = /^Driver:\s+docker-container\s*$/mu.test(output);
+  const isRunning = /^Status:\s+running\s*$/mu.test(output);
+  if (!hasName || !hasDriver || !isRunning)
+    throw new Error(
+      `Z620 staging runner preflight failed: dedicated buildx builder ${DEDICATED_BUILDER} must use the running docker-container driver`
+    );
+  return { status: 'ready', builder: DEDICATED_BUILDER, driver: 'docker-container' };
+}
+
+export function verifyDedicatedBuilder(executor = execFileSync) {
+  const output = executor('docker', ['buildx', 'inspect', DEDICATED_BUILDER], {
+    encoding: 'utf8',
+    shell: false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 30_000,
+  });
+  return evaluateDedicatedBuilderInspection(output);
+}
+
+export function pruneDedicatedBuilder(executor = execFileSync) {
+  executor('docker', DEDICATED_PRUNE_ARGS, {
+    shell: false,
+    stdio: 'inherit',
+    timeout: 300_000,
+  });
+  return { status: 'pruned', builder: DEDICATED_BUILDER, olderThan: '168h' };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const mode = process.argv[2] || 'preflight';
+    const result =
+      mode === 'preflight'
+        ? evaluateRunnerPreflight(collectRunnerSnapshot())
+        : mode === 'verify-builder'
+          ? verifyDedicatedBuilder()
+          : mode === 'prune'
+            ? pruneDedicatedBuilder()
+            : (() => {
+                throw new Error(`unsupported Z620 staging runner operation: ${mode}`);
+              })();
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    console.error(error?.message || 'Z620 staging runner preflight failed');
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/cd-runner-preflight.mjs
+++ b/scripts/ci/cd-runner-preflight.mjs
@@ -6,6 +6,7 @@ export const GIB = 1024 ** 3;
 const DISK_FLOOR = 30 * GIB;
 const MEMORY_FLOOR = 8 * GIB;
 const EXPECTED_RUNNER = 'interdomestik-z620-staging';
+const DOCKER_COMMAND = '/usr/bin/docker';
 export const EXPECTED_RUNNER_TEMP = '/home/arben/actions-runner-interdomestik-staging/_work/_temp';
 export const EXPECTED_DOCKER_ROOT = '/var/lib/docker';
 export const DEDICATED_PRUNE_ARGS = Object.freeze([
@@ -36,7 +37,7 @@ function availableMemoryBytes() {
 
 function dockerState() {
   try {
-    const output = execFileSync('docker', ['info', '--format', '{{json .DockerRootDir}}'], {
+    const output = execFileSync(DOCKER_COMMAND, ['info', '--format', '{{json .DockerRootDir}}'], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 15_000,
@@ -103,7 +104,7 @@ export function evaluateDedicatedBuilderInspection(output) {
 }
 
 export function verifyDedicatedBuilder(executor = execFileSync) {
-  const output = executor('docker', ['buildx', 'inspect', DEDICATED_BUILDER], {
+  const output = executor(DOCKER_COMMAND, ['buildx', 'inspect', DEDICATED_BUILDER], {
     encoding: 'utf8',
     shell: false,
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -113,7 +114,7 @@ export function verifyDedicatedBuilder(executor = execFileSync) {
 }
 
 export function pruneDedicatedBuilder(executor = execFileSync) {
-  executor('docker', DEDICATED_PRUNE_ARGS, {
+  executor(DOCKER_COMMAND, DEDICATED_PRUNE_ARGS, {
     shell: false,
     stdio: 'inherit',
     timeout: 300_000,
@@ -121,19 +122,16 @@ export function pruneDedicatedBuilder(executor = execFileSync) {
   return { status: 'pruned', builder: DEDICATED_BUILDER, olderThan: '168h' };
 }
 
+function runMode(mode) {
+  if (mode === 'preflight') return evaluateRunnerPreflight(collectRunnerSnapshot());
+  if (mode === 'verify-builder') return verifyDedicatedBuilder();
+  if (mode === 'prune') return pruneDedicatedBuilder();
+  throw new Error(`unsupported Z620 staging runner operation: ${mode}`);
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
-    const mode = process.argv[2] || 'preflight';
-    const result =
-      mode === 'preflight'
-        ? evaluateRunnerPreflight(collectRunnerSnapshot())
-        : mode === 'verify-builder'
-          ? verifyDedicatedBuilder()
-          : mode === 'prune'
-            ? pruneDedicatedBuilder()
-            : (() => {
-                throw new Error(`unsupported Z620 staging runner operation: ${mode}`);
-              })();
+    const result = runMode(process.argv[2] || 'preflight');
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
     console.error(error?.message || 'Z620 staging runner preflight failed');

--- a/scripts/ci/cd-runner-preflight.mjs
+++ b/scripts/ci/cd-runner-preflight.mjs
@@ -6,6 +6,8 @@ export const GIB = 1024 ** 3;
 const DISK_FLOOR = 30 * GIB;
 const MEMORY_FLOOR = 8 * GIB;
 const EXPECTED_RUNNER = 'interdomestik-z620-staging';
+export const EXPECTED_RUNNER_TEMP = '/home/arben/actions-runner-interdomestik-staging/_work/_temp';
+export const EXPECTED_DOCKER_ROOT = '/var/lib/docker';
 export const DEDICATED_PRUNE_ARGS = Object.freeze([
   'buildx',
   '--builder',
@@ -17,9 +19,13 @@ export const DEDICATED_PRUNE_ARGS = Object.freeze([
 ]);
 const DEDICATED_BUILDER = 'interdomestik-cd-staging';
 
-function freeBytes(target) {
-  if (!target) return 0;
-  const stats = statfsSync(target, { bigint: true });
+function runnerTempFreeBytes() {
+  const stats = statfsSync(EXPECTED_RUNNER_TEMP, { bigint: true });
+  return Number(stats.bavail * stats.bsize);
+}
+
+function dockerRootFreeBytes() {
+  const stats = statfsSync(EXPECTED_DOCKER_ROOT, { bigint: true });
   return Number(stats.bavail * stats.bsize);
 }
 
@@ -47,8 +53,9 @@ export function collectRunnerSnapshot(env = process.env) {
     runnerName: env.RUNNER_NAME,
     runnerOs: env.RUNNER_OS,
     runnerArch: env.RUNNER_ARCH,
-    runnerTempFreeBytes: freeBytes(env.RUNNER_TEMP),
-    dockerRootFreeBytes: freeBytes(docker.dockerRoot),
+    runnerTemp: env.RUNNER_TEMP,
+    runnerTempFreeBytes: env.RUNNER_TEMP === EXPECTED_RUNNER_TEMP ? runnerTempFreeBytes() : 0,
+    dockerRootFreeBytes: docker.dockerRoot === EXPECTED_DOCKER_ROOT ? dockerRootFreeBytes() : 0,
     availableMemoryBytes: availableMemoryBytes(),
     ...docker,
   };
@@ -61,6 +68,10 @@ export function evaluateRunnerPreflight(snapshot) {
   if (snapshot.runnerOs !== 'Linux') failures.push('runner OS must be Linux');
   if (snapshot.runnerArch !== 'X64') failures.push('runner architecture must be X64');
   if (!snapshot.dockerAvailable) failures.push('Docker must be available');
+  if (snapshot.runnerTemp !== EXPECTED_RUNNER_TEMP)
+    failures.push('RUNNER_TEMP must use the exclusive runner path');
+  if (snapshot.dockerRoot !== EXPECTED_DOCKER_ROOT)
+    failures.push('Docker data root must use the exclusive runner path');
   if (snapshot.runnerTempFreeBytes < DISK_FLOOR)
     failures.push('RUNNER_TEMP must have at least 30 GiB free');
   if (snapshot.dockerRootFreeBytes < DISK_FLOOR)

--- a/scripts/ci/cd-runner-preflight.test.mjs
+++ b/scripts/ci/cd-runner-preflight.test.mjs
@@ -108,7 +108,7 @@ test('executes only the bounded dedicated-builder prune command', () => {
   const calls = [];
   pruneDedicatedBuilder((command, args, options) => calls.push({ command, args, options }));
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].command, 'docker');
+  assert.equal(calls[0].command, '/usr/bin/docker');
   assert.deepEqual(calls[0].args, DEDICATED_PRUNE_ARGS);
   assert.equal(calls[0].options.shell, false);
   assert.equal(calls[0].options.timeout, 300_000);
@@ -125,7 +125,7 @@ test('inspects the exact dedicated builder without a shell', () => {
     ].join('\n');
   });
   assert.equal(calls.length, 1);
-  assert.equal(calls[0].command, 'docker');
+  assert.equal(calls[0].command, '/usr/bin/docker');
   assert.deepEqual(calls[0].args, ['buildx', 'inspect', 'interdomestik-cd-staging']);
   assert.equal(calls[0].options.shell, false);
   assert.equal(calls[0].options.timeout, 30_000);

--- a/scripts/ci/cd-runner-preflight.test.mjs
+++ b/scripts/ci/cd-runner-preflight.test.mjs
@@ -3,6 +3,8 @@ import test from 'node:test';
 
 import {
   DEDICATED_PRUNE_ARGS,
+  EXPECTED_DOCKER_ROOT,
+  EXPECTED_RUNNER_TEMP,
   GIB,
   evaluateDedicatedBuilderInspection,
   evaluateRunnerPreflight,
@@ -14,7 +16,8 @@ const ready = overrides => ({
   runnerName: 'interdomestik-z620-staging',
   runnerOs: 'Linux',
   runnerArch: 'X64',
-  dockerRoot: '/var/lib/docker',
+  runnerTemp: EXPECTED_RUNNER_TEMP,
+  dockerRoot: EXPECTED_DOCKER_ROOT,
   dockerAvailable: true,
   runnerTempFreeBytes: 31 * GIB,
   dockerRootFreeBytes: 31 * GIB,
@@ -47,6 +50,17 @@ test('enforces independent 30 GiB runner-temp and Docker-root floors', () => {
   assert.throws(
     () => evaluateRunnerPreflight(ready({ dockerRootFreeBytes: 30 * GIB - 1 })),
     /Docker data root.*30 GiB/u
+  );
+});
+
+test('rejects untrusted runner-temp and Docker-root paths', () => {
+  assert.throws(
+    () => evaluateRunnerPreflight(ready({ runnerTemp: '/tmp/attacker-controlled' })),
+    /RUNNER_TEMP.*exclusive runner path/u
+  );
+  assert.throws(
+    () => evaluateRunnerPreflight(ready({ dockerRoot: '/tmp/attacker-controlled' })),
+    /Docker data root.*exclusive runner path/u
   );
 });
 

--- a/scripts/ci/cd-runner-preflight.test.mjs
+++ b/scripts/ci/cd-runner-preflight.test.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEDICATED_PRUNE_ARGS,
+  GIB,
+  evaluateDedicatedBuilderInspection,
+  evaluateRunnerPreflight,
+  pruneDedicatedBuilder,
+  verifyDedicatedBuilder,
+} from './cd-runner-preflight.mjs';
+
+const ready = overrides => ({
+  runnerName: 'interdomestik-z620-staging',
+  runnerOs: 'Linux',
+  runnerArch: 'X64',
+  dockerRoot: '/var/lib/docker',
+  dockerAvailable: true,
+  runnerTempFreeBytes: 31 * GIB,
+  dockerRootFreeBytes: 31 * GIB,
+  availableMemoryBytes: 9 * GIB,
+  ...overrides,
+});
+
+test('accepts only the exclusive Linux X64 staging runner above every floor', () => {
+  const result = evaluateRunnerPreflight(ready());
+  assert.equal(result.status, 'ready');
+  assert.equal(result.runner, 'interdomestik-z620-staging');
+});
+
+test('rejects the wrong runner identity, OS, architecture, or Docker state', () => {
+  for (const [override, expected] of [
+    [{ runnerName: 'interdomestik-mac-Arbens-Mac-mini' }, /exclusive runner/u],
+    [{ runnerOs: 'macOS' }, /Linux/u],
+    [{ runnerArch: 'ARM64' }, /X64/u],
+    [{ dockerAvailable: false }, /Docker/u],
+  ]) {
+    assert.throws(() => evaluateRunnerPreflight(ready(override)), expected);
+  }
+});
+
+test('enforces independent 30 GiB runner-temp and Docker-root floors', () => {
+  assert.throws(
+    () => evaluateRunnerPreflight(ready({ runnerTempFreeBytes: 30 * GIB - 1 })),
+    /RUNNER_TEMP.*30 GiB/u
+  );
+  assert.throws(
+    () => evaluateRunnerPreflight(ready({ dockerRootFreeBytes: 30 * GIB - 1 })),
+    /Docker data root.*30 GiB/u
+  );
+});
+
+test('enforces the 8 GiB available-memory floor', () => {
+  assert.throws(
+    () => evaluateRunnerPreflight(ready({ availableMemoryBytes: 8 * GIB - 1 })),
+    /available memory.*8 GiB/u
+  );
+});
+
+test('publishes only the bounded dedicated-builder prune command', () => {
+  assert.deepEqual(DEDICATED_PRUNE_ARGS, [
+    'buildx',
+    '--builder',
+    'interdomestik-cd-staging',
+    'prune',
+    '--filter',
+    'until=168h',
+    '--force',
+  ]);
+  assert.doesNotMatch(DEDICATED_PRUNE_ARGS.join(' '), /system prune|volume|container|image/u);
+});
+
+test('accepts only the named running docker-container builder', () => {
+  const inspection = [
+    'Name:          interdomestik-cd-staging',
+    'Driver:        docker-container',
+    'Status:        running',
+  ].join('\n');
+  assert.deepEqual(evaluateDedicatedBuilderInspection(inspection), {
+    status: 'ready',
+    builder: 'interdomestik-cd-staging',
+    driver: 'docker-container',
+  });
+  for (const invalid of [
+    inspection.replace('interdomestik-cd-staging', 'default'),
+    inspection.replace('docker-container', 'docker'),
+    inspection.replace('running', 'stopped'),
+  ]) {
+    assert.throws(() => evaluateDedicatedBuilderInspection(invalid), /dedicated buildx builder/u);
+  }
+});
+
+test('executes only the bounded dedicated-builder prune command', () => {
+  const calls = [];
+  pruneDedicatedBuilder((command, args, options) => calls.push({ command, args, options }));
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'docker');
+  assert.deepEqual(calls[0].args, DEDICATED_PRUNE_ARGS);
+  assert.equal(calls[0].options.shell, false);
+  assert.equal(calls[0].options.timeout, 300_000);
+});
+
+test('inspects the exact dedicated builder without a shell', () => {
+  const calls = [];
+  verifyDedicatedBuilder((command, args, options) => {
+    calls.push({ command, args, options });
+    return [
+      'Name:          interdomestik-cd-staging',
+      'Driver:        docker-container',
+      'Status:        running',
+    ].join('\n');
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'docker');
+  assert.deepEqual(calls[0].args, ['buildx', 'inspect', 'interdomestik-cd-staging']);
+  assert.equal(calls[0].options.shell, false);
+  assert.equal(calls[0].options.timeout, 30_000);
+});

--- a/scripts/ci/configure-vercel-gate-url.mjs
+++ b/scripts/ci/configure-vercel-gate-url.mjs
@@ -68,15 +68,25 @@ async function writeRollback(receipt, outcome, error) {
   });
 }
 
-async function guardRollback() {
+export async function guardRollback() {
   let receipt = { alias: state.CANONICAL_STAGING_ALIAS };
   try {
     receipt = await readPreimage();
     if (!receipt.aliasMoved) await writeRollback(receipt, 'not-required');
     process.stdout.write(`should_restore=${receipt.aliasMoved}\n`);
+    return receipt.aliasMoved;
   } catch (error) {
-    await writeRollback(receipt, 'failed', error);
-    throw error;
+    if (error?.code === 'ENOENT' && process.env.STAGING_ALIAS_MOVED_SIGNAL !== 'true') {
+      await writeRollback(receipt, 'not-required');
+      process.stdout.write('should_restore=false\n');
+      return false;
+    }
+    const failure =
+      error?.code === 'ENOENT'
+        ? new Error('confirmed alias movement has no usable staging preimage receipt')
+        : error;
+    await writeRollback(receipt, 'failed', failure);
+    throw failure;
   }
 }
 

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -32,7 +32,6 @@ function normalizeNeeds(needs) {
   if (Array.isArray(needs)) {
     return needs;
   }
-
   if (typeof needs === 'string') {
     return [needs];
   }
@@ -494,7 +493,7 @@ test('V3 onboarding and env docs describe Paddle-only runtime and Vercel deploym
     /NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY|STRIPE_SECRET_KEY|STRIPE_WEBHOOK_SECRET/
   );
 });
-
+// prettier-ignore
 test('CD builds distinct staging and production artifacts with explicit Supabase environment separation', () => {
   const cdWorkflowSource = fs.readFileSync(path.join(rootDir, '.github/workflows/cd.yml'), 'utf8');
   const cdWorkflow = readWorkflow('.github/workflows/cd.yml');
@@ -531,6 +530,7 @@ test('CD builds distinct staging and production artifacts with explicit Supabase
   assert.deepEqual(normalizeNeeds(deployStagingJob.needs), ['build-staging']);
   assert.equal(deployStagingJob['timeout-minutes'], 25);
   assert.deepEqual(deployStagingJob.outputs, {
+    alias_moved: '${{ steps.vercel.outputs.alias_moved }}',
     base_url: '${{ steps.vercel.outputs.base_url }}',
     hostname: '${{ steps.vercel.outputs.hostname }}',
     gate_base_url: '${{ steps.vercel.outputs.gate_base_url }}',

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -7,7 +7,7 @@
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",
     ".github/workflows/pilot-gate.yml": "4b9ad1e56df586849ad3b02111178322297ab6d56fa730083ebc1e60e8148bc3",
     ".github/workflows/release-candidate.yml": "ec03f5eb63d19bff1e8502257e36d264fed70733ca682f5820cd74af93f99bac",
-    ".github/workflows/cd.yml": "960927faac277cdedde951b3edd56346d06c797cadf4ee807e1a123baa24f7f5"
+    ".github/workflows/cd.yml": "076a1e680d6d622e4f157b9a3be311e546fb1fd3349a5c621666f348b443ff92"
   },
   "workflows": {
     ".github/workflows/ci.yml": {

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -7,7 +7,7 @@
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",
     ".github/workflows/pilot-gate.yml": "4b9ad1e56df586849ad3b02111178322297ab6d56fa730083ebc1e60e8148bc3",
     ".github/workflows/release-candidate.yml": "ec03f5eb63d19bff1e8502257e36d264fed70733ca682f5820cd74af93f99bac",
-    ".github/workflows/cd.yml": "1e78d39cf3ed7c6df1c0421553d19c101f632c361da78f678bdbd774d708ed25"
+    ".github/workflows/cd.yml": "960927faac277cdedde951b3edd56346d06c797cadf4ee807e1a123baa24f7f5"
   },
   "workflows": {
     ".github/workflows/ci.yml": {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59233203,
+  "maxTrackedBytes": 59233887,
   "maxTrackedFiles": 5614,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16761549,
     "docs/text": 7991902,
-    "source/scripts": 7910758,
-    "tests/e2e": 5901695,
+    "source/scripts": 7911419,
+    "tests/e2e": 5901864,
     "config/data/messages": 1810921
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59233887,
+  "maxTrackedBytes": 59233909,
   "maxTrackedFiles": 5614,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16761549,
     "docs/text": 7991902,
-    "source/scripts": 7911419,
-    "tests/e2e": 5901864,
+    "source/scripts": 7911423,
+    "tests/e2e": 5901882,
     "config/data/messages": 1810921
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59216818,
-  "maxTrackedFiles": 5611,
+  "maxTrackedBytes": 59233203,
+  "maxTrackedFiles": 5614,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16761549,
     "docs/text": 7991902,
-    "source/scripts": 7905680,
-    "tests/e2e": 5892080,
-    "config/data/messages": 1809212
+    "source/scripts": 7910758,
+    "tests/e2e": 5901695,
+    "config/data/messages": 1810921
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Outcome

Moves the heavy staging CD execution from the Mac runner to the dedicated `interdomestik-z620-staging` runner while keeping production authority unchanged and fail-closed behind staging and existing production authorization.

Final reviewed head: `253dcfbb013aa03c2b9e377d544168165e956370`

## Scope

- routes `build-staging`, `deploy-staging`, `e2e-staging`, and `rollback-staging-alias` to the exact Z620 label
- adds a fail-closed runner preflight for exact runner identity, Linux/X64, fixed runner/Docker paths, disk, memory, Docker, and exact buildx builder state
- pins Docker execution to root-owned `/usr/bin/docker`; no PATH resolution or shell
- uses one named docker-container builder with `cleanup:true` and `keep-state:true`
- keeps cache pruning out of the workflow; the fixed 168h dedicated-builder helper remains operator-only after a measured threshold breach
- preserves staging-only Vercel scope, alias-movement evidence, and rollback receipt guards
- preserves `cancel-in-progress:false` and all production gates
- leaves `apps/web/src/proxy.ts` untouched

Production evidence remains hosted and production build/deploy/verify remain on Mac in this slice. Moving production requires a separately authorized and independently proven follow-up.

## Fail-closed and rollback behavior

- pre-alias failure or missing preimage: rollback is `not-required`
- confirmed alias movement with a valid receipt: rollback is eligible
- confirmed movement with missing or malformed receipt: hard failure
- ordinary `main` pushes continue to skip production
- no broad or automatic Docker prune is introduced

## Verification

Final head `253dcfbb013aa03c2b9e377d544168165e956370`:

- GitHub PR checks: 29 passed, 0 pending, 0 failed
- CodeQL: both analyses passed, PR gate passed, open alerts 0
- SonarCloud: Quality Gate `OK`, open issues 0
- `pnpm test:ci:contracts`: 461/461 passed
- focused runner/builder/rollback contracts: 16/16 passed on Z620
- `pnpm security:guard`: passed
- repo size, parity 4/4, formatter, and diff checks: passed
- real Z620 preflight: 98.7 GiB free on runner-temp and Docker root; 24.3 GiB available RAM
- exact candidate clean on Z620

The original functional head `679fc0d5b12386e46c1e4e3bb15f4bf006c3c368` additionally passed the complete local `pnpm pr:verify` in 30m22s and a separate `pnpm e2e:gate` in 22m04.498s. Subsequent commits are limited to reviewed CI preflight/workflow hardening and were exercised by all final-head GitHub gates above.

## Review disposition

- Claude Opus 4.8 valid reviews: 5
- elapsed: 248.098s, 201.172s, 47.936s, 47.464s, 34.729s
- average: 115.880s (1m55.9s)
- all valid reviews: no blocker
- one 7.508s procedural call produced no verdict and is excluded
- GitHub Codex P1/P2 findings were fixed, answered, and resolved
- CodeQL path injection and Sonar PATH vulnerability were fixed without suppression
- Codex Security diff scan was intentionally not run per explicit user direction; repository-native `pnpm security:guard` passed

Residual operational notes: human-readable buildx inspect parsing fails closed if upstream output changes; hard cancellation can leave a builder registration for the next verify-builder to reject; the pre-existing alias-mutation/receipt process-death window requires separate provider reconciliation semantics.

Runtime authority and scope were documented separately in merged PR #1462.