### PR TITLE
ci: activate exact-head certification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,7 @@ on:
   pull_request:
     branches:
       - '**'
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - converted_to_draft
-      - labeled
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -38,10 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.gate_policy.outputs.should_run }}
-      reason: ${{ steps.gate_policy.outputs.reason }}
       non_product_only_paths: ${{ steps.gate_policy.outputs.non_product_only_paths }}
-      run_full: ${{ steps.gate_policy.outputs.run_full }}
-      force_full: ${{ steps.gate_policy.outputs.force_full }}
+      run_broad: ${{ steps.certification.outputs.run_broad }}
+      certification_reason: ${{ steps.certification.outputs.certification_reason }}
       ai_eval_should_run: ${{ steps.gate_policy.outputs.ai_eval_should_run }}
       ai_eval_reason: ${{ steps.gate_policy.outputs.ai_eval_reason }}
       ai_eval_matched_paths: ${{ steps.gate_policy.outputs.ai_eval_matched_paths }}
@@ -55,10 +48,15 @@ jobs:
           package-manager-cache: false
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}
+      - name: Resolve exact-head certification admission
+        id: certification
+        uses: interdomestik/interdomestik/.github/actions/exact-head-certification@ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b
+        with:
+          policy-json: ${{ toJSON(steps.gate_policy.outputs) }}
   audit:
     needs:
       - validation-surface
@@ -70,7 +68,7 @@ jobs:
         run: >-
           pnpm track:audit && pnpm plan:audit && pnpm repo:size:check && node --test scripts/ci/docs-closeout-main-push-contract.test.mjs scripts/ci/z620-parity-policy.test.mjs
       - name: Run Audits
-        if: needs.validation-surface.outputs.should_run == 'true'
+        if: needs.validation-surface.outputs.run_broad == 'true'
         run: |
           node scripts/check-env-ci.mjs
           pnpm test:ci:contracts
@@ -84,17 +82,17 @@ jobs:
           # Browser PR coverage lives in the dedicated PR E2E workflow.
           # Push/mainline gate coverage stays in the e2e-gate job below.
       - name: Check E2E quarantine budget
-        if: needs.validation-surface.outputs.should_run == 'true'
+        if: needs.validation-surface.outputs.run_broad == 'true'
         run: pnpm check:e2e-quarantine-budget
       - name: Report quick draft lane
-        if: needs.validation-surface.outputs.should_run != 'true'
+        if: needs.validation-surface.outputs.run_broad != 'true'
         run: |
           echo "Heavy audit lane skipped."
-          echo "Reason: ${{ needs.validation-surface.outputs.reason }}"
+          echo "Reason: ${{ needs.validation-surface.outputs.certification_reason }}"
   static:
     needs:
       - validation-surface
-    if: needs.validation-surface.outputs.should_run == 'true'
+    if: needs.validation-surface.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -119,7 +117,7 @@ jobs:
   unit:
     needs:
       - validation-surface
-    if: needs.validation-surface.outputs.should_run == 'true'
+    if: needs.validation-surface.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -135,7 +133,7 @@ jobs:
   ai-eval:
     needs:
       - validation-surface
-    if: needs.validation-surface.outputs.should_run == 'true' && needs.validation-surface.outputs.ai_eval_should_run == 'true'
+    if: needs.validation-surface.outputs.run_broad == 'true' && needs.validation-surface.outputs.ai_eval_should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -146,7 +144,7 @@ jobs:
   e2e-gate:
     needs:
       - validation-surface
-    if: needs.validation-surface.outputs.should_run == 'true'
+    if: needs.validation-surface.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     services:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled]
     # Protected checks must always materialize on PRs; the validation-surface
     # policy below skips heavy work for docs-only and other non-product changes.
-  workflow_dispatch: {}
 
 concurrency:
   group: e2e-pr-${{ github.ref }}
