### PR TITLE
docs: authorize CI01 exact-tree E2E reuse

### DIFF
--- a/docs/plans/2026-08-13-ida-dg37-ci01-main-e2e-exact-tree-evidence-reuse.md
+++ b/docs/plans/2026-08-13-ida-dg37-ci01-main-e2e-exact-tree-evidence-reuse.md
@@ -1,0 +1,259 @@
+# IDA-DG37-CI01 Main E2E Exact-Tree Evidence Reuse
+
+Status: proposed current authority; runtime not authorized
+
+Date: 2026-08-13
+
+Authority base: `6ca7ce02ae430c3a78cde5449b2c625d5cd58917`
+
+Authority tree: `75401bf05a0f229e6fa573e233571a1b66a34bf6`
+
+Tier: 3 — CI and merge-gate infrastructure
+
+## Decision
+
+Promote exactly one bounded infrastructure slice:
+`IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE`.
+
+The slice must stop running the same browser-gate projects a second time after
+merge only when GitHub proves that a successful, concrete PR E2E runner tested
+the exact Git tree now present on `main`. Every gate remains present. When any
+identity, freshness, API, workflow, job, repository, or substrate check is
+missing or invalid, the existing main E2E gate must run.
+
+This decision does not authorize product work, broad CI cleanup, deletion of
+tests, relaxed branch protection, or a second optimization.
+
+## Problem and measured baseline
+
+The accepted Value Mode closeout identified repeated PR-to-main browser work as
+a material wait surface. A representative same-tree pair provides the bounded
+baseline:
+
+- PR `#1545` reviewed head `364f186752fb3f9961672a959d0e746d25705395`
+- main merge `6ca7ce02ae430c3a78cde5449b2c625d5cd58917`
+- both resolve to tree `75401bf05a0f229e6fa573e233571a1b66a34bf6`
+- PR E2E: `20m31s`
+- repeated main `E2E Gate Suite`: `16m15s`
+- whole main `e2e-gate` job: `19m02s`
+- observed main critical-path delay relative to the parallel unit lane: about
+  `6m13s`
+
+The `16m15s` suite duration is the compute/wait target, not a guaranteed
+end-to-end delivery saving. Only post-merge measurements may establish actual
+critical-path savings.
+
+## Mandatory prerequisite
+
+Inspection found that the historical main browser suite defaulted to
+`127.0.0.1:54322/postgres`, while the CI job prepared its declared Postgres 16
+service at `127.0.0.1:5432/interdomestik_test`. Evidence reuse must not hide an
+unproved correction to that substrate.
+
+Before reuse is enabled, one prerequisite PR must:
+
+1. bind the existing main `E2E Gate Suite` to the workflow-level
+   `DATABASE_URL` for both `E2E_DATABASE_URL` and `E2E_DATABASE_URL_RLS`;
+2. add one focused contract test for service database, port, prepare-step, and
+   suite binding;
+3. preserve every other step and condition;
+4. merge without reuse logic; and
+5. produce one successful concrete main `E2E Gate Suite` on the corrected
+   substrate.
+
+Draft PR `#1546` and commit `e542df612760578ee985e37552e1883b4b1931da`
+were created before the mandatory current-authority promotion was noticed.
+They are non-authoritative prototype evidence only, must remain unmerged, and
+must not be reused as the post-authority implementation head. After authority
+and runtime approval, the prerequisite must be recreated from then-current
+clean main and reviewed again.
+
+## Frozen authority and implementation scope
+
+### Docs-only authority writers
+
+- `docs/plans/2026-08-13-ida-dg37-ci01-main-e2e-exact-tree-evidence-reuse.md`
+- `docs/plans/current-program.md`
+- `docs/plans/current-tracker.md`
+- `scripts/repo-size-budget.json` only when deterministic committed-tree size
+  accounting requires it
+
+The authority PR must append one current-program revision and one matching
+tracker revision that promote only CI01, record this gate's exact byte count and
+SHA-256 after review and approval, freeze the two-stage runtime boundary below,
+and leave `runtime_authorized:false`. Those canonical append-only revisions,
+not this standalone file, make CI01 current authority.
+
+### Prerequisite writers
+
+- `.github/workflows/ci.yml`
+- `scripts/ci/main-e2e-db-parity.test.mjs`
+- `scripts/ci/z620-parity.json`
+- `scripts/repo-size-budget.json` only when deterministic committed-tree size
+  accounting requires it
+
+### Evidence-reuse writers
+
+- `.github/workflows/ci.yml`
+- `scripts/ci/github-api-url-lib.mjs`
+- `scripts/ci/github-api-url-lib.test.mjs`
+- `scripts/ci/main-e2e-reuse.mjs`
+- `scripts/ci/main-e2e-reuse-core.mjs`
+- `scripts/ci/main-e2e-reuse-core.test.mjs`
+- `scripts/ci/main-e2e-reuse-fixture.mjs`
+- `scripts/ci/main-e2e-reuse-github.mjs`
+- `scripts/ci/main-e2e-reuse-github.test.mjs`
+- `scripts/ci/main-e2e-reuse-cli.test.mjs`
+- `scripts/ci/main-e2e-reuse-workflow.test.mjs`
+- `scripts/ci/workflow-contracts.test.mjs` only for non-duplicated contract
+  placement
+- `scripts/ci/z620-parity.json`
+- `scripts/repo-size-budget.json` only when deterministic committed-tree size
+  accounting requires it
+
+No other writer path is authorized. Existing user-owned or skip-worktree files
+must not be changed or incorporated into size metadata.
+
+## Exact acceptance contract
+
+Main browser-suite reuse is allowed only when all conditions below hold:
+
+1. event is `push`, ref is exactly `refs/heads/main`, repository is exactly
+   `interdomestik/interdomestik`, and the local checked-out `HEAD` equals
+   `GITHUB_SHA`;
+2. exactly one merged same-repository pull request has
+   `merge_commit_sha == GITHUB_SHA`, `base.repo.full_name == GITHUB_REPOSITORY`,
+   and `base.ref == main`;
+3. the PR head commit tree equals local `HEAD^{tree}`;
+4. a completed successful run exists for workflow path
+   `.github/workflows/e2e-pr.yml`, event `pull_request`, the exact PR head SHA,
+   and the same repository and head repository; the run's `pull_requests`
+   association must contain exactly the selected merged PR number/id with base
+   repository/ref equal to this repository/`main` and matching head repository,
+   ref, and SHA;
+5. the concrete job named `PR E2E Runner` exists exactly once and completed
+   successfully;
+6. the run started within the frozen 24-hour freshness window, with at most a
+   five-minute future clock tolerance;
+7. the PR workflow explicitly checks out
+   `${{ github.event.pull_request.head.sha }}`;
+8. the PR project list is a strict superset of the main gate project list and
+   shared flags and database substrate are identical; and
+9. the resolver completes within bounded GitHub API pagination and request
+   timeouts without exposing tokens, response bodies, or unbounded error text.
+
+The resolver must write only one normalized decision. `reuse=true` is valid
+only with reason `exact_pr_evidence`. Every exception, timeout, malformed
+payload, missing output, direct push, fork, ambiguity, stale run, mismatched
+tree, wrong workflow, wrong head, wrong repository, skipped job, or failed job
+must resolve to reuse false or leave no true output. The workflow condition
+must treat anything other than the exact string `true` as a command to run the
+main E2E suite.
+
+## Gates that remain mandatory
+
+Reuse may skip only `pnpm e2e:gate` inside the existing main `e2e-gate` job.
+It must not skip or weaken:
+
+- workflow checkout and setup required by remaining steps;
+- ephemeral credential generation;
+- strict E2E best-practice guards;
+- database migration, seed, and seed assertion;
+- RLS integration and coverage checks;
+- CI audit, static, unit, AI eval, security, CodeQL, Semgrep, OSV, gitleaks,
+  Sonar, finalizer, or branch protection; or
+- the full PR E2E runner.
+
+The resolver itself is advisory evidence selection. It must use read-only
+GitHub token permissions and `continue-on-error`; failure never fails open.
+
+## TDD and review sequence
+
+1. Establish RED tests for prerequisite DB parity before editing the workflow.
+2. Land and merge the prerequisite from current main.
+3. Verify a real main browser suite passed on the corrected DB substrate.
+4. Establish RED tests for resolver absence and every security-critical
+   negative predicate, including wrong workflow path, fork head repository,
+   wrong head SHA, wrong base repository/ref, same-head association with a
+   different PR, stale start time, missing concrete runner, hostile reason, and
+   checkout-ref drift.
+5. Implement the smallest dependency-free resolver and workflow wiring.
+6. Run focused contracts, the full CI contract suite, repository-native
+   security and modularity guards, format/diff checks, and exact metadata
+   checks.
+7. Obtain one bounded Opus 5 implementation review, at most one consolidated
+   remediation, and one substantive same-route re-review. If Opus 5 is blocked
+   by a recorded quota/tooling receipt, GPT-5.6-Sol Ultra is the only approved
+   fallback and counts only after Arben explicitly approves that route; the
+   blocked Opus attempt remains `unavailable`, never pass.
+8. Explicitly request GitHub Copilot code review on the final ready PR using
+   `copilot-pull-request-reviewer[bot]`. If GitHub does not deliver a retained
+   review, record `unavailable`, not pass.
+9. Run exactly one full exact-head PR E2E. Rerun only invalidated evidence.
+10. Merge only after all repository-required checks and unresolved-thread
+    checks pass.
+11. On exact main, require the resolver to accept the merged same-tree PR,
+    require `E2E Gate Suite` to be skipped, and require every non-reused gate to
+    remain green.
+
+## Measurement and stop rule
+
+Record for the prerequisite and reuse PRs:
+
+- PR E2E runner duration;
+- main `e2e-gate` job and browser-suite duration;
+- main CI completion time and its critical path relative to parallel jobs;
+- resolver duration and outcome;
+- reruns, retries, quarantines, and failures;
+- review findings and remediation count; and
+- actual implementation/review overhead spent to obtain the saving.
+
+Compare post-reuse main against the same-tree baseline above and the
+prerequisite proof run. Report suite compute avoided separately from observed
+critical-path time saved. Do not claim ROI from a single run if queueing,
+caching, or unrelated job variance prevents a fair comparison.
+
+If the resolver does not safely reuse exact evidence, causes a gate bypass,
+requires broader workflow architecture, or saves no material wait after three
+representative merges, disable or revert reuse and retain only the proven DB
+substrate correction.
+
+## Explicit exclusions
+
+- no product, route, proxy, auth, session, tenancy, schema/RLS-policy, billing,
+  provider, deployment, or production behavior change;
+- no deletion, quarantine, weakening, renaming, or consolidation of tests or
+  required checks;
+- no broad CI/E2E/preflight deduplication;
+- no AI OS, Brain, retrieval, graph, persona, dashboard, agent-count, or
+  workflow-system expansion;
+- no automatic merge; and
+- no second product or infrastructure slice.
+
+## Authority and runtime boundary
+
+This document and the matching append-only current-program/current-tracker
+revisions may be reviewed and exact-hash approved as one docs-only design gate.
+Their merge promotes only `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE` with
+`runtime_authorized:false`.
+
+After the docs-only authority merge, the runner must re-read current main and
+re-run repository preflight/resolver checks. The execution then has two
+separately approved stages:
+
+1. `CI01-RUNTIME-R1` binds then-current main, this exact gate hash, and only the
+   prerequisite writer map. The runner must stop for Arben's exact approval of
+   R1 before recreating the prerequisite from clean main or mutating code.
+2. After the prerequisite merges and one corrected-substrate main browser suite
+   passes, `CI01-RUNTIME-R2` binds that new exact main, the prerequisite merge
+   and proof run, this exact gate hash, and only the evidence-reuse writer map.
+   The runner must stop again for Arben's exact approval of R2 before creating
+   the reuse branch or mutating reuse code.
+
+R1 cannot authorize reuse and R2 cannot be precomputed before prerequisite
+main proof. A failed prerequisite consumes neither R2 nor permission to proceed.
+
+Terminal closeout consumes the promotion, records prerequisite and reuse merge
+identities plus measured before/after evidence, restores
+`blocked_requires_current_authority` with `activeSlice=null`, and promotes no
+successor.

