### PR TITLE
fix(deps): patch nanoid 3.x security override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
   hono: ^4.12.34
   '@hono/node-server': 2.0.10
   postcss: 8.5.23
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   defu: ^6.1.5
   path-to-regexp: ^8.4.0
   picomatch@<2.3.2: 2.3.2
@@ -11743,10 +11743,10 @@ packages:
         integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
-  nanoid@3.3.17:
+  nanoid@3.3.18:
     resolution:
       {
-        integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==,
+        integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -22041,7 +22041,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -22561,7 +22561,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ overrides:
   hono: ^4.12.34
   '@hono/node-server': 2.0.10
   postcss: 8.5.23
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   defu: ^6.1.5
   path-to-regexp: ^8.4.0
   picomatch@<2.3.2: 2.3.2


### PR DESCRIPTION
## Summary

- raise the existing nanoid 3.x override from `nanoid@<3.3.17: 3.3.17` to `nanoid@<3.3.18: 3.3.18`
- regenerate the lockfile with the repository-pinned pnpm 10.28.2 and preserve the direct `nanoid@5.1.16` resolution unchanged
- keep the change limited to the override and the transitive PostCSS nanoid 3.x lock node

This PR is the security prerequisite for #1550. It intentionally does not address the separate moderate DOMPurify advisory.

## Security evidence

- RED before the change: advisory 1139427 blocked the repository high+ audit gate for transitive `nanoid@3.3.17`
- GREEN after the change: advisory 1139427 is absent; audit metadata reports 0 high and 0 critical vulnerabilities
- the repository audit filter and `pnpm security:guard` pass
- the remaining reported advisory is moderate DOMPurify 1138538 and is outside this PR's authorized scope

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`
- `pnpm audit --prod --audit-level=high --json | node scripts/pnpm-audit-gate.mjs`
- `pnpm security:guard`
- `node scripts/ci/z620-security-audit.mjs`
- `node scripts/repo-size-budget-sync.mjs --check`
- `pnpm repo:size:check`
- `pnpm exec prettier --check pnpm-workspace.yaml pnpm-lock.yaml`
- `git diff --check`

## Rollback

Run `git revert 77bead952e163112d249b0f7149f16be1b28c6b4`. This exactly restores the prior `<3.3.17 -> 3.3.17` override and `nanoid@3.3.17` lock node while leaving the direct `nanoid@5.1.16` resolution unchanged.