@@ -16,33 +15,35 @@ jobs:
     name: PR E2E Preflight
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.gate_policy.outputs.should_run }}
-      reason: ${{ steps.gate_policy.outputs.reason }}
-      run_full: ${{ steps.gate_policy.outputs.run_full }}
-      force_full: ${{ steps.gate_policy.outputs.force_full }}
+      run_broad: ${{ steps.certification.outputs.run_broad }}
+      certification_required: ${{ steps.certification.outputs.certification_required }}
+      certification_reason: ${{ steps.certification.outputs.certification_reason }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}
-      - name: Report quick draft lane
-        if: steps.gate_policy.outputs.should_run != 'true'
-        run: echo "PR E2E heavy runner skipped (${{ steps.gate_policy.outputs.reason }})."
+      - name: Resolve exact-head certification admission
+        id: certification
+        uses: interdomestik/interdomestik/.github/actions/exact-head-certification@ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b
+        with:
+          policy-json: ${{ toJSON(steps.gate_policy.outputs) }}
+          consume-full-gate: 'true'
 
   e2e-runner:
     name: PR E2E Runner
     permissions:
       contents: read
     needs: [e2e-preflight]
-    if: needs.e2e-preflight.outputs.should_run == 'true'
+    if: needs.e2e-preflight.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     services:
@@ -126,25 +127,10 @@ jobs:
     permissions: {}
     steps:
       - name: Enforce PR E2E preflight/result contract
-        shell: bash
-        run: |
-          set -euo pipefail
-          preflight_result="${{ needs.e2e-preflight.result }}"
-          should_run="${{ needs.e2e-preflight.outputs.should_run }}"
-          reason="${{ needs.e2e-preflight.outputs.reason }}"
-          runner_result="${{ needs.e2e-runner.result }}"
-
-          if [[ "${preflight_result}" != "success" ]]; then
-            echo "::error::PR E2E preflight failed before the heavy runner became eligible."
-            exit 1
-          fi
-
-          if [[ "${should_run}" != "true" ]]; then
-            echo "PR E2E heavy runner skipped (${reason})."
-            exit 0
-          fi
-
-          if [[ "${runner_result}" != "success" ]]; then
-            echo "::error::PR E2E runner did not complete successfully (result=${runner_result})."
-            exit 1
-          fi
+        uses: interdomestik/interdomestik/.github/actions/exact-head-certification-result@ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b
+        with:
+          preflight-result: ${{ needs.e2e-preflight.result }}
+          run-broad: ${{ needs.e2e-preflight.outputs.run_broad }}
+          certification-required: ${{ needs.e2e-preflight.outputs.certification_required }}
+          certification-reason: ${{ needs.e2e-preflight.outputs.certification_reason }}
+          runner-result: ${{ needs.e2e-runner.result }}

--- a/.github/workflows/pilot-gate.yml
+++ b/.github/workflows/pilot-gate.yml
@@ -4,13 +4,7 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - converted_to_draft
-      - labeled
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled]
     # Protected checks must always materialize on PRs; the validation-surface
     # policy below skips heavy work for docs-only and other non-product changes.
   workflow_dispatch:
@@ -29,10 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.gate_policy.outputs.should_run }}
-      reason: ${{ steps.gate_policy.outputs.reason }}
       non_product_only_paths: ${{ steps.gate_policy.outputs.non_product_only_paths }}
-      run_full: ${{ steps.gate_policy.outputs.run_full }}
-      force_full: ${{ steps.gate_policy.outputs.force_full }}
+      run_broad: ${{ steps.certification.outputs.run_broad }}
+      certification_reason: ${{ steps.certification.outputs.certification_reason }}
       sonar_gate_enabled: ${{ steps.validate_secrets.outputs.sonar_gate_enabled }}
       needs_manual_sonar_fallback: ${{ steps.sonar_strategy.outputs.needs_manual_sonar_fallback }}
       needs_dependabot_better_auth_fallback: ${{ steps.validate_secrets.outputs.needs_dependabot_better_auth_fallback }}
@@ -55,17 +48,23 @@ jobs:
 
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}
           dispatch-base-ref: main
 
+      - name: Resolve exact-head certification admission
+        id: certification
+        uses: interdomestik/interdomestik/.github/actions/exact-head-certification@ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b
+        with:
+          policy-json: ${{ toJSON(steps.gate_policy.outputs) }}
+
       - name: Skip pilot gate for non-product-only changes
