### PR TITLE
fix(security): pin patched nanoid transitive

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   hono: ^4.12.34
   '@hono/node-server': 2.0.10
   postcss: 8.5.23
+  nanoid@<3.3.17: 3.3.17
   defu: ^6.1.5
   path-to-regexp: ^8.4.0
   picomatch@<2.3.2: 2.3.2
@@ -11742,10 +11743,10 @@ packages:
         integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
-  nanoid@3.3.16:
+  nanoid@3.3.17:
     resolution:
       {
-        integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==,
+        integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -22040,7 +22041,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   nanoid@5.1.16: {}
 
@@ -22560,7 +22561,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,7 @@ overrides:
   hono: ^4.12.34
   '@hono/node-server': 2.0.10
   postcss: 8.5.23
+  nanoid@<3.3.17: 3.3.17
   defu: ^6.1.5
   path-to-regexp: ^8.4.0
   picomatch@<2.3.2: 2.3.2

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 59957732,
+  "maxTrackedBytes": 59957782,
   "maxTrackedFiles": 5672,
   "maxCategoryBytes": {
     "other": 18856395,
-    "large support/generated-ish": 16877945,
+    "large support/generated-ish": 16877970,
     "docs/text": 8294133,
     "source/scripts": 8011558,
     "tests/e2e": 6084082,
-    "config/data/messages": 1833619
+    "config/data/messages": 1833644
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Scope

Minimal security unblock for the new high-severity `nanoid <3.3.17` advisory blocking the already-approved docs-only IDA-DG29 gate PR #1506. This is ancillary security maintenance, not a product slice and does not modify the R7 gate.

- selectively overrides only vulnerable `nanoid@<3.3.17` to `3.3.17`
- updates the lockfile resolution used through `postcss@8.5.23`
- synchronizes the required repository-size budget

## Evidence

- RED: production audit gate failed on advisory 1138813 (`nanoid <3.3.17`)
- GREEN: `pnpm audit --prod --audit-level=high --json | node scripts/pnpm-audit-gate.mjs`
- GREEN: `pnpm security:guard`
- GREEN: `node scripts/repo-size-budget-sync.mjs --check`
- GREEN: `git diff --check`
- lockfile remained byte-identical during post-fix audit proof

## Residual

One pre-existing moderate `dompurify` advisory remains. It is intentionally outside this exact minimal authorization. No application, runtime, route, auth, schema, deployment, or production change is included.

## Follow-up

After this PR is merged, #1506 will be updated onto exact main and only invalidated exact-head checks will rerun.