### PR TITLE
fix(cd): force IPv4 for Z620 Vercel staging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,12 +47,8 @@ jobs:
     timeout-minutes: 25
     environment: { name: staging }
     permissions: { contents: read, id-token: write, attestations: write }
-    outputs:
-      alias_moved: ${{ steps.vercel.outputs.alias_moved }}
-      base_url: ${{ steps.vercel.outputs.base_url }}
-      hostname: ${{ steps.vercel.outputs.hostname }}
-      gate_base_url: ${{ steps.vercel.outputs.gate_base_url }}
-      gate_hostname: ${{ steps.vercel.outputs.gate_hostname }}
+    # prettier-ignore
+    outputs: { alias_moved: '${{ steps.vercel.outputs.alias_moved }}', base_url: '${{ steps.vercel.outputs.base_url }}', hostname: '${{ steps.vercel.outputs.hostname }}', gate_base_url: '${{ steps.vercel.outputs.gate_base_url }}', gate_hostname: '${{ steps.vercel.outputs.gate_hostname }}' }
     env: { EXPECTED_COMMIT_SHA: '${{ github.sha }}', STAGING_PREIMAGE_RECEIPT_PATH: 'tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage.json' }
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
@@ -64,6 +60,8 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DATABASE_URL_RLS: ${{ secrets.DATABASE_URL_RLS }}
           ENABLE_VERCEL_DEPLOYMENTS: '1'
+          INTERDOMESTIK_VERCEL_IPV4_ONLY: '1'
+          NODE_OPTIONS: '--import=${{ github.workspace }}/scripts/ci/cd-runner-preflight.mjs'
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}

--- a/scripts/ci/cd-runner-contract.test.mjs
+++ b/scripts/ci/cd-runner-contract.test.mjs
@@ -67,6 +67,18 @@ test('generates staging image metadata offline from exact trusted inputs', () =>
   );
 });
 
