### PR TITLE
docs: amend CI01 PR association proof

### DIFF
--- a/docs/plans/2026-08-13-ida-dg37-ci01-main-e2e-exact-tree-evidence-reuse.md
+++ b/docs/plans/2026-08-13-ida-dg37-ci01-main-e2e-exact-tree-evidence-reuse.md
@@ -1,12 +1,16 @@
 # IDA-DG37-CI01 Main E2E Exact-Tree Evidence Reuse
 
-Status: proposed current authority; runtime not authorized
+Status: current authority; R1 consumed; R2 blocked pending exact-approved association amendment
 
 Date: 2026-08-13
 
 Authority base: `6ca7ce02ae430c3a78cde5449b2c625d5cd58917`
 
 Authority tree: `75401bf05a0f229e6fa573e233571a1b66a34bf6`
+
+Association-amendment base:
+`d7274986b18e7dcb55fc062f43dc69c2909d0c71` / tree
+`342c33ea41cb164fdd9feadf74ad86e8102cc1bc`
 
 Tier: 3 — CI and merge-gate infrastructure
 
@@ -68,6 +72,22 @@ must not be reused as the post-authority implementation head. After authority
 and runtime approval, the prerequisite must be recreated from then-current
 clean main and reviewed again.
 
+The approved prerequisite was recreated as PR `#1548`, reviewed at head
+`b760d2253a1973294613770d09260bea45ddad95`, and squash-merged as
+`d7274986b18e7dcb55fc062f43dc69c2909d0c71`. Main CI run `31715521046`
+passed on the corrected substrate without rerun. Its `E2E Gate Suite` took
+`13m29s`; the whole `e2e-gate` job took `15m41s`.
+
+The successful PR E2E run `31712197425` is event `pull_request`, workflow
+`.github/workflows/e2e-pr.yml`, head
+`b760d2253a1973294613770d09260bea45ddad95`, and concrete runner success, but
+GitHub's run payload returns an empty `pull_requests` array. The bounded
+`commits/{head_sha}/pulls` endpoint returns exactly PR `#1548` with the same
+number/id, head repository/ref/SHA, base repository/`main`, merge SHA, and
+merged timestamp. The association amendment below permits that second official
+edge only when the run association array is exactly empty; it does not weaken
+any tree, repository, workflow, job, freshness, or substrate predicate.
+
 ## Frozen authority and implementation scope
 
 ### Docs-only authority writers
@@ -127,10 +147,18 @@ Main browser-suite reuse is allowed only when all conditions below hold:
 3. the PR head commit tree equals local `HEAD^{tree}`;
 4. a completed successful run exists for workflow path
    `.github/workflows/e2e-pr.yml`, event `pull_request`, the exact PR head SHA,
-   and the same repository and head repository; the run's `pull_requests`
-   association must contain exactly the selected merged PR number/id with base
-   repository/ref equal to this repository/`main` and matching head repository,
-   ref, and SHA;
+   and the same repository and head repository. Association to the selected
+   merged PR must be proved by exactly one of these closed branches:
+   - when the run's `pull_requests` array is non-empty, it must contain exactly
+     one entry and that entry must equal the selected PR number/id, base
+     repository/`main`, and head repository/ref/SHA; or
+   - only when the run's `pull_requests` array is exactly empty, a bounded
+     `commits/{run.head_sha}/pulls` query must return exactly one PR, and it must
+     equal the selected PR number/id, merged state/timestamp and merge SHA, base
+     repository/`main`, and head repository/ref/SHA. A missing, malformed,
+     truncated, ambiguous, or mismatched response is not association evidence.
+     A non-empty direct association that mismatches the selected PR may never be
+     replaced or repaired by the commit-to-PR fallback;
 5. the concrete job named `PR E2E Runner` exists exactly once and completed
    successfully;
 6. the run started within the frozen 24-hour freshness window, with at most a
@@ -139,7 +167,8 @@ Main browser-suite reuse is allowed only when all conditions below hold:
    `${{ github.event.pull_request.head.sha }}`;
 8. the PR project list is a strict superset of the main gate project list and
    shared flags and database substrate are identical; and
