### PR TITLE
feat(ci): reuse exact-tree PR E2E evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,12 @@ on:
     branches: [main, master]
     paths-ignore: ['docs/**', 'scripts/repo-size-budget.json']
   pull_request:
-    branches:
-      - '**'
+    branches: ['**']
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled]
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
-permissions:
-  actions: read
-  contents: read
-  pull-requests: read
+permissions: { actions: read, contents: read, pull-requests: read }
 env:
   DATABASE_URL: ${{ secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}
   BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET || 'test-secret-for-ci-only-do-not-use-in-production' }}
@@ -36,7 +32,7 @@ jobs:
       ai_eval_should_run: ${{ steps.gate_policy.outputs.ai_eval_should_run }}
       ai_eval_reason: ${{ steps.gate_policy.outputs.ai_eval_reason }}
       ai_eval_matched_paths: ${{ steps.gate_policy.outputs.ai_eval_matched_paths }}
-      main_e2e_reuse: ${{ steps.main_e2e_reuse.outputs.reuse }}
+      main_e2e_reuse: ${{ steps.main_e2e_reuse_safe.outputs.reuse }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -46,11 +42,19 @@ jobs:
           node-version-file: '.nvmrc'
           package-manager-cache: false
       - name: Resolve main E2E exact-tree reuse
-        id: main_e2e_reuse
+        id: main_e2e_reuse_raw
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         continue-on-error: true
         env: { GITHUB_TOKEN: '${{ github.token }}' }
         run: node scripts/ci/main-e2e-reuse.mjs >> "$GITHUB_OUTPUT"
+      - name: Normalize main E2E reuse decision
+        id: main_e2e_reuse_safe
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          {
+            RESOLVER_RESULT: '${{ steps.main_e2e_reuse_raw.outcome }}:${{ steps.main_e2e_reuse_raw.outputs.reuse }}',
+          }
+        run: case "$RESOLVER_RESULT" in success:true) reuse=1 ;; *) reuse=0 ;; esac; echo "reuse=$reuse" >> "$GITHUB_OUTPUT"
       - name: Evaluate PR gate policy
         id: gate_policy
         uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717
@@ -63,8 +67,7 @@ jobs:
         with:
           policy-json: ${{ toJSON(steps.gate_policy.outputs) }}
   audit:
-    needs:
-      - validation-surface
+    needs: [validation-surface]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -92,8 +95,7 @@ jobs:
           echo "Heavy audit lane skipped."
           echo "Reason: ${{ needs.validation-surface.outputs.certification_reason }}"
   static:
-    needs:
-      - validation-surface
+    needs: [validation-surface]
     if: needs.validation-surface.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -116,8 +118,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
   unit:
-    needs:
-      - validation-surface
+    needs: [validation-surface]
     if: needs.validation-surface.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -131,8 +132,7 @@ jobs:
       - name: Release Gate Unit Tests
         run: pnpm test:release-gate
   ai-eval:
-    needs:
-      - validation-surface
+    needs: [validation-surface]
     if: needs.validation-surface.outputs.run_broad == 'true' && needs.validation-surface.outputs.ai_eval_should_run == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -141,8 +141,7 @@ jobs:
       - name: Run AI Eval Fixtures
         run: pnpm ai:eval
   e2e-gate:
-    needs:
-      - validation-surface
+    needs: [validation-surface]
     if: needs.validation-surface.outputs.run_broad == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -185,7 +184,7 @@ jobs:
           REQUIRE_RLS_COVERAGE: '1'
         run: pnpm db:rls:test
       - name: E2E Gate Suite