+test('forces IPv4 DNS only inside the staging Vercel composite action', () => {
+  const stagingDeploy = step(cd.jobs['deploy-staging'], 'Deploy Staging to Vercel');
+  assert.equal(stagingDeploy.env.INTERDOMESTIK_VERCEL_IPV4_ONLY, '1');
+  assert.equal(
+    stagingDeploy.env.NODE_OPTIONS,
+    '--import=${{ github.workspace }}/scripts/ci/cd-runner-preflight.mjs'
+  );
+  const productionDeploy = step(cd.jobs['deploy-production'], 'Deploy Production to Vercel');
+  assert.equal(productionDeploy.env?.INTERDOMESTIK_VERCEL_IPV4_ONLY, undefined);
+  assert.equal(productionDeploy.env?.NODE_OPTIONS, undefined);
+});
+
 test('propagates alias movement independently and always reaches the local guard', () => {
   const deploy = cd.jobs['deploy-staging'];
   const rollback = cd.jobs['rollback-staging-alias'];

--- a/scripts/ci/cd-runner-preflight.mjs
+++ b/scripts/ci/cd-runner-preflight.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import dns from 'node:dns';
 import { readFileSync, statfsSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
@@ -9,16 +10,22 @@ const EXPECTED_RUNNER = 'interdomestik-z620-staging';
 const DOCKER_COMMAND = '/usr/bin/docker';
 export const EXPECTED_RUNNER_TEMP = '/home/arben/actions-runner-interdomestik-staging/_work/_temp';
 export const EXPECTED_DOCKER_ROOT = '/var/lib/docker';
-export const DEDICATED_PRUNE_ARGS = Object.freeze([
-  'buildx',
-  '--builder',
-  'interdomestik-cd-staging',
-  'prune',
-  '--filter',
-  'until=168h',
-  '--force',
-]);
+// prettier-ignore
+export const DEDICATED_PRUNE_ARGS = Object.freeze(['buildx', '--builder', 'interdomestik-cd-staging', 'prune', '--filter', 'until=168h', '--force']);
 const DEDICATED_BUILDER = 'interdomestik-cd-staging';
+
+export function installStagingIpv4Dns(env = process.env, dnsApi = dns) {
+  if (env.INTERDOMESTIK_VERCEL_IPV4_ONLY !== '1') return false;
+  const lookup = dnsApi.lookup.bind(dnsApi);
+  dnsApi.lookup = (hostname, options, callback) => {
+    if (typeof options === 'function') return lookup(hostname, { family: 4 }, options);
+    if (typeof options === 'number') return lookup(hostname, 4, callback);
+    const ipv4Options = options ? { ...options, family: 4 } : { family: 4 };
+    return lookup(hostname, ipv4Options, callback);
+  };
+  return true;
+}
+installStagingIpv4Dns();
 
 function runnerTempFreeBytes() {
   const stats = statfsSync(EXPECTED_RUNNER_TEMP, { bigint: true });

--- a/scripts/ci/cd-runner-preflight.test.mjs
+++ b/scripts/ci/cd-runner-preflight.test.mjs
@@ -8,6 +8,7 @@ import {
   GIB,
   evaluateDedicatedBuilderInspection,
   evaluateRunnerPreflight,
+  installStagingIpv4Dns,
   pruneDedicatedBuilder,
   verifyDedicatedBuilder,
 } from './cd-runner-preflight.mjs';
@@ -69,6 +70,21 @@ test('enforces the 8 GiB available-memory floor', () => {
     () => evaluateRunnerPreflight(ready({ availableMemoryBytes: 8 * GIB - 1 })),
     /available memory.*8 GiB/u
   );
+});
+
+test('forces IPv4 DNS only for the opted-in staging deploy process', () => {
+  const calls = [];
+  const dnsApi = {
+    lookup: (hostname, options, callback) => calls.push({ hostname, options, callback }),
+  };
+  assert.equal(installStagingIpv4Dns({}, dnsApi), false);
+  assert.equal(installStagingIpv4Dns({ INTERDOMESTIK_VERCEL_IPV4_ONLY: '1' }, dnsApi), true);
+  const callback = () => {};
+  dnsApi.lookup('api.vercel.com', { all: true }, callback);
+  dnsApi.lookup('vercel.com', callback);
+  // prettier-ignore
+  assert.deepEqual(calls[0], { hostname: 'api.vercel.com', options: { all: true, family: 4 }, callback });
+  assert.deepEqual(calls[1], { hostname: 'vercel.com', options: { family: 4 }, callback });
 });
 
 test('publishes only the bounded dedicated-builder prune command', () => {

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -7,7 +7,7 @@
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",
     ".github/workflows/pilot-gate.yml": "4b9ad1e56df586849ad3b02111178322297ab6d56fa730083ebc1e60e8148bc3",
     ".github/workflows/release-candidate.yml": "ec03f5eb63d19bff1e8502257e36d264fed70733ca682f5820cd74af93f99bac",
-    ".github/workflows/cd.yml": "397b07a8165641c88435abdd95828c410eb1d32f59bdeb676b9c50ffb7bebea2"
+    ".github/workflows/cd.yml": "d81138389c8b0a2c0e87021417bc391db9610ea6650519793ff63ffdab66c70b"
   },
   "workflows": {
     ".github/workflows/ci.yml": {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59235466,
+  "maxTrackedBytes": 59237574,
   "maxTrackedFiles": 5614,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16761549,
     "docs/text": 7991902,
-    "source/scripts": 7911423,
-    "tests/e2e": 5902882,
-    "config/data/messages": 1811315
+    "source/scripts": 7912028,
+    "tests/e2e": 5904235,
+    "config/data/messages": 1811465
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Çfarë ndryshon

- Aktivizon IPv4 vetëm për komandën `vercel deploy --prebuilt` në staging mbi runner-in ekskluziv Z620.
- Ngarkon preload-in ekzistues të preflight-it dhe mbështjell `dns.lookup` me `family: 4` vetëm kur `INTERDOMESTIK_VERCEL_IPV4_ONLY=1`.
- Shton teste kontraktuale për izolimin staging-only dhe ruan production deploy pa këtë konfigurim.
- Sinkronizon digest-in e workflow-it dhe repo-size budget.

## Pse

Automatic main CD run [30317918428](https://github.com/interdomestik/interdomestik/actions/runs/30317918428) provoi build/attestation në Z620, por `vercel deploy --prebuilt` dështoi me `fetch failed`. Diagnostika tregoi IPv4 funksional dhe IPv6 DNS timeout në Z620; Node auto-family po hynte në këtë rrugë të prishur. Aliasi nuk u zhvendos, rollback-i u krye si no-op dhe production u mbajt fail-closed.

Ky ndryshim nuk prek TLS/hostname verification, system DNS, production deployment ose routing/auth/tenant authority.

## Verifikimi

- Focused CD/preflight tests: 19/19
- CI contracts: 464/464
- `pnpm pr:verify:hosts`: green
  - PR E2E: 209 passed / 9 skipped
  - smoke: 13 passed / 11 skipped
  - coverage: 85.60%
  - RLS: 41/41, 100% coverage
- `pnpm e2e:gate`: 209 passed / 9 skipped
- `pnpm security:guard`: green
- `pnpm repo:size:check`: green
- scope audit dhe `git diff --check`: green
- Opus review: `NO BLOCKER`

Pas merge-it, automatic exact-main CD duhet të provojë deploy + staging E2E success, rollback skipped dhe production jobs skipped.