### PR TITLE
test: follow canonical claim schema source

### DIFF
--- a/packages/database/test/deferred-backfills.test.ts
+++ b/packages/database/test/deferred-backfills.test.ts
@@ -42,8 +42,8 @@ describe('ARCH-M1-12 deferred-backfills', () => {
     });
   });
 
-  describe('claims.ts schema — claimNumber uniqueIndex', () => {
-    const src = readFileSync(join(DB_ROOT, 'src', 'schema', 'claims.ts'), 'utf-8');
+  describe('claim schema — claimNumber uniqueIndex', () => {
+    const src = readFileSync(join(DB_ROOT, 'src', 'schema', 'claim-core.ts'), 'utf-8');
 
     it('uniqueIndex idx_claims_tenant_number has no "Enable after backfill" comment', () => {
       assert.doesNotMatch(src, /Enable after backfill/);


### PR DESCRIPTION
## Summary

- Updates the deferred-backfill regression test to read the canonical claim schema owner, `claim-core.ts`, after the existing schema split.
- Test-only prerequisite repair for IDA-UI03a2-B5; no product behavior or B5 writer-map change.

## Review focus

- Confirm `claim-core.ts` remains the source that owns `idx_claims_tenant_number`.
- Confirm the diff is limited to `packages/database/test/deferred-backfills.test.ts`.

## Evidence

- RED: current-main `slice:verify` failed because the test read the `claims.ts` re-export.
- GREEN: `pnpm --filter @interdomestik/database exec tsx --test test/deferred-backfills.test.ts` — 9/9 passed.
- `pnpm exec prettier --check packages/database/test/deferred-backfills.test.ts` — passed.
- No product E2E consumed; this repair is test-only.

## Guardrails

- No product code, routing, auth, tenancy, schema, migration, tracker, or B5 scope changes.
- External model review was not authorized for this repair.
