### PR TITLE
feat(web): retire anonymous Hero membership row

### DIFF
--- a/apps/web/e2e/public-entry-hero.spec.ts
+++ b/apps/web/e2e/public-entry-hero.spec.ts
@@ -13,49 +13,47 @@ const viewports = [
   { width: 844, height: 390 },
 ];
 
-async function openHero(page: Page, testInfo: TestInfo, locale: Locale = 'sq') {
-  await gotoApp(page, routes.home(locale), testInfo, { marker: 'public-entry-hero' });
+async function openHero(page: Page, info: TestInfo, locale: Locale = 'sq') {
+  await gotoApp(page, routes.home(locale), info, { marker: 'public-entry-hero' });
   return page.getByTestId('public-entry-hero');
 }
 
-async function expectNoOverflow(locator: Locator) {
-  expect(await locator.evaluate(element => element.scrollWidth <= element.clientWidth + 1)).toBe(
-    true
-  );
+async function expectFits(locator: Locator) {
+  expect(await locator.evaluate(el => el.scrollWidth <= el.clientWidth + 1)).toBeTruthy();
 }
 
-async function expectReadableContrast(hero: Locator) {
+async function expectContrast(hero: Locator) {
   const ratios = await hero.locator('h1, p, a, span, small').evaluateAll(elements => {
     const rgb = (value: string) => (value.match(/[\d.]+/g) ?? []).slice(0, 3).map(Number);
     const luminance = (value: string) => {
       const channels = rgb(value).map(channel => {
-        const normalized = channel / 255;
-        return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+        const n = channel / 255;
+        return n <= 0.04045 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
       });
       return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
     };
-    const background = (element: Element) => {
-      let current: Element | null = element;
-      while (current) {
-        const value = getComputedStyle(current).backgroundColor;
+    const background = (el: Element) => {
+      let node: Element | null = el;
+      while (node) {
+        const value = getComputedStyle(node).backgroundColor;
         if (value !== 'rgba(0, 0, 0, 0)') return value;
-        current = current.parentElement;
+        node = node.parentElement;
       }
       return 'rgb(255, 255, 255)';
     };
     return elements
-      .filter(element => element.children.length === 0 && element.textContent?.trim())
-      .map(element => {
-        const foreground = luminance(getComputedStyle(element).color);
-        const behind = luminance(background(element));
-        return (Math.max(foreground, behind) + 0.05) / (Math.min(foreground, behind) + 0.05);
+      .filter(el => el.children.length === 0 && el.textContent?.trim())
+      .map(el => {
+        const fg = luminance(getComputedStyle(el).color);
+        const bg = luminance(background(el));
+        return (Math.max(fg, bg) + 0.05) / (Math.min(fg, bg) + 0.05);
       });
   });
   expect(Math.min(...ratios)).toBeGreaterThanOrEqual(4.5);
 }
 
 test.describe('Help Now public entry', () => {
-  test('keeps the same truthful help-first contract in all locales', async ({ browser }, info) => {
+  test('keeps truthful help-first behavior in all locales', async ({ browser }, info) => {
     await withAnonymousPage(browser, info, async page => {
       for (const locale of ['sq', 'en', 'sr', 'mk'] as const) {
         const hero = await openHero(page, info, locale);
@@ -71,17 +69,20 @@ test.describe('Help Now public entry', () => {
           /#flight-guidance$/
         );
         await expect(hero.getByText(/WhatsApp/i)).toHaveCount(2);
-        await expect(hero.getByTestId('public-entry-membership')).toHaveAttribute(
+        const retired = hero.locator('[data-testid="public-entry-membership"],a[href*="/pricing"]');
+        await expect(retired).toHaveCount(0);
+        await expect(hero.locator(':scope > div > div')).toHaveCount(2);
+        await expect(page.getByTestId('pricing-plan-link-standard')).toHaveAttribute(
           'href',
-          new RegExp(`/${locale}/pricing$`)
+          `/${locale}/pricing?plan=standard`
         );
         await expect(hero).not.toContainText(/4\.9|8[.,]500|100\s?%|24\/7|guarantee|garant/i);
-        await expectNoOverflow(hero);
+        await expectFits(hero);
       }
     });
   });
 
-  test('keeps header and hero controls accessible by keyboard', async ({ browser }, info) => {
+  test('keeps header and Hero keyboard access', async ({ browser }, info) => {
     await withAnonymousPage(browser, info, async page => {
       const hero = await openHero(page, info);
       const language = page.getByRole('button', { name: /gjuha/i });
@@ -99,23 +100,21 @@ test.describe('Help Now public entry', () => {
     });
   });
 
-  test('protects readable mobile reflow, targets, contrast, and reduced motion', async ({
-    browser,
-  }, info) => {
+  test('keeps mobile reflow, targets, contrast, and reduced motion', async ({ browser }, info) => {
     await withAnonymousPage(browser, info, async page => {
       await page.emulateMedia({ reducedMotion: 'reduce' });
       for (const viewport of viewports) {
         await page.setViewportSize(viewport);
         const locale: Locale = viewport.width === 390 ? 'mk' : 'sq';
         const hero = await openHero(page, info, locale);
-        await expectNoOverflow(page.locator('html'));
-        await expectNoOverflow(hero);
+        await expectFits(page.locator('html'));
+        await expectFits(hero);
         for (const action of await hero.getByRole('link').all()) {
           const box = await action.boundingBox();
           expect(box?.height).toBeGreaterThanOrEqual(44);
           expect(box?.width).toBeGreaterThanOrEqual(44);
         }
-        await expectReadableContrast(hero);
+        await expectContrast(hero);
         const duration = await hero
           .getByTestId('public-entry-vehicle')
           .locator('svg:last-child')

--- a/apps/web/src/app/[locale]/components/home/hero-section.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/hero-section.test.tsx
@@ -34,16 +34,16 @@ vi.mock('@/i18n/routing', () => ({
 }));
 
 describe('HeroSection', () => {
-  it('renders the approved Help Now hierarchy for an anonymous visitor', () => {
+  it('renders anonymous Help Now hierarchy', () => {
     render(<HeroSection locale="sq" tenantId="tenant_ks" />);
-
     const hero = screen.getByTestId('public-entry-hero');
     expect(within(hero).getByText('NDIHMË TANI')).toBeInTheDocument();
     expect(
       within(hero).getByRole('heading', { level: 1, name: 'Çfarë ju ka ndodhur?' })
     ).toBeInTheDocument();
     expect(within(hero).getByTestId('public-entry-situations')).toBeInTheDocument();
-    expect(within(hero).getByTestId('public-entry-membership')).toHaveAttribute('href', '/pricing');
+    expect(hero.querySelector('a[href*="/pricing"]')).toBeNull();
+    expect(hero.firstElementChild?.children).toHaveLength(2);
     expect(getSupportContacts).toHaveBeenCalledWith({ locale: 'sq', tenantId: 'tenant_ks' });
     expect(
       within(hero).queryByText(/udhëzime praktike|4\.9|8[.,]500|100\s?%|24\/7/i)

--- a/apps/web/src/app/[locale]/components/home/hero-section.tsx
+++ b/apps/web/src/app/[locale]/components/home/hero-section.tsx
@@ -3,11 +3,7 @@ import { PUBLIC_FREE_START_ANCHOR_HREF } from '@/lib/public-membership-entry';
 import { getSupportContacts } from '@/lib/support-contacts';
 import { ArrowRight } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import {
-  PublicMembershipAction,
-  PublicSituationActions,
-  PublicSupportPanel,
-} from './public-entry-actions';
+import { PublicSituationActions, PublicSupportPanel } from './public-entry-actions';
 
 type HeroSectionProps = Readonly<{
   locale?: string;
@@ -92,9 +88,6 @@ export function HeroSection({
           <div className="min-w-0">
             <PublicSituationActions />
             <PublicSupportPanel whatsappHref={contacts.whatsappHref} />
-          </div>
-          <div className="min-w-0 lg:col-span-2">
-            <PublicMembershipAction />
           </div>
         </div>
       )}

--- a/apps/web/src/app/[locale]/components/home/public-entry-actions.test.tsx
+++ b/apps/web/src/app/[locale]/components/home/public-entry-actions.test.tsx
@@ -65,16 +65,13 @@ describe('PublicEntryActions', () => {
     expect(document.body).not.toHaveTextContent(/24\/7|garant/i);
   });
 
-  it('places annual membership after the immediate-help journey', () => {
+  it('keeps only the immediate-help and support groups without the retired membership row', () => {
     render(<PublicEntryActions whatsappHref="https://wa.me/38349900600" />);
 
-    const situations = screen.getByTestId('public-entry-situations');
-    const membership = screen.getByTestId('public-entry-membership');
-    expect(membership).toHaveAttribute('href', '/pricing');
-    expect(membership).toHaveAccessibleName(/Shihni anëtarësimin vjetor/i);
-    expect(
-      situations.compareDocumentPosition(membership) & Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy();
+    expect(screen.getByTestId('public-entry-situations')).toBeInTheDocument();
+    expect(screen.getAllByText(/WhatsApp/i)).toHaveLength(2);
+    expect(screen.queryByTestId('public-entry-membership')).not.toBeInTheDocument();
+    expect(document.querySelector('a[href*="/pricing"]')).toBeNull();
   });
 
   it('hands off all four situations as one-shot local intents', () => {

--- a/apps/web/src/app/[locale]/components/home/public-entry-actions.tsx
+++ b/apps/web/src/app/[locale]/components/home/public-entry-actions.tsx
@@ -1,6 +1,4 @@
-import { Link } from '@/i18n/routing';
-import { PUBLIC_MEMBERSHIP_ENTRY_HREF } from '@/lib/public-membership-entry';
-import { ArrowRight, Globe2, MessageCircle, ShieldAlert, ShieldCheck } from 'lucide-react';
+import { Globe2, MessageCircle, ShieldAlert, ShieldCheck } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { PublicSituationActions } from './public-situation-actions';
 
@@ -56,34 +54,11 @@ export function PublicSupportPanel({ whatsappHref }: PublicEntryActionsProps) {
   );
 }
 
-export function PublicMembershipAction() {
-  const t = useTranslations('hero.publicEntry');
-  return (
-    <div className="grid gap-5 border-t border-[#B8C7C7] pt-7 lg:grid-cols-[minmax(0,0.7fr)_minmax(0,1.3fr)_auto] lg:items-center">
-      <p className="font-serif text-2xl font-semibold text-[#001A33] sm:text-3xl">
-        {t('membershipPrompt')}
-      </p>
-      <p className="max-w-2xl text-sm leading-6 text-[#334D5C] sm:text-base">
-        {t('membershipBody')}
-      </p>
-      <Link
-        data-testid="public-entry-membership"
-        href={PUBLIC_MEMBERSHIP_ENTRY_HREF}
-        className="inline-flex min-h-12 items-center justify-between gap-4 border border-[#006A70] px-5 py-3 font-semibold text-[#005F64] transition-colors hover:bg-[#006A70] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#006A70] focus-visible:ring-offset-2 motion-reduce:transition-none"
-      >
-        {t('membershipLabel')}
-        <ArrowRight aria-hidden="true" className="h-5 w-5 shrink-0" />
-      </Link>
-    </div>
-  );
-}
-
 export function PublicEntryActions({ whatsappHref }: PublicEntryActionsProps) {
   return (
     <>
       <PublicSituationActions />
       <PublicSupportPanel whatsappHref={whatsappHref} />
-      <PublicMembershipAction />
     </>
   );
 }

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59785711,
+  "maxTrackedBytes": 59783363,
   "maxTrackedFiles": 5640,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16860825,
     "docs/text": 8253452,
-    "source/scripts": 7953083,
-    "tests/e2e": 6036508,
-    "config/data/messages": 1825448
+    "source/scripts": 7951731,
+    "tests/e2e": 6036414,
+    "config/data/messages": 1824546
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## IDA-UI06b

Retires only the legacy annual-membership row from the anonymous Help Now Hero while preserving the four situation actions, both support paths, member continuation, header/intake/routes, and pricing access outside the Hero.

Authority:

- Gate: `IDA-DG26`, approved 16,274 bytes / SHA-256 `7ae4b97a79fa5ad3e110dd8f2b5e3b68c5e15319e6519dbe04aa39d8d7f5fb79`
- Runtime: `IDA-UI06b-RUNTIME-R1`, approved 19,701 bytes / SHA-256 `c4dbbdf83d95b3453318fc2aa43b05a2b83abbe77291c03eb27922a7ef7a6750`
- Base: `b657f7d52ffb4bc7fb4e9959da05c13394e60af4`

## Exact scope

- Remove `PublicMembershipAction` from `HeroSection` and the compatibility aggregate.
- Keep `PublicSituationActions`, `PublicSupportPanel`, and settled-member continuation unchanged.
- Require no marked or unmarked `/pricing` link inside the Hero.
- Require the exact localized `/{locale}/pricing?plan=standard` link outside the Hero.
- Synchronize the repo-size budget deterministically after staging.

Exactly six approved writer paths changed; no proxy, routes, page composition, header, intake, pricing implementation, copy/i18n, auth, tenancy, schema/RLS, billing, analytics, CI/CD, deployment, or production surface changed.

## Evidence

- TDD RED: two expected focused failures while the retired row remained; four retained-behavior tests passed.
- TDD GREEN: focused unit `6/6` pass.
- Web lint: pass.
- Web `tsc --noEmit`: pass.
- Prettier and `git diff --check`: pass.
- Canonical tracked-only repo-size sync check and `pnpm repo:size:check`: pass.
- Every touched TS/TSX is at or below its exact base line/byte size and below 150 lines.
- Claude Opus 5 priority route: blocked before model execution by expired OAuth (`401`); no valid call/quota/average entry.
- GPT-5.6 Sol Max final exact-head review: approve, zero blocker/hardening/optional findings, 723.192 seconds.
- Codex Security diff scan: explicitly waived by user; repo-native security remains mandatory.

## Pending merge proof

- Governed Z620 browser/E2E proof (runner currently offline at PR creation; no Mac heavy fallback).
- `pnpm pr:verify`, `pnpm security:guard`, and `pnpm e2e:gate` on this exact head.
- Exact-head CI, Sonar/new issues, CodeQL, gitleaks/audit/security, one Copilot review request, finalizer, mergeability, and zero unresolved threads.

Rollback is the exact implementation merge revert. There is no schema, data, provider, deployment, or production rollback for this slice.