-9. the resolver completes within bounded GitHub API pagination and request
+9. the resolver completes all run, job, PR, commit-tree, and conditional
+   commit-to-PR requests within bounded GitHub API pagination and request
    timeouts without exposing tokens, response bodies, or unbounded error text.
 
 The resolver must write only one normalized decision. `reuse=true` is valid
@@ -175,8 +204,10 @@ GitHub token permissions and `continue-on-error`; failure never fails open.
 4. Establish RED tests for resolver absence and every security-critical
    negative predicate, including wrong workflow path, fork head repository,
    wrong head SHA, wrong base repository/ref, same-head association with a
-   different PR, stale start time, missing concrete runner, hostile reason, and
-   checkout-ref drift.
+   different PR, empty-array fallback success, fallback ambiguity, fallback
+   head/ref/repository/merge mismatch, forbidden fallback after a non-empty
+   direct mismatch, stale start time, missing concrete runner, hostile reason,
+   and checkout-ref drift.
 5. Implement the smallest dependency-free resolver and workflow wiring.
 6. Run focused contracts, the full CI contract suite, repository-native
    security and modularity guards, format/diff checks, and exact metadata
@@ -246,9 +277,10 @@ separately approved stages:
    R1 before recreating the prerequisite from clean main or mutating code.
 2. After the prerequisite merges and one corrected-substrate main browser suite
    passes, `CI01-RUNTIME-R2` binds that new exact main, the prerequisite merge
-   and proof run, this exact gate hash, and only the evidence-reuse writer map.
-   The runner must stop again for Arben's exact approval of R2 before creating
-   the reuse branch or mutating reuse code.
+   and proof run, the exact-approved association-amended gate hash, and only the
+   evidence-reuse writer map. The runner must stop again for Arben's exact
+   approval of R2 before creating the reuse implementation branch or mutating
+   reuse code.
 
 R1 cannot authorize reuse and R2 cannot be precomputed before prerequisite
 main proof. A failed prerequisite consumes neither R2 nor permission to proceed.

--- a/docs/plans/current-program.md
+++ b/docs/plans/current-program.md
@@ -7588,3 +7588,32 @@ main proof, fresh `CI01-RUNTIME-R2` exact approval is required for reuse. No
 implementation branch or code mutation may precede its stage-specific receipt.
 <!-- prettier-ignore -->
 The next active governed implementation goal is exactly one canonical tracker slice: `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE` (Tier 3 CI infrastructure; `runtime_authorized:false`; proposed authority activates only after exact approval of gate 11,781 bytes / SHA-256 3858f54297766167f0e4d1d3716fb394fb2a656176b84c3441c00cdce7f61025 and docs-only merge).
+
+Rev 225 proposes one association-only amendment to the already active CI01
+authority after prerequisite PR `#1548` merged as
+`d7274986b18e7dcb55fc062f43dc69c2909d0c71` and corrected-substrate main CI
+run `31715521046` passed without rerun. The amended gate remains
+`docs/plans/2026-08-13-ida-dg37-ci01-main-e2e-exact-tree-evidence-reuse.md`,
+now exactly 13,822 UTF-8 bytes / SHA-256
+`3d704bce6637fa3ac09a4f08d1eca45abac7c19df3b85bcdc3c557efe423b0f6`,
+bound to amendment base `d7274986b18e7dcb55fc062f43dc69c2909d0c71` / tree
+`342c33ea41cb164fdd9feadf74ad86e8102cc1bc`.
+
+GitHub returned an empty `pull_requests` array for successful exact-head PR E2E
+run `31712197425`. The amendment retains direct run association whenever that
+array is non-empty and permits the official bounded
+`commits/{run.head_sha}/pulls` edge only when it is exactly empty. That fallback
+must return exactly one PR and reproduce the selected PR number/id, merged
+state/timestamp and merge SHA, base repository/`main`, and head
+repository/ref/SHA. Any ambiguity, mismatch, malformed response, pagination or
+timeout runs the existing main E2E suite; a non-empty mismatch may never use
+the fallback.
+
+This amendment activates only after Arben exact-approves the 13,822-byte gate
+identity above and this docs-only revision merges. R1 is consumed. R2 remains
+`runtime_authorized:false` and requires a fresh exact-main `CI01-RUNTIME-R2`
+receipt and separate exact approval before any reuse implementation branch or
+code mutation. No package-script cleanup, test consolidation, product work,
+deployment or second slice is promoted.
+<!-- prettier-ignore -->
+The next active governed implementation goal remains exactly one canonical tracker slice: `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE` (Tier 3 CI infrastructure; R1 consumed; association amendment pending exact approval and docs-only merge; R2 `runtime_authorized:false`).