-        if: steps.gate_policy.outputs.should_run != 'true'
+        if: steps.certification.outputs.run_broad != 'true'
         run: |
           echo "Skipping pilot gate."
-          echo "Reason: ${{ steps.gate_policy.outputs.reason }}"
+          echo "Reason: ${{ steps.certification.outputs.certification_reason }}"
           echo "Non-product-only paths: ${{ steps.gate_policy.outputs.non_product_only_paths }}"
 
       - name: Validate required gate secrets
@@ -73,7 +72,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ steps.gate_policy.outputs.should_run }}" != "true" ]]; then
+          if [[ "${{ steps.certification.outputs.run_broad }}" != "true" ]]; then
             echo "sonar_gate_enabled=false" >> "$GITHUB_OUTPUT"
             echo "needs_dependabot_better_auth_fallback=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -112,7 +111,7 @@ jobs:
 
       - name: Await SonarCloud Code Analysis check
         id: await_sonar_check
-        if: github.event_name == 'pull_request' && steps.gate_policy.outputs.should_run == 'true' && steps.validate_secrets.outputs.sonar_gate_enabled == 'true'
+        if: github.event_name == 'pull_request' && steps.certification.outputs.run_broad == 'true' && steps.validate_secrets.outputs.sonar_gate_enabled == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -132,7 +131,7 @@ jobs:
             sonarcloud_automatic_analysis=true
           fi
 
-          if [[ "${{ steps.gate_policy.outputs.should_run }}" == "true" && \
+          if [[ "${{ steps.certification.outputs.run_broad }}" == "true" && \
                 "${{ steps.validate_secrets.outputs.sonar_gate_enabled }}" == "true" && \
                 "${{ github.event_name }}" == "pull_request" && \
                 "${{ steps.await_sonar_check.outcome }}" != "success" ]]; then
@@ -150,7 +149,7 @@ jobs:
     name: Pilot Gate Runner
     needs:
       - pilot-gate-preflight
-    if: needs.pilot-gate-preflight.outputs.should_run == 'true'
+    if: needs.pilot-gate-preflight.outputs.run_broad == 'true'
     permissions:
       checks: read
       contents: read
@@ -312,8 +311,8 @@ jobs:
         run: |
           set -euo pipefail
           preflight_result="${{ needs.pilot-gate-preflight.result }}"
-          should_run="${{ needs.pilot-gate-preflight.outputs.should_run }}"
-          reason="${{ needs.pilot-gate-preflight.outputs.reason }}"
+          run_broad="${{ needs.pilot-gate-preflight.outputs.run_broad }}"
+          reason="${{ needs.pilot-gate-preflight.outputs.certification_reason }}"
           runner_result="${{ needs.pilot-gate-runner.result }}"
 
           if [[ "${preflight_result}" != "success" ]]; then
@@ -321,7 +320,7 @@ jobs:
             exit 1
           fi
 
-          if [[ "${should_run}" != "true" ]]; then
+          if [[ "${run_broad}" != "true" ]]; then
             echo "Pilot gate skipped."
             echo "Reason: ${reason}"
             exit 0

--- a/.github/workflows/pr-deterministic-backstops.yml
+++ b/.github/workflows/pr-deterministic-backstops.yml
@@ -4,13 +4,7 @@ on:
   pull_request:
     branches:
       - '**'
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - converted_to_draft
-      - labeled
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled]
 
 permissions:
   contents: read
@@ -21,25 +15,30 @@ jobs:
     name: Deterministic Backstops Draft Policy
     runs-on: ubuntu-latest
     outputs:
-      run_full: ${{ steps.gate_policy.outputs.run_full }}
-      reason: ${{ steps.gate_policy.outputs.reason }}
+      run_broad: ${{ steps.certification.outputs.run_broad }}
+      certification_reason: ${{ steps.certification.outputs.certification_reason }}
     steps:
       - uses: actions/checkout@v5
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}
+      - name: Resolve exact-head certification admission
+        id: certification
+        uses: interdomestik/interdomestik/.github/actions/exact-head-certification@ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b
+        with:
+          policy-json: ${{ toJSON(steps.gate_policy.outputs) }}
       - name: Report quick draft lane
