### PR TITLE
test: isolate Help Now protected-request watcher

### DIFF
--- a/apps/web/e2e/gate/help-now-public.spec.ts
+++ b/apps/web/e2e/gate/help-now-public.spec.ts
@@ -17,10 +17,9 @@ async function expectOnlyPublicHelpNowSurface(page: Page) {
     'data-scope',
     'public-no-account'
   );
-  await expect(page.getByTestId('member-page-ready')).toHaveCount(0);
-  await expect(page.getByTestId('agent-page-ready')).toHaveCount(0);
-  await expect(page.getByTestId('staff-page-ready')).toHaveCount(0);
-  await expect(page.getByTestId('admin-page-ready')).toHaveCount(0);
+  for (const role of ['member', 'agent', 'staff', 'admin']) {
+    await expect(page.getByTestId(`${role}-page-ready`)).toHaveCount(0);
+  }
 }
 
 function watchProtectedSurfaceRequests(page: Page) {
@@ -61,17 +60,18 @@ test.describe('MOB-01 public Help Now route', () => {
 
   test('signed-in member stays on Help Now public route', async ({ page, loginAs }, testInfo) => {
     await loginAs('member');
-    await page.waitForLoadState('networkidle');
-    const protectedRequests = watchProtectedSurfaceRequests(page);
+    const helpNowPage = await page.context().newPage();
+    const protectedRequests = watchProtectedSurfaceRequests(helpNowPage);
 
-    const response = await gotoApp(page, routes.helpNow(testInfo), testInfo, {
+    const response = await gotoApp(helpNowPage, routes.helpNow(testInfo), testInfo, {
       marker: 'help-now-page-ready',
     });
 
     expect(response?.status(), 'member should not be redirected away from Help Now').toBe(200);
-    await expect(page).toHaveURL(new RegExp(`${routes.helpNow(testInfo)}$`));
-    await expectOnlyPublicHelpNowSurface(page);
+    await expect(helpNowPage).toHaveURL(new RegExp(`${routes.helpNow(testInfo)}$`));
+    await expectOnlyPublicHelpNowSurface(helpNowPage);
     expect(protectedRequests).toEqual([]);
+    await helpNowPage.close();
   });
 
   test('MK Help Now exposes the accepted public pack only', async ({ browser }, testInfo) => {


### PR DESCRIPTION
## Summary
- isolate the signed-in Help Now request watcher in a fresh authenticated browser context
- prevent residual member-dashboard prefetches from being misclassified as Help Now protected requests
- keep runtime/product behavior unchanged

## Scope
- `apps/web/e2e/gate/help-now-public.spec.ts` only
- prerequisite repair for IDA-UI03a2-B8; no B8 writer-map or product-scope change

## Evidence
- focused Z620 regression on exact head `660e3d60ca167d65f081c49352014cd05642a7f3`
- `gate-mk-contract`, `--repeat-each=3`, one worker: 9/9 passed in 30.0s
- pre-commit lint-staged/Prettier passed
- base `c1328603e3dafe68523a9766adcee3cb53191262` Nightly E2E was green; observed failure was residual dashboard prefetch capture outside B8 diff

## Risk / rollback
Test-only change. Revert this commit if the isolated authenticated context stops matching canonical session semantics.
