### PR TITLE
fix(cd): apply IPv4 across Z620 staging checks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,7 +49,7 @@ jobs:
     permissions: { contents: read, id-token: write, attestations: write }
     # prettier-ignore
     outputs: { alias_moved: '${{ steps.vercel.outputs.alias_moved }}', base_url: '${{ steps.vercel.outputs.base_url }}', hostname: '${{ steps.vercel.outputs.hostname }}', gate_base_url: '${{ steps.vercel.outputs.gate_base_url }}', gate_hostname: '${{ steps.vercel.outputs.gate_hostname }}' }
-    env: { EXPECTED_COMMIT_SHA: '${{ github.sha }}', STAGING_PREIMAGE_RECEIPT_PATH: 'tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage.json' }
+    env: { EXPECTED_COMMIT_SHA: '${{ github.sha }}', INTERDOMESTIK_VERCEL_IPV4_ONLY: '1', STAGING_PREIMAGE_RECEIPT_PATH: 'tmp/cd-evidence/${{ github.run_id }}/staging-alias-preimage.json' }
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v4
       - run: node scripts/ci/cd-runner-preflight.mjs
@@ -166,12 +166,7 @@ jobs:
       - name: Restore exact staging alias preimage
         if: ${{ success() && steps.rollback_guard.outputs.should_restore == 'true' }}
         shell: bash
-        env:
-          STAGING_ALIAS_DOMAIN: staging.interdomestik.com
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+        env: { INTERDOMESTIK_VERCEL_IPV4_ONLY: '1', NODE_OPTIONS: '--import=${{ github.workspace }}/scripts/ci/cd-runner-preflight.mjs', STAGING_ALIAS_DOMAIN: staging.interdomestik.com, VERCEL_AUTOMATION_BYPASS_SECRET: '${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}', VERCEL_TOKEN: '${{ secrets.VERCEL_TOKEN }}', VERCEL_ORG_ID: '${{ vars.VERCEL_ORG_ID }}', VERCEL_PROJECT_ID: '${{ vars.VERCEL_PROJECT_ID }}' }
         run: node scripts/ci/configure-vercel-gate-url.mjs restore
       - name: Upload staging alias rollback receipt
         if: ${{ always() }}

--- a/scripts/ci/cd-runner-contract.test.mjs
+++ b/scripts/ci/cd-runner-contract.test.mjs
@@ -67,18 +67,6 @@ test('generates staging image metadata offline from exact trusted inputs', () =>
   );
 });
 
-test('forces IPv4 DNS only inside the staging Vercel composite action', () => {
-  const stagingDeploy = step(cd.jobs['deploy-staging'], 'Deploy Staging to Vercel');
-  assert.equal(stagingDeploy.env.INTERDOMESTIK_VERCEL_IPV4_ONLY, '1');
-  assert.equal(
-    stagingDeploy.env.NODE_OPTIONS,
-    '--import=${{ github.workspace }}/scripts/ci/cd-runner-preflight.mjs'
-  );
-  const productionDeploy = step(cd.jobs['deploy-production'], 'Deploy Production to Vercel');
-  assert.equal(productionDeploy.env?.INTERDOMESTIK_VERCEL_IPV4_ONLY, undefined);
-  assert.equal(productionDeploy.env?.NODE_OPTIONS, undefined);
-});
-
 test('propagates alias movement independently and always reaches the local guard', () => {
   const deploy = cd.jobs['deploy-staging'];
   const rollback = cd.jobs['rollback-staging-alias'];

--- a/scripts/ci/cd-runner-ipv4-contract.test.mjs
+++ b/scripts/ci/cd-runner-ipv4-contract.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const cd = yaml.load(fs.readFileSync(path.join(root, '.github/workflows/cd.yml'), 'utf8'));
+const step = (job, name) => job.steps.find(candidate => candidate.name === name);
+
+test('forces IPv4 DNS only across staging deploy and rollback execution', () => {
+  const stagingDeploy = step(cd.jobs['deploy-staging'], 'Deploy Staging to Vercel');
+  const stagingRollback = step(
+    cd.jobs['rollback-staging-alias'],
+    'Restore exact staging alias preimage'
+  );
+  const productionDeploy = step(cd.jobs['deploy-production'], 'Deploy Production to Vercel');
+  const preload = '--import=${{ github.workspace }}/scripts/ci/cd-runner-preflight.mjs';
+  assert.deepEqual(
+    [
+      cd.jobs['deploy-staging'].env.INTERDOMESTIK_VERCEL_IPV4_ONLY,
+      stagingDeploy.env.INTERDOMESTIK_VERCEL_IPV4_ONLY,
+      stagingDeploy.env.NODE_OPTIONS,
+      stagingRollback.env.INTERDOMESTIK_VERCEL_IPV4_ONLY,
+      stagingRollback.env.NODE_OPTIONS,
+      productionDeploy.env?.INTERDOMESTIK_VERCEL_IPV4_ONLY,
+      productionDeploy.env?.NODE_OPTIONS,
+    ],
+    ['1', '1', preload, '1', preload, undefined, undefined]
+  );
+});

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -7,7 +7,7 @@
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",
     ".github/workflows/pilot-gate.yml": "4b9ad1e56df586849ad3b02111178322297ab6d56fa730083ebc1e60e8148bc3",
     ".github/workflows/release-candidate.yml": "ec03f5eb63d19bff1e8502257e36d264fed70733ca682f5820cd74af93f99bac",
-    ".github/workflows/cd.yml": "d81138389c8b0a2c0e87021417bc391db9610ea6650519793ff63ffdab66c70b"
+    ".github/workflows/cd.yml": "a19d5d8909f0e4d4a28d1ca453b12a6c2aefcc5c31df6ab8378749de700efd36"
   },
   "workflows": {
     ".github/workflows/ci.yml": {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59238621,
-  "maxTrackedFiles": 5615,
+  "maxTrackedBytes": 59239525,
+  "maxTrackedFiles": 5616,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16761549,
     "docs/text": 7991902,
     "source/scripts": 7912151,
-    "tests/e2e": 5905159,
-    "config/data/messages": 1811465
+    "tests/e2e": 5905938,
+    "config/data/messages": 1811590
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- propagate the staging-only IPv4 opt-in across the full `deploy-staging` job so post-deploy health/provenance checks use `curl --ipv4`
- apply the same bounded IPv4 + Node preload only to the rollback restore step
- keep every production job and default health behavior unchanged
- split the IPv4 workflow contract into a focused 33-line test and refresh the reviewed Z620 parity digest

## Evidence
- predecessor exact-main run `30328501213`: Z620 build passed; composite deploy/preimage passed; separate health wait failed without the job-scoped flag; rollback failed on the same DNS surface; all production jobs skipped
- canonical staging verified from Z620 with IPv4: HTTP 200, healthy, exact commit `eb3076199afc715ea9b0d7be4e64f75af8a7e5b8`
- `pnpm test:ci:contracts`: 465/465
- `pnpm security:guard`: passed
- focused workflow/health/parity tests: 32/32
- repo-size, formatting, parity digest, and `git diff --check`: passed
- Opus exact-patch review: `NO BLOCKER` (93.3s)

No Codex Security diff scan was run.