-        if: steps.gate_policy.outputs.run_full != 'true'
-        run: echo "Deterministic backstops skipped (${{ steps.gate_policy.outputs.reason }})."
+        if: steps.certification.outputs.run_broad != 'true'
+        run: echo "Deterministic backstops skipped (${{ steps.certification.outputs.certification_reason }})."
 
   dependency-review:
     name: Dependency Review
     needs:
       - draft-policy
-    if: needs.draft-policy.outputs.run_full == 'true' && github.event.repository.private == false
+    if: needs.draft-policy.outputs.run_broad == 'true' && github.event.repository.private == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,7 +54,7 @@ jobs:
     name: OSV Scanner PR
     needs:
       - draft-policy
-    if: needs.draft-policy.outputs.run_full == 'true'
+    if: needs.draft-policy.outputs.run_broad == 'true'
     permissions:
       actions: read
       contents: read
@@ -72,7 +71,7 @@ jobs:
     name: Semgrep CE Diff Scan
     needs:
       - draft-policy
-    if: needs.draft-policy.outputs.run_full == 'true'
+    if: needs.draft-policy.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -116,7 +115,7 @@ jobs:
     name: reviewdog ESLint Annotations
     needs:
       - draft-policy
-    if: needs.draft-policy.outputs.run_full == 'true'
+    if: needs.draft-policy.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write

--- a/.github/workflows/pr-finalizer.yml
+++ b/.github/workflows/pr-finalizer.yml
@@ -4,13 +4,7 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - converted_to_draft
-      - labeled
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled]
 
 concurrency:
   group: pr-finalizer-${{ github.event.pull_request.number }}
@@ -31,17 +25,22 @@ jobs:
           fetch-depth: 1
       - name: Evaluate PR gate policy
         id: gate_policy
-        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19
+        uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717
         with:
           event-name: ${{ github.event_name }}
           event-path: ${{ github.event_path }}
+      - name: Resolve exact-head certification admission
+        id: certification
+        uses: interdomestik/interdomestik/.github/actions/exact-head-certification@ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b
+        with:
+          policy-json: ${{ toJSON(steps.gate_policy.outputs) }}
       - name: Report quick draft lane
-        if: steps.gate_policy.outputs.run_full != 'true'
-        run: echo "PR finalizer attestation deferred (${{ steps.gate_policy.outputs.reason }})."
+        if: steps.certification.outputs.run_broad != 'true'
+        run: echo "PR finalizer attestation deferred (${{ steps.certification.outputs.certification_reason }})."
       - uses: ./.github/actions/setup
-        if: steps.gate_policy.outputs.run_full == 'true'
+        if: steps.certification.outputs.run_broad == 'true'
       - name: Run PR finalizer gate
-        if: steps.gate_policy.outputs.run_full == 'true'
+        if: steps.certification.outputs.run_broad == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/ci/draft-gate-workflow-contracts.test.mjs
+++ b/scripts/ci/draft-gate-workflow-contracts.test.mjs
@@ -9,7 +9,7 @@ import './pr-e2e-evidence-workflow-contracts.mjs';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const TRUSTED_GATE_ACTION =
-  'interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19';
+  'interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717';
 const EVENT_TYPES = [
   'opened',
   'synchronize',
@@ -72,11 +72,11 @@ test('CI exposes one effective heavy-lane decision while keeping required audit 
   const policy = findStep(preflight, 'Evaluate PR gate policy');
   assert.equal(policy.uses, TRUSTED_GATE_ACTION);
   assert.equal(preflight.outputs.should_run, '${{ steps.gate_policy.outputs.should_run }}');
-  assert.equal(preflight.outputs.run_full, '${{ steps.gate_policy.outputs.run_full }}');
+  assert.equal(preflight.outputs.run_broad, '${{ steps.certification.outputs.run_broad }}');
   assert.ok(needs(audit, 'validation-surface'));
   assert.equal(
     findStep(audit, 'Run Audits').if,
-    "needs.validation-surface.outputs.should_run == 'true'"
+    "needs.validation-surface.outputs.run_broad == 'true'"
   );
   assert.ok(findStep(audit, 'Report quick draft lane'));
 });
