### PR TITLE
fix(cd): preload IPv4 for Z620 staging gate

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -128,8 +128,7 @@ jobs:
         with: { install-playwright: 'true' }
       - name: Run Staging Release Gate
         shell: bash
-        env:
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        env: { INTERDOMESTIK_VERCEL_IPV4_ONLY: '1', NODE_OPTIONS: '--import=${{ github.workspace }}/scripts/ci/cd-runner-preflight.mjs', VERCEL_AUTOMATION_BYPASS_SECRET: '${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}' }
         run: >-
           set -euo pipefail; mkdir -p "${EVIDENCE_DIR}/logs" "${EVIDENCE_DIR}/release-gates"; pnpm -s release:gate:raw --envName staging --suite p0 --baseUrl "${BASE_URL}" --authBaseUrl "${AUTH_BASE_URL}" --outDir "${EVIDENCE_DIR}/release-gates" 2>&1 | tee "${EVIDENCE_DIR}/logs/release-gate-staging.log"
       - name: Upload staging verification artifacts

--- a/scripts/ci/cd-runner-ipv4-contract.test.mjs
+++ b/scripts/ci/cd-runner-ipv4-contract.test.mjs
@@ -10,8 +10,9 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const cd = yaml.load(fs.readFileSync(path.join(root, '.github/workflows/cd.yml'), 'utf8'));
 const step = (job, name) => job.steps.find(candidate => candidate.name === name);
 
-test('forces IPv4 DNS only across staging deploy and rollback execution', () => {
+test('forces IPv4 DNS only across staging execution', () => {
   const stagingDeploy = step(cd.jobs['deploy-staging'], 'Deploy Staging to Vercel');
+  const stagingGate = step(cd.jobs['e2e-staging'], 'Run Staging Release Gate');
   const stagingRollback = step(
     cd.jobs['rollback-staging-alias'],
     'Restore exact staging alias preimage'
@@ -23,11 +24,13 @@ test('forces IPv4 DNS only across staging deploy and rollback execution', () => 
       cd.jobs['deploy-staging'].env.INTERDOMESTIK_VERCEL_IPV4_ONLY,
       stagingDeploy.env.INTERDOMESTIK_VERCEL_IPV4_ONLY,
       stagingDeploy.env.NODE_OPTIONS,
+      stagingGate.env.INTERDOMESTIK_VERCEL_IPV4_ONLY,
+      stagingGate.env.NODE_OPTIONS,
       stagingRollback.env.INTERDOMESTIK_VERCEL_IPV4_ONLY,
       stagingRollback.env.NODE_OPTIONS,
       productionDeploy.env?.INTERDOMESTIK_VERCEL_IPV4_ONLY,
       productionDeploy.env?.NODE_OPTIONS,
     ],
-    ['1', '1', preload, '1', preload, undefined, undefined]
+    ['1', '1', preload, '1', preload, '1', preload, undefined, undefined]
   );
 });

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -7,7 +7,7 @@
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",
     ".github/workflows/pilot-gate.yml": "4b9ad1e56df586849ad3b02111178322297ab6d56fa730083ebc1e60e8148bc3",
     ".github/workflows/release-candidate.yml": "ec03f5eb63d19bff1e8502257e36d264fed70733ca682f5820cd74af93f99bac",
-    ".github/workflows/cd.yml": "a19d5d8909f0e4d4a28d1ca453b12a6c2aefcc5c31df6ab8378749de700efd36"
+    ".github/workflows/cd.yml": "b865817353226d4a372357b004f546100c37d9c3690edbd57bfad5192f2410e2"
   },
   "workflows": {
     ".github/workflows/ci.yml": {

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59239525,
+  "maxTrackedBytes": 59239807,
   "maxTrackedFiles": 5616,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16761549,
     "docs/text": 7991902,
     "source/scripts": 7912151,
-    "tests/e2e": 5905938,
-    "config/data/messages": 1811590
+    "tests/e2e": 5906102,
+    "config/data/messages": 1811708
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- preload the existing staging-only IPv4 DNS shim only for `Run Staging Release Gate`
- preserve the Vercel bypass secret and all production defaults
- extend the focused IPv4 workflow contract to cover the E2E staging step
- refresh reviewed parity and repo-size receipts

## Exact-main evidence
Run `30331864763` on `cc27bfacfc3753167508a76895a199d05e73287d` proved:
- build-staging: success on Z620 (~20m)
- deploy-staging: success on Z620 (~23m), including health/provenance/canonical alias verification
- e2e-staging: failed only because Node auth preflight `fetch` timed out resolving canonical staging
- rollback-staging-alias: success with the new rollback IPv4 preload
- every production job: skipped
- Z620 minima: 72 GiB disk free, 17.0 GiB RAM available; no ENOSPC/OOM

## Validation
- `pnpm test:ci:contracts`: 465/465
- `pnpm security:guard`: passed
- focused workflow/parity tests: passed
- format, repo-size, parity digest, diff-check: passed
- Opus exact-patch review: `NO BLOCKER` (42.4s)

No Codex Security diff scan was run.