### PR TITLE
ci: remove duplicate quarantine budget run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,6 @@ jobs:
           # Contract Compliance: pnpm check remains the Golden Path marker.
           # Browser PR coverage lives in the dedicated PR E2E workflow.
           # Push/mainline gate coverage stays in the e2e-gate job below.
-      - name: Check E2E quarantine budget
-        if: needs.validation-surface.outputs.run_broad == 'true'
-        run: pnpm check:e2e-quarantine-budget
       - name: Report quick draft lane
         if: needs.validation-surface.outputs.run_broad != 'true'
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file contains agent guidelines and commands. For reviews, also follow `code
 
 ## ⚠️ V3 / Current Program Execution Rules (MANDATORY)
 
-`docs/plans/current-program.md` is the sole authority for the current phase, priorities, and sequencing. Active execution follows the canonical M0→M5 path; Phase C remains the historical evidence ledger, and its guardrails continue to apply.
+`docs/plans/current-program.md` is the sole authority for the current phase, priorities, and sequencing. Do not infer the active slice from this file: M0→M5 is the conditional architecture-finalization authority when explicitly promoted, while Phase C remains the historical evidence ledger and its guardrails continue to apply.
 
 The following rules are non-negotiable for all agents (human or AI):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 This file contains agent guidelines and commands. For reviews, also follow `code_review.md`.
 
-## ⚠️ V3 / Phase C Execution Rules (MANDATORY)
+## ⚠️ V3 / Current Program Execution Rules (MANDATORY)
 
-This repository is currently operating in **Phase C – Pilot Delivery**.
+`docs/plans/current-program.md` is the sole authority for the current phase, priorities, and sequencing. Active execution follows the canonical M0→M5 path; Phase C remains the historical evidence ledger, and its guardrails continue to apply.
 
 The following rules are non-negotiable for all agents (human or AI):
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ V3 uses strict **Canonical Routes**. All access is governed by `apps/web/src/pro
 
 > **V3 Pilot Scope**
 > `docs/plans/current-program.md` is the sole authority for the current phase, priorities, and sequencing.
