### PR TITLE
fix(cd): force IPv4 for Z620 health probes

### DIFF
--- a/scripts/ci/fetch-vercel-health-ipv4.test.mjs
+++ b/scripts/ci/fetch-vercel-health-ipv4.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { requestVercelHealth } from './fetch-vercel-health.mjs';
+
+test('requestVercelHealth forces IPv4 only for the opted-in staging process', async () => {
+  const calls = [];
+  const execFileImpl = async (file, args) => {
+    calls.push({ file, args });
+    return { stdout: '{}\n__INTERDOMESTIK_HEALTH_STATUS__:200' };
+  };
+  const url = new URL('https://interdomestik-web-git-main-ecohub.vercel.app/api/health');
+
+  await requestVercelHealth(url, {}, 1_000, execFileImpl, {
+    INTERDOMESTIK_VERCEL_IPV4_ONLY: '1',
+  });
+  await requestVercelHealth(url, {}, 1_000, execFileImpl, {});
+
+  assert.equal(calls[0].file, 'curl');
+  assert.equal(calls[0].args.includes('--ipv4'), true);
+  assert.equal(calls[0].args.includes('--silent'), true);
+  assert.equal(calls[0].args.at(-1), url.href);
+  assert.equal(calls[1].args.includes('--ipv4'), false);
+});

--- a/scripts/ci/fetch-vercel-health.mjs
+++ b/scripts/ci/fetch-vercel-health.mjs
@@ -50,15 +50,23 @@ function sanitizeHealthBody(body) {
     .slice(0, 1_200);
 }
 
-async function requestVercelHealth(url, headers, timeoutMs, execFileImpl = execFile) {
-  const args = [
+export async function requestVercelHealth(
+  url,
+  headers,
+  timeoutMs,
+  execFileImpl = execFile,
+  env = process.env
+) {
+  const args = [];
+  if (env.INTERDOMESTIK_VERCEL_IPV4_ONLY === '1') args.push('--ipv4');
+  args.push(
     '--silent',
     '--show-error',
     '--max-time',
     String(Math.max(1, Math.ceil(timeoutMs / 1000))),
     '--write-out',
-    `${STATUS_MARKER}%{http_code}`,
-  ];
+    `${STATUS_MARKER}%{http_code}`
+  );
   for (const [name, value] of Object.entries(headers)) {
     args.push('--header', `${name}: ${value}`);
   }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59237574,
-  "maxTrackedFiles": 5614,
+  "maxTrackedBytes": 59238621,
+  "maxTrackedFiles": 5615,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16761549,
     "docs/text": 7991902,
-    "source/scripts": 7912028,
-    "tests/e2e": 5904235,
+    "source/scripts": 7912151,
+    "tests/e2e": 5905159,
     "config/data/messages": 1811465
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Çfarë ndryshon

- Shton `curl --ipv4` vetëm kur procesi staging ka `INTERDOMESTIK_VERCEL_IPV4_ONLY=1`.
- E kufizon ndryshimin te `requestVercelHealth`; production dhe çdo thirrje pa opt-in ruajnë argumentet ekzistuese.
- Shton test të izoluar që provon opt-in, opt-out, argumentet legacy dhe URL-në finale.
- Sinkronizon mekanikisht repo-size budget për testin e ri.

## Pse

Exact-main CD run [30325664640](https://github.com/interdomestik/interdomestik/actions/runs/30325664640) provoi që fix-i paraprak funksionoi për Node/Vercel CLI:

- Z620 build + image attestation: green
- Vercel pull/prebuild/output attestation: green
- `vercel deploy --prebuilt`: `✓ Ready in 1m`
- pastaj `snapshotStagingAlias` dështoi fail-closed kur child `curl` bëri DNS resolution timeout pas 10s mbi health URL-në e deployment-it ekzistues
- rollback: green/no-op; E2E dhe çdo production job: skipped

Node DNS preload nuk ndikon një proces të jashtëm `curl`; ky patch e aplikon IPv4 në shtresën e saktë pa ndryshuar system DNS, TLS, hostname validation, alias guards ose production.

## Verifikimi

- Focused health/alias tests: 26/26
- CI contracts: 465/465 (pre- dhe post-commit)
- `pnpm security:guard`: green (pre- dhe post-commit)
- `pnpm repo:size:check`: green
- scope audit dhe `git diff --check`: green
- Opus exact-patch review: `NO BLOCKER`

Pas merge-it, automatic exact-main CD duhet të provojë deploy + staging E2E success, rollback skipped dhe të gjitha production jobs skipped.