--- a/docs/plans/current-program.md
+++ b/docs/plans/current-program.md
@@ -7563,3 +7563,28 @@ terminal AI OS/Brain verification remain post-merge closeout actions and are
 not claimed by this repository record.
 <!-- prettier-ignore -->
 The next active governed implementation goal is blocked pending a fresh current-authority/design-gate selection; resolver target is `blocked_requires_current_authority`, `activeSlice=null`.
+
+Rev 224 proposed current-authority selection supersedes only the Rev 223
+terminal no-promotion sentence. The proposed docs-only gate is
+`docs/plans/2026-08-13-ida-dg37-ci01-main-e2e-exact-tree-evidence-reuse.md`,
+exactly 11,781 UTF-8 bytes / SHA-256
+`3858f54297766167f0e4d1d3716fb394fb2a656176b84c3441c00cdce7f61025`,
+bound to clean main `6ca7ce02ae430c3a78cde5449b2c625d5cd58917` and tree
+`75401bf05a0f229e6fa573e233571a1b66a34bf6`. It promotes exactly one Tier 3
+infrastructure slice: `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE`.
+
+The slice first requires a separately approved prerequisite that binds the
+existing main E2E suite to the Postgres 16 database already prepared by CI and
+then proves one real corrected-substrate main browser run. Only after that
+merge and proof may a second exact-main runtime receipt authorize same-tree PR
+E2E evidence reuse. Every gate remains; any missing, stale, mismatched,
+ambiguous, forked, wrong-base, wrong-PR, failed-job or API-error condition runs
+the existing main browser gate. Product behavior, test removal, broad CI
+cleanup, deployment and every second slice remain unpromoted.
+
+This proposed authority remains `runtime_authorized:false`. After docs merge,
+`CI01-RUNTIME-R1` exact approval is required for the prerequisite. After its
+main proof, fresh `CI01-RUNTIME-R2` exact approval is required for reuse. No
+implementation branch or code mutation may precede its stage-specific receipt.
+<!-- prettier-ignore -->
+The next active governed implementation goal is exactly one canonical tracker slice: `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE` (Tier 3 CI infrastructure; `runtime_authorized:false`; proposed authority activates only after exact approval of gate 11,781 bytes / SHA-256 3858f54297766167f0e4d1d3716fb394fb2a656176b84c3441c00cdce7f61025 and docs-only merge).