-        if: github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != 'true'
+        if: github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != '1'
         env:
           E2E_DATABASE_URL: ${{ env.DATABASE_URL }}
           E2E_DATABASE_URL_RLS: ${{ env.DATABASE_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   push:
     branches: [main, master]
@@ -8,15 +7,13 @@ on:
     branches:
       - '**'
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled]
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
+  actions: read
   contents: read
   pull-requests: read
-
 env:
   DATABASE_URL: ${{ secrets.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:5432/interdomestik_test' }}
   BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET || 'test-secret-for-ci-only-do-not-use-in-production' }}
@@ -39,6 +36,7 @@ jobs:
       ai_eval_should_run: ${{ steps.gate_policy.outputs.ai_eval_should_run }}
       ai_eval_reason: ${{ steps.gate_policy.outputs.ai_eval_reason }}
       ai_eval_matched_paths: ${{ steps.gate_policy.outputs.ai_eval_matched_paths }}
+      main_e2e_reuse: ${{ steps.main_e2e_reuse.outputs.reuse }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -47,6 +45,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           package-manager-cache: false
+      - name: Resolve main E2E exact-tree reuse
+        id: main_e2e_reuse
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        env: { GITHUB_TOKEN: '${{ github.token }}' }
+        run: node scripts/ci/main-e2e-reuse.mjs >> "$GITHUB_OUTPUT"
       - name: Evaluate PR gate policy
         id: gate_policy
         uses: interdomestik/interdomestik/.github/actions/pr-gate-policy@f4b39fc4f7fed7e875363807faea11cc2c4cf717
@@ -126,7 +130,6 @@ jobs:
         run: pnpm coverage:gate
       - name: Release Gate Unit Tests
         run: pnpm test:release-gate
-
   ai-eval:
     needs:
       - validation-surface
@@ -137,7 +140,6 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Run AI Eval Fixtures
         run: pnpm ai:eval
-
   e2e-gate:
     needs:
       - validation-surface
@@ -165,7 +167,6 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-playwright: ${{ github.event_name != 'pull_request' }}
-
       - name: Generate ephemeral E2E credentials
         run: bash scripts/ci/export-e2e-credentials.sh
       - name: Enforce E2E Best Practices
@@ -183,9 +184,8 @@ jobs:
           REQUIRE_RLS_INTEGRATION: '1'
           REQUIRE_RLS_COVERAGE: '1'
         run: pnpm db:rls:test
-
       - name: E2E Gate Suite
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != 'true'
         env:
           E2E_DATABASE_URL: ${{ env.DATABASE_URL }}
           E2E_DATABASE_URL_RLS: ${{ env.DATABASE_URL }}

--- a/scripts/ci/github-api-url-lib.mjs
+++ b/scripts/ci/github-api-url-lib.mjs
@@ -25,19 +25,49 @@ function parseRepositoryFullName(repositoryFullName) {
   };
 }
 
-function encodePath(filePath) {
-  const segments = String(filePath || '')
-    .split('/')
-    .filter(Boolean);
+function relativePath(value, label) {
+  const raw = String(value || '');
+  const segments = raw.split('/').filter(Boolean);
 
   if (
+    raw.startsWith('/') ||
     segments.length === 0 ||
     segments.some(segment => segment === '.' || segment === '..' || /[?#\\]/u.test(segment))
   ) {
-    throw new TypeError('filePath must be a repository-relative path');
+    throw new TypeError(`${label} must be a repository-relative path`);
   }
 
-  return segments.map(segment => encodeURIComponent(segment)).join('/');
+  return segments.join('/');
+}
+
+function encodePath(filePath) {
+  return relativePath(filePath, 'filePath')
+    .split('/')
+    .map(segment => encodeURIComponent(segment))
+    .join('/');
+}
+
+function commitSha(value) {
+  const sha = String(value || '').trim();
+  if (!/^[0-9a-f]{40}$/u.test(sha)) {
+    throw new TypeError('commitSha must be a full commit SHA');
+  }
+  return sha;
+}
+
+function positiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(`${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function setPagination(url, { page, perPage }) {
+  positiveInteger(page, 'page');
+  positiveInteger(perPage, 'perPage');
+  if (perPage > 100) throw new TypeError('perPage must not exceed 100');
+  url.searchParams.set('per_page', String(perPage));
+  url.searchParams.set('page', String(page));
 }
 
 export function buildPullRequestFilesUrl({ repositoryFullName, pullRequestNumber, page, perPage }) {
@@ -58,5 +88,48 @@ export function buildRepositoryFileContentUrl({ repositoryFullName, filePath, re
     repo
   )}/contents/${encodePath(filePath)}`;
   url.searchParams.set('ref', String(ref));
+  return url.toString();
+}
+
+export function buildCommitPullRequestsUrl({ repositoryFullName, commitSha: sha, page, perPage }) {
+  const url = createGitHubApiUrl();
+  const { owner, repo } = parseRepositoryFullName(repositoryFullName);
+  url.pathname = `${apiPathPrefix(url)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+    repo
+  )}/commits/${commitSha(sha)}/pulls`;
+  setPagination(url, { page, perPage });
+  return url.toString();
+}
+
+export function buildCommitUrl({ repositoryFullName, commitSha: sha }) {
+  const url = createGitHubApiUrl();
+  const { owner, repo } = parseRepositoryFullName(repositoryFullName);
+  url.pathname = `${apiPathPrefix(url)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+    repo
+  )}/commits/${commitSha(sha)}`;
+  return url.toString();
+}
+
+export function buildWorkflowRunsUrl({ repositoryFullName, workflowPath, headSha, page, perPage }) {
+  const url = createGitHubApiUrl();
+  const { owner, repo } = parseRepositoryFullName(repositoryFullName);
+  const workflow = encodeURIComponent(relativePath(workflowPath, 'workflowPath'));
+  url.pathname = `${apiPathPrefix(url)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+    repo
+  )}/actions/workflows/${workflow}/runs`;
+  url.searchParams.set('event', 'pull_request');
+  url.searchParams.set('status', 'completed');
+  url.searchParams.set('head_sha', commitSha(headSha));
+  setPagination(url, { page, perPage });
+  return url.toString();
+}
+
+export function buildRunJobsUrl({ repositoryFullName, runId, page, perPage }) {
+  const url = createGitHubApiUrl();
+  const { owner, repo } = parseRepositoryFullName(repositoryFullName);
+  url.pathname = `${apiPathPrefix(url)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+    repo
+  )}/actions/runs/${positiveInteger(runId, 'runId')}/jobs`;
+  setPagination(url, { page, perPage });
   return url.toString();
 }

--- a/scripts/ci/github-api-url-lib.test.mjs
+++ b/scripts/ci/github-api-url-lib.test.mjs
@@ -1,7 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildPullRequestFilesUrl, buildRepositoryFileContentUrl } from './github-api-url-lib.mjs';
+import {
+  buildCommitPullRequestsUrl,
+  buildCommitUrl,
+  buildPullRequestFilesUrl,
+  buildRepositoryFileContentUrl,
+  buildRunJobsUrl,
+  buildWorkflowRunsUrl,
+} from './github-api-url-lib.mjs';
 
 test('GitHub API URL builder encodes repository, path, and query components', () => {
   const url = buildRepositoryFileContentUrl({
@@ -26,5 +33,60 @@ test('GitHub API URL builder rejects invalid repository slugs', () => {
         perPage: 100,
       }),
     /repositoryFullName must be an owner\/repo slug/u
+  );
+});
+
+test('GitHub API URL builder creates bounded exact-tree evidence endpoints', () => {
+  const repositoryFullName = 'interdomestik/interdomestik';
+  const commitSha = 'b760d2253a1973294613770d09260bea45ddad95';
+
+  assert.equal(
+    buildCommitPullRequestsUrl({ repositoryFullName, commitSha, page: 2, perPage: 100 }),
+    `https://api.github.com/repos/interdomestik/interdomestik/commits/${commitSha}/pulls?per_page=100&page=2`
+  );
+  assert.equal(
+    buildCommitUrl({ repositoryFullName, commitSha }),
+    `https://api.github.com/repos/interdomestik/interdomestik/commits/${commitSha}`
+  );
+  assert.equal(
+    buildWorkflowRunsUrl({
+      repositoryFullName,
+      workflowPath: '.github/workflows/e2e-pr.yml',
+      headSha: commitSha,
+      page: 1,
+      perPage: 20,
+    }),
+    `https://api.github.com/repos/interdomestik/interdomestik/actions/workflows/.github%2Fworkflows%2Fe2e-pr.yml/runs?event=pull_request&status=completed&head_sha=${commitSha}&per_page=20&page=1`
+  );
+  assert.equal(
+    buildRunJobsUrl({ repositoryFullName, runId: 31_712_197_425, page: 1, perPage: 100 }),
+    'https://api.github.com/repos/interdomestik/interdomestik/actions/runs/31712197425/jobs?per_page=100&page=1'
+  );
+});
+
+test('GitHub API URL builder rejects unsafe identifiers and pagination', () => {
+  const repositoryFullName = 'interdomestik/interdomestik';
+  assert.throws(
+    () =>
+      buildCommitUrl({
+        repositoryFullName,
+        commitSha: 'main?access_token=secret',
+      }),
+    /commitSha must be a full commit SHA/u
+  );
+  assert.throws(
+    () =>
+      buildWorkflowRunsUrl({
+        repositoryFullName,
+        workflowPath: '../e2e-pr.yml',
+        headSha: 'b760d2253a1973294613770d09260bea45ddad95',
+        page: 1,
+        perPage: 20,
+      }),
+    /workflowPath must be a repository-relative path/u
+  );
+  assert.throws(
+    () => buildRunJobsUrl({ repositoryFullName, runId: -1, page: 0, perPage: 101 }),
+    /runId must be a positive integer/u
   );
 });

--- a/scripts/ci/main-e2e-reuse-cli.test.mjs
+++ b/scripts/ci/main-e2e-reuse-cli.test.mjs
@@ -66,7 +66,7 @@ test('parity drift always resolves to a fail-closed reuse decision', async () =>
   const gateScript = '"e2e:gate": "node scripts/run-e2e-lane.mjs gate"';
   const prGateScript = '"e2e:gate:pr": "node scripts/run-e2e-lane.mjs pr"';
   const database = '127.0.0.1:5432/interdomestik_test';
-  const helperDrifts = commandChainDrifts.map(before => ['commandChain', 'laneSource', before, '']);
+  const helperDrifts = commandChainDrifts.map(parts => ['commandChain', 'laneSource', ...parts]);
   const drifts = [
     ['checkoutHead', 'prWorkflow', checkout, 'ref: ${{ github.sha }}'],
     ['checkoutHead', 'prWorkflow', checkout, reorderedCheckout],

--- a/scripts/ci/main-e2e-reuse-cli.test.mjs
+++ b/scripts/ci/main-e2e-reuse-cli.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  formatReuseDecision,
+  inspectRepositoryParity,
+  resolveMainE2eReuse,
+} from './main-e2e-reuse.mjs';
+import { MAIN_SHA, NOW_MS, REPOSITORY, reusableEvidence } from './main-e2e-reuse-fixture.mjs';
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const paths = {
+  ci: path.join(root, '.github/workflows/ci.yml'),
+  pr: path.join(root, '.github/workflows/e2e-pr.yml'),
+  lanes: path.join(root, 'scripts/run-e2e-lane.mjs'),
+};
+function sources() {
+  return {
+    ciWorkflow: readFileSync(paths.ci, 'utf8'),
+    prWorkflow: readFileSync(paths.pr, 'utf8'),
+    laneSource: readFileSync(paths.lanes, 'utf8'),
+  };
+}
+function environment(overrides = {}) {
+  return {
+    GITHUB_EVENT_NAME: 'push',
+    GITHUB_REF: 'refs/heads/main',
+    GITHUB_REPOSITORY: REPOSITORY,
+    GITHUB_SHA: MAIN_SHA,
+    GITHUB_TOKEN: 'test-token',
+    ...overrides,
+  };
+}
+function dependencies(overrides = {}) {
+  const fixture = reusableEvidence();
+  const { pullRequests, headCommit, candidates } = fixture;
+  return {
+    git: value => (value === 'HEAD' ? MAIN_SHA : fixture.local.treeSha),
+    readFile: value => readFileSync(path.join(root, value), 'utf8'),
+    collectEvidence: async () => ({ pullRequests, headCommit, candidates }),
+    nowMs: NOW_MS,
+    ...overrides,
+  };
+}
+test('repository parity recognizes exact PR-head checkout and strict project superset', () => {
+  assert.deepEqual(inspectRepositoryParity(sources()), {
+    checkoutHead: true,
+    projectSuperset: true,
+    sharedFlags: true,
+    databaseSubstrate: true,
+  });
+});
+test('repository parity rejects checkout trigger, project, flag, and database drift', () => {
+  const current = sources();
+  const checkoutOnlySha = {
+    ...current,
+    prWorkflow: current.prWorkflow.replace(
+      'ref: ${{ github.event.pull_request.head.sha || github.sha }}',
+      'ref: ${{ github.sha }}'
+    ),
+  };
+  assert.equal(inspectRepositoryParity(checkoutOnlySha).checkoutHead, false);
+  const reorderedCheckout = {
+    ...current,
+    prWorkflow: current.prWorkflow.replace(
+      'ref: ${{ github.event.pull_request.head.sha || github.sha }}',
+      'ref: ${{ github.sha || github.event.pull_request.head.sha }}'
+    ),
+  };
+  assert.equal(inspectRepositoryParity(reorderedCheckout).checkoutHead, false);
+  const addedTrigger = {
+    ...current,
+    prWorkflow: current.prWorkflow.replace('on:\n  pull_request:', 'on:\n  push:\n  pull_request:'),
+  };
+  assert.equal(inspectRepositoryParity(addedTrigger).checkoutHead, false);
+  const missingMainProject = {
+    ...current,
+    laneSource: current.laneSource.replace(
+      'pr: gateLane([ksSq, mkContract, mkMk], true)',
+      'pr: gateLane([ksSq, mkContract], true)'
+    ),
+  };
+  assert.equal(inspectRepositoryParity(missingMainProject).projectSuperset, false);
+  const flagDrift = {
+    ...current,
+    laneSource: current.laneSource.replace(
+      'pr: gateLane([ksSq, mkContract, mkMk], true)',
+      'pr: gateLane([ksSq, mkContract, mkMk], false)'
+    ),
+  };
+  assert.equal(inspectRepositoryParity(flagDrift).sharedFlags, false);
+  const databaseDrift = {
+    ...current,
+    prWorkflow: current.prWorkflow.replace(
+      '127.0.0.1:5432/interdomestik_test',
+      '127.0.0.1:54322/postgres'
+    ),
+  };
+  assert.equal(inspectRepositoryParity(databaseDrift).databaseSubstrate, false);
+  const serviceDrift = {
+    ...current,
+    prWorkflow: current.prWorkflow.replace('image: postgres:16', 'image: postgres:17'),
+  };
+  assert.equal(inspectRepositoryParity(serviceDrift).databaseSubstrate, false);
+});
+test('CLI resolver emits true only for normalized exact evidence', async () => {
+  const decision = await resolveMainE2eReuse(environment(), dependencies());
+  assert.deepEqual(decision, { reuse: true, reason: 'exact_pr_evidence' });
+  assert.equal(formatReuseDecision(decision), 'reuse=true\nreason=exact_pr_evidence\n');
+});
+test('CLI resolver fails closed before GitHub access for an ineligible context', async () => {
+  let calls = 0;
+  const decision = await resolveMainE2eReuse(
+    environment({ GITHUB_REF: 'refs/heads/master' }),
+    dependencies({
+      collectEvidence: async () => {
+        calls += 1;
+        throw new Error('must not run');
+      },
+    })
+  );
+  assert.deepEqual(decision, { reuse: false, reason: 'evidence_not_exact' });
+  assert.equal(calls, 0);
+});
+test('CLI resolver converts GitHub, schema, and local failures to one safe decision', async () => {
+  const fail = () => {
+    throw new Error('token=secret body=secret');
+  };
+  for (const overrides of [{ collectEvidence: fail }, { git: fail }, { readFile: fail }]) {
+    assert.deepEqual(await resolveMainE2eReuse(environment(), dependencies(overrides)), {
+      reuse: false,
+      reason: 'evidence_not_exact',
+    });
+  }
+});
+test('direct CLI invocation prints only the safe normalized decision', () => {
+  const result = spawnSync(process.execPath, ['scripts/ci/main-e2e-reuse.mjs'], {
+    cwd: root,
+    env: { ...process.env, ...environment({ GITHUB_EVENT_NAME: 'pull_request' }) },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, 'reuse=false\nreason=evidence_not_exact\n');
+  assert.equal(result.stderr, '');
+});

--- a/scripts/ci/main-e2e-reuse-cli.test.mjs
+++ b/scripts/ci/main-e2e-reuse-cli.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import test from 'node:test';
@@ -10,18 +11,22 @@ import {
   resolveMainE2eReuse,
 } from './main-e2e-reuse.mjs';
 import { MAIN_SHA, NOW_MS, REPOSITORY, reusableEvidence } from './main-e2e-reuse-fixture.mjs';
+import { commandChainDrifts } from './main-e2e-reuse-fixture.mjs';
+import { readLocalGitObjectId } from './main-e2e-reuse-github.mjs';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const paths = {
-  ci: path.join(root, '.github/workflows/ci.yml'),
-  pr: path.join(root, '.github/workflows/e2e-pr.yml'),
-  lanes: path.join(root, 'scripts/run-e2e-lane.mjs'),
+const sourceKeys = {
+  '.github/workflows/ci.yml': 'ciWorkflow',
+  '.github/workflows/e2e-pr.yml': 'prWorkflow',
+  'scripts/run-e2e-lane.mjs': 'laneSource',
+  'package.json': 'packageJson',
 };
 function sources() {
-  return {
-    ciWorkflow: readFileSync(paths.ci, 'utf8'),
-    prWorkflow: readFileSync(paths.pr, 'utf8'),
-    laneSource: readFileSync(paths.lanes, 'utf8'),
-  };
+  return Object.fromEntries(
+    Object.entries(sourceKeys).map(([file, key]) => [
+      key,
+      readFileSync(path.join(root, file), 'utf8'),
+    ])
+  );
 }
 function environment(overrides = {}) {
   return {
@@ -50,60 +55,40 @@ test('repository parity recognizes exact PR-head checkout and strict project sup
     projectSuperset: true,
     sharedFlags: true,
     databaseSubstrate: true,
+    commandChain: true,
   });
 });
-test('repository parity rejects checkout trigger, project, flag, and database drift', () => {
+test('parity drift always resolves to a fail-closed reuse decision', async () => {
   const current = sources();
-  const checkoutOnlySha = {
-    ...current,
-    prWorkflow: current.prWorkflow.replace(
-      'ref: ${{ github.event.pull_request.head.sha || github.sha }}',
-      'ref: ${{ github.sha }}'
-    ),
-  };
-  assert.equal(inspectRepositoryParity(checkoutOnlySha).checkoutHead, false);
-  const reorderedCheckout = {
-    ...current,
-    prWorkflow: current.prWorkflow.replace(
-      'ref: ${{ github.event.pull_request.head.sha || github.sha }}',
-      'ref: ${{ github.sha || github.event.pull_request.head.sha }}'
-    ),
-  };
-  assert.equal(inspectRepositoryParity(reorderedCheckout).checkoutHead, false);
-  const addedTrigger = {
-    ...current,
-    prWorkflow: current.prWorkflow.replace('on:\n  pull_request:', 'on:\n  push:\n  pull_request:'),
-  };
-  assert.equal(inspectRepositoryParity(addedTrigger).checkoutHead, false);
-  const missingMainProject = {
-    ...current,
-    laneSource: current.laneSource.replace(
-      'pr: gateLane([ksSq, mkContract, mkMk], true)',
-      'pr: gateLane([ksSq, mkContract], true)'
-    ),
-  };
-  assert.equal(inspectRepositoryParity(missingMainProject).projectSuperset, false);
-  const flagDrift = {
-    ...current,
-    laneSource: current.laneSource.replace(
-      'pr: gateLane([ksSq, mkContract, mkMk], true)',
-      'pr: gateLane([ksSq, mkContract, mkMk], false)'
-    ),
-  };
-  assert.equal(inspectRepositoryParity(flagDrift).sharedFlags, false);
-  const databaseDrift = {
-    ...current,
-    prWorkflow: current.prWorkflow.replace(
-      '127.0.0.1:5432/interdomestik_test',
-      '127.0.0.1:54322/postgres'
-    ),
-  };
-  assert.equal(inspectRepositoryParity(databaseDrift).databaseSubstrate, false);
-  const serviceDrift = {
-    ...current,
-    prWorkflow: current.prWorkflow.replace('image: postgres:16', 'image: postgres:17'),
-  };
-  assert.equal(inspectRepositoryParity(serviceDrift).databaseSubstrate, false);
+  const checkout = 'ref: ${{ github.event.pull_request.head.sha || github.sha }}';
+  const reorderedCheckout = 'ref: ${{ github.sha || github.event.pull_request.head.sha }}';
+  const prLane = 'pr: gateLane([ksSq, mkContract, mkMk], true)';
+  const gateScript = '"e2e:gate": "node scripts/run-e2e-lane.mjs gate"';
+  const prGateScript = '"e2e:gate:pr": "node scripts/run-e2e-lane.mjs pr"';
+  const database = '127.0.0.1:5432/interdomestik_test';
+  const helperDrifts = commandChainDrifts.map(before => ['commandChain', 'laneSource', before, '']);
+  const drifts = [
+    ['checkoutHead', 'prWorkflow', checkout, 'ref: ${{ github.sha }}'],
+    ['checkoutHead', 'prWorkflow', checkout, reorderedCheckout],
+    ['checkoutHead', 'prWorkflow', 'on:\n  pull_request:', 'on:\n  push:\n  pull_request:'],
+    ['projectSuperset', 'laneSource', prLane, 'pr: gateLane([ksSq, mkContract], true)'],
+    ['sharedFlags', 'laneSource', prLane, 'pr: gateLane([ksSq, mkContract, mkMk], false)'],
+    ['databaseSubstrate', 'prWorkflow', database, '127.0.0.1:54322/postgres'],
+    ['databaseSubstrate', 'prWorkflow', 'image: postgres:16', 'image: postgres:17'],
+    ['commandChain', 'packageJson', gateScript, '"e2e:gate": "true"'],
+    ['commandChain', 'packageJson', prGateScript, '"e2e:gate:pr": "true"'],
+    ...helperDrifts,
+  ];
+  for (const [predicate, key, before, after] of drifts) {
+    const mutation = { ...current, [key]: current[key].replace(before, after) };
+    assert.notEqual(mutation[key], current[key], `${predicate} mutation did not apply`);
+    assert.equal(inspectRepositoryParity(mutation)[predicate], false, predicate);
+    const readFile = value => mutation[sourceKeys[value]];
+    assert.deepEqual(await resolveMainE2eReuse(environment(), dependencies({ readFile })), {
+      reuse: false,
+      reason: 'evidence_not_exact',
+    });
+  }
 });
 test('CLI resolver emits true only for normalized exact evidence', async () => {
   const decision = await resolveMainE2eReuse(environment(), dependencies());
@@ -111,18 +96,15 @@ test('CLI resolver emits true only for normalized exact evidence', async () => {
   assert.equal(formatReuseDecision(decision), 'reuse=true\nreason=exact_pr_evidence\n');
 });
 test('CLI resolver fails closed before GitHub access for an ineligible context', async () => {
-  let calls = 0;
   const decision = await resolveMainE2eReuse(
     environment({ GITHUB_REF: 'refs/heads/master' }),
     dependencies({
       collectEvidence: async () => {
-        calls += 1;
         throw new Error('must not run');
       },
     })
   );
   assert.deepEqual(decision, { reuse: false, reason: 'evidence_not_exact' });
-  assert.equal(calls, 0);
 });
 test('CLI resolver converts GitHub, schema, and local failures to one safe decision', async () => {
   const fail = () => {
@@ -144,4 +126,22 @@ test('direct CLI invocation prints only the safe normalized decision', () => {
   assert.equal(result.status, 0);
   assert.equal(result.stdout, 'reuse=false\nreason=evidence_not_exact\n');
   assert.equal(result.stderr, '');
+});
+test('default git lookup ignores a writable PATH executable', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'ci01-path-'));
+  const fakeGit = path.join(directory, 'git');
+  const marker = path.join(directory, 'executed');
+  const originalPath = process.env.PATH;
+  try {
+    writeFileSync(fakeGit, '#!/bin/sh\n: > "$CI01_MARKER"\nprintf "%s\\n" "$GITHUB_SHA"\n');
+    chmodSync(fakeGit, 0o755);
+    process.env.PATH = directory;
+    process.env.CI01_MARKER = marker;
+    assert.match(readLocalGitObjectId(root, 'HEAD'), /^[0-9a-f]{40}$/u);
+    assert.equal(existsSync(marker), false);
+  } finally {
+    process.env.PATH = originalPath;
+    delete process.env.CI01_MARKER;
+    rmSync(directory, { force: true, recursive: true });
+  }
 });

--- a/scripts/ci/main-e2e-reuse-cli.test.mjs
+++ b/scripts/ci/main-e2e-reuse-cli.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -20,14 +21,9 @@ const sourceKeys = {
   'scripts/run-e2e-lane.mjs': 'laneSource',
   'package.json': 'packageJson',
 };
-function sources() {
-  return Object.fromEntries(
-    Object.entries(sourceKeys).map(([file, key]) => [
-      key,
-      readFileSync(path.join(root, file), 'utf8'),
-    ])
-  );
-}
+const read = file => readFileSync(path.join(root, file), 'utf8');
+const sources = () =>
+  Object.fromEntries(Object.entries(sourceKeys).map(([file, key]) => [key, read(file)]));
 function environment(overrides = {}) {
   return {
     GITHUB_EVENT_NAME: 'push',
@@ -43,14 +39,17 @@ function dependencies(overrides = {}) {
   const { pullRequests, headCommit, candidates } = fixture;
   return {
     git: value => (value === 'HEAD' ? MAIN_SHA : fixture.local.treeSha),
-    readFile: value => readFileSync(path.join(root, value), 'utf8'),
+    readFile: read,
     collectEvidence: async () => ({ pullRequests, headCommit, candidates }),
     nowMs: NOW_MS,
     ...overrides,
   };
 }
 test('repository parity recognizes exact PR-head checkout and strict project superset', () => {
-  assert.deepEqual(inspectRepositoryParity(sources()), {
+  const current = sources();
+  const laneDigest = createHash('sha256').update(current.laneSource).digest('hex');
+  assert.equal(laneDigest, '9beb625efc7ffb6cadf88809063ee8b1b15cd5080c1419de5aa888db504cf685');
+  assert.deepEqual(inspectRepositoryParity(current), {
     checkoutHead: true,
     projectSuperset: true,
     sharedFlags: true,
@@ -78,6 +77,7 @@ test('parity drift always resolves to a fail-closed reuse decision', async () =>
     ['commandChain', 'packageJson', gateScript, '"e2e:gate": "true"'],
     ['commandChain', 'packageJson', prGateScript, '"e2e:gate:pr": "true"'],
     ...helperDrifts,
+    ['commandChain', 'laneSource', current.laneSource, `${current.laneSource}\n`],
   ];
   for (const [predicate, key, before, after] of drifts) {
     const mutation = { ...current, [key]: current[key].replace(before, after) };

--- a/scripts/ci/main-e2e-reuse-core.mjs
+++ b/scripts/ci/main-e2e-reuse-core.mjs
@@ -9,8 +9,16 @@ const FUTURE_TOLERANCE_MS = 5 * 60 * 1000;
 const positiveId = value => Number.isSafeInteger(value) && value > 0;
 const nonEmpty = value => typeof value === 'string' && value.length > 0;
 const sha = value => typeof value === 'string' && SHA_PATTERN.test(value);
-const timestamp = value =>
-  typeof value === 'string' && ISO_PATTERN.test(value) && Number.isFinite(Date.parse(value));
+const PARITY_KEYS = 'checkoutHead projectSuperset sharedFlags databaseSubstrate commandChain'.split(
+  ' '
+);
+function timestamp(value) {
+  if (typeof value !== 'string' || !ISO_PATTERN.test(value)) return false;
+  const parsed = Date.parse(value);
+  const base = value.slice(0, -1);
+  const canonical = base.includes('.') ? base.padEnd(23, '0') : `${base}.000`;
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === `${canonical}Z`;
+}
 function exactRepository(repo, fullName, id) {
   return (
     positiveId(repo?.id) &&
@@ -87,13 +95,7 @@ function hasSuccessfulRunner(jobs) {
   );
 }
 function hasExactParity(parity) {
-  return [
-    'checkoutHead',
-    'projectSuperset',
-    'sharedFlags',
-    'databaseSubstrate',
-    'commandChain',
-  ].every(key => parity?.[key] === true);
+  return PARITY_KEYS.every(key => parity?.[key] === true);
 }
 function isReusableCandidate(candidate, selected, context) {
   const run = candidate?.run;

--- a/scripts/ci/main-e2e-reuse-core.mjs
+++ b/scripts/ci/main-e2e-reuse-core.mjs
@@ -1,0 +1,146 @@
+const EXPECTED_REPOSITORY = 'interdomestik/interdomestik';
+const EXPECTED_WORKFLOW = '.github/workflows/e2e-pr.yml';
+const SUCCESS = { reuse: true, reason: 'exact_pr_evidence' };
+const REJECT = { reuse: false, reason: 'evidence_not_exact' };
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const FUTURE_TOLERANCE_MS = 5 * 60 * 1000;
+
+function exactRepository(repo, fullName, id) {
+  return (
+    repo?.full_name === fullName &&
+    Number.isSafeInteger(repo?.id) &&
+    (id === undefined || repo.id === id)
+  );
+}
+
+function associationRepository(repo, expected) {
+  return (
+    Number.isSafeInteger(repo?.id) &&
+    repo.id === expected?.id &&
+    (repo.full_name === undefined || repo.full_name === expected?.full_name)
+  );
+}
+
+function isMergedPullRequest(pr, context) {
+  return (
+    Number.isSafeInteger(pr?.id) &&
+    Number.isSafeInteger(pr?.number) &&
+    pr.state === 'closed' &&
+    Number.isFinite(Date.parse(pr.merged_at)) &&
+    pr.merge_commit_sha === context.githubSha &&
+    pr.base?.ref === 'main' &&
+    exactRepository(pr.base?.repo, context.repository) &&
+    typeof pr.head?.ref === 'string' &&
+    pr.head.ref.length > 0 &&
+    typeof pr.head?.sha === 'string' &&
+    exactRepository(pr.head?.repo, context.repository, pr.base.repo.id)
+  );
+}
+
+function samePullRequest(candidate, selected) {
+  return (
+    isMergedPullRequest(candidate, {
+      githubSha: selected.merge_commit_sha,
+      repository: selected.base.repo.full_name,
+    }) &&
+    candidate.id === selected.id &&
+    candidate.number === selected.number &&
+    candidate.merged_at === selected.merged_at &&
+    candidate.head.ref === selected.head.ref &&
+    candidate.head.sha === selected.head.sha &&
+    candidate.base.repo.id === selected.base.repo.id &&
+    candidate.head.repo.id === selected.head.repo.id
+  );
+}
+
+function sameDirectAssociation(candidate, selected) {
+  return (
+    candidate?.id === selected.id &&
+    candidate?.number === selected.number &&
+    candidate.base?.ref === selected.base.ref &&
+    associationRepository(candidate.base?.repo, selected.base.repo) &&
+    candidate.head?.ref === selected.head.ref &&
+    candidate.head?.sha === selected.head.sha &&
+    associationRepository(candidate.head?.repo, selected.head.repo)
+  );
+}
+
+function hasExactAssociation(candidate, selected) {
+  const direct = candidate?.run?.pull_requests;
+  if (!Array.isArray(direct)) return false;
+  if (direct.length > 0) {
+    return direct.length === 1 && sameDirectAssociation(direct[0], selected);
+  }
+  const fallback = candidate.fallbackPullRequests;
+  return Array.isArray(fallback) && fallback.length === 1 && samePullRequest(fallback[0], selected);
+}
+
+function isFresh(startedAt, nowMs) {
+  const startedMs = Date.parse(startedAt);
+  if (!Number.isFinite(startedMs) || !Number.isFinite(nowMs)) return false;
+  const ageMs = nowMs - startedMs;
+  return ageMs >= -FUTURE_TOLERANCE_MS && ageMs <= MAX_AGE_MS;
+}
+
+function hasSuccessfulRunner(jobs) {
+  if (!Array.isArray(jobs)) return false;
+  const runners = jobs.filter(job => job?.name === 'PR E2E Runner');
+  return (
+    runners.length === 1 && runners[0].status === 'completed' && runners[0].conclusion === 'success'
+  );
+}
+
+function hasExactParity(parity) {
+  return (
+    parity?.checkoutHead === true &&
+    parity.projectSuperset === true &&
+    parity.sharedFlags === true &&
+    parity.databaseSubstrate === true
+  );
+}
+
+function isReusableCandidate(candidate, selected, context) {
+  const run = candidate?.run;
+  return (
+    run?.path === EXPECTED_WORKFLOW &&
+    run.event === 'pull_request' &&
+    run.status === 'completed' &&
+    run.conclusion === 'success' &&
+    run.head_sha === selected.head.sha &&
+    exactRepository(run.repository, context.repository, selected.base.repo.id) &&
+    exactRepository(run.head_repository, context.repository, selected.head.repo.id) &&
+    isFresh(run.run_started_at, context.nowMs) &&
+    hasExactAssociation(candidate, selected) &&
+    hasSuccessfulRunner(candidate.jobs)
+  );
+}
+
+export function normalizeReuseDecision(value) {
+  return value?.reuse === true && value?.reason === SUCCESS.reason ? { ...SUCCESS } : { ...REJECT };
+}
+
+export function decideMainE2eReuse(evidence) {
+  const { context, local, pullRequests, headCommit, candidates, parity } = evidence ?? {};
+  if (
+    context?.eventName !== 'push' ||
+    context.ref !== 'refs/heads/main' ||
+    context.repository !== EXPECTED_REPOSITORY ||
+    local?.headSha !== context.githubSha ||
+    !hasExactParity(parity) ||
+    !Array.isArray(pullRequests) ||
+    pullRequests.length !== 1
+  ) {
+    return { ...REJECT };
+  }
+  const selected = pullRequests[0];
+  if (
+    !isMergedPullRequest(selected, context) ||
+    headCommit?.sha !== selected.head.sha ||
+    headCommit?.commit?.tree?.sha !== local?.treeSha ||
+    !Array.isArray(candidates) ||
+    !candidates.some(candidate => isReusableCandidate(candidate, selected, context))
+  ) {
+    return { ...REJECT };
+  }
+  return { ...SUCCESS };
+}

--- a/scripts/ci/main-e2e-reuse-core.mjs
+++ b/scripts/ci/main-e2e-reuse-core.mjs
@@ -2,47 +2,49 @@ const EXPECTED_REPOSITORY = 'interdomestik/interdomestik';
 const EXPECTED_WORKFLOW = '.github/workflows/e2e-pr.yml';
 const SUCCESS = { reuse: true, reason: 'exact_pr_evidence' };
 const REJECT = { reuse: false, reason: 'evidence_not_exact' };
+const SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const ISO_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/u;
 const MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const FUTURE_TOLERANCE_MS = 5 * 60 * 1000;
-
+const positiveId = value => Number.isSafeInteger(value) && value > 0;
+const nonEmpty = value => typeof value === 'string' && value.length > 0;
+const sha = value => typeof value === 'string' && SHA_PATTERN.test(value);
+const timestamp = value =>
+  typeof value === 'string' && ISO_PATTERN.test(value) && Number.isFinite(Date.parse(value));
 function exactRepository(repo, fullName, id) {
   return (
-    repo?.full_name === fullName &&
-    Number.isSafeInteger(repo?.id) &&
+    positiveId(repo?.id) &&
+    nonEmpty(repo.full_name) &&
+    repo.full_name === fullName &&
     (id === undefined || repo.id === id)
   );
 }
-
 function associationRepository(repo, expected) {
-  return (
-    Number.isSafeInteger(repo?.id) &&
-    repo.id === expected?.id &&
-    (repo.full_name === undefined || repo.full_name === expected?.full_name)
-  );
+  if (!positiveId(repo?.id) || !positiveId(expected?.id) || repo.id !== expected.id) return false;
+  return repo.full_name === undefined || repo.full_name === expected.full_name;
 }
-
 function isMergedPullRequest(pr, context) {
   return (
-    Number.isSafeInteger(pr?.id) &&
-    Number.isSafeInteger(pr?.number) &&
+    positiveId(pr?.id) &&
+    positiveId(pr.number) &&
     pr.state === 'closed' &&
-    Number.isFinite(Date.parse(pr.merged_at)) &&
+    timestamp(pr.merged_at) &&
+    sha(pr.merge_commit_sha) &&
     pr.merge_commit_sha === context.githubSha &&
     pr.base?.ref === 'main' &&
-    exactRepository(pr.base?.repo, context.repository) &&
-    typeof pr.head?.ref === 'string' &&
-    pr.head.ref.length > 0 &&
-    typeof pr.head?.sha === 'string' &&
-    exactRepository(pr.head?.repo, context.repository, pr.base.repo.id)
+    exactRepository(pr.base.repo, context.repository) &&
+    nonEmpty(pr.head?.ref) &&
+    sha(pr.head.sha) &&
+    exactRepository(pr.head.repo, context.repository, pr.base.repo.id)
   );
 }
-
 function samePullRequest(candidate, selected) {
+  const context = {
+    githubSha: selected.merge_commit_sha,
+    repository: selected.base.repo.full_name,
+  };
   return (
-    isMergedPullRequest(candidate, {
-      githubSha: selected.merge_commit_sha,
-      repository: selected.base.repo.full_name,
-    }) &&
+    isMergedPullRequest(candidate, context) &&
     candidate.id === selected.id &&
     candidate.number === selected.number &&
     candidate.merged_at === selected.merged_at &&
@@ -52,80 +54,81 @@ function samePullRequest(candidate, selected) {
     candidate.head.repo.id === selected.head.repo.id
   );
 }
-
 function sameDirectAssociation(candidate, selected) {
   return (
-    candidate?.id === selected.id &&
-    candidate?.number === selected.number &&
+    positiveId(candidate?.id) &&
+    positiveId(candidate.number) &&
+    candidate.id === selected.id &&
+    candidate.number === selected.number &&
     candidate.base?.ref === selected.base.ref &&
-    associationRepository(candidate.base?.repo, selected.base.repo) &&
-    candidate.head?.ref === selected.head.ref &&
-    candidate.head?.sha === selected.head.sha &&
-    associationRepository(candidate.head?.repo, selected.head.repo)
+    associationRepository(candidate.base.repo, selected.base.repo) &&
+    nonEmpty(candidate.head?.ref) &&
+    sha(candidate.head.sha) &&
+    candidate.head.ref === selected.head.ref &&
+    candidate.head.sha === selected.head.sha &&
+    associationRepository(candidate.head.repo, selected.head.repo)
   );
 }
-
 function hasExactAssociation(candidate, selected) {
   const direct = candidate?.run?.pull_requests;
   if (!Array.isArray(direct)) return false;
-  if (direct.length > 0) {
-    return direct.length === 1 && sameDirectAssociation(direct[0], selected);
-  }
+  if (direct.length > 0) return direct.length === 1 && sameDirectAssociation(direct[0], selected);
   const fallback = candidate.fallbackPullRequests;
   return Array.isArray(fallback) && fallback.length === 1 && samePullRequest(fallback[0], selected);
 }
-
-function isFresh(startedAt, nowMs) {
-  const startedMs = Date.parse(startedAt);
-  if (!Number.isFinite(startedMs) || !Number.isFinite(nowMs)) return false;
-  const ageMs = nowMs - startedMs;
-  return ageMs >= -FUTURE_TOLERANCE_MS && ageMs <= MAX_AGE_MS;
-}
-
 function hasSuccessfulRunner(jobs) {
   if (!Array.isArray(jobs)) return false;
   const runners = jobs.filter(job => job?.name === 'PR E2E Runner');
   return (
-    runners.length === 1 && runners[0].status === 'completed' && runners[0].conclusion === 'success'
+    runners.length === 1 &&
+    positiveId(runners[0].id) &&
+    runners[0].status === 'completed' &&
+    runners[0].conclusion === 'success'
   );
 }
-
 function hasExactParity(parity) {
-  return (
-    parity?.checkoutHead === true &&
-    parity.projectSuperset === true &&
-    parity.sharedFlags === true &&
-    parity.databaseSubstrate === true
-  );
+  return [
+    'checkoutHead',
+    'projectSuperset',
+    'sharedFlags',
+    'databaseSubstrate',
+    'commandChain',
+  ].every(key => parity?.[key] === true);
 }
-
 function isReusableCandidate(candidate, selected, context) {
   const run = candidate?.run;
+  const ageMs = context.nowMs - Date.parse(run?.run_started_at);
   return (
-    run?.path === EXPECTED_WORKFLOW &&
+    positiveId(run?.id) &&
+    run.path === EXPECTED_WORKFLOW &&
     run.event === 'pull_request' &&
     run.status === 'completed' &&
     run.conclusion === 'success' &&
+    sha(run.head_sha) &&
     run.head_sha === selected.head.sha &&
     exactRepository(run.repository, context.repository, selected.base.repo.id) &&
     exactRepository(run.head_repository, context.repository, selected.head.repo.id) &&
-    isFresh(run.run_started_at, context.nowMs) &&
+    timestamp(run.run_started_at) &&
+    ageMs >= -FUTURE_TOLERANCE_MS &&
+    ageMs <= MAX_AGE_MS &&
     hasExactAssociation(candidate, selected) &&
     hasSuccessfulRunner(candidate.jobs)
   );
 }
-
 export function normalizeReuseDecision(value) {
   return value?.reuse === true && value?.reason === SUCCESS.reason ? { ...SUCCESS } : { ...REJECT };
 }
-
 export function decideMainE2eReuse(evidence) {
   const { context, local, pullRequests, headCommit, candidates, parity } = evidence ?? {};
   if (
     context?.eventName !== 'push' ||
     context.ref !== 'refs/heads/main' ||
     context.repository !== EXPECTED_REPOSITORY ||
-    local?.headSha !== context.githubSha ||
+    !sha(context.githubSha) ||
+    !sha(local?.headSha) ||
+    !sha(local.treeSha) ||
+    local.headSha !== context.githubSha ||
+    !Number.isFinite(context.nowMs) ||
     !hasExactParity(parity) ||
     !Array.isArray(pullRequests) ||
     pullRequests.length !== 1
@@ -133,14 +136,13 @@ export function decideMainE2eReuse(evidence) {
     return { ...REJECT };
   }
   const selected = pullRequests[0];
-  if (
-    !isMergedPullRequest(selected, context) ||
-    headCommit?.sha !== selected.head.sha ||
-    headCommit?.commit?.tree?.sha !== local?.treeSha ||
-    !Array.isArray(candidates) ||
-    !candidates.some(candidate => isReusableCandidate(candidate, selected, context))
-  ) {
-    return { ...REJECT };
-  }
-  return { ...SUCCESS };
+  const reusable =
+    isMergedPullRequest(selected, context) &&
+    sha(headCommit?.sha) &&
+    sha(headCommit?.commit?.tree?.sha) &&
+    headCommit.sha === selected.head.sha &&
+    headCommit.commit.tree.sha === local.treeSha &&
+    Array.isArray(candidates) &&
+    candidates.some(candidate => isReusableCandidate(candidate, selected, context));
+  return reusable ? { ...SUCCESS } : { ...REJECT };
 }

--- a/scripts/ci/main-e2e-reuse-core.test.mjs
+++ b/scripts/ci/main-e2e-reuse-core.test.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { decideMainE2eReuse, normalizeReuseDecision } from './main-e2e-reuse-core.mjs';
+import {
+  HEAD_SHA,
+  MAIN_SHA,
+  NOW_MS,
+  REPOSITORY,
+  directAssociation,
+  reusableEvidence,
+} from './main-e2e-reuse-fixture.mjs';
+const reject = { reuse: false, reason: 'evidence_not_exact' };
+function mutate(mutator, options) {
+  const fixture = structuredClone(reusableEvidence(options));
+  mutator(fixture);
+  return fixture;
+}
+test('exact empty-association fallback and exact direct association permit reuse', () => {
+  assert.deepEqual(decideMainE2eReuse(reusableEvidence()), {
+    reuse: true,
+    reason: 'exact_pr_evidence',
+  });
+  assert.deepEqual(decideMainE2eReuse(reusableEvidence({ direct: true })), {
+    reuse: true,
+    reason: 'exact_pr_evidence',
+  });
+});
+const rejectionCases = [
+  ['wrong event', value => (value.context.eventName = 'pull_request')],
+  ['wrong ref', value => (value.context.ref = 'refs/heads/master')],
+  ['wrong repository', value => (value.context.repository = 'attacker/interdomestik')],
+  ['local head mismatch', value => (value.local.headSha = HEAD_SHA)],
+  ['ambiguous merged PR', value => value.pullRequests.push(value.pullRequests[0])],
+  ['missing merged PR', value => (value.pullRequests = [])],
+  ['unmerged PR', value => (value.pullRequests[0].merged_at = null)],
+  ['wrong merge SHA', value => (value.pullRequests[0].merge_commit_sha = HEAD_SHA)],
+  ['wrong base repository', value => (value.pullRequests[0].base.repo.full_name = 'other/repo')],
+  ['wrong base ref', value => (value.pullRequests[0].base.ref = 'develop')],
+  ['fork head repository', value => (value.pullRequests[0].head.repo.full_name = 'fork/repo')],
+  ['tree mismatch', value => (value.headCommit.commit.tree.sha = MAIN_SHA)],
+  ['wrong workflow path', value => (value.candidates[0].run.path = '.github/workflows/ci.yml')],
+  ['wrong run event', value => (value.candidates[0].run.event = 'push')],
+  ['wrong run head', value => (value.candidates[0].run.head_sha = MAIN_SHA)],
+  ['wrong run repository', value => (value.candidates[0].run.repository.full_name = 'other/repo')],
+  [
+    'wrong run head repository',
+    value => (value.candidates[0].run.head_repository.full_name = 'fork/repo'),
+  ],
+  ['failed run', value => (value.candidates[0].run.conclusion = 'failure')],
+  ['malformed direct association', value => (value.candidates[0].run.pull_requests = null)],
+  ['invalid start time', value => (value.candidates[0].run.run_started_at = 'not-a-date')],
+  ['stale run', value => (value.candidates[0].run.run_started_at = '2026-08-12T15:59:59Z')],
+  [
+    'future run outside tolerance',
+    value => (value.candidates[0].run.run_started_at = '2026-08-13T16:05:01Z'),
+  ],
+  ['missing runner', value => (value.candidates[0].jobs = [])],
+  ['duplicate runner', value => value.candidates[0].jobs.push(value.candidates[0].jobs[0])],
+  ['skipped runner', value => (value.candidates[0].jobs[0].conclusion = 'skipped')],
+  ['incomplete runner', value => (value.candidates[0].jobs[0].status = 'in_progress')],
+  [
+    'fallback ambiguity',
+    value => value.candidates[0].fallbackPullRequests.push(value.pullRequests[0]),
+  ],
+  ['fallback PR mismatch', value => (value.candidates[0].fallbackPullRequests[0].number = 9999)],
+  ['fallback ID mismatch', value => (value.candidates[0].fallbackPullRequests[0].id += 1)],
+  [
+    'fallback timestamp mismatch',
+    value => (value.candidates[0].fallbackPullRequests[0].merged_at = '2026-08-13T15:27:40Z'),
+  ],
+  [
+    'fallback ref mismatch',
+    value => (value.candidates[0].fallbackPullRequests[0].head.ref = 'other-branch'),
+  ],
+  [
+    'fallback head mismatch',
+    value => (value.candidates[0].fallbackPullRequests[0].head.sha = MAIN_SHA),
+  ],
+  [
+    'fallback head repository mismatch',
+    value => (value.candidates[0].fallbackPullRequests[0].head.repo.full_name = 'fork/repo'),
+  ],
+  [
+    'fallback base repository mismatch',
+    value => (value.candidates[0].fallbackPullRequests[0].base.repo.full_name = 'other/repo'),
+  ],
+  [
+    'fallback base ref mismatch',
+    value => (value.candidates[0].fallbackPullRequests[0].base.ref = 'develop'),
+  ],
+  [
+    'fallback merged-state mismatch',
+    value => (value.candidates[0].fallbackPullRequests[0].state = 'open'),
+  ],
+  [
+    'fallback merge mismatch',
+    value => (value.candidates[0].fallbackPullRequests[0].merge_commit_sha = HEAD_SHA),
+  ],
+  ['checkout drift', value => (value.parity.checkoutHead = false)],
+  ['missing parity evidence', value => (value.parity = {})],
+  ['partial parity evidence', value => delete value.parity.databaseSubstrate],
+  ['project drift', value => (value.parity.projectSuperset = false)],
+  ['flag drift', value => (value.parity.sharedFlags = false)],
+  ['database drift', value => (value.parity.databaseSubstrate = false)],
+];
+for (const [name, mutator] of rejectionCases) {
+  test(`rejects ${name}`, () => {
+    assert.deepEqual(decideMainE2eReuse(mutate(mutator)), reject);
+  });
+}
+
+test('a non-empty direct mismatch cannot be repaired by fallback evidence', () => {
+  const fixture = mutate(value => {
+    value.candidates[0].run.pull_requests = [
+      { ...directAssociation(), number: value.pullRequests[0].number + 1 },
+    ];
+    value.candidates[0].fallbackPullRequests = [structuredClone(value.pullRequests[0])];
+  });
+  assert.deepEqual(decideMainE2eReuse(fixture), reject);
+});
+
+for (const [name, mutateAssociation] of [
+  ['id', value => (value.id += 1)],
+  ['base ref', value => (value.base.ref = 'develop')],
+  ['base repository', value => (value.base.repo.id += 1)],
+  ['head ref', value => (value.head.ref = 'other-branch')],
+  ['head SHA', value => (value.head.sha = MAIN_SHA)],
+  ['head repository', value => (value.head.repo.id += 1)],
+]) {
+  test(`rejects direct association ${name} mismatch`, () => {
+    const fixture = mutate(value => {
+      const association = directAssociation();
+      mutateAssociation(association);
+      value.candidates[0].run.pull_requests = [association];
+      value.candidates[0].fallbackPullRequests = [structuredClone(value.pullRequests[0])];
+    });
+    assert.deepEqual(decideMainE2eReuse(fixture), reject);
+  });
+}
+
+test('normalization never accepts a hostile or incomplete true decision', () => {
+  assert.deepEqual(normalizeReuseDecision({ reuse: true, reason: '$(touch /tmp/pwned)' }), reject);
+  assert.deepEqual(normalizeReuseDecision({ reuse: 'true', reason: 'exact_pr_evidence' }), reject);
+  assert.deepEqual(normalizeReuseDecision(null), reject);
+  assert.deepEqual(
+    normalizeReuseDecision({ reuse: true, reason: 'exact_pr_evidence', repository: REPOSITORY }),
+    { reuse: true, reason: 'exact_pr_evidence' }
+  );
+  assert.equal(NOW_MS > 0 && MAIN_SHA.length === 40, true);
+});

--- a/scripts/ci/main-e2e-reuse-core.test.mjs
+++ b/scripts/ci/main-e2e-reuse-core.test.mjs
@@ -4,10 +4,10 @@ import { decideMainE2eReuse, normalizeReuseDecision } from './main-e2e-reuse-cor
 import {
   HEAD_SHA,
   MAIN_SHA,
-  NOW_MS,
   REPOSITORY,
   directAssociation,
   reusableEvidence,
+  strictSchemaRejectionCases,
 } from './main-e2e-reuse-fixture.mjs';
 const reject = { reuse: false, reason: 'evidence_not_exact' };
 function mutate(mutator, options) {
@@ -15,6 +15,12 @@ function mutate(mutator, options) {
   mutator(fixture);
   return fixture;
 }
+const pr = value => value.pullRequests[0];
+const candidate = value => value.candidates[0];
+const run = value => candidate(value).run;
+const fallback = value => candidate(value).fallbackPullRequests[0];
+const directPr = value => run(value).pull_requests[0];
+const direct = { direct: true };
 test('exact empty-association fallback and exact direct association permit reuse', () => {
   assert.deepEqual(decideMainE2eReuse(reusableEvidence()), {
     reuse: true,
@@ -32,83 +38,73 @@ const rejectionCases = [
   ['local head mismatch', value => (value.local.headSha = HEAD_SHA)],
   ['ambiguous merged PR', value => value.pullRequests.push(value.pullRequests[0])],
   ['missing merged PR', value => (value.pullRequests = [])],
-  ['unmerged PR', value => (value.pullRequests[0].merged_at = null)],
-  ['wrong merge SHA', value => (value.pullRequests[0].merge_commit_sha = HEAD_SHA)],
-  ['wrong base repository', value => (value.pullRequests[0].base.repo.full_name = 'other/repo')],
-  ['wrong base ref', value => (value.pullRequests[0].base.ref = 'develop')],
-  ['fork head repository', value => (value.pullRequests[0].head.repo.full_name = 'fork/repo')],
+  ['unmerged PR', value => (pr(value).merged_at = null)],
+  ['wrong merge SHA', value => (pr(value).merge_commit_sha = HEAD_SHA)],
+  ['wrong base repository', value => (pr(value).base.repo.full_name = 'other/repo')],
+  ['wrong base ref', value => (pr(value).base.ref = 'develop')],
+  ['fork head repository', value => (pr(value).head.repo.full_name = 'fork/repo')],
   ['tree mismatch', value => (value.headCommit.commit.tree.sha = MAIN_SHA)],
-  ['wrong workflow path', value => (value.candidates[0].run.path = '.github/workflows/ci.yml')],
-  ['wrong run event', value => (value.candidates[0].run.event = 'push')],
-  ['wrong run head', value => (value.candidates[0].run.head_sha = MAIN_SHA)],
-  ['wrong run repository', value => (value.candidates[0].run.repository.full_name = 'other/repo')],
-  [
-    'wrong run head repository',
-    value => (value.candidates[0].run.head_repository.full_name = 'fork/repo'),
-  ],
-  ['failed run', value => (value.candidates[0].run.conclusion = 'failure')],
-  ['malformed direct association', value => (value.candidates[0].run.pull_requests = null)],
-  ['invalid start time', value => (value.candidates[0].run.run_started_at = 'not-a-date')],
-  ['stale run', value => (value.candidates[0].run.run_started_at = '2026-08-12T15:59:59Z')],
-  [
-    'future run outside tolerance',
-    value => (value.candidates[0].run.run_started_at = '2026-08-13T16:05:01Z'),
-  ],
-  ['missing runner', value => (value.candidates[0].jobs = [])],
-  ['duplicate runner', value => value.candidates[0].jobs.push(value.candidates[0].jobs[0])],
-  ['skipped runner', value => (value.candidates[0].jobs[0].conclusion = 'skipped')],
-  ['incomplete runner', value => (value.candidates[0].jobs[0].status = 'in_progress')],
-  [
-    'fallback ambiguity',
-    value => value.candidates[0].fallbackPullRequests.push(value.pullRequests[0]),
-  ],
-  ['fallback PR mismatch', value => (value.candidates[0].fallbackPullRequests[0].number = 9999)],
-  ['fallback ID mismatch', value => (value.candidates[0].fallbackPullRequests[0].id += 1)],
-  [
-    'fallback timestamp mismatch',
-    value => (value.candidates[0].fallbackPullRequests[0].merged_at = '2026-08-13T15:27:40Z'),
-  ],
-  [
-    'fallback ref mismatch',
-    value => (value.candidates[0].fallbackPullRequests[0].head.ref = 'other-branch'),
-  ],
-  [
-    'fallback head mismatch',
-    value => (value.candidates[0].fallbackPullRequests[0].head.sha = MAIN_SHA),
-  ],
+  ['wrong workflow path', value => (run(value).path = '.github/workflows/ci.yml')],
+  ['wrong run event', value => (run(value).event = 'push')],
+  ['wrong run head', value => (run(value).head_sha = MAIN_SHA)],
+  ['wrong run repository', value => (run(value).repository.full_name = 'other/repo')],
+  ['wrong run head repository', value => (run(value).head_repository.full_name = 'fork/repo')],
+  ['failed run', value => (run(value).conclusion = 'failure')],
+  ['malformed direct association', value => (run(value).pull_requests = null)],
+  ['invalid start time', value => (run(value).run_started_at = 'not-a-date')],
+  ['stale run', value => (run(value).run_started_at = '2026-08-12T15:59:59Z')],
+  ['future run outside tolerance', value => (run(value).run_started_at = '2026-08-13T16:05:01Z')],
+  ['missing runner', value => (candidate(value).jobs = [])],
+  ['duplicate runner', value => candidate(value).jobs.push(candidate(value).jobs[0])],
+  ['skipped runner', value => (candidate(value).jobs[0].conclusion = 'skipped')],
+  ['incomplete runner', value => (candidate(value).jobs[0].status = 'in_progress')],
+  ['fallback ambiguity', value => candidate(value).fallbackPullRequests.push(pr(value))],
+  ['fallback PR mismatch', value => (fallback(value).number = 9999)],
+  ['fallback ID mismatch', value => (fallback(value).id += 1)],
+  ['fallback timestamp mismatch', value => (fallback(value).merged_at = '2026-08-13T15:27:40Z')],
+  ['fallback ref mismatch', value => (fallback(value).head.ref = 'other-branch')],
+  ['fallback head mismatch', value => (fallback(value).head.sha = MAIN_SHA)],
   [
     'fallback head repository mismatch',
-    value => (value.candidates[0].fallbackPullRequests[0].head.repo.full_name = 'fork/repo'),
+    value => (fallback(value).head.repo.full_name = 'fork/repo'),
   ],
   [
     'fallback base repository mismatch',
-    value => (value.candidates[0].fallbackPullRequests[0].base.repo.full_name = 'other/repo'),
+    value => (fallback(value).base.repo.full_name = 'other/repo'),
   ],
-  [
-    'fallback base ref mismatch',
-    value => (value.candidates[0].fallbackPullRequests[0].base.ref = 'develop'),
-  ],
-  [
-    'fallback merged-state mismatch',
-    value => (value.candidates[0].fallbackPullRequests[0].state = 'open'),
-  ],
-  [
-    'fallback merge mismatch',
-    value => (value.candidates[0].fallbackPullRequests[0].merge_commit_sha = HEAD_SHA),
-  ],
+  ['fallback base ref mismatch', value => (fallback(value).base.ref = 'develop')],
+  ['fallback merged-state mismatch', value => (fallback(value).state = 'open')],
+  ['fallback merge mismatch', value => (fallback(value).merge_commit_sha = HEAD_SHA)],
   ['checkout drift', value => (value.parity.checkoutHead = false)],
   ['missing parity evidence', value => (value.parity = {})],
   ['partial parity evidence', value => delete value.parity.databaseSubstrate],
+  ['command chain drift', value => (value.parity.commandChain = false)],
   ['project drift', value => (value.parity.projectSuperset = false)],
   ['flag drift', value => (value.parity.sharedFlags = false)],
   ['database drift', value => (value.parity.databaseSubstrate = false)],
+  ...strictSchemaRejectionCases,
+  ['array PR timestamp', value => (pr(value).merged_at = ['2026-08-13T15:27:39Z'])],
+  ['array run timestamp', value => (run(value).run_started_at = ['2026-08-13T14:50:50Z'])],
+  ['zero PR ID', value => (pr(value).id = 0)],
+  ['negative PR number', value => (pr(value).number = -1)],
+  ['zero base repository ID', value => (pr(value).base.repo.id = 0)],
+  ['zero head repository ID', value => (pr(value).head.repo.id = 0)],
+  ['zero run ID', value => (run(value).id = 0)],
+  ['negative runner ID', value => (candidate(value).jobs[0].id = -1)],
+  ['zero run repository ID', value => (run(value).repository.id = 0)],
+  ['zero run head repository ID', value => (run(value).head_repository.id = 0)],
+  ['zero direct PR ID', value => (directPr(value).id = 0), direct],
+  ['negative direct PR number', value => (directPr(value).number = -1), direct],
+  ['zero direct base repository ID', value => (directPr(value).base.repo.id = 0), direct],
+  ['zero direct head repository ID', value => (directPr(value).head.repo.id = 0), direct],
+  ['zero fallback base repository ID', value => (fallback(value).base.repo.id = 0)],
+  ['zero fallback head repository ID', value => (fallback(value).head.repo.id = 0)],
 ];
-for (const [name, mutator] of rejectionCases) {
+for (const [name, mutator, options] of rejectionCases) {
   test(`rejects ${name}`, () => {
-    assert.deepEqual(decideMainE2eReuse(mutate(mutator)), reject);
+    assert.deepEqual(decideMainE2eReuse(mutate(mutator, options)), reject);
   });
 }
-
 test('a non-empty direct mismatch cannot be repaired by fallback evidence', () => {
   const fixture = mutate(value => {
     value.candidates[0].run.pull_requests = [
@@ -118,7 +114,6 @@ test('a non-empty direct mismatch cannot be repaired by fallback evidence', () =
   });
   assert.deepEqual(decideMainE2eReuse(fixture), reject);
 });
-
 for (const [name, mutateAssociation] of [
   ['id', value => (value.id += 1)],
   ['base ref', value => (value.base.ref = 'develop')],
@@ -146,5 +141,4 @@ test('normalization never accepts a hostile or incomplete true decision', () => 
     normalizeReuseDecision({ reuse: true, reason: 'exact_pr_evidence', repository: REPOSITORY }),
     { reuse: true, reason: 'exact_pr_evidence' }
   );
-  assert.equal(NOW_MS > 0 && MAIN_SHA.length === 40, true);
 });

--- a/scripts/ci/main-e2e-reuse-fixture.mjs
+++ b/scripts/ci/main-e2e-reuse-fixture.mjs
@@ -4,9 +4,7 @@ export const HEAD_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 export const TREE_SHA = 'cccccccccccccccccccccccccccccccccccccccc';
 export const NOW_MS = Date.parse('2026-08-13T16:00:00Z');
 
-function repository() {
-  return { id: 1_128_472_973, full_name: REPOSITORY };
-}
+const repository = () => ({ id: 1_128_472_973, full_name: REPOSITORY });
 
 export function reusablePullRequest() {
   return {
@@ -114,19 +112,39 @@ function setLinkedHeadSha(value, sha) {
   run.head_sha = sha;
   fallback.head.sha = sha;
 }
+function setRunTimestamp(value, timestamp) {
+  parts(value).run.run_started_at = timestamp;
+  value.context.nowMs = Date.parse(timestamp);
+}
 export const strictSchemaRejectionCases = [
   ['paired missing main SHAs', removeMainSha],
   ['paired missing tree SHAs', removeTreeSha],
   ['invalid linked tree SHAs', setTreeSha],
   ['empty linked head SHAs', value => setLinkedHeadSha(value, '')],
   ['invalid linked head SHAs', value => setLinkedHeadSha(value, 'not-a-full-sha')],
+  ...['2025-02-29', '2024-02-30', '2026-04-31', '2026-13-01'].flatMap(date => [
+    [
+      `impossible merged timestamp ${date}`,
+      value => (parts(value).pr.merged_at = `${date}T15:27:39Z`),
+      { direct: true },
+    ],
+    [`impossible run timestamp ${date}`, value => setRunTimestamp(value, `${date}T14:50:50Z`)],
+  ]),
 ];
-
+const STATE_RUN =
+  "if (lane.state) await run('pnpm', [...pwArgs, ...laneDefinitions.state.playwrightArgs], stateEnv);";
+const FINAL_RUN =
+  "await run('pnpm', [...pwArgs, ...lane.playwrightArgs, ...extraPlaywrightArgs], finalEnv);";
+const removed = value => [value, ''];
 export const commandChainDrifts = [
-  'playwrightReportArgs(process.env.PW_EVIDENCE_LANE)',
-  "const fastEnv = { PW_FAST_GATES: '1' };",
-  "const strictArgs = ['--max-failures=1', ...reportArgs];",
-  "const strictWorkers = ['--workers=1', ...strictArgs];",
-  "const gateArgs = ['e2e/gate', ...strictWorkers];",
-  'gatekeeper: true,',
+  removed('playwrightReportArgs(process.env.PW_EVIDENCE_LANE)'),
+  removed("const fastEnv = { PW_FAST_GATES: '1' };"),
+  removed("const strictArgs = ['--max-failures=1', ...reportArgs];"),
+  removed("const strictWorkers = ['--workers=1', ...strictArgs];"),
+  removed("const gateArgs = ['e2e/gate', ...strictWorkers];"),
+  removed('gatekeeper: true,'),
+  removed("const pwArgs = ['--filter', '@interdomestik/web', 'exec', 'playwright', 'test'];"),
+  removed('await runDetachedCommand(command, args, { cwd: rootDir, env });'),
+  removed(STATE_RUN),
+  [FINAL_RUN, "await run('/usr/bin/true', [], finalEnv);"],
 ];

--- a/scripts/ci/main-e2e-reuse-fixture.mjs
+++ b/scripts/ci/main-e2e-reuse-fixture.mjs
@@ -1,0 +1,87 @@
+export const REPOSITORY = 'interdomestik/interdomestik';
+export const MAIN_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+export const HEAD_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+export const TREE_SHA = 'cccccccccccccccccccccccccccccccccccccccc';
+export const NOW_MS = Date.parse('2026-08-13T16:00:00Z');
+
+function repository() {
+  return { id: 1_128_472_973, full_name: REPOSITORY };
+}
+
+export function reusablePullRequest() {
+  return {
+    id: 4_272_213_126,
+    number: 1548,
+    state: 'closed',
+    merged_at: '2026-08-13T15:27:39Z',
+    merge_commit_sha: MAIN_SHA,
+    base: { ref: 'main', repo: repository() },
+    head: {
+      ref: 'codex/ci-main-e2e-db-parity-r1',
+      sha: HEAD_SHA,
+      repo: repository(),
+    },
+  };
+}
+
+export function reusableRun({ pullRequests = [] } = {}) {
+  return {
+    id: 31_712_197_425,
+    path: '.github/workflows/e2e-pr.yml',
+    event: 'pull_request',
+    status: 'completed',
+    conclusion: 'success',
+    head_sha: HEAD_SHA,
+    run_started_at: '2026-08-13T14:50:50Z',
+    repository: repository(),
+    head_repository: repository(),
+    pull_requests: pullRequests,
+  };
+}
+
+export function directAssociation() {
+  const pr = reusablePullRequest();
+  return {
+    id: pr.id,
+    number: pr.number,
+    base: { ref: pr.base.ref, sha: MAIN_SHA, repo: { id: pr.base.repo.id } },
+    head: { ref: pr.head.ref, sha: pr.head.sha, repo: { id: pr.head.repo.id } },
+  };
+}
+
+export function reusableEvidence({ direct = false } = {}) {
+  const pr = reusablePullRequest();
+  const run = reusableRun({ pullRequests: direct ? [directAssociation()] : [] });
+  return {
+    context: {
+      eventName: 'push',
+      ref: 'refs/heads/main',
+      repository: REPOSITORY,
+      githubSha: MAIN_SHA,
+      nowMs: NOW_MS,
+    },
+    local: { headSha: MAIN_SHA, treeSha: TREE_SHA },
+    pullRequests: [pr],
+    headCommit: { sha: HEAD_SHA, commit: { tree: { sha: TREE_SHA } } },
+    candidates: [
+      {
+        run,
+        jobs: [
+          {
+            id: 94_487_829_021,
+            name: 'PR E2E Runner',
+            status: 'completed',
+            conclusion: 'success',
+          },
+        ],
+        fallbackPullRequests: direct ? undefined : [structuredClone(pr)],
+      },
+    ],
+    parity: {
+      checkoutHead: true,
+      projectSuperset: true,
+      sharedFlags: true,
+      databaseSubstrate: true,
+    },
+  };
+}

--- a/scripts/ci/main-e2e-reuse-fixture.mjs
+++ b/scripts/ci/main-e2e-reuse-fixture.mjs
@@ -3,7 +3,6 @@ export const MAIN_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 export const HEAD_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 export const TREE_SHA = 'cccccccccccccccccccccccccccccccccccccccc';
 export const NOW_MS = Date.parse('2026-08-13T16:00:00Z');
-
 const repository = () => ({ id: 1_128_472_973, full_name: REPOSITORY });
 
 export function reusablePullRequest() {
@@ -147,4 +146,5 @@ export const commandChainDrifts = [
   removed('await runDetachedCommand(command, args, { cwd: rootDir, env });'),
   removed(STATE_RUN),
   [FINAL_RUN, "await run('/usr/bin/true', [], finalEnv);"],
+  [FINAL_RUN, `if (false) ${FINAL_RUN}\nawait run('/usr/bin/true', [], finalEnv);`],
 ];

--- a/scripts/ci/main-e2e-reuse-fixture.mjs
+++ b/scripts/ci/main-e2e-reuse-fixture.mjs
@@ -82,6 +82,51 @@ export function reusableEvidence({ direct = false } = {}) {
       projectSuperset: true,
       sharedFlags: true,
       databaseSubstrate: true,
+      commandChain: true,
     },
   };
 }
+
+function parts(value) {
+  const pr = value.pullRequests[0];
+  const candidate = value.candidates[0];
+  return { pr, candidate, run: candidate.run, fallback: candidate.fallbackPullRequests?.[0] };
+}
+function removeMainSha(value) {
+  const { pr, fallback } = parts(value);
+  delete value.context.githubSha;
+  delete value.local.headSha;
+  delete pr.merge_commit_sha;
+  delete fallback.merge_commit_sha;
+}
+function removeTreeSha(value) {
+  delete value.local.treeSha;
+  delete value.headCommit.commit.tree.sha;
+}
+function setTreeSha(value) {
+  value.local.treeSha = 'not-a-full-tree-sha';
+  value.headCommit.commit.tree.sha = 'not-a-full-tree-sha';
+}
+function setLinkedHeadSha(value, sha) {
+  const { pr, run, fallback } = parts(value);
+  pr.head.sha = sha;
+  value.headCommit.sha = sha;
+  run.head_sha = sha;
+  fallback.head.sha = sha;
+}
+export const strictSchemaRejectionCases = [
+  ['paired missing main SHAs', removeMainSha],
+  ['paired missing tree SHAs', removeTreeSha],
+  ['invalid linked tree SHAs', setTreeSha],
+  ['empty linked head SHAs', value => setLinkedHeadSha(value, '')],
+  ['invalid linked head SHAs', value => setLinkedHeadSha(value, 'not-a-full-sha')],
+];
+
+export const commandChainDrifts = [
+  'playwrightReportArgs(process.env.PW_EVIDENCE_LANE)',
+  "const fastEnv = { PW_FAST_GATES: '1' };",
+  "const strictArgs = ['--max-failures=1', ...reportArgs];",
+  "const strictWorkers = ['--workers=1', ...strictArgs];",
+  "const gateArgs = ['e2e/gate', ...strictWorkers];",
+  'gatekeeper: true,',
+];

--- a/scripts/ci/main-e2e-reuse-github.mjs
+++ b/scripts/ci/main-e2e-reuse-github.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import {
   buildCommitPullRequestsUrl,
   buildCommitUrl,
@@ -6,6 +7,15 @@ import {
 } from './github-api-url-lib.mjs';
 
 const WORKFLOW_PATH = '.github/workflows/e2e-pr.yml';
+
+export function readLocalGitObjectId(cwd, revision) {
+  return execFileSync('/usr/bin/git', ['rev-parse', revision], {
+    cwd,
+    encoding: 'utf8',
+    env: { LC_ALL: 'C', PATH: '/usr/bin:/bin' },
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
 
 async function requestJson({ url, token, fetchImpl, timeoutMs }) {
   const controller = new AbortController();

--- a/scripts/ci/main-e2e-reuse-github.mjs
+++ b/scripts/ci/main-e2e-reuse-github.mjs
@@ -1,0 +1,133 @@
+import {
+  buildCommitPullRequestsUrl,
+  buildCommitUrl,
+  buildRunJobsUrl,
+  buildWorkflowRunsUrl,
+} from './github-api-url-lib.mjs';
+
+const WORKFLOW_PATH = '.github/workflows/e2e-pr.yml';
+
+async function requestJson({ url, token, fetchImpl, timeoutMs }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      signal: controller.signal,
+    });
+    if (!response?.ok) throw new Error('request rejected');
+    return await response.json();
+  } catch {
+    throw new Error('GitHub API request failed');
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function collectArrayPages({ buildUrl, request, perPage, maxPages }) {
+  const items = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    const payload = await request(buildUrl(page, perPage));
+    if (!Array.isArray(payload)) throw new Error('GitHub API schema invalid');
+    items.push(...payload);
+    if (payload.length < perPage) return items;
+  }
+  throw new Error('GitHub API pagination incomplete');
+}
+
+async function collectWrappedPages({ buildUrl, key, request, perPage, maxPages }) {
+  const items = [];
+  let totalCount;
+  for (let page = 1; page <= maxPages; page += 1) {
+    const payload = await request(buildUrl(page, perPage));
+    if (
+      !payload ||
+      !Number.isSafeInteger(payload.total_count) ||
+      payload.total_count < 0 ||
+      !Array.isArray(payload[key])
+    ) {
+      throw new Error('GitHub API schema invalid');
+    }
+    if (totalCount === undefined) totalCount = payload.total_count;
+    if (payload.total_count !== totalCount || items.length + payload[key].length > totalCount) {
+      throw new Error('GitHub API schema invalid');
+    }
+    items.push(...payload[key]);
+    if (items.length === totalCount) return items;
+    if (payload[key].length === 0) break;
+  }
+  throw new Error('GitHub API pagination incomplete');
+}
+
+export async function collectGitHubEvidence({
+  repositoryFullName,
+  githubSha,
+  token,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 8_000,
+  perPage = 100,
+  maxPages = 3,
+  maxRuns = 20,
+}) {
+  if (typeof token !== 'string' || token.length === 0 || typeof fetchImpl !== 'function') {
+    throw new Error('GitHub evidence selection failed');
+  }
+  const request = url => requestJson({ url, token, fetchImpl, timeoutMs });
+  const commitPulls = sha =>
+    collectArrayPages({
+      buildUrl: (page, size) =>
+        buildCommitPullRequestsUrl({
+          repositoryFullName,
+          commitSha: sha,
+          page,
+          perPage: size,
+        }),
+      request,
+      perPage,
+      maxPages,
+    });
+  const pullRequests = await commitPulls(githubSha);
+  if (pullRequests.length !== 1 || typeof pullRequests[0]?.head?.sha !== 'string') {
+    throw new Error('GitHub evidence selection failed');
+  }
+  const headSha = pullRequests[0].head.sha;
+  const headCommit = await request(buildCommitUrl({ repositoryFullName, commitSha: headSha }));
+  const runs = await collectWrappedPages({
+    buildUrl: (page, size) =>
+      buildWorkflowRunsUrl({
+        repositoryFullName,
+        workflowPath: WORKFLOW_PATH,
+        headSha,
+        page,
+        perPage: Math.min(size, 20),
+      }),
+    key: 'workflow_runs',
+    request,
+    perPage: Math.min(perPage, 20),
+    maxPages,
+  });
+  if (runs.length > maxRuns) throw new Error('GitHub evidence selection failed');
+
+  const candidates = [];
+  for (const run of runs) {
+    const jobs = await collectWrappedPages({
+      buildUrl: (page, size) =>
+        buildRunJobsUrl({ repositoryFullName, runId: run?.id, page, perPage: size }),
+      key: 'jobs',
+      request,
+      perPage,
+      maxPages,
+    });
+    const candidate = { run, jobs };
+    if (Array.isArray(run?.pull_requests) && run.pull_requests.length === 0) {
+      candidate.fallbackPullRequests = await commitPulls(run.head_sha);
+    }
+    candidates.push(candidate);
+  }
+
+  return { pullRequests, headCommit, candidates };
+}

--- a/scripts/ci/main-e2e-reuse-github.test.mjs
+++ b/scripts/ci/main-e2e-reuse-github.test.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { collectGitHubEvidence } from './main-e2e-reuse-github.mjs';
+import {
+  HEAD_SHA,
+  MAIN_SHA,
+  REPOSITORY,
+  directAssociation,
+  reusablePullRequest,
+  reusableRun,
+} from './main-e2e-reuse-fixture.mjs';
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function githubApi({
+  mainPulls = [reusablePullRequest()],
+  fallbackPulls = [reusablePullRequest()],
+  run = reusableRun(),
+  runsPayload,
+  jobsPayload,
+} = {}) {
+  const requests = [];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url: String(url), options });
+    if (String(url).includes(`/commits/${MAIN_SHA}/pulls`)) return jsonResponse(mainPulls);
+    if (String(url).includes(`/commits/${HEAD_SHA}/pulls`)) return jsonResponse(fallbackPulls);
+    if (String(url).includes(`/commits/${HEAD_SHA}`)) {
+      return jsonResponse({ sha: HEAD_SHA, commit: { tree: { sha: 'c'.repeat(40) } } });
+    }
+    if (String(url).includes('/actions/workflows/')) {
+      return jsonResponse(runsPayload ?? { total_count: 1, workflow_runs: [run] });
+    }
+    if (String(url).includes('/actions/runs/')) {
+      return jsonResponse(
+        jobsPayload ?? {
+          total_count: 1,
+          jobs: [
+            {
+              id: 94_487_829_021,
+              name: 'PR E2E Runner',
+              status: 'completed',
+              conclusion: 'success',
+            },
+          ],
+        }
+      );
+    }
+    throw new Error(`unexpected test URL: ${url}`);
+  };
+  return { fetchImpl, requests };
+}
+
+function collect(api, overrides = {}) {
+  return collectGitHubEvidence({
+    repositoryFullName: REPOSITORY,
+    githubSha: MAIN_SHA,
+    token: 'test-token',
+    fetchImpl: api.fetchImpl,
+    timeoutMs: 100,
+    ...overrides,
+  });
+}
+
+test('collects bounded PR, tree, run, job, and empty-association fallback evidence', async () => {
+  const api = githubApi();
+  const evidence = await collect(api);
+
+  assert.equal(evidence.pullRequests.length, 1);
+  assert.equal(evidence.headCommit.sha, HEAD_SHA);
+  assert.equal(evidence.candidates.length, 1);
+  assert.equal(evidence.candidates[0].fallbackPullRequests[0].number, 1548);
+  assert.equal(api.requests.length, 5);
+  for (const request of api.requests) {
+    assert.equal(request.options.headers.Authorization, 'Bearer test-token');
+    assert.ok(request.options.signal instanceof AbortSignal);
+  }
+});
+
+test('never queries fallback after a non-empty direct association, even when it mismatches', async () => {
+  const mismatch = { ...directAssociation(), number: 9999 };
+  const api = githubApi({ run: reusableRun({ pullRequests: [mismatch] }) });
+  const evidence = await collect(api);
+
+  assert.equal(evidence.candidates[0].fallbackPullRequests, undefined);
+  assert.equal(
+    api.requests.some(request => request.url.includes(`/commits/${HEAD_SHA}/pulls`)),
+    false
+  );
+});
+
+test('fails closed on ambiguous merged pull request selection', async () => {
+  const pr = reusablePullRequest();
+  const api = githubApi({ mainPulls: [pr, structuredClone(pr)] });
+  await assert.rejects(() => collect(api), /GitHub evidence selection failed/u);
+});
+
+test('fails closed when bounded pagination cannot prove completion', async () => {
+  const api = githubApi();
+  await assert.rejects(
+    () => collect(api, { perPage: 1, maxPages: 1 }),
+    /GitHub API pagination incomplete/u
+  );
+});
+
+test('fails closed on malformed response schemas', async () => {
+  const api = githubApi({ mainPulls: { pull_requests: [reusablePullRequest()] } });
+  await assert.rejects(() => collect(api), /GitHub API schema invalid/u);
+
+  const wrapped = githubApi({ runsPayload: { total_count: 2, workflow_runs: [] } });
+  await assert.rejects(() => collect(wrapped), /GitHub API pagination incomplete/u);
+});
+
+test('bounds requests by timeout', async () => {
+  const fetchImpl = (_url, { signal }) =>
+    new Promise((resolve, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('aborted')));
+    });
+  await assert.rejects(
+    () =>
+      collectGitHubEvidence({
+        repositoryFullName: REPOSITORY,
+        githubSha: MAIN_SHA,
+        token: 'test-token',
+        fetchImpl,
+        timeoutMs: 5,
+      }),
+    /GitHub API request failed/u
+  );
+});
+
+test('API failures expose neither tokens nor response bodies', async () => {
+  const fetchImpl = async () => new Response('TOP-SECRET-BODY', { status: 500 });
+  const error = await collectGitHubEvidence({
+    repositoryFullName: REPOSITORY,
+    githubSha: MAIN_SHA,
+    token: 'TOP-SECRET-TOKEN',
+    fetchImpl,
+  }).catch(value => value);
+
+  assert.match(error.message, /GitHub API request failed/u);
+  assert.doesNotMatch(error.message, /TOP-SECRET/u);
+});

--- a/scripts/ci/main-e2e-reuse-workflow.test.mjs
+++ b/scripts/ci/main-e2e-reuse-workflow.test.mjs
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import test from 'node:test';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import yaml from 'js-yaml';
@@ -15,6 +17,26 @@ function step(job, name) {
   return job.steps.find(value => value?.name === name);
 }
 
+function normalizedReuse(rawReuse, resolverOutcome) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'ci01-reuse-'));
+  const output = path.join(directory, 'github-output');
+  const normalizer = step(validation, 'Normalize main E2E reuse decision');
+  try {
+    const result = spawnSync('/bin/bash', ['-c', `set -euo pipefail\n${normalizer.run}`], {
+      encoding: 'utf8',
+      env: {
+        GITHUB_OUTPUT: output,
+        PATH: '/usr/bin:/bin',
+        RESOLVER_RESULT: `${resolverOutcome}:${rawReuse}`,
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return readFileSync(output, 'utf8');
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
 test('main CI resolves exact-tree reuse with bounded read-only evidence access', () => {
   assert.equal(workflow.permissions.contents, 'read');
   assert.equal(workflow.permissions['pull-requests'], 'read');
@@ -22,20 +44,39 @@ test('main CI resolves exact-tree reuse with bounded read-only evidence access',
 
   const resolver = step(validation, 'Resolve main E2E exact-tree reuse');
   assert.ok(resolver);
-  assert.equal(resolver.id, 'main_e2e_reuse');
+  assert.equal(resolver.id, 'main_e2e_reuse_raw');
   assert.equal(resolver['continue-on-error'], true);
   assert.equal(resolver.if, "github.event_name == 'push' && github.ref == 'refs/heads/main'");
   assert.equal(resolver.env.GITHUB_TOKEN, '${{ github.token }}');
   assert.equal(resolver.run, 'node scripts/ci/main-e2e-reuse.mjs >> "$GITHUB_OUTPUT"');
-  assert.equal(validation.outputs.main_e2e_reuse, '${{ steps.main_e2e_reuse.outputs.reuse }}');
+  const normalizer = step(validation, 'Normalize main E2E reuse decision');
+  assert.ok(normalizer);
+  assert.equal(normalizer.id, 'main_e2e_reuse_safe');
+  assert.equal(
+    normalizer.if,
+    "always() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+  );
+  assert.equal(
+    normalizer.env.RESOLVER_RESULT,
+    '${{ steps.main_e2e_reuse_raw.outcome }}:${{ steps.main_e2e_reuse_raw.outputs.reuse }}'
+  );
+  assert.equal(validation.outputs.main_e2e_reuse, '${{ steps.main_e2e_reuse_safe.outputs.reuse }}');
   assert.equal(validation.outputs.main_e2e_reuse_reason, undefined);
+});
+
+test('normalizer accepts only exact lowercase true from a successful resolver', () => {
+  assert.equal(normalizedReuse('true', 'success'), 'reuse=1\n');
+  for (const raw of ['TRUE', 'True', ' true', 'true ', '']) {
+    assert.equal(normalizedReuse(raw, 'success'), 'reuse=0\n', JSON.stringify(raw));
+  }
+  assert.equal(normalizedReuse('true', 'failure'), 'reuse=0\n');
 });
 
 test('only the main browser suite consumes the exact true reuse decision', () => {
   const suite = step(e2e, 'E2E Gate Suite');
   assert.equal(
     suite.if,
-    "github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != 'true'"
+    "github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != '1'"
   );
   assert.equal(suite.run, 'pnpm e2e:gate');
 
@@ -58,5 +99,5 @@ test('workflow does not trust the reason output or condition the whole job', () 
   const source = readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf8');
   assert.doesNotMatch(step(e2e, 'E2E Gate Suite').if, /main_e2e_reuse_reason/u);
   assert.doesNotMatch(e2e.if, /main_e2e_reuse/u);
-  assert.equal((source.match(/main_e2e_reuse != 'true'/gu) ?? []).length, 1);
+  assert.equal((source.match(/main_e2e_reuse != '1'/gu) ?? []).length, 1);
 });

--- a/scripts/ci/main-e2e-reuse-workflow.test.mjs
+++ b/scripts/ci/main-e2e-reuse-workflow.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const workflow = yaml.load(readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf8'));
+const validation = workflow.jobs['validation-surface'];
+const e2e = workflow.jobs['e2e-gate'];
+
+function step(job, name) {
+  return job.steps.find(value => value?.name === name);
+}
+
+test('main CI resolves exact-tree reuse with bounded read-only evidence access', () => {
+  assert.equal(workflow.permissions.contents, 'read');
+  assert.equal(workflow.permissions['pull-requests'], 'read');
+  assert.equal(workflow.permissions.actions, 'read');
+
+  const resolver = step(validation, 'Resolve main E2E exact-tree reuse');
+  assert.ok(resolver);
+  assert.equal(resolver.id, 'main_e2e_reuse');
+  assert.equal(resolver['continue-on-error'], true);
+  assert.equal(resolver.if, "github.event_name == 'push' && github.ref == 'refs/heads/main'");
+  assert.equal(resolver.env.GITHUB_TOKEN, '${{ github.token }}');
+  assert.equal(resolver.run, 'node scripts/ci/main-e2e-reuse.mjs >> "$GITHUB_OUTPUT"');
+  assert.equal(validation.outputs.main_e2e_reuse, '${{ steps.main_e2e_reuse.outputs.reuse }}');
+  assert.equal(validation.outputs.main_e2e_reuse_reason, undefined);
+});
+
+test('only the main browser suite consumes the exact true reuse decision', () => {
+  const suite = step(e2e, 'E2E Gate Suite');
+  assert.equal(
+    suite.if,
+    "github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != 'true'"
+  );
+  assert.equal(suite.run, 'pnpm e2e:gate');
+
+  for (const name of [
+    'Generate ephemeral E2E credentials',
+    'Enforce E2E Best Practices',
+    'Prepare E2E Database',
+    'RLS Integration Test',
+  ]) {
+    const candidate = step(e2e, name);
+    assert.ok(candidate, name);
+    assert.doesNotMatch(candidate.if ?? '', /main_e2e_reuse/u, name);
+  }
+  const setup = e2e.steps.find(candidate => candidate?.uses === './.github/actions/setup');
+  assert.doesNotMatch(setup.if ?? '', /main_e2e_reuse/u);
+  assert.equal(e2e.if, "needs.validation-surface.outputs.run_broad == 'true'");
+});
+
+test('workflow does not trust the reason output or condition the whole job', () => {
+  const source = readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf8');
+  assert.doesNotMatch(step(e2e, 'E2E Gate Suite').if, /main_e2e_reuse_reason/u);
+  assert.doesNotMatch(e2e.if, /main_e2e_reuse/u);
+  assert.equal((source.match(/main_e2e_reuse != 'true'/gu) ?? []).length, 1);
+});

--- a/scripts/ci/main-e2e-reuse.mjs
+++ b/scripts/ci/main-e2e-reuse.mjs
@@ -1,0 +1,150 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { decideMainE2eReuse, normalizeReuseDecision } from './main-e2e-reuse-core.mjs';
+import { collectGitHubEvidence } from './main-e2e-reuse-github.mjs';
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SOURCE_PATHS = {
+  ciWorkflow: '.github/workflows/ci.yml',
+  prWorkflow: '.github/workflows/e2e-pr.yml',
+  laneSource: 'scripts/run-e2e-lane.mjs',
+};
+function triggerIsPullRequestOnly(source) {
+  const block = /^on:\n([\s\S]*?)^concurrency:/mu.exec(source)?.[1] ?? '';
+  const triggers = [...block.matchAll(/^  ([a-zA-Z0-9_-]+):/gmu)].map(match => match[1]);
+  return triggers.length === 1 && triggers[0] === 'pull_request';
+}
+function jobBlock(source, jobName, nextJobName) {
+  const start = source.indexOf(`  ${jobName}:`);
+  const end = source.indexOf(`\n  ${nextJobName}:`, start + 1);
+  return start >= 0 ? source.slice(start, end >= 0 ? end : undefined) : '';
+}
+function checkoutUsesPullRequestHead(source) {
+  const runner = jobBlock(source, 'e2e-runner', 'e2e');
+  const expression = /\bref:\s*\$\{\{\s*([^}\n]+?)\s*\}\}/u.exec(runner)?.[1]?.trim();
+  return (
+    triggerIsPullRequestOnly(source) &&
+    (expression === 'github.event.pull_request.head.sha' ||
+      expression === 'github.event.pull_request.head.sha || github.sha')
+  );
+}
+function lane(source, name) {
+  const constants = new Map(
+    [...source.matchAll(/const\s+(\w+)\s*=\s*'--project=([^']+)'/gu)].map(match => [
+      match[1],
+      match[2],
+    ])
+  );
+  const definition = new RegExp(
+    `\\b${name}:\\s*gateLane\\(\\[([^\\]]+)\\],\\s*(true|false)\\)`,
+    'u'
+  ).exec(source);
+  if (!definition) return { projects: [], shared: false };
+  const projects = definition[1]
+    .split(',')
+    .map(value => constants.get(value.trim()))
+    .filter(Boolean);
+  return {
+    projects,
+    shared:
+      definition[2] === 'true' && projects.length > 0 && projects.length === new Set(projects).size,
+  };
+}
+function databaseDefault(source) {
+  return /DATABASE_URL:\s*\$\{\{\s*secrets\.E2E_DATABASE_URL\s*\|\|\s*'([^']+)'\s*\}\}/u.exec(
+    source
+  )?.[1];
+}
+function stepBlock(source, name) {
+  const start = source.indexOf(`- name: ${name}`);
+  const end = source.indexOf('\n      - name:', start + 1);
+  return start >= 0 ? source.slice(start, end >= 0 ? end : undefined) : '';
+}
+function usesWorkflowDatabase(block, command) {
+  return (
+    block.includes('E2E_DATABASE_URL: ${{ env.DATABASE_URL }}') &&
+    block.includes('E2E_DATABASE_URL_RLS: ${{ env.DATABASE_URL }}') &&
+    block.includes(`run: ${command}`)
+  );
+}
+function usesCorrectedPostgres(block) {
+  return /image: postgres:16[\s\S]*POSTGRES_USER: postgres[\s\S]*POSTGRES_DB: interdomestik_test[\s\S]*- 5432:5432[\s\S]*pg_isready -U postgres -d interdomestik_test/u.test(
+    block
+  );
+}
+export function inspectRepositoryParity({ ciWorkflow, prWorkflow, laneSource }) {
+  const main = lane(laneSource, 'gate');
+  const pr = lane(laneSource, 'pr');
+  const mainProjects = new Set(main.projects);
+  const prProjects = new Set(pr.projects);
+  const ciDatabase = databaseDefault(ciWorkflow);
+  const prDatabase = databaseDefault(prWorkflow);
+  return {
+    checkoutHead: checkoutUsesPullRequestHead(prWorkflow),
+    projectSuperset:
+      mainProjects.size > 0 &&
+      prProjects.size > mainProjects.size &&
+      [...mainProjects].every(project => prProjects.has(project)),
+    sharedFlags: main.shared && pr.shared,
+    databaseSubstrate:
+      Boolean(ciDatabase) &&
+      ciDatabase === prDatabase &&
+      usesCorrectedPostgres(jobBlock(ciWorkflow, 'e2e-gate', '__last_job__')) &&
+      usesCorrectedPostgres(jobBlock(prWorkflow, 'e2e-runner', 'e2e')) &&
+      usesWorkflowDatabase(stepBlock(ciWorkflow, 'E2E Gate Suite'), 'pnpm e2e:gate') &&
+      usesWorkflowDatabase(stepBlock(prWorkflow, 'Run PR E2E Gate'), 'pnpm e2e:gate:pr'),
+  };
+}
+function defaultGit(revision) {
+  return execFileSync('git', ['rev-parse', revision], {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+export async function resolveMainE2eReuse(env, dependencies = {}) {
+  const reject = normalizeReuseDecision(null);
+  try {
+    const git = dependencies.git ?? defaultGit;
+    const readFile =
+      dependencies.readFile ?? (value => readFileSync(path.join(root, value), 'utf8'));
+    const collectEvidence = dependencies.collectEvidence ?? collectGitHubEvidence;
+    const context = {
+      eventName: env.GITHUB_EVENT_NAME,
+      ref: env.GITHUB_REF,
+      repository: env.GITHUB_REPOSITORY,
+      githubSha: env.GITHUB_SHA,
+      nowMs: dependencies.nowMs ?? Date.now(),
+    };
+    const local = { headSha: git('HEAD'), treeSha: git('HEAD^{tree}') };
+    if (
+      context.eventName !== 'push' ||
+      context.ref !== 'refs/heads/main' ||
+      context.repository !== 'interdomestik/interdomestik' ||
+      local.headSha !== context.githubSha
+    ) {
+      return reject;
+    }
+    const inputs = Object.fromEntries(
+      Object.entries(SOURCE_PATHS).map(([key, value]) => [key, readFile(value)])
+    );
+    const parity = inspectRepositoryParity(inputs);
+    if (!Object.values(parity).every(Boolean)) return reject;
+    const remote = await collectEvidence({
+      repositoryFullName: context.repository,
+      githubSha: context.githubSha,
+      token: env.GITHUB_TOKEN,
+    });
+    return normalizeReuseDecision(decideMainE2eReuse({ context, local, parity, ...remote }));
+  } catch {
+    return reject;
+  }
+}
+export function formatReuseDecision(value) {
+  const decision = normalizeReuseDecision(value);
+  return `reuse=${decision.reuse}\nreason=${decision.reason}\n`;
+}
+if (path.resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  process.stdout.write(formatReuseDecision(await resolveMainE2eReuse(process.env)));
+}

--- a/scripts/ci/main-e2e-reuse.mjs
+++ b/scripts/ci/main-e2e-reuse.mjs
@@ -11,6 +11,10 @@ const GATE_HELPER_CONTRACTS = [
   "['--workers=1',...strictArgs]",
   "['e2e/gate',...strictWorkers]",
   'gatekeeper:true,state,env:fastEnv,playwrightArgs:[...gateArgs,...projects]',
+  "constpwArgs=['--filter','@interdomestik/web','exec','playwright','test']",
+  'awaitrunDetachedCommand(command,args,{cwd:rootDir,env})',
+  "if(lane.state)awaitrun('pnpm',[...pwArgs,...laneDefinitions.state.playwrightArgs],stateEnv)",
+  "awaitrun('pnpm',[...pwArgs,...lane.playwrightArgs,...extraPlaywrightArgs],finalEnv)",
 ];
 function sourceBlock(source, startMarker, endMarker) {
   const start = source.indexOf(startMarker);
@@ -70,15 +74,10 @@ function usesWorkflowDatabase(block, command) {
     block.includes(`run: ${command}`)
   );
 }
-function usesCorrectedPostgres(block) {
-  return [
-    'postgres:16',
-    'POSTGRES_USER: postgres',
-    'POSTGRES_DB: interdomestik_test',
-    '5432:5432',
-    'pg_isready -U postgres -d interdomestik_test',
-  ].every(value => block.includes(value));
-}
+const POSTGRES_CONTRACT =
+  'postgres:16|POSTGRES_USER: postgres|POSTGRES_DB: interdomestik_test|5432:5432|pg_isready -U postgres -d interdomestik_test';
+const usesCorrectedPostgres = block =>
+  POSTGRES_CONTRACT.split('|').every(value => block.includes(value));
 export function inspectRepositoryParity({ ciWorkflow, prWorkflow, laneSource, packageJson }) {
   const main = lane(laneSource, 'gate');
   const pr = lane(laneSource, 'pr');

--- a/scripts/ci/main-e2e-reuse.mjs
+++ b/scripts/ci/main-e2e-reuse.mjs
@@ -1,66 +1,68 @@
-import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { decideMainE2eReuse, normalizeReuseDecision } from './main-e2e-reuse-core.mjs';
-import { collectGitHubEvidence } from './main-e2e-reuse-github.mjs';
+import { collectGitHubEvidence, readLocalGitObjectId } from './main-e2e-reuse-github.mjs';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const SOURCE_PATHS = {
-  ciWorkflow: '.github/workflows/ci.yml',
-  prWorkflow: '.github/workflows/e2e-pr.yml',
-  laneSource: 'scripts/run-e2e-lane.mjs',
-};
-function triggerIsPullRequestOnly(source) {
-  const block = /^on:\n([\s\S]*?)^concurrency:/mu.exec(source)?.[1] ?? '';
-  const triggers = [...block.matchAll(/^  ([a-zA-Z0-9_-]+):/gmu)].map(match => match[1]);
-  return triggers.length === 1 && triggers[0] === 'pull_request';
-}
-function jobBlock(source, jobName, nextJobName) {
-  const start = source.indexOf(`  ${jobName}:`);
-  const end = source.indexOf(`\n  ${nextJobName}:`, start + 1);
-  return start >= 0 ? source.slice(start, end >= 0 ? end : undefined) : '';
+const GATE_HELPER_CONTRACTS = [
+  'playwrightReportArgs(process.env.PW_EVIDENCE_LANE)',
+  "PW_FAST_GATES:'1'",
+  "['--max-failures=1',...reportArgs]",
+  "['--workers=1',...strictArgs]",
+  "['e2e/gate',...strictWorkers]",
+  'gatekeeper:true,state,env:fastEnv,playwrightArgs:[...gateArgs,...projects]',
+];
+function sourceBlock(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) return '';
+  const end = source.indexOf(endMarker, start + 1);
+  return source.slice(start, end < 0 ? undefined : end);
 }
 function checkoutUsesPullRequestHead(source) {
-  const runner = jobBlock(source, 'e2e-runner', 'e2e');
-  const expression = /\bref:\s*\$\{\{\s*([^}\n]+?)\s*\}\}/u.exec(runner)?.[1]?.trim();
+  const triggerBlock = source.slice(source.indexOf('on:\n'), source.indexOf('concurrency:'));
+  const triggers = [...triggerBlock.matchAll(/^ {2}([a-zA-Z0-9_-]+):/gmu)];
+  const lines = new Set(
+    sourceBlock(source, '  e2e-runner:', '\n  e2e:')
+      .split('\n')
+      .map(value => value.trim())
+  );
   return (
-    triggerIsPullRequestOnly(source) &&
-    (expression === 'github.event.pull_request.head.sha' ||
-      expression === 'github.event.pull_request.head.sha || github.sha')
+    triggers.length === 1 &&
+    triggers[0][1] === 'pull_request' &&
+    (lines.has('ref: ${{ github.event.pull_request.head.sha }}') ||
+      lines.has('ref: ${{ github.event.pull_request.head.sha || github.sha }}'))
   );
 }
 function lane(source, name) {
-  const constants = new Map(
-    [...source.matchAll(/const\s+(\w+)\s*=\s*'--project=([^']+)'/gu)].map(match => [
-      match[1],
-      match[2],
-    ])
+  const constants = Object.fromEntries(
+    [...source.matchAll(/const\s+(\w+)\s*=\s*'--project=([^']+)'/gu)].map(match => match.slice(1))
   );
-  const definition = new RegExp(
-    `\\b${name}:\\s*gateLane\\(\\[([^\\]]+)\\],\\s*(true|false)\\)`,
+  const pattern = new RegExp(
+    String.raw`\b${name}:\s*gateLane\(\[([^\]]+)\],\s*(true|false)\)`,
     'u'
-  ).exec(source);
+  );
+  const definition = pattern.exec(source);
   if (!definition) return { projects: [], shared: false };
-  const projects = definition[1]
-    .split(',')
-    .map(value => constants.get(value.trim()))
-    .filter(Boolean);
-  return {
-    projects,
-    shared:
-      definition[2] === 'true' && projects.length > 0 && projects.length === new Set(projects).size,
-  };
+  const projects = definition[1].split(',').map(value => constants[value.trim()]);
+  if (projects.some(value => !value) || projects.length !== new Set(projects).size)
+    return { projects: [], shared: false };
+  return { projects, shared: definition[2] === 'true' && projects.length > 0 };
 }
-function databaseDefault(source) {
-  return /DATABASE_URL:\s*\$\{\{\s*secrets\.E2E_DATABASE_URL\s*\|\|\s*'([^']+)'\s*\}\}/u.exec(
-    source
-  )?.[1];
+function hasExactCommandChain(packageJson, laneSource) {
+  try {
+    const scripts = JSON.parse(packageJson)?.scripts;
+    const compactSource = laneSource.replace(/\s+/gu, '');
+    return (
+      scripts?.['e2e:gate'] === 'node scripts/run-e2e-lane.mjs gate' &&
+      scripts?.['e2e:gate:pr'] === 'node scripts/run-e2e-lane.mjs pr' &&
+      GATE_HELPER_CONTRACTS.every(contract => compactSource.includes(contract))
+    );
+  } catch {
+    return false;
+  }
 }
-function stepBlock(source, name) {
-  const start = source.indexOf(`- name: ${name}`);
-  const end = source.indexOf('\n      - name:', start + 1);
-  return start >= 0 ? source.slice(start, end >= 0 ? end : undefined) : '';
-}
+const databaseDefault = source => /DATABASE_URL:[^\n]*\|\|\s*'([^']+)'/u.exec(source)?.[1];
+const stepBlock = (source, name) => sourceBlock(source, `- name: ${name}`, '\n      - name:');
 function usesWorkflowDatabase(block, command) {
   return (
     block.includes('E2E_DATABASE_URL: ${{ env.DATABASE_URL }}') &&
@@ -69,17 +71,19 @@ function usesWorkflowDatabase(block, command) {
   );
 }
 function usesCorrectedPostgres(block) {
-  return /image: postgres:16[\s\S]*POSTGRES_USER: postgres[\s\S]*POSTGRES_DB: interdomestik_test[\s\S]*- 5432:5432[\s\S]*pg_isready -U postgres -d interdomestik_test/u.test(
-    block
-  );
+  return [
+    'postgres:16',
+    'POSTGRES_USER: postgres',
+    'POSTGRES_DB: interdomestik_test',
+    '5432:5432',
+    'pg_isready -U postgres -d interdomestik_test',
+  ].every(value => block.includes(value));
 }
-export function inspectRepositoryParity({ ciWorkflow, prWorkflow, laneSource }) {
+export function inspectRepositoryParity({ ciWorkflow, prWorkflow, laneSource, packageJson }) {
   const main = lane(laneSource, 'gate');
   const pr = lane(laneSource, 'pr');
   const mainProjects = new Set(main.projects);
   const prProjects = new Set(pr.projects);
-  const ciDatabase = databaseDefault(ciWorkflow);
-  const prDatabase = databaseDefault(prWorkflow);
   return {
     checkoutHead: checkoutUsesPullRequestHead(prWorkflow),
     projectSuperset:
@@ -88,28 +92,21 @@ export function inspectRepositoryParity({ ciWorkflow, prWorkflow, laneSource }) 
       [...mainProjects].every(project => prProjects.has(project)),
     sharedFlags: main.shared && pr.shared,
     databaseSubstrate:
-      Boolean(ciDatabase) &&
-      ciDatabase === prDatabase &&
-      usesCorrectedPostgres(jobBlock(ciWorkflow, 'e2e-gate', '__last_job__')) &&
-      usesCorrectedPostgres(jobBlock(prWorkflow, 'e2e-runner', 'e2e')) &&
+      Boolean(databaseDefault(ciWorkflow)) &&
+      databaseDefault(ciWorkflow) === databaseDefault(prWorkflow) &&
+      usesCorrectedPostgres(sourceBlock(ciWorkflow, '  e2e-gate:', '\n  __last_job__:')) &&
+      usesCorrectedPostgres(sourceBlock(prWorkflow, '  e2e-runner:', '\n  e2e:')) &&
       usesWorkflowDatabase(stepBlock(ciWorkflow, 'E2E Gate Suite'), 'pnpm e2e:gate') &&
       usesWorkflowDatabase(stepBlock(prWorkflow, 'Run PR E2E Gate'), 'pnpm e2e:gate:pr'),
+    commandChain: hasExactCommandChain(packageJson, laneSource),
   };
-}
-function defaultGit(revision) {
-  return execFileSync('git', ['rev-parse', revision], {
-    cwd: root,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore'],
-  }).trim();
 }
 export async function resolveMainE2eReuse(env, dependencies = {}) {
   const reject = normalizeReuseDecision(null);
   try {
-    const git = dependencies.git ?? defaultGit;
+    const git = dependencies.git ?? (revision => readLocalGitObjectId(root, revision));
     const readFile =
       dependencies.readFile ?? (value => readFileSync(path.join(root, value), 'utf8'));
-    const collectEvidence = dependencies.collectEvidence ?? collectGitHubEvidence;
     const context = {
       eventName: env.GITHUB_EVENT_NAME,
       ref: env.GITHUB_REF,
@@ -126,12 +123,15 @@ export async function resolveMainE2eReuse(env, dependencies = {}) {
     ) {
       return reject;
     }
-    const inputs = Object.fromEntries(
-      Object.entries(SOURCE_PATHS).map(([key, value]) => [key, readFile(value)])
-    );
+    const inputs = {
+      ciWorkflow: readFile('.github/workflows/ci.yml'),
+      prWorkflow: readFile('.github/workflows/e2e-pr.yml'),
+      laneSource: readFile('scripts/run-e2e-lane.mjs'),
+      packageJson: readFile('package.json'),
+    };
     const parity = inspectRepositoryParity(inputs);
-    if (!Object.values(parity).every(Boolean)) return reject;
-    const remote = await collectEvidence({
+    if (!Object.values(parity).every(value => value === true)) return reject;
+    const remote = await (dependencies.collectEvidence ?? collectGitHubEvidence)({
       repositoryFullName: context.repository,
       githubSha: context.githubSha,
       token: env.GITHUB_TOKEN,

--- a/scripts/ci/main-e2e-reuse.mjs
+++ b/scripts/ci/main-e2e-reuse.mjs
@@ -1,21 +1,14 @@
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { decideMainE2eReuse, normalizeReuseDecision } from './main-e2e-reuse-core.mjs';
 import { collectGitHubEvidence, readLocalGitObjectId } from './main-e2e-reuse-github.mjs';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const GATE_HELPER_CONTRACTS = [
-  'playwrightReportArgs(process.env.PW_EVIDENCE_LANE)',
-  "PW_FAST_GATES:'1'",
-  "['--max-failures=1',...reportArgs]",
-  "['--workers=1',...strictArgs]",
-  "['e2e/gate',...strictWorkers]",
-  'gatekeeper:true,state,env:fastEnv,playwrightArgs:[...gateArgs,...projects]',
-  "constpwArgs=['--filter','@interdomestik/web','exec','playwright','test']",
-  'awaitrunDetachedCommand(command,args,{cwd:rootDir,env})',
-  "if(lane.state)awaitrun('pnpm',[...pwArgs,...laneDefinitions.state.playwrightArgs],stateEnv)",
-  "awaitrun('pnpm',[...pwArgs,...lane.playwrightArgs,...extraPlaywrightArgs],finalEnv)",
-];
+// SHA-256 of scripts/run-e2e-lane.mjs at the authorized CI01 base 726c421dca7231d11ada013acdd421bb5420690d.
+const AUTHORIZED_LANE_SOURCE_SHA256 =
+  '9beb625efc7ffb6cadf88809063ee8b1b15cd5080c1419de5aa888db504cf685';
+const sha256 = value => createHash('sha256').update(value, 'utf8').digest('hex');
 function sourceBlock(source, startMarker, endMarker) {
   const start = source.indexOf(startMarker);
   if (start < 0) return '';
@@ -55,11 +48,10 @@ function lane(source, name) {
 function hasExactCommandChain(packageJson, laneSource) {
   try {
     const scripts = JSON.parse(packageJson)?.scripts;
-    const compactSource = laneSource.replace(/\s+/gu, '');
     return (
       scripts?.['e2e:gate'] === 'node scripts/run-e2e-lane.mjs gate' &&
       scripts?.['e2e:gate:pr'] === 'node scripts/run-e2e-lane.mjs pr' &&
-      GATE_HELPER_CONTRACTS.every(contract => compactSource.includes(contract))
+      sha256(laneSource) === AUTHORIZED_LANE_SOURCE_SHA256
     );
   } catch {
     return false;

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -159,7 +159,7 @@ test('CI delegates PR browser gate to PR E2E', () => {
   const e2eGateSuiteStep = findStep(ciSteps, 'E2E Gate Suite');
   assert.equal(
     e2eGateSuiteStep.if,
-    "github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != 'true'"
+    "github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != '1'"
   );
   const staticJob = ciWorkflow.jobs.static;
   assert.ok(normalizeNeeds(staticJob.needs).includes('validation-surface'));

--- a/scripts/ci/workflow-contracts.test.mjs
+++ b/scripts/ci/workflow-contracts.test.mjs
@@ -147,7 +147,6 @@ test('CI delegates PR browser gate to PR E2E', () => {
 
   const setupStep = ciSteps.find(step => step?.uses === './.github/actions/setup');
   assert.equal(setupStep.with['install-playwright'], "${{ github.event_name != 'pull_request' }}");
-
   const strictGuardStep = findStep(ciSteps, 'Enforce E2E Best Practices');
   assert.equal(strictGuardStep.if, "github.event_name != 'pull_request'");
   assert.match(strictGuardStep.run, /guards/u);
@@ -158,12 +157,13 @@ test('CI delegates PR browser gate to PR E2E', () => {
   assert.equal(rlsStep.if, undefined);
 
   const e2eGateSuiteStep = findStep(ciSteps, 'E2E Gate Suite');
-  assert.equal(e2eGateSuiteStep.if, "github.event_name != 'pull_request'");
-
+  assert.equal(
+    e2eGateSuiteStep.if,
+    "github.event_name != 'pull_request' && needs.validation-surface.outputs.main_e2e_reuse != 'true'"
+  );
   const staticJob = ciWorkflow.jobs.static;
   assert.ok(normalizeNeeds(staticJob.needs).includes('validation-surface'));
   assert.equal(staticJob.if, "needs.validation-surface.outputs.run_broad == 'true'");
-
   const unitJob = ciWorkflow.jobs.unit;
   assert.ok(normalizeNeeds(unitJob.needs).includes('validation-surface'));
   assert.equal(unitJob.if, "needs.validation-surface.outputs.run_broad == 'true'");

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "workflowDigests": {
-    ".github/workflows/ci.yml": "49db1acb1efb1507059d47a83f2846c8682dc734a7be3855fd891799854ca910",
+    ".github/workflows/ci.yml": "79596aeed5123a7771332cfd0f437b36d53734b2983e2583202bf2818f179dd2",
     ".github/workflows/security.yml": "72e957bba4773deb3212d6db1d16f398c8fed53e538c6a060ca04f07f688195a",
     ".github/workflows/e2e-pr.yml": "5607206adf40e9f63567e71f41311f386519990ffdfbbd6fc7c469c355a720bc",
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",

--- a/scripts/ci/z620-parity.json
+++ b/scripts/ci/z620-parity.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "workflowDigests": {
-    ".github/workflows/ci.yml": "79596aeed5123a7771332cfd0f437b36d53734b2983e2583202bf2818f179dd2",
+    ".github/workflows/ci.yml": "61e43eb2503e424e60ecb2b6c95f0f487933c982f9fe2bc201d06be4ac98ccbb",
     ".github/workflows/security.yml": "72e957bba4773deb3212d6db1d16f398c8fed53e538c6a060ca04f07f688195a",
     ".github/workflows/e2e-pr.yml": "5607206adf40e9f63567e71f41311f386519990ffdfbbd6fc7c469c355a720bc",
     ".github/workflows/sonar-main-gate.yml": "626baa9e4bc3df173f297829076a2ec4711f36fac3de26e66d3cd1fdde7cc0ef",

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60592065,
+  "maxTrackedBytes": 60593671,
   "maxTrackedFiles": 5712,
   "maxCategoryBytes": {
     "other": 18856416,
     "large support/generated-ish": 16967570,
     "docs/text": 8680973,
-    "source/scripts": 8080545,
-    "tests/e2e": 6167689,
+    "source/scripts": 8082154,
+    "tests/e2e": 6167686,
     "config/data/messages": 1838872
   },
   "maxLargestFileBytes": 3266530,

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60585240,
+  "maxTrackedBytes": 60592065,
   "maxTrackedFiles": 5712,
   "maxCategoryBytes": {
     "other": 18856416,
     "large support/generated-ish": 16967570,
     "docs/text": 8680973,
-    "source/scripts": 8077619,
-    "tests/e2e": 6164207,
-    "config/data/messages": 1838455
+    "source/scripts": 8080545,
+    "tests/e2e": 6167689,
+    "config/data/messages": 1838872
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60542827,
-  "maxTrackedFiles": 5704,
+  "maxTrackedBytes": 60585240,
+  "maxTrackedFiles": 5712,
   "maxCategoryBytes": {
     "other": 18856416,
     "large support/generated-ish": 16967570,
     "docs/text": 8680973,
-    "source/scripts": 8057531,
-    "tests/e2e": 6142318,
-    "config/data/messages": 1838019
+    "source/scripts": 8077619,
+    "tests/e2e": 6164207,
+    "config/data/messages": 1838455
   },
   "maxLargestFileBytes": 3266530,
   "maxSourceOrTestLines": 3000

--- a/scripts/repo-size-budget.json
+++ b/scripts/repo-size-budget.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "maxTrackedBytes": 60593671,
+  "maxTrackedBytes": 60593668,
   "maxTrackedFiles": 5712,
   "maxCategoryBytes": {
     "other": 18856416,
     "large support/generated-ish": 16967570,
     "docs/text": 8680973,
-    "source/scripts": 8082154,
-    "tests/e2e": 6167686,
+    "source/scripts": 8081870,
+    "tests/e2e": 6167967,
     "config/data/messages": 1838872
   },
   "maxLargestFileBytes": 3266530,


### PR DESCRIPTION
## Summary

- Add a dependency-free, fail-closed resolver that reuses a successful PR browser gate only when merged-PR identity, exact tree, workflow/run/job association, repository identity, freshness, checkout, project coverage, flags, and database substrate all match.
- Support the approved empty `pull_requests` case with a bounded commit-to-PR fallback; non-empty mismatch, ambiguity, malformed schema, pagination failure, timeout, or any other incomplete evidence resolves to `reuse=false`.
- Wire the normalized decision into the existing CI workflow with read-only permissions and `continue-on-error`; only `pnpm e2e:gate` may be skipped, and only for the exact output string `true`. Setup, credentials, guards, DB preparation, seeding, and RLS remain mandatory.
- Scope is exactly the 14 CI01-RUNTIME-R2 writer paths; no product, auth, routing, schema, deployment, or second-slice changes.

## Review focus

- Primary surface: `scripts/ci/main-e2e-reuse-{core,github}.mjs`, the repository-parity inspection in `main-e2e-reuse.mjs`, and the `E2E Gate Suite` condition in `ci.yml`.
- Verify the direct-association and empty-array fallback branches stay mutually exclusive and exact.
- Verify every resolver/API/schema/output failure remains fail closed and that no token, response body, or unbounded error reaches output.
- Verify reuse conditions only the browser suite step, never the job or its non-browser gates.

## Acceptance

- [x] Slice criteria are explicit and covered by focused contracts.
- [x] No behavior changed outside the approved CI01 evidence-reuse scope.
- [x] The resolver emits `reuse=true` only with `reason=exact_pr_evidence`.
- [x] Anything other than exact string `true` runs main `pnpm e2e:gate`.
- [x] Empty direct association requires exactly one matching fallback PR; direct mismatch cannot fall back.

## TDD evidence

RED:

- `node --test --test-concurrency=1 scripts/ci/github-api-url-lib.test.mjs scripts/ci/main-e2e-reuse-core.test.mjs` — exit 1: missing resolver exports/modules.
- `node --test --test-concurrency=1 scripts/ci/main-e2e-reuse-github.test.mjs` — exit 1: missing GitHub adapter.
- `node --test --test-concurrency=1 scripts/ci/main-e2e-reuse-cli.test.mjs` — exit 1: missing CLI resolver.
- `node --test --test-concurrency=1 scripts/ci/main-e2e-reuse-workflow.test.mjs` — 3/3 expected failures after dependencies were installed: missing Actions permission, resolver/output wiring, and exact suite condition.
- `node --test --test-concurrency=1 scripts/ci/main-e2e-reuse-core.test.mjs` — 50 pass / 2 expected fail for absent and partial parity evidence.

GREEN:

- Focused resolver/workflow bundle — 91/91 pass.
- `pnpm test:ci:contracts` — 614/614 pass.
- Parity/runner/repo-size metadata bundle — 26/26 pass.
- `pnpm security:guard` — pass.
- `pnpm check:modularity-guard --base=726c421dca7231d11ada013acdd421bb5420690d` — pass, exactly 14 changed files.
- Prettier, `pnpm repo:size:check`, repo-size fixed-point check, z620 parity, and `git diff --check` — pass.
- Read-only live response-shape canary against approved evidence PR `#1548` / run `31712197425` — exact fallback accepted; direct association count 0, fallback count 1.

## Evidence and caveats

- PR status: `PARTIAL` pending current-head hosted checks, requested reviewer passes, and the single exact-head PR E2E required by the design gate.
- Local `pnpm e2e:gate` and the heavy `pnpm pr:verify` aggregate were intentionally not run; the runtime handoff reserves browser proof for the repository’s official exact-head wrapper/workflow.
- No review bots were requested here; the CI01 root runner owns Copilot/senior review and remote merge-gate closeout.
- Rollback: revert this commit. Independently, missing/failed resolver output already leaves the main browser suite enabled.

## Pilot guardrails

- [x] No auth, routing, proxy, product API, tenancy, RLS policy, billing, provider, or deployment files changed.
- [x] No tests or required checks were deleted, weakened, renamed, or consolidated.
- [ ] Current-head Copilot and senior review pending root-runner orchestration.
- [ ] Required hosted checks and exact-head PR E2E pending.
