### PR TITLE
ci: align main E2E database substrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,14 +165,11 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-playwright: ${{ github.event_name != 'pull_request' }}
-
       - name: Generate ephemeral E2E credentials
         run: bash scripts/ci/export-e2e-credentials.sh
-
       - name: Enforce E2E Best Practices
         if: github.event_name != 'pull_request'
         run: pnpm --filter @interdomestik/web run e2e:guards
-
       - name: Prepare E2E Database
         run: |
           pnpm db:migrate
@@ -189,4 +186,7 @@ jobs:
 
       - name: E2E Gate Suite
         if: github.event_name != 'pull_request'
+        env:
+          E2E_DATABASE_URL: ${{ env.DATABASE_URL }}
+          E2E_DATABASE_URL_RLS: ${{ env.DATABASE_URL }}
         run: pnpm e2e:gate

--- a/scripts/ci/main-e2e-db-parity.test.mjs
+++ b/scripts/ci/main-e2e-db-parity.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '../..');
+
+test('main E2E gate uses the database prepared by its Postgres service', () => {
+  const workflow = yaml.load(
+    fs.readFileSync(path.join(rootDir, '.github/workflows/ci.yml'), 'utf8')
+  );
+  const gate = workflow.jobs['e2e-gate'];
+  const prepare = gate.steps.find(step => step?.name === 'Prepare E2E Database');
+  const suite = gate.steps.find(step => step?.name === 'E2E Gate Suite');
+
+  assert.ok(prepare);
+  assert.ok(suite);
+  assert.equal(gate.services.postgres.env.POSTGRES_DB, 'interdomestik_test');
+  assert.equal(gate.services.postgres.ports[0], '5432:5432');
+  assert.equal(
+    workflow.env.DATABASE_URL,
+    "${{ secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}"
+  );
+  assert.deepEqual(suite.env, {
+    E2E_DATABASE_URL: '${{ env.DATABASE_URL }}',
+    E2E_DATABASE_URL_RLS: '${{ env.DATABASE_URL }}',
+  });
+  assert.equal(prepare.env, undefined);
+});

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "workflowDigests": {
-    ".github/workflows/ci.yml": "0c32d6e9a122d9cf5f0f88239452fb7bae80c16d1a2fa0efc4c22ce293d77fe6",
+    ".github/workflows/ci.yml": "d2f4eeb61b413d997cd51fe70abc2d1ad93bed6f10ca0fe5cd23c8b7979b1b97",
     ".github/workflows/security.yml": "72e957bba4773deb3212d6db1d16f398c8fed53e538c6a060ca04f07f688195a",
     ".github/workflows/e2e-pr.yml": "5607206adf40e9f63567e71f41311f386519990ffdfbbd6fc7c469c355a720bc",
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60520631,
-  "maxTrackedFiles": 5702,
+  "maxTrackedBytes": 60521980,
+  "maxTrackedFiles": 5703,
   "maxCategoryBytes": {
     "other": 18856416,
     "large support/generated-ish": 16964616,
     "docs/text": 8663426,
     "source/scripts": 8057531,
-    "tests/e2e": 6140741,
-    "config/data/messages": 1837901
+    "tests/e2e": 6141972,
+    "config/data/messages": 1838019
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary
- bind the main E2E gate to the Postgres 16 service database already prepared by CI
- add one focused workflow contract test
- update required parity and exact committed-tree size metadata

## Why
The main gate previously defaulted to port 54322 while CI prepared Postgres on 5432. This prerequisite deliberately contains no evidence-reuse logic, so its main merge must execute the concrete E2E gate once before reuse can be enabled.

## Verification
- CI contracts 544/544
- security guard and modularity green
- Opus 5 substantive re-review PASS, zero P0/P1/P2
- no product code or gate removal