--- a/docs/plans/current-tracker.md
+++ b/docs/plans/current-tracker.md
@@ -2792,3 +2792,27 @@ deployment or a second slice. Current proposed state is
 `runtime_authorized:false`.
 <!-- prettier-ignore -->
 The next active governed implementation goal is exactly one canonical tracker slice: `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE` (Tier 3 CI infrastructure; `runtime_authorized:false`; proposed authority activates only after exact approval of gate 11,781 bytes / SHA-256 3858f54297766167f0e4d1d3716fb394fb2a656176b84c3441c00cdce7f61025 and docs-only merge).
+
+Rev 225 keeps the sole active queue row
+`IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE` and proposes only its bounded
+GitHub association amendment. Prerequisite PR `#1548` merged as
+`d7274986b18e7dcb55fc062f43dc69c2909d0c71`; main run `31715521046` passed the
+corrected DB substrate without rerun. The amended gate is exactly 13,822 UTF-8
+bytes / SHA-256
+`3d704bce6637fa3ac09a4f08d1eca45abac7c19df3b85bcdc3c557efe423b0f6`.
+
+For successful PR run `31712197425`, GitHub's run association array is empty,
+while the bounded commit-to-PR endpoint returns exactly the selected merged PR
+with matching number/id, merge identity, base repository/`main`, and head
+repository/ref/SHA. The fallback is permitted only for an exactly empty array;
+all ambiguity, mismatch, malformed response, timeout, and non-empty direct
+mismatch remain fail-closed to the existing main browser gate.
+
+The amendment is inactive until its exact gate identity is approved and this
+docs-only revision merges. R1 is consumed; R2 remains
+`runtime_authorized:false` pending a new exact-main receipt and separate exact
+approval. Package-script cleanup, the observed MK project duplication,
+shared-auth coverage, RC-RLS evidence, product, deployment and every second
+slice remain outside this row.
+<!-- prettier-ignore -->
+The next active governed implementation goal remains exactly one canonical tracker slice: `IDA-CI01-MAIN-E2E-EXACT-TREE-EVIDENCE-REUSE` (Tier 3 CI infrastructure; R1 consumed; association amendment pending exact approval and docs-only merge; R2 `runtime_authorized:false`).

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60537329,
+  "maxTrackedBytes": 60542827,
   "maxTrackedFiles": 5704,
   "maxCategoryBytes": {
     "other": 18856416,
-    "large support/generated-ish": 16966011,
-    "docs/text": 8677034,
+    "large support/generated-ish": 16967570,
+    "docs/text": 8680973,
     "source/scripts": 8057531,
     "tests/e2e": 6142318,
     "config/data/messages": 1838019


### PR DESCRIPTION
## Scope\n- records the successful R1 prerequisite and corrected-substrate main proof\n- permits a bounded commit-to-PR association only when GitHub's run pull_requests array is exactly empty\n- preserves direct association, exact-tree, repository, workflow, job, freshness, DB-substrate, and fail-closed predicates\n- keeps R2 runtime unauthorized pending a fresh exact receipt and approval\n\n## Verification\n- GPT-5.6 Sol Ultra review: PASS\n- prettier, plan:audit, track:audit, repo:size:check, diff-check: PASS\n- exact-approved gate: 13,822 bytes / 3d704bce6637fa3ac09a4f08d1eca45abac7c19df3b85bcdc3c557efe423b0f6\n\nNo CI implementation, product code, test consolidation, deployment, or second slice.