--- a/docs/plans/current-tracker.md
+++ b/docs/plans/current-tracker.md
@@ -2773,3 +2773,22 @@ OS/Brain verification remain post-merge closeout actions and are not claimed by
 this repository record.
 <!-- prettier-ignore -->
 The next active governed implementation goal is blocked pending a fresh current-authority/design-gate selection; resolver target is `blocked_requires_current_authority`, `activeSlice=null`.
+
+Rev 224 proposed selection adds exactly one bounded Tier 3 queue row:
+`IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE`. Its proposed gate is
+`docs/plans/2026-08-13-ida-dg37-ci01-main-e2e-exact-tree-evidence-reuse.md`,
+exactly 11,781 UTF-8 bytes / SHA-256
+`3858f54297766167f0e4d1d3716fb394fb2a656176b84c3441c00cdce7f61025`,
+bound to main `6ca7ce02ae430c3a78cde5449b2c625d5cd58917`. The outcome is to retain every
+gate while avoiding a second main browser suite only when the exact merged PR,
+base `main`, head/tree, workflow run, concrete runner, freshness, repository,
+DB substrate and static lane-superset contracts all agree.
+
+Execution has two mandatory exact approvals. `CI01-RUNTIME-R1` authorizes only
+the DB-parity prerequisite; after it merges and corrected main E2E passes,
+`CI01-RUNTIME-R2` authorizes only evidence reuse from the new exact main.
+Neither stage authorizes product work, test deletion, broad CI cleanup,
+deployment or a second slice. Current proposed state is
+`runtime_authorized:false`.
+<!-- prettier-ignore -->
+The next active governed implementation goal is exactly one canonical tracker slice: `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE` (Tier 3 CI infrastructure; `runtime_authorized:false`; proposed authority activates only after exact approval of gate 11,781 bytes / SHA-256 3858f54297766167f0e4d1d3716fb394fb2a656176b84c3441c00cdce7f61025 and docs-only merge).

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60520631,
-  "maxTrackedFiles": 5702,
+  "maxTrackedBytes": 60535634,
+  "maxTrackedFiles": 5703,
   "maxCategoryBytes": {
     "other": 18856416,
-    "large support/generated-ish": 16964616,
-    "docs/text": 8663426,
+    "large support/generated-ish": 16966011,
+    "docs/text": 8677034,
     "source/scripts": 8057531,
     "tests/e2e": 6140741,
     "config/data/messages": 1837901


### PR DESCRIPTION
## Authority
Promotes exactly one Tier 3 infrastructure slice: `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE`.

Exact-approved gate: 11,781 UTF-8 bytes, SHA-256 `3858f54297766167f0e4d1d3716fb394fb2a656176b84c3441c00cdce7f61025`, bound to main `6ca7ce02ae430c3a78cde5449b2c625d5cd58917`. Arben approved the exact phrase in the owning task.

## Boundaries
- docs-only authority plus deterministic size metadata
- no runtime authorization
- two later exact approvals: R1 prerequisite, R2 reuse
- all gates preserved; no product or broad workflow expansion
- draft PR #1546 is non-authoritative prototype evidence and remains unmerged

## Review
- GPT-5.6-Sol Ultra substantive review and re-review: PASS
- Opus 5 route blocked by quota; not counted as pass
- plan:audit, track:audit, Prettier and diff-check pass