@@ -91,14 +91,14 @@ test('required PR E2E context wraps a service-free preflight and conditional hea
   assert.equal(workflow.permissions, undefined);
   assert.deepEqual(preflight.permissions, {
     contents: 'read',
-    'pull-requests': 'read',
+    'pull-requests': 'write',
   });
   assert.deepEqual(runner.permissions, { contents: 'read' });
   assert.equal(preflight.services, undefined);
   assert.equal(checkout.with['fetch-depth'], 1);
   assert.ok(findStep(preflight, 'Evaluate PR gate policy'));
   assert.ok(needs(runner, 'e2e-preflight'));
-  assert.equal(runner.if, "needs.e2e-preflight.outputs.should_run == 'true'");
+  assert.equal(runner.if, "needs.e2e-preflight.outputs.run_broad == 'true'");
   assert.ok(runner.services.postgres);
   assert.equal(wrapper.name, 'e2e');
   assert.equal(wrapper.if, 'always()');
@@ -113,18 +113,18 @@ test('pilot and optional deterministic backstops honor the shared full-lane deci
   assert.ok(findStep(pilotPreflight, 'Evaluate PR gate policy'));
   assert.equal(
     pilot.jobs['pilot-gate-runner'].if,
-    "needs.pilot-gate-preflight.outputs.should_run == 'true'"
+    "needs.pilot-gate-preflight.outputs.run_broad == 'true'"
   );
 
   const backstops = readWorkflow('pr-deterministic-backstops.yml');
   assert.ok(backstops.jobs['draft-policy']);
   for (const name of ['osv-scanner', 'semgrep-ce', 'reviewdog-eslint']) {
     assert.ok(needs(backstops.jobs[name], 'draft-policy'), name);
-    assert.equal(backstops.jobs[name].if, "needs.draft-policy.outputs.run_full == 'true'", name);
+    assert.equal(backstops.jobs[name].if, "needs.draft-policy.outputs.run_broad == 'true'", name);
   }
   assert.equal(
     backstops.jobs['dependency-review'].if,
-    "needs.draft-policy.outputs.run_full == 'true' && github.event.repository.private == false"
+    "needs.draft-policy.outputs.run_broad == 'true' && github.event.repository.private == false"
   );
   assert.equal(backstops.jobs['osv-scanner'].with['upload-sarif'], false);
   assert.equal(backstops.jobs['osv-scanner'].permissions['security-events'], 'write');
@@ -145,6 +145,6 @@ test('PR finalizer stays required but only attests full-lane current heads', () 
   assert.ok(policy);
   assert.ok(findStep(job, 'Report quick draft lane'));
   assert.equal(policy.uses, TRUSTED_GATE_ACTION);
-  assert.equal(finalizer.if, "steps.gate_policy.outputs.run_full == 'true'");
+  assert.equal(finalizer.if, "steps.certification.outputs.run_broad == 'true'");
   assert.equal(finalizer.env.PR_FINALIZER_SKIP_CHECK_POLLING, 'false');
 });

--- a/scripts/ci/exact-head-certification-workflows.test.mjs
+++ b/scripts/ci/exact-head-certification-workflows.test.mjs
@@ -52,7 +52,10 @@ test('result enforcement receives only explicit certification evidence', () => {
   assert.match(source, /GITHUB_RUN_ATTEMPT: \$\{\{ github\.run_attempt \}\}/u);
 });
 
-test('bootstrap remains inert until callers can pin its merged SHA', () => {
+const trustedBootstrap =
+  'interdomestik/interdomestik/.github/actions/exact-head-certification@ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b';
+
+test('all five callers pin exact-head admission to the bootstrap SHA', () => {
   for (const name of [
     'ci.yml',
     'e2e-pr.yml',
@@ -60,6 +63,16 @@ test('bootstrap remains inert until callers can pin its merged SHA', () => {
     'pr-deterministic-backstops.yml',
     'pr-finalizer.yml',
   ]) {
-    assert.doesNotMatch(workflow(name), /exact-head-certification/u, name);
+    assert.match(workflow(name), new RegExp(trustedBootstrap.replaceAll('.', '\\.'), 'u'), name);
   }
+});
+
+test('PR E2E pins result authority and removes its colliding manual trigger', () => {
+  const source = workflow('e2e-pr.yml');
+  assert.match(
+    source,
+    /interdomestik\/interdomestik\/\.github\/actions\/exact-head-certification-result@ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b/u
+  );
+  assert.doesNotMatch(source, /^  workflow_dispatch:/mu);
+  assert.match(source, /if: needs\.e2e-preflight\.outputs\.run_broad == 'true'/u);
 });

--- a/scripts/ci/pr-gate-pin-contracts.test.mjs
+++ b/scripts/ci/pr-gate-pin-contracts.test.mjs
@@ -8,7 +8,7 @@ import yaml from 'js-yaml';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const trustedAction =
-  'interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19';
+  'interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717';
 const targets = [
   ['ci.yml', 'validation-surface'],
   ['e2e-pr.yml', 'e2e-preflight'],

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -15,7 +15,7 @@ import {
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '../..');
 const TRUSTED_GATE_ACTION =
-  'interdomestik/interdomestik/.github/actions/pr-gate-policy@2a5d9fa14334766e0668c7b160ea065a0c25ec19';
+  'interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717';
 function readWorkflow(relativePath) {
   const content = fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
   return yaml.load(content);
@@ -144,7 +144,7 @@ test('CI delegates PR browser gate to PR E2E', () => {
   const ciE2eNeeds = normalizeNeeds(ciE2eGateJob.needs);
 
   assert.ok(ciE2eNeeds.includes('validation-surface'));
-  assert.equal(ciE2eGateJob.if, "needs.validation-surface.outputs.should_run == 'true'");
+  assert.equal(ciE2eGateJob.if, "needs.validation-surface.outputs.run_broad == 'true'");
 
   const setupStep = ciSteps.find(step => step?.uses === './.github/actions/setup');
   assert.equal(setupStep.with['install-playwright'], "${{ github.event_name != 'pull_request' }}");
@@ -163,11 +163,11 @@ test('CI delegates PR browser gate to PR E2E', () => {
 
   const staticJob = ciWorkflow.jobs.static;
   assert.ok(normalizeNeeds(staticJob.needs).includes('validation-surface'));
-  assert.equal(staticJob.if, "needs.validation-surface.outputs.should_run == 'true'");
+  assert.equal(staticJob.if, "needs.validation-surface.outputs.run_broad == 'true'");
 
   const unitJob = ciWorkflow.jobs.unit;
   assert.ok(normalizeNeeds(unitJob.needs).includes('validation-surface'));
-  assert.equal(unitJob.if, "needs.validation-surface.outputs.should_run == 'true'");
+  assert.equal(unitJob.if, "needs.validation-surface.outputs.run_broad == 'true'");
 
   const prE2eJob = prE2eWorkflow.jobs['e2e-runner'];
   const prE2eSetupStep = prE2eJob.steps.find(step => step?.uses === './.github/actions/setup');
@@ -210,7 +210,7 @@ test('CI materializes AI eval as a blocking surface-gated lane', () => {
   assert.ok(normalizeNeeds(aiEvalJob.needs).includes('validation-surface'));
   assert.equal(
     aiEvalJob.if,
-    "needs.validation-surface.outputs.should_run == 'true' && needs.validation-surface.outputs.ai_eval_should_run == 'true'"
+    "needs.validation-surface.outputs.run_broad == 'true' && needs.validation-surface.outputs.ai_eval_should_run == 'true'"
   );
   assert.equal(aiEvalJob['continue-on-error'], undefined);
   const runStep = findStep(aiEvalJob.steps, 'Run AI Eval Fixtures');
@@ -248,7 +248,7 @@ test('CI unit lane runs the blocking repository coverage gate', () => {
 
   assert.ok(unitJob);
   assert.ok(normalizeNeeds(unitJob.needs).includes('validation-surface'));
-  assert.equal(unitJob.if, "needs.validation-surface.outputs.should_run == 'true'");
+  assert.equal(unitJob.if, "needs.validation-surface.outputs.run_broad == 'true'");
 
   const coverageStep = findStep(unitJob.steps, 'Coverage Gate');
   assert.ok(coverageStep);
@@ -378,7 +378,7 @@ test('Pilot gate heavy runner depends on preflight before Postgres, setup, build
   const buildIndex = findStepIndex(steps, 'Build web standalone artifact');
 
   assert.ok(needs.includes('pilot-gate-preflight'));
-  assert.equal(pilotGateJob.if, "needs.pilot-gate-preflight.outputs.should_run == 'true'");
+  assert.equal(pilotGateJob.if, "needs.pilot-gate-preflight.outputs.run_broad == 'true'");
   assert.equal(pilotGateJob.env.DATABASE_URL_RLS, pilotGateJob.env.DATABASE_URL);
   assert.equal(pilotGateJob.env.NODE_OPTIONS, '--max-old-space-size=4096');
   assert.ok(setupIndex >= 0);

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "workflowDigests": {
-    ".github/workflows/ci.yml": "a0faa0139d25460f6886d9f9addf82e8e89db74334e30e2e82c328fe4ecae8ce",
+    ".github/workflows/ci.yml": "bc199e94dc1a27ec4d2e8677df38705472067f307103c72d18aa4331e3d77a77",
     ".github/workflows/security.yml": "72e957bba4773deb3212d6db1d16f398c8fed53e538c6a060ca04f07f688195a",
-    ".github/workflows/e2e-pr.yml": "4ec80d9b258cb812f8ad7756d170f1150a4bcf6bb5da30f504a33c076d5cd572",
+    ".github/workflows/e2e-pr.yml": "075b511cb9679544b9770bac802f70fffef3fbfdab51ffa2492d5ef61913b1bd",
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",
-    ".github/workflows/pilot-gate.yml": "4b9ad1e56df586849ad3b02111178322297ab6d56fa730083ebc1e60e8148bc3",
+    ".github/workflows/pilot-gate.yml": "9c04ed1616c84f984ac396c73c293591400fa9352eec952f8abaa6f2dc1351ac",
     ".github/workflows/release-candidate.yml": "ec03f5eb63d19bff1e8502257e36d264fed70733ca682f5820cd74af93f99bac",
     ".github/workflows/cd.yml": "b865817353226d4a372357b004f546100c37d9c3690edbd57bfad5192f2410e2"
   },
@@ -24,7 +24,7 @@
     ".github/workflows/e2e-pr.yml": {
       "e2e-preflight": ["policy", "pnpm validation-surface"],
       "e2e-runner": ["equivalent", "pnpm e2e:gate:pr"],
-      "e2e": ["contract", "local result aggregation"]
+      "e2e": ["contract", "pinned result aggregation"]
     },
     ".github/workflows/sonar-main-gate.yml": {
       "sonar-gate": ["provider", "pnpm sonar:gate"]

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59850271,
+  "maxTrackedBytes": 59851697,
   "maxTrackedFiles": 5660,
   "maxCategoryBytes": {
     "other": 18856395,
     "large support/generated-ish": 16864107,
     "docs/text": 8264824,
     "source/scripts": 7974807,
-    "tests/e2e": 6061454,
-    "config/data/messages": 1828684
+    "tests/e2e": 6062055,
+    "config/data/messages": 1829509
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- pin the trusted exact-head admission action into all five PR gate callers
- pin the PR E2E result wrapper to the bootstrap merge SHA and remove its colliding manual trigger
- preserve quick draft lanes while requiring one broad certification for ready heads and explicit recertification after later head changes
- refresh Z620 parity digests and exact repo-size budgets

## Verification
- 528/528 CI contract regression tests passed
- 33 focused workflow contract tests passed
- 4/4 Z620 parity tests passed
- workflow YAML parsing passed for all five callers
- security guard passed
- repository size budget passed
- independent activation review: ACCEPT

## Boundaries
- no product code, database, provider, deployment, or production mutation
- all certification actions are pinned to bootstrap merge SHA ecd31cf47a5d2fbd6c164aea0c0c6fcfb686011b
- Mac Docker was not used