### PR TITLE
ci: align main E2E database substrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,11 +168,9 @@ jobs:
 
       - name: Generate ephemeral E2E credentials
         run: bash scripts/ci/export-e2e-credentials.sh
-
       - name: Enforce E2E Best Practices
         if: github.event_name != 'pull_request'
         run: pnpm --filter @interdomestik/web run e2e:guards
-
       - name: Prepare E2E Database
         run: |
           pnpm db:migrate
@@ -180,7 +178,6 @@ jobs:
             pnpm seed:e2e
             pnpm seed:assert-e2e
           fi
-
       - name: RLS Integration Test
         env:
           REQUIRE_RLS_INTEGRATION: '1'
@@ -189,4 +186,7 @@ jobs:
 
       - name: E2E Gate Suite
         if: github.event_name != 'pull_request'
+        env:
+          E2E_DATABASE_URL: ${{ env.DATABASE_URL }}
+          E2E_DATABASE_URL_RLS: ${{ env.DATABASE_URL }}
         run: pnpm e2e:gate

--- a/scripts/ci/main-e2e-db-parity.test.mjs
+++ b/scripts/ci/main-e2e-db-parity.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '../..');
+const workflow = yaml.load(fs.readFileSync(path.join(rootDir, '.github/workflows/ci.yml'), 'utf8'));
+
+test('main E2E uses the Postgres 16 database prepared by its CI job', () => {
+  const e2eJob = workflow.jobs['e2e-gate'];
+  const postgres = e2eJob.services.postgres;
+  const prepare = e2eJob.steps.find(step => step?.name === 'Prepare E2E Database');
+  const suite = e2eJob.steps.find(step => step?.name === 'E2E Gate Suite');
+
+  assert.equal(postgres.image, 'postgres:16');
+  assert.equal(postgres.env.POSTGRES_USER, 'postgres');
+  assert.equal(postgres.env.POSTGRES_DB, 'interdomestik_test');
+  assert.deepEqual(postgres.ports, ['5432:5432']);
+  assert.equal(
+    workflow.env.DATABASE_URL,
+    "${{ secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}"
+  );
+
+  assert.ok(prepare);
+  assert.equal(prepare.env?.DATABASE_URL, undefined);
+  assert.equal(prepare.env?.E2E_DATABASE_URL, undefined);
+  assert.equal(prepare.env?.E2E_DATABASE_URL_RLS, undefined);
+  assert.doesNotMatch(prepare.run, /\b(?:DATABASE_URL|E2E_DATABASE_URL(?:_RLS)?)=/u);
+
+  assert.ok(suite);
+  assert.equal(suite.env?.E2E_DATABASE_URL, '${{ env.DATABASE_URL }}');
+  assert.equal(suite.env?.E2E_DATABASE_URL_RLS, '${{ env.DATABASE_URL }}');
+});

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "workflowDigests": {
-    ".github/workflows/ci.yml": "0c32d6e9a122d9cf5f0f88239452fb7bae80c16d1a2fa0efc4c22ce293d77fe6",
+    ".github/workflows/ci.yml": "49db1acb1efb1507059d47a83f2846c8682dc734a7be3855fd891799854ca910",
     ".github/workflows/security.yml": "72e957bba4773deb3212d6db1d16f398c8fed53e538c6a060ca04f07f688195a",
     ".github/workflows/e2e-pr.yml": "5607206adf40e9f63567e71f41311f386519990ffdfbbd6fc7c469c355a720bc",
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60535634,
-  "maxTrackedFiles": 5703,
+  "maxTrackedBytes": 60537329,
+  "maxTrackedFiles": 5704,
   "maxCategoryBytes": {
     "other": 18856416,
     "large support/generated-ish": 16966011,
     "docs/text": 8677034,
     "source/scripts": 8057531,
-    "tests/e2e": 6140741,
-    "config/data/messages": 1837901
+    "tests/e2e": 6142318,
+    "config/data/messages": 1838019
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000


### PR DESCRIPTION
## Summary

- bind the main-only `E2E Gate Suite` to the same workflow-level PostgreSQL URL already used by migration and seeding
- add one focused contract test that pins the service/database/URL and rejects step or inline overrides
- refresh the exact Z620 workflow digest and repository-size metadata

## Authority

- Gate: `IDA-DG37-CI01`
- Gate identity: 11,781 bytes; SHA-256 `3858f54297766167f0e4d1d3716fb394fb2a656176b84c3441c00cdce7f61025`
- Runtime receipt: `CI01-RUNTIME-R1`
- Runtime identity: 2,983 bytes; SHA-256 `1e6a32163f8e3938fad7b0260ecf30a0e5611273e571dfe86ab1e0dcaf756c0d`
- Authorized base: `4ae3f3ef6198a4a53304a0a9dbea9f18d25c648d`
- Exact head: `b760d2253a1973294613770d09260bea45ddad95`

## Verification

- TDD RED captured before implementation
- focused parity contracts: 5/5
- CI contract suite: 544/544
- `pnpm repo:size:check`
- `pnpm check:modularity-guard`
- `pnpm check:e2e-contracts`
- `pnpm security:guard`
- Codex Security diff scan: complete, zero findings
- senior substantive review + re-review: PASS, P0/P1/P2/P3 = 0

## Scope

R1 prerequisite only. No exact-tree reuse logic, product code, deployment, test removal, gate weakening, or broad cleanup.