-> Active execution follows the canonical M0→M5 path; Phase C remains the historical evidence ledger, and its guardrails continue to apply.
+> Do not infer the active slice from this README: M0→M5 is the conditional architecture-finalization authority when explicitly promoted, while Phase C remains the historical evidence ledger and its guardrails continue to apply.
 > Architecture, routing, clarity markers, and security guards are locked.
 
 We enforce strict quality standards ("The Guard") for the V3 Pilot.

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ V3 uses strict **Canonical Routes**. All access is governed by `apps/web/src/pro
 ## ✅ Pilot Readiness & Quality Gates
 
 > **V3 Pilot Scope**
-> This repository is currently in Phase C (Pilot Delivery).
+> `docs/plans/current-program.md` is the sole authority for the current phase, priorities, and sequencing.
+> Active execution follows the canonical M0→M5 path; Phase C remains the historical evidence ledger, and its guardrails continue to apply.
 > Architecture, routing, clarity markers, and security guards are locked.
-> Feature completeness is being finalized through explicit pilot workflows.
 
 We enforce strict quality standards ("The Guard") for the V3 Pilot.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,10 @@
-# 🏗️ Interdomestik V3 Architecture (Phase C Pilot)
+# 🏗️ Interdomestik V3 Architecture
 
-> **Status:** Phase C (Pilot Delivery)  
+> **Program Authority:** `docs/plans/current-program.md` alone defines the current phase, priorities, and sequencing.
+> **Active Authority:** Canonical M0→M5 architecture finalization.
+> **Historical Guardrails:** Phase C (Pilot Delivery) remains the evidence ledger, and its guardrails continue to apply.
 > **Enforcement:** Strict (CI/CD Gates active)  
-> **Source of Truth:** This document describes the runtime architecture for the V3 Pilot.
+> **Scope:** This document describes the runtime architecture for the V3 Pilot; it does not set current program sequencing.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,8 @@
 # 🏗️ Interdomestik V3 Architecture
 
 > **Program Authority:** `docs/plans/current-program.md` alone defines the current phase, priorities, and sequencing.
-> **Active Authority:** Canonical M0→M5 architecture finalization.
+> **Current Selection:** Read the latest entry in `docs/plans/current-program.md`; this architecture reference does not declare an active slice.
+> **Conditional Authority:** M0→M5 architecture finalization applies only when explicitly promoted.
 > **Historical Guardrails:** Phase C (Pilot Delivery) remains the evidence ledger, and its guardrails continue to apply.
 > **Enforcement:** Strict (CI/CD Gates active)  
 > **Scope:** This document describes the runtime architecture for the V3 Pilot; it does not set current program sequencing.

--- a/scripts/ci/e2e-quarantine-budget.test.mjs
+++ b/scripts/ci/e2e-quarantine-budget.test.mjs
@@ -9,7 +9,6 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '../..');
 const budgetScript = path.join(rootDir, 'scripts/check-e2e-quarantine-budget.mjs');
-
 function readRepoJson(relativePath) {
   return JSON.parse(fs.readFileSync(path.join(rootDir, relativePath), 'utf8'));
 }
@@ -72,8 +71,9 @@ test('E2E quarantine budget is wired into contract checks and PR verification', 
     packageJson.scripts['check:e2e-tenant-host-lanes'],
     'node scripts/check-e2e-tenant-host-lanes.mjs'
   );
-  assert.match(packageJson.scripts['check:e2e-contracts'], /pnpm check:e2e-tenant-host-lanes/u);
-  assert.match(packageJson.scripts['check:e2e-contracts'], /pnpm check:e2e-quarantine-budget/u);
+  const composite =
+    'pnpm check:e2e-contracts:base && pnpm check:e2e-tenant-host-lanes && pnpm check:e2e-quarantine-budget';
+  assert.equal(packageJson.scripts['check:e2e-contracts'], composite);
   assert.match(packageJson.scripts['pr:verify'], /pnpm check:e2e-contracts/u);
   assert.equal(baseline.version, 1);
   assert.equal(baseline.tags.quarantine.count, 6);

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -24,7 +24,6 @@ function readWorkflow(relativePath) {
 function findStep(steps, name) {
   return steps.find(step => step?.name === name);
 }
-
 function findStepIndex(steps, name) {
   return steps.findIndex(step => step?.name === name);
 }
@@ -455,14 +454,15 @@ test('CI audit job runs the scripts/ci contract suite', () => {
   const ciWorkflow = readWorkflow('.github/workflows/ci.yml');
   const auditJob = ciWorkflow.jobs.audit;
   const auditRunStep = findStep(auditJob.steps, 'Run Audits');
-  const quarantineBudgetStep = findStep(auditJob.steps, 'Check E2E quarantine budget');
+  const standaloneBudgetSteps = auditJob.steps.filter(
+    step => step?.run?.trim() === 'pnpm check:e2e-quarantine-budget'
+  );
   assert.ok(auditRunStep);
   assert.match(auditRunStep.run, /\bpnpm test:ci:contracts\b/);
   assert.doesNotMatch(auditRunStep.run, /playbook-contracts\.mjs/);
   assert.match(auditRunStep.run, /\bpnpm check:e2e-contracts\b/);
   assert.match(auditRunStep.run, /\bpnpm lint:production-warnings\b/);
-  assert.ok(quarantineBudgetStep);
-  assert.equal(quarantineBudgetStep.run, 'pnpm check:e2e-quarantine-budget');
+  assert.equal(standaloneBudgetSteps.length, 0);
 });
 
 test('Composite CI setup action uses Node 24-compatible hosted actions', () => {

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "workflowDigests": {
-    ".github/workflows/ci.yml": "d88cab1f675cd82d56dc6dd16b68f71c20aa15c49fa556db15a60d0116b03253",
+    ".github/workflows/ci.yml": "0c32d6e9a122d9cf5f0f88239452fb7bae80c16d1a2fa0efc4c22ce293d77fe6",
     ".github/workflows/security.yml": "72e957bba4773deb3212d6db1d16f398c8fed53e538c6a060ca04f07f688195a",
     ".github/workflows/e2e-pr.yml": "5607206adf40e9f63567e71f41311f386519990ffdfbbd6fc7c469c355a720bc",
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60519874,
+  "maxTrackedBytes": 60521179,
   "maxTrackedFiles": 5702,
   "maxCategoryBytes": {
     "other": 18856416,
     "large support/generated-ish": 16964616,
-    "docs/text": 8662497,
+    "docs/text": 8663072,
     "source/scripts": 8057531,
-    "tests/e2e": 6140760,
-    "config/data/messages": 1838054
+    "tests/e2e": 6140741,
+    "config/data/messages": 1838803
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60521179,
+  "maxTrackedBytes": 60520631,
   "maxTrackedFiles": 5702,
   "maxCategoryBytes": {
     "other": 18856416,
     "large support/generated-ish": 16964616,
-    "docs/text": 8663072,
+    "docs/text": 8663426,
     "source/scripts": 8057531,
     "tests/e2e": 6140741,
-    "config/data/messages": 1838803
+    "config/data/messages": 1837901
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Outcome

- Aligns README, AGENTS, and architecture status wording with docs/plans/current-program.md as the sole current phase/priority/sequence authority.
- Keeps Phase C as the historical evidence ledger and preserves its active guardrails.
- Removes one proven duplicate quarantine-budget invocation from the CI audit job.

## Gate preservation

- The audit job still runs pnpm check:e2e-contracts.
- That composite still runs base contracts, tenant-host lanes, and quarantine budget exactly once.
- No required job context, E2E lane, pilot gate, RLS check, preflight, security check, Sonar, finalizer, CD path, product code, or test inventory changed.

## Review and proof

- User explicitly authorized README, AGENTS, architecture-status, and CI-dedup changes.
- Opus 5 bounded Tier 3 design review: completed; findings applied.
- Opus 5 exact-diff substantive re-review: PASS.
- Focused workflow/quarantine/parity contracts: 30/30.
- Full CI contract suite: 543/543.
- E2E contract composite: pass.
- Security guard: pass.
- Documentation locks: pass.
- Repository size budget and synchronization check: pass.
- Targeted Prettier and git diff checks: pass.

## Scope

Eight files, net -1 line. This PR intentionally does not attempt broader workflow, preflight, E2E, finalizer, or product cleanup.
