### PR TITLE
fix(cd): generate staging metadata offline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,12 +23,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Generate deterministic image metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: type=raw,value=staging-${{ github.sha }}
+        shell: bash
+        run: >-
+          set -euo pipefail; [[ "${GITHUB_SHA}" =~ ^[a-f0-9]{40}$ ]] || { echo "::error::Invalid exact commit SHA for staging image metadata."; exit 1; }; [[ "${REGISTRY}" == "ghcr.io" && "${IMAGE_NAME}" == "${GITHUB_REPOSITORY}" && "${GITHUB_SERVER_URL}" == "https://github.com" ]] || { echo "::error::Untrusted staging image metadata context."; exit 1; }; version="staging-${GITHUB_SHA}"; { printf 'version=%s\n' "${version}"; printf 'tags=%s/%s:%s\n' "${REGISTRY}" "${IMAGE_NAME}" "${version}"; printf 'labels<<EOF\norg.opencontainers.image.source=%s/%s\norg.opencontainers.image.revision=%s\norg.opencontainers.image.version=%s\nEOF\n' "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${GITHUB_SHA}" "${version}"; } >> "${GITHUB_OUTPUT}"
       - name: Build, attest, and verify Docker image
         id: build
         uses: ./.github/actions/build-attested-image

--- a/scripts/ci/cd-runner-contract.test.mjs
+++ b/scripts/ci/cd-runner-contract.test.mjs
@@ -46,6 +46,27 @@ test('preflights every staging job directly after checkout and bounds heavy jobs
   assert.equal(step(cd.jobs['build-staging'], 'Prune stale dedicated build cache'), undefined);
 });
 
+test('generates staging image metadata offline from exact trusted inputs', () => {
+  const build = cd.jobs['build-staging'];
+  const metadata = step(build, 'Generate deterministic image metadata');
+  assert.match(metadata.run, /set -euo pipefail/u);
+  assert.match(metadata.run, /GITHUB_SHA.*\^\[a-f0-9\]\{40\}\$/u);
+  assert.match(metadata.run, /REGISTRY.*ghcr\.io/u);
+  assert.match(metadata.run, /IMAGE_NAME.*GITHUB_REPOSITORY/u);
+  assert.match(metadata.run, /GITHUB_SERVER_URL.*https:\/\/github\.com/u);
+  assert.match(metadata.run, /tags=.*REGISTRY.*IMAGE_NAME.*version/u);
+  assert.match(metadata.run, /org\.opencontainers\.image\.(source|revision|version)/u);
+  assert.match(metadata.run, /GITHUB_OUTPUT/u);
+  assert.equal(
+    build.steps.some(candidate => /docker\/metadata-action@/u.test(candidate.uses || '')),
+    false
+  );
+  assert.match(
+    step(cd.jobs['build-production'], 'Extract metadata (tags, labels) for Docker').uses,
+    /^docker\/metadata-action@[a-f0-9]{40}$/u
+  );
+});
+
 test('propagates alias movement independently and always reaches the local guard', () => {
   const deploy = cd.jobs['deploy-staging'];
   const rollback = cd.jobs['rollback-staging-alias'];

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -7,7 +7,7 @@
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",
     ".github/workflows/pilot-gate.yml": "4b9ad1e56df586849ad3b02111178322297ab6d56fa730083ebc1e60e8148bc3",
     ".github/workflows/release-candidate.yml": "ec03f5eb63d19bff1e8502257e36d264fed70733ca682f5820cd74af93f99bac",
-    ".github/workflows/cd.yml": "076a1e680d6d622e4f157b9a3be311e546fb1fd3349a5c621666f348b443ff92"
+    ".github/workflows/cd.yml": "397b07a8165641c88435abdd95828c410eb1d32f59bdeb676b9c50ffb7bebea2"
   },
   "workflows": {
     ".github/workflows/ci.yml": {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59233909,
+  "maxTrackedBytes": 59235466,
   "maxTrackedFiles": 5614,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16761549,
     "docs/text": 7991902,
     "source/scripts": 7911423,
-    "tests/e2e": 5901882,
-    "config/data/messages": 1810921
+    "tests/e2e": 5902882,
+    "config/data/messages": 1811315
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Outcome

Removes the avoidable GitHub API dependency from staging image metadata generation after automatic main CD run 30316687485 failed in `docker/metadata-action` with `Connect Timeout Error` on Z620.

Exact head: `a2db3da2df79e6ae6a0bd6a9597ec23a85578fa3`

## Root cause and containment

- Z620 preflight, setup-buildx, verify-builder, and registry login passed
- the pinned metadata action still calls `toolkit.github.repoData()` even with `context: git`
- Z620 router DNS was degraded; a privileged DNS override was unavailable and was not bypassed
- failure occurred before image build, Vercel deploy, or alias movement
- deploy, E2E, rollback, and every production job skipped fail-closed
- post-job cleanup removed the named builder registration while retaining state

## Fix

- replace `docker/metadata-action` only in `build-staging`
- generate version, tag, and three OCI labels from exact GitHub runner inputs with no API call
- require exact lowercase 40-char SHA
- require registry `ghcr.io`, image name equal to repository, and server URL `https://github.com`
- use strict Bash, quoted expansions, constant `printf` formats, and quoted `GITHUB_OUTPUT`
- preserve `steps.meta.outputs.version/tags/labels` and the existing SBOM, provenance, digest, and exact-SHA verification chain
- keep the pinned metadata action unchanged for production on Mac

## Verification

- executed the parsed workflow step: exact 7-line output passed
- negative runtime cases: bad SHA, registry, image name, and server URL all failed closed
- focused runner + attestation tests: 9/9 passed
- `pnpm test:ci:contracts`: 462/462 passed
- `pnpm security:guard`: passed
- Z620 parity: 4/4 passed
- repo size, formatter, and diff checks: passed
- workflow 345 lines; changed test 135 lines

## Review

Claude Opus 4.8 elapsed 78.760s, `NO BLOCKER`. It confirmed shell/delimiter safety, network independence, intact attestation semantics, and correct staging-only scope. Residual notes: `org.opencontainers.image.created` is omitted as non-security trace metadata; production metadata remains API-dependent on Mac and should be tracked separately rather than widened into this recovery PR.

No Codex Security diff scan was run per explicit user direction; repository-native security